### PR TITLE
fix: clarify distribution controls and wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+output/
 *.local
 var/
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "npm run test:issue-1",
+    "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/scripts/test-issue-1-view-controls.mjs
+++ b/scripts/test-issue-1-view-controls.mjs
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import assert from 'node:assert/strict'
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const chartSource = readFileSync(join(repoRoot, 'src/components/ModelShareChart.tsx'), 'utf8')
+const cssSource = readFileSync(join(repoRoot, 'src/styles.css'), 'utf8')
+
+assert.match(
+  chartSource,
+  /className="chart-control-group"[\s\S]*aria-label=\{t\.charts\.dimensionControlLabel\}/,
+  'distribution chart should expose the dimension controls as their own labelled group',
+)
+
+assert.match(
+  chartSource,
+  /className="chart-control-group"[\s\S]*aria-label=\{t\.charts\.metricControlLabel\}/,
+  'distribution chart should expose the metric controls as their own labelled group',
+)
+
+assert.match(
+  chartSource,
+  /\{hasRenderableData \? \(\s*<div className="share-center">/,
+  'distribution chart should hide the center metric when the empty-state message is shown',
+)
+
+assert.match(
+  cssSource,
+  /\.chart-control-group\s*\{[\s\S]*?border:\s*1px solid var\(--line-subtle\);[\s\S]*?\}/,
+  'distribution control groups should have a visible boundary between independent selectors',
+)
+
+assert.match(
+  cssSource,
+  /\.pill-strip button\s*\{[\s\S]*?white-space:\s*nowrap;[\s\S]*?\}/,
+  'pill buttons should keep short option labels on one line',
+)
+
+assert.match(
+  cssSource,
+  /\.chart-heading h3\s*\{[\s\S]*?white-space:\s*nowrap;[\s\S]*?\}/,
+  'chart titles should not wrap short labels like model share',
+)
+
+assert.doesNotMatch(
+  cssSource,
+  /\.metric-card strong\s*\{[\s\S]*?word-break:\s*break-word;[\s\S]*?\}/,
+  'metric values should not break arbitrary words or numeric units',
+)
+
+assert.match(
+  cssSource,
+  /\.metric-card:not\(\.metric-card--featured\) strong\s*\{[\s\S]*?font-size:\s*clamp\(1\.18rem,\s*1\.8vw,\s*1\.72rem\);[\s\S]*?\}/,
+  'standard metric cards should use a value size that fits short currency values without wrapping',
+)

--- a/scripts/test-issue-1-view-controls.mjs
+++ b/scripts/test-issue-1-view-controls.mjs
@@ -9,14 +9,26 @@ const cssSource = readFileSync(join(repoRoot, 'src/styles.css'), 'utf8')
 
 assert.match(
   chartSource,
-  /className="chart-control-group"[\s\S]*aria-label=\{t\.charts\.dimensionControlLabel\}/,
-  'distribution chart should expose the dimension controls as their own labelled group',
+  /className="chart-control-group"[\s\S]*role="radiogroup"[\s\S]*aria-label=\{t\.charts\.dimensionControlLabel\}/,
+  'distribution chart should expose the dimension controls as their own labelled radio group',
 )
 
 assert.match(
   chartSource,
-  /className="chart-control-group"[\s\S]*aria-label=\{t\.charts\.metricControlLabel\}/,
-  'distribution chart should expose the metric controls as their own labelled group',
+  /className="chart-control-group"[\s\S]*role="radiogroup"[\s\S]*aria-label=\{t\.charts\.metricControlLabel\}/,
+  'distribution chart should expose the metric controls as their own labelled radio group',
+)
+
+assert.match(
+  chartSource,
+  /role="radio"[\s\S]*aria-checked=\{dimension === 'model'\}/,
+  'dimension selector should expose selected state with aria-checked',
+)
+
+assert.match(
+  chartSource,
+  /role="radio"[\s\S]*aria-checked=\{mode === 'value'\}/,
+  'metric selector should expose selected state with aria-checked',
 )
 
 assert.match(
@@ -39,8 +51,20 @@ assert.match(
 
 assert.match(
   cssSource,
-  /\.chart-heading h3\s*\{[\s\S]*?white-space:\s*nowrap;[\s\S]*?\}/,
-  'chart titles should not wrap short labels like model share',
+  /\.chart-heading > div:first-child\s*\{[\s\S]*?min-width:\s*0;[\s\S]*?\}/,
+  'chart heading copy should be allowed to shrink before controls overflow',
+)
+
+assert.doesNotMatch(
+  cssSource,
+  /\.chart-heading > div:first-child\s*\{[\s\S]*?min-width:\s*max-content;[\s\S]*?\}/,
+  'chart heading copy should not force max-content width',
+)
+
+assert.match(
+  cssSource,
+  /@media \(max-width: 760px\)[\s\S]*?\.chart-shell--secondary \.chart-heading\s*\{[\s\S]*?flex-direction:\s*column;[\s\S]*?\}/,
+  'distribution chart heading should stack above controls on narrow screens',
 )
 
 assert.doesNotMatch(
@@ -53,4 +77,10 @@ assert.match(
   cssSource,
   /\.metric-card:not\(\.metric-card--featured\) strong\s*\{[\s\S]*?font-size:\s*clamp\(1\.18rem,\s*1\.8vw,\s*1\.72rem\);[\s\S]*?\}/,
   'standard metric cards should use a value size that fits short currency values without wrapping',
+)
+
+assert.match(
+  chartSource + readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8'),
+  /<strong[^>]*aria-label=\{value\}[^>]*title=\{value\}/,
+  'metric values should expose the full value to assistive technology as well as hover',
 )

--- a/scripts/test-issue-1-view-controls.mjs
+++ b/scripts/test-issue-1-view-controls.mjs
@@ -9,26 +9,32 @@ const cssSource = readFileSync(join(repoRoot, 'src/styles.css'), 'utf8')
 
 assert.match(
   chartSource,
-  /className="chart-control-group"[\s\S]*role="radiogroup"[\s\S]*aria-label=\{t\.charts\.dimensionControlLabel\}/,
-  'distribution chart should expose the dimension controls as their own labelled radio group',
+  /className="chart-control-group"[\s\S]*role="group"[\s\S]*aria-label=\{t\.charts\.dimensionControlLabel\}/,
+  'distribution chart should expose the dimension controls as their own labelled button group',
 )
 
 assert.match(
   chartSource,
-  /className="chart-control-group"[\s\S]*role="radiogroup"[\s\S]*aria-label=\{t\.charts\.metricControlLabel\}/,
-  'distribution chart should expose the metric controls as their own labelled radio group',
+  /className="chart-control-group"[\s\S]*role="group"[\s\S]*aria-label=\{t\.charts\.metricControlLabel\}/,
+  'distribution chart should expose the metric controls as their own labelled button group',
 )
 
 assert.match(
   chartSource,
-  /role="radio"[\s\S]*aria-checked=\{dimension === 'model'\}/,
-  'dimension selector should expose selected state with aria-checked',
+  /aria-pressed=\{dimension === 'model'\}/,
+  'dimension selector should expose selected state with aria-pressed',
 )
 
 assert.match(
   chartSource,
-  /role="radio"[\s\S]*aria-checked=\{mode === 'value'\}/,
-  'metric selector should expose selected state with aria-checked',
+  /aria-pressed=\{mode === 'value'\}/,
+  'metric selector should expose selected state with aria-pressed',
+)
+
+assert.doesNotMatch(
+  chartSource,
+  /role="radiogroup"|role="radio"|aria-checked=/,
+  'distribution controls should not use custom radio semantics without radio keyboard behavior',
 )
 
 assert.match(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -898,7 +898,9 @@ function MetricCard({
       }`}
     >
       <span className="metric-label">{caption}</span>
-      <strong title={value}>{value}</strong>
+      <strong aria-label={value} title={value}>
+        {value}
+      </strong>
       {note ? <span className="stat-caption">{note}</span> : null}
     </section>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -898,7 +898,7 @@ function MetricCard({
       }`}
     >
       <span className="metric-label">{caption}</span>
-      <strong>{value}</strong>
+      <strong title={value}>{value}</strong>
       {note ? <span className="stat-caption">{note}</span> : null}
     </section>
   )

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -115,6 +115,8 @@ export type TranslationSet = {
     apiValue: string
     tokens: string
     noShareData: string
+    dimensionControlLabel: string
+    metricControlLabel: string
     byModel: string
     byStructure: string
     byValue: string
@@ -360,6 +362,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       apiValue: 'API 价值',
       tokens: 'Tokens',
       noShareData: '当前窗口没有可用占比数据。',
+      dimensionControlLabel: '分布维度',
+      metricControlLabel: '分布指标',
       byModel: '按模型',
       byStructure: '按结构',
       byValue: '按价值',
@@ -599,6 +603,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       apiValue: 'API value',
       tokens: 'Tokens',
       noShareData: 'No share data in this window.',
+      dimensionControlLabel: 'Distribution dimension',
+      metricControlLabel: 'Distribution metric',
       byModel: 'By model',
       byStructure: 'By structure',
       byValue: 'By value',

--- a/src/components/ModelShareChart.tsx
+++ b/src/components/ModelShareChart.tsx
@@ -42,11 +42,10 @@ export function ModelShareChart({
         </div>
         <div className="chart-controls">
           {onDimensionChange ? (
-            <div className="chart-control-group" role="radiogroup" aria-label={t.charts.dimensionControlLabel}>
+            <div className="chart-control-group" role="group" aria-label={t.charts.dimensionControlLabel}>
               <div className="pill-strip">
                 <button
-                  role="radio"
-                  aria-checked={dimension === 'model'}
+                  aria-pressed={dimension === 'model'}
                   className={dimension === 'model' ? 'active' : ''}
                   onClick={() => onDimensionChange('model')}
                   type="button"
@@ -54,8 +53,7 @@ export function ModelShareChart({
                   {t.charts.byModel}
                 </button>
                 <button
-                  role="radio"
-                  aria-checked={dimension === 'composition'}
+                  aria-pressed={dimension === 'composition'}
                   className={dimension === 'composition' ? 'active' : ''}
                   onClick={() => onDimensionChange('composition')}
                   type="button"
@@ -66,11 +64,10 @@ export function ModelShareChart({
             </div>
           ) : null}
           {onModeChange ? (
-            <div className="chart-control-group" role="radiogroup" aria-label={t.charts.metricControlLabel}>
+            <div className="chart-control-group" role="group" aria-label={t.charts.metricControlLabel}>
               <div className="pill-strip">
                 <button
-                  role="radio"
-                  aria-checked={mode === 'value'}
+                  aria-pressed={mode === 'value'}
                   className={mode === 'value' ? 'active' : ''}
                   onClick={() => onModeChange('value')}
                   type="button"
@@ -78,8 +75,7 @@ export function ModelShareChart({
                   {t.charts.byValue}
                 </button>
                 <button
-                  role="radio"
-                  aria-checked={mode === 'tokens'}
+                  aria-pressed={mode === 'tokens'}
                   className={mode === 'tokens' ? 'active' : ''}
                   onClick={() => onModeChange('tokens')}
                   type="button"

--- a/src/components/ModelShareChart.tsx
+++ b/src/components/ModelShareChart.tsx
@@ -42,39 +42,43 @@ export function ModelShareChart({
         </div>
         <div className="chart-controls">
           {onDimensionChange ? (
-            <div className="pill-strip">
-              <button
-                className={dimension === 'model' ? 'active' : ''}
-                onClick={() => onDimensionChange('model')}
-                type="button"
-              >
-                {t.charts.byModel}
-              </button>
-              <button
-                className={dimension === 'composition' ? 'active' : ''}
-                onClick={() => onDimensionChange('composition')}
-                type="button"
-              >
-                {t.charts.byStructure}
-              </button>
+            <div className="chart-control-group" role="group" aria-label={t.charts.dimensionControlLabel}>
+              <div className="pill-strip">
+                <button
+                  className={dimension === 'model' ? 'active' : ''}
+                  onClick={() => onDimensionChange('model')}
+                  type="button"
+                >
+                  {t.charts.byModel}
+                </button>
+                <button
+                  className={dimension === 'composition' ? 'active' : ''}
+                  onClick={() => onDimensionChange('composition')}
+                  type="button"
+                >
+                  {t.charts.byStructure}
+                </button>
+              </div>
             </div>
           ) : null}
           {onModeChange ? (
-            <div className="pill-strip">
-              <button
-                className={mode === 'value' ? 'active' : ''}
-                onClick={() => onModeChange('value')}
-                type="button"
-              >
-                {t.charts.byValue}
-              </button>
-              <button
-                className={mode === 'tokens' ? 'active' : ''}
-                onClick={() => onModeChange('tokens')}
-                type="button"
-              >
-                {t.charts.byTokens}
-              </button>
+            <div className="chart-control-group" role="group" aria-label={t.charts.metricControlLabel}>
+              <div className="pill-strip">
+                <button
+                  className={mode === 'value' ? 'active' : ''}
+                  onClick={() => onModeChange('value')}
+                  type="button"
+                >
+                  {t.charts.byValue}
+                </button>
+                <button
+                  className={mode === 'tokens' ? 'active' : ''}
+                  onClick={() => onModeChange('tokens')}
+                  type="button"
+                >
+                  {t.charts.byTokens}
+                </button>
+              </div>
             </div>
           ) : null}
         </div>
@@ -122,14 +126,16 @@ export function ModelShareChart({
           ) : (
             <div className="share-empty">{t.charts.noShareData}</div>
           )}
-          <div className="share-center">
-            <span>{mode === 'value' ? t.charts.apiValue : t.charts.tokens}</span>
-            <strong>
-              {mode === 'value'
-                ? formatUsd(totalValue, language)
-                : formatTokenCount(totalTokens, language)}
-            </strong>
-          </div>
+          {hasRenderableData ? (
+            <div className="share-center">
+              <span>{mode === 'value' ? t.charts.apiValue : t.charts.tokens}</span>
+              <strong>
+                {mode === 'value'
+                  ? formatUsd(totalValue, language)
+                  : formatTokenCount(totalTokens, language)}
+              </strong>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/ModelShareChart.tsx
+++ b/src/components/ModelShareChart.tsx
@@ -42,9 +42,11 @@ export function ModelShareChart({
         </div>
         <div className="chart-controls">
           {onDimensionChange ? (
-            <div className="chart-control-group" role="group" aria-label={t.charts.dimensionControlLabel}>
+            <div className="chart-control-group" role="radiogroup" aria-label={t.charts.dimensionControlLabel}>
               <div className="pill-strip">
                 <button
+                  role="radio"
+                  aria-checked={dimension === 'model'}
                   className={dimension === 'model' ? 'active' : ''}
                   onClick={() => onDimensionChange('model')}
                   type="button"
@@ -52,6 +54,8 @@ export function ModelShareChart({
                   {t.charts.byModel}
                 </button>
                 <button
+                  role="radio"
+                  aria-checked={dimension === 'composition'}
                   className={dimension === 'composition' ? 'active' : ''}
                   onClick={() => onDimensionChange('composition')}
                   type="button"
@@ -62,9 +66,11 @@ export function ModelShareChart({
             </div>
           ) : null}
           {onModeChange ? (
-            <div className="chart-control-group" role="group" aria-label={t.charts.metricControlLabel}>
+            <div className="chart-control-group" role="radiogroup" aria-label={t.charts.metricControlLabel}>
               <div className="pill-strip">
                 <button
+                  role="radio"
+                  aria-checked={mode === 'value'}
                   className={mode === 'value' ? 'active' : ''}
                   onClick={() => onModeChange('value')}
                   type="button"
@@ -72,6 +78,8 @@ export function ModelShareChart({
                   {t.charts.byValue}
                 </button>
                 <button
+                  role="radio"
+                  aria-checked={mode === 'tokens'}
                   className={mode === 'tokens' ? 'active' : ''}
                   onClick={() => onModeChange('tokens')}
                   type="button"

--- a/src/styles.css
+++ b/src/styles.css
@@ -131,11 +131,15 @@ select:focus-visible {
 }
 
 .chart-heading > div:first-child {
-  min-width: max-content;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .chart-heading h3 {
+  max-width: 100%;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .brand p,
@@ -1944,6 +1948,16 @@ select:focus-visible {
   .modal-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .chart-shell--secondary .chart-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chart-shell--secondary .chart-controls {
+    justify-content: flex-start;
+    width: 100%;
   }
 
   .timeline-value-group {

--- a/src/styles.css
+++ b/src/styles.css
@@ -130,6 +130,14 @@ select:focus-visible {
   line-height: 1.02;
 }
 
+.chart-heading > div:first-child {
+  min-width: max-content;
+}
+
+.chart-heading h3 {
+  white-space: nowrap;
+}
+
 .brand p,
 .subtitle,
 .stat-caption,
@@ -404,9 +412,19 @@ select:focus-visible {
 
 .chart-controls {
   display: flex;
-  gap: 8px;
+  align-items: center;
+  gap: 12px;
   flex-wrap: wrap;
   justify-content: flex-end;
+}
+
+.chart-control-group {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--line-subtle);
+  background: rgba(7, 13, 24, 0.48);
 }
 
 .header-actions,
@@ -431,6 +449,12 @@ select:focus-visible {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  max-width: 100%;
+}
+
+.chart-control-group .pill-strip {
+  flex-wrap: nowrap;
+  gap: 4px;
 }
 
 .pill-strip button {
@@ -439,6 +463,7 @@ select:focus-visible {
   border-radius: 999px;
   border: 1px solid transparent;
   background: rgba(7, 13, 24, 0.72);
+  white-space: nowrap;
 }
 
 .pill-strip button.active {
@@ -531,10 +556,19 @@ select:focus-visible {
 }
 
 .metric-card strong {
+  display: block;
+  max-width: 100%;
   font-family: 'Fira Code', monospace;
   font-size: clamp(1.38rem, 2.7vw, 2.12rem);
   line-height: 1.04;
-  word-break: break-word;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric-card:not(.metric-card--featured) strong {
+  font-size: clamp(1.18rem, 1.8vw, 1.72rem);
 }
 
 .metric-card--featured strong {


### PR DESCRIPTION
## Summary
- Split distribution controls into two labelled visual groups so dimension and metric selections are not read as one option set.
- Prevent short chart labels, pill buttons, and metric values from wrapping awkwardly.
- Hide the distribution center metric when the empty-state message is shown.

## Test Plan
- [x] npm test
- [x] npm run lint
- [x] npm run build
- [x] Playwright screenshots at 1440x900, 768x900, and 375x900

Fixes #1