### PR TITLE
feat: add custom dashboard date range

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "npm run test:issue-1",
+    "test": "npm run test:issue-1 && npm run test:issue-3",
     "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
+    "test:issue-3": "node scripts/test-issue-3-custom-range.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/scripts/test-issue-3-custom-range.mjs
+++ b/scripts/test-issue-3-custom-range.mjs
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import assert from 'node:assert/strict'
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
+const apiSource = readFileSync(join(repoRoot, 'src/app/api.ts'), 'utf8')
+const typeSource = readFileSync(join(repoRoot, 'src/app/types.ts'), 'utf8')
+const i18nSource = readFileSync(join(repoRoot, 'src/app/i18n.ts'), 'utf8')
+
+assert.match(
+  typeSource,
+  /\|\s*'custom'/,
+  'overview buckets should include a dashboard custom range option',
+)
+
+assert.match(
+  apiSource,
+  /customStart\?:\s*string\s*\|\s*null[\s\S]*customEnd\?:\s*string\s*\|\s*null/,
+  'dashboard API should accept custom range start and end dates',
+)
+
+assert.match(
+  apiSource,
+  /customStart:\s*bucket === 'custom' \? customStart \?\? null : null/,
+  'dashboard API should send customStart only for the custom bucket',
+)
+
+assert.match(
+  apiSource,
+  /customEnd:\s*bucket === 'custom' \? customEnd \?\? null : null/,
+  'dashboard API should send customEnd only for the custom bucket',
+)
+
+assert.match(
+  appSource,
+  /const \[customStart,\s*setCustomStart\] = useState\(todayInputValue\(\)\)/,
+  'dashboard should keep custom range start in local state',
+)
+
+assert.match(
+  appSource,
+  /const \[customEnd,\s*setCustomEnd\] = useState\(todayInputValue\(\)\)/,
+  'dashboard should keep custom range end in local state',
+)
+
+assert.match(
+  appSource,
+  /name="customRangeStartDate"[\s\S]*type="date"[\s\S]*value=\{customStart\}/,
+  'custom range controls should expose a labelled start date input',
+)
+
+assert.match(
+  appSource,
+  /name="customRangeEndDate"[\s\S]*type="date"[\s\S]*value=\{customEnd\}/,
+  'custom range controls should expose a labelled end date input',
+)
+
+assert.match(
+  appSource,
+  /loadDashboard\([\s\S]*(?:customStart|requestCustomStart),[\s\S]*(?:customEnd|requestCustomEnd),[\s\S]*\)/,
+  'dashboard load should pass the custom range to the backend',
+)
+
+assert.match(
+  i18nSource,
+  /custom:\s*'自定义'/,
+  'Chinese bucket labels should include custom range',
+)
+
+assert.match(
+  i18nSource,
+  /custom:\s*'Custom'/,
+  'English bucket labels should include custom range',
+)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,10 +102,20 @@ fn getOverview(
   state: State<'_, AppState>,
   bucket: Option<String>,
   anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
   let live_rate_limits = maybe_live_rate_limits_for_bucket(state.inner(), bucket.as_deref(), live_window_offset)?;
-  get_overview(&state.db_path, bucket, anchor, live_rate_limits, live_window_offset)
+  get_overview(
+    &state.db_path,
+    bucket,
+    anchor,
+    custom_start,
+    custom_end,
+    live_rate_limits,
+    live_window_offset,
+  )
 }
 
 #[allow(non_snake_case)]
@@ -167,6 +177,8 @@ async fn loadDashboard(
   state: State<'_, AppState>,
   bucket: Option<String>,
   anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
   search: Option<String>,
   live_window_offset: Option<i64>,
 ) -> Result<DashboardSnapshot, String> {
@@ -179,6 +191,8 @@ async fn loadDashboard(
       &state.db_path,
       Some(normalized_bucket.clone()),
       anchor.clone(),
+      custom_start.clone(),
+      custom_end.clone(),
       search,
       live_rate_limits.clone(),
       live_window_offset,
@@ -434,6 +448,8 @@ fn current_menu_bar_title_parts(
       &state.db_path,
       Some(bucket.clone()),
       if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
+      None,
+      None,
       live_rate_limits.clone(),
       None,
     )?;
@@ -979,6 +995,8 @@ fn build_menu_bar_popup_snapshot(
     &state.db_path,
     Some(selected_bucket.clone()),
     anchor,
+    None,
+    None,
     if bucket_uses_live_rate_limits(&selected_bucket) {
       live_rate_limits.clone()
     } else {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -161,6 +161,8 @@ impl Default for SubscriptionProfile {
 pub struct ConversationFilters {
   pub bucket: Option<String>,
   pub anchor: Option<String>,
+  pub custom_start: Option<String>,
+  pub custom_end: Option<String>,
   pub search: Option<String>,
   pub live_window_offset: Option<i64>,
 }

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -97,6 +97,8 @@ pub fn get_overview(
   db_path: &Path,
   bucket: Option<String>,
   anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
@@ -113,6 +115,8 @@ pub fn get_overview(
     &catalog,
     bucket,
     anchor,
+    custom_start,
+    custom_end,
     live_rate_limits,
     live_window_offset,
   )
@@ -129,6 +133,8 @@ pub fn get_quota_trend(
   let resolved_window = resolve_window(
     &conn,
     Some(bucket),
+    None,
+    None,
     None,
     &events,
     profile.billing_anchor_day,
@@ -166,6 +172,8 @@ pub fn load_dashboard_data(
   db_path: &Path,
   bucket: Option<String>,
   anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
   search: Option<String>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
@@ -184,6 +192,8 @@ pub fn load_dashboard_data(
     &catalog,
     bucket.clone(),
     anchor.clone(),
+    custom_start.clone(),
+    custom_end.clone(),
     live_rate_limits.clone(),
     live_window_offset,
   )?;
@@ -195,6 +205,8 @@ pub fn load_dashboard_data(
     Some(ConversationFilters {
       bucket,
       anchor,
+      custom_start,
+      custom_end,
       search,
       live_window_offset,
     }),
@@ -216,6 +228,8 @@ fn build_overview(
   catalog: &HashMap<String, PricingCatalogEntry>,
   bucket: Option<String>,
   anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
@@ -223,6 +237,8 @@ fn build_overview(
     conn,
     bucket,
     anchor,
+    custom_start,
+    custom_end,
     events,
     profile.billing_anchor_day,
     live_rate_limits.as_ref(),
@@ -311,6 +327,8 @@ fn build_conversation_list(
     conn,
     filters.bucket.clone(),
     filters.anchor.clone(),
+    filters.custom_start.clone(),
+    filters.custom_end.clone(),
     events,
     profile.billing_anchor_day,
     live_rate_limits,
@@ -1204,6 +1222,8 @@ fn resolve_window(
   conn: &Connection,
   bucket: Option<String>,
   anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
   events: &[EventRow],
   billing_anchor_day: i64,
   live_rate_limits: Option<&LiveRateLimitSnapshot>,
@@ -1229,6 +1249,27 @@ fn resolve_window(
     }
     "five_hour" => resolve_live_rate_limit_window(conn, &bucket, live_rate_limits, requested_live_window_offset)?,
     "seven_day" => resolve_live_rate_limit_window(conn, &bucket, live_rate_limits, requested_live_window_offset)?,
+    "custom" => {
+      let start_date = custom_start
+        .as_deref()
+        .map(parse_date)
+        .transpose()?
+        .unwrap_or(anchor_date);
+      let end_date = custom_end
+        .as_deref()
+        .map(parse_date)
+        .transpose()?
+        .unwrap_or(start_date);
+      if end_date < start_date {
+        return Err("Custom range end date cannot be before start date.".to_string());
+      }
+      let start = local_midnight(start_date)?;
+      let exclusive_end_date = end_date
+        .checked_add_days(Days::new(1))
+        .ok_or_else(|| "Custom range end date is too large.".to_string())?;
+      let end = local_midnight(exclusive_end_date)?;
+      (start, end, start_date, 0, 0)
+    }
     "subscription_month" => {
       let cycle_start_date = billing_cycle_start(anchor_date, billing_anchor_day as u32);
       let start = local_midnight(cycle_start_date)?;
@@ -1274,7 +1315,7 @@ fn resolve_window(
     }
     _ => {
       return Err(format!(
-        "Unsupported bucket {}. Expected day, week, five_hour, seven_day, subscription_month, month, year, or total.",
+        "Unsupported bucket {}. Expected day, week, five_hour, seven_day, custom, subscription_month, month, year, or total.",
         bucket
       ))
     }
@@ -1524,6 +1565,13 @@ fn build_bins(window: &Window) -> Vec<TrendBin> {
       "five_hour" => current + chrono::Duration::minutes(15),
       "week" | "subscription_month" | "month" => current + chrono::Duration::days(1),
       "seven_day" => current + chrono::Duration::hours(1),
+      "custom" if custom_window_uses_hourly_bins(window) => current + chrono::Duration::hours(1),
+      "custom" if custom_window_uses_monthly_bins(window) => {
+        let current_date = current.date_naive();
+        let next_date = add_months(current_date, 1);
+        local_midnight(next_date).unwrap_or(window.end)
+      }
+      "custom" => current + chrono::Duration::days(1),
       "year" | "total" => {
         let current_date = current.date_naive();
         let next_date = add_months(current_date, 1);
@@ -1535,6 +1583,8 @@ fn build_bins(window: &Window) -> Vec<TrendBin> {
     let label = match window.bucket.as_str() {
       "day" | "five_hour" => current.format("%H:%M").to_string(),
       "seven_day" => current.format("%b %d %H:%M").to_string(),
+      "custom" if custom_window_uses_hourly_bins(window) => current.format("%H:%M").to_string(),
+      "custom" if custom_window_uses_monthly_bins(window) => current.format("%b %Y").to_string(),
       "year" | "total" => current.format("%b %Y").to_string(),
       _ => current.format("%b %d").to_string(),
     };
@@ -1547,6 +1597,14 @@ fn build_bins(window: &Window) -> Vec<TrendBin> {
     current = next;
   }
   bins
+}
+
+fn custom_window_uses_hourly_bins(window: &Window) -> bool {
+  window.end.signed_duration_since(window.start) <= chrono::Duration::days(1)
+}
+
+fn custom_window_uses_monthly_bins(window: &Window) -> bool {
+  window.end.signed_duration_since(window.start) > chrono::Duration::days(62)
 }
 
 fn subscription_cost_for_window(window: &Window, monthly_price: f64, billing_anchor_day: u32) -> f64 {
@@ -2136,6 +2194,8 @@ mod tests {
       &conn,
       Some("subscription_month".to_string()),
       Some("2026-03-26".to_string()),
+      None,
+      None,
       &[],
       23,
       None,
@@ -2156,6 +2216,8 @@ mod tests {
       &conn,
       Some("subscription_month".to_string()),
       Some("2026-03-05".to_string()),
+      None,
+      None,
       &[],
       23,
       None,
@@ -2166,6 +2228,49 @@ mod tests {
     assert_eq!(window.window.anchor, "2026-02-23");
     assert_eq!(window.window.start.date_naive(), NaiveDate::from_ymd_opt(2026, 2, 23).unwrap());
     assert_eq!(window.window.end.date_naive(), NaiveDate::from_ymd_opt(2026, 3, 23).unwrap());
+  }
+
+  #[test]
+  fn custom_window_includes_selected_end_date() {
+    let conn = Connection::open_in_memory().expect("open in-memory database");
+    init_db(&conn).expect("init db");
+    let window = resolve_window(
+      &conn,
+      Some("custom".to_string()),
+      None,
+      Some("2026-04-10".to_string()),
+      Some("2026-04-12".to_string()),
+      &[],
+      1,
+      None,
+      None,
+    )
+    .expect("resolve custom window");
+
+    assert_eq!(window.window.bucket, "custom");
+    assert_eq!(window.window.anchor, "2026-04-10");
+    assert_eq!(window.window.start.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 10).unwrap());
+    assert_eq!(window.window.end.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 13).unwrap());
+  }
+
+  #[test]
+  fn custom_window_rejects_end_before_start() {
+    let conn = Connection::open_in_memory().expect("open in-memory database");
+    init_db(&conn).expect("init db");
+    let error = resolve_window(
+      &conn,
+      Some("custom".to_string()),
+      None,
+      Some("2026-04-12".to_string()),
+      Some("2026-04-10".to_string()),
+      &[],
+      1,
+      None,
+      None,
+    )
+    .expect_err("custom end before start should fail");
+
+    assert!(error.contains("Custom range end date cannot be before start date"));
   }
 
   #[test]
@@ -2189,7 +2294,7 @@ mod tests {
     insert_live_rate_limit_snapshot(&conn, &live_rate_limits).expect("insert live rate limit snapshot");
 
     let window =
-      resolve_window(&conn, Some("five_hour".to_string()), None, &[], 1, Some(&live_rate_limits), None)
+      resolve_window(&conn, Some("five_hour".to_string()), None, None, None, &[], 1, Some(&live_rate_limits), None)
         .expect("resolve live window");
 
     assert_eq!(window.window.anchor, "2026-03-26");
@@ -2234,7 +2339,7 @@ mod tests {
     insert_live_rate_limit_snapshot(&conn, &current).expect("insert current live window");
 
     let window =
-      resolve_window(&conn, Some("five_hour".to_string()), None, &[], 1, Some(&current), Some(1))
+      resolve_window(&conn, Some("five_hour".to_string()), None, None, None, &[], 1, Some(&current), Some(1))
         .expect("resolve historical live window");
 
     assert_eq!(window.live_window_offset, 1);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ const BUCKETS: OverviewBucket[] = [
   'subscription_month',
   'month',
   'year',
+  'custom',
   'total',
 ]
 
@@ -78,6 +79,8 @@ function App() {
   const [bucket, setBucket] = useState<OverviewBucket>('subscription_month')
   const [liveWindowOffset, setLiveWindowOffset] = useState(0)
   const [anchor, setAnchor] = useState(todayInputValue())
+  const [customStart, setCustomStart] = useState(todayInputValue())
+  const [customEnd, setCustomEnd] = useState(todayInputValue())
   const [shareMode, setShareMode] = useState<ShareMode>('value')
   const [shareDimension, setShareDimension] = useState<ShareDimension>('model')
   const [overview, setOverview] = useState<OverviewResponse | null>(null)
@@ -121,11 +124,15 @@ function App() {
     latestLoadRequestIdRef.current = requestId
     const requestBucket = bucket
     const requestAnchor = bucketUsesAnchor(requestBucket) ? anchor : null
+    const requestCustomStart = requestBucket === 'custom' ? customStart : null
+    const requestCustomEnd = requestBucket === 'custom' ? customEnd : null
     const requestSearch = deferredSearch || null
     const requestLiveWindowOffset = requestBucket === 'five_hour' || requestBucket === 'seven_day' ? liveWindowOffset : 0
     lastRequestedQueryKeyRef.current = buildQueryKey(
       requestBucket,
       requestAnchor,
+      requestCustomStart,
+      requestCustomEnd,
       requestSearch,
       requestLiveWindowOffset,
     )
@@ -153,6 +160,8 @@ function App() {
         requestAnchor,
         requestSearch,
         requestLiveWindowOffset,
+        requestCustomStart,
+        requestCustomEnd,
       )
       if (requestId !== latestLoadRequestIdRef.current) {
         return
@@ -179,6 +188,8 @@ function App() {
           buildQueryKey(
             requestBucket,
             requestAnchor,
+            requestCustomStart,
+            requestCustomEnd,
             requestSearch,
             snapshot.overview.liveWindowOffset,
           ),
@@ -202,11 +213,13 @@ function App() {
         setIsBusy(false)
       }
     }
-  }, [anchor, bucket, deferredSearch, liveWindowOffset, t, waitForScanToSettle])
+  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t, waitForScanToSettle])
 
   const currentQueryKey = buildQueryKey(
     bucket,
     bucketUsesAnchor(bucket) ? anchor : null,
+    bucket === 'custom' ? customStart : null,
+    bucket === 'custom' ? customEnd : null,
     deferredSearch || null,
     bucket === 'five_hour' || bucket === 'seven_day' ? liveWindowOffset : 0,
   )
@@ -391,7 +404,9 @@ function App() {
   const activeLiveWindowCount = activeOverview?.liveWindowCount ?? (isLiveBucket ? 1 : 0)
   const isHistoricalLiveWindow = isLiveBucket && activeLiveWindowOffset > 0
   const currentBucketLabel =
-    activeOverview?.bucket === 'subscription_month' && subscriptionProfile
+    activeOverview?.bucket === 'custom'
+      ? formatCustomRangeLabel(activeOverview.windowStart, activeOverview.windowEnd, language)
+      : activeOverview?.bucket === 'subscription_month' && subscriptionProfile
       ? t.bucketDescriptions.subscriptionMonth(subscriptionProfile.billingAnchorDay)
       : bucket === 'five_hour'
         ? isHistoricalLiveWindow
@@ -505,7 +520,37 @@ function App() {
                     </button>
                   ))}
                 </div>
-                {bucketUsesAnchor(bucket) ? (
+                {bucket === 'custom' ? (
+                  <div className="custom-range-controls">
+                    <label className="custom-range-field">
+                      <span>{t.common.start}</span>
+                      <input
+                        aria-label={t.common.customRangeStartDate}
+                        className="anchor-input custom-range-input"
+                        max={customEnd}
+                        name="customRangeStartDate"
+                        onChange={(event) => setCustomStart(event.target.value)}
+                        type="date"
+                        value={customStart}
+                      />
+                    </label>
+                    <span aria-hidden="true" className="range-separator">
+                      →
+                    </span>
+                    <label className="custom-range-field">
+                      <span>{t.common.end}</span>
+                      <input
+                        aria-label={t.common.customRangeEndDate}
+                        className="anchor-input custom-range-input"
+                        min={customStart}
+                        name="customRangeEndDate"
+                        onChange={(event) => setCustomEnd(event.target.value)}
+                        type="date"
+                        value={customEnd}
+                      />
+                    </label>
+                  </div>
+                ) : bucketUsesAnchor(bucket) ? (
                   <input
                     aria-label={anchorInputLabel}
                     className="anchor-input anchor-input-inline"
@@ -918,16 +963,29 @@ function MiniCard({ label, value, tone = 'secondary' }: MiniCardProps) {
 export default App
 
 function bucketUsesAnchor(bucket: OverviewBucket) {
-  return !['five_hour', 'seven_day', 'total'].includes(bucket)
+  return !['five_hour', 'seven_day', 'custom', 'total'].includes(bucket)
 }
 
 function buildQueryKey(
   bucket: OverviewBucket,
   anchor: string | null,
+  customStart: string | null,
+  customEnd: string | null,
   search: string | null,
   liveWindowOffset: number,
 ) {
-  return [bucket, anchor ?? '', search ?? '', String(liveWindowOffset)].join('::')
+  return [bucket, anchor ?? '', customStart ?? '', customEnd ?? '', search ?? '', String(liveWindowOffset)].join('::')
+}
+
+function formatCustomRangeLabel(windowStart: string | null, windowEnd: string | null, language: 'zh-CN' | 'en') {
+  return `${formatShortDate(windowStart, language)} → ${formatShortDate(inclusiveWindowEnd(windowEnd), language)}`
+}
+
+function inclusiveWindowEnd(windowEnd: string | null) {
+  if (!windowEnd) return null
+  const timestamp = new Date(windowEnd).getTime()
+  if (!Number.isFinite(timestamp)) return null
+  return new Date(timestamp - 1).toISOString()
 }
 
 function selectActiveRateLimitWindow(

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -13,7 +13,7 @@ import type {
 } from './types'
 
 function bucketUsesAnchor(bucket: OverviewBucket) {
-  return !['five_hour', 'seven_day', 'total'].includes(bucket)
+  return !['five_hour', 'seven_day', 'custom', 'total'].includes(bucket)
 }
 
 function nowIso() {
@@ -71,13 +71,40 @@ function createMockLiveRateLimits(): LiveRateLimitSnapshot {
   }
 }
 
-function createMockOverview(bucket: OverviewBucket, anchor?: string | null): OverviewResponse {
+function localDateStartIso(value: string | null | undefined) {
+  const fallback = todayInputValue()
+  return new Date(`${value ?? fallback}T00:00:00`).toISOString()
+}
+
+function localDateExclusiveEndIso(value: string | null | undefined) {
+  const fallback = todayInputValue()
+  const date = new Date(`${value ?? fallback}T00:00:00`)
+  date.setDate(date.getDate() + 1)
+  return date.toISOString()
+}
+
+function todayInputValue() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function createMockOverview(
+  bucket: OverviewBucket,
+  anchor?: string | null,
+  customStart?: string | null,
+  customEnd?: string | null,
+): OverviewResponse {
   const timestamp = nowIso()
+  const resolvedAnchor =
+    bucket === 'custom'
+      ? customStart ?? timestamp.slice(0, 10)
+      : bucketUsesAnchor(bucket)
+        ? anchor ?? timestamp.slice(0, 10)
+        : timestamp.slice(0, 10)
   return {
     bucket,
-    anchor: bucketUsesAnchor(bucket) ? anchor ?? timestamp.slice(0, 10) : timestamp.slice(0, 10),
-    windowStart: timestamp,
-    windowEnd: timestamp,
+    anchor: resolvedAnchor,
+    windowStart: bucket === 'custom' ? localDateStartIso(customStart) : timestamp,
+    windowEnd: bucket === 'custom' ? localDateExclusiveEndIso(customEnd ?? customStart) : timestamp,
     liveWindowOffset: 0,
     liveWindowCount: 0,
     stats: {
@@ -192,15 +219,22 @@ export async function refreshPricing() {
   return invokeOrMock('refreshPricing', {}, () => [])
 }
 
-export async function getOverview(bucket: OverviewBucket, anchor?: string | null): Promise<OverviewResponse> {
+export async function getOverview(
+  bucket: OverviewBucket,
+  anchor?: string | null,
+  customStart?: string | null,
+  customEnd?: string | null,
+): Promise<OverviewResponse> {
   return invokeOrMock(
     'getOverview',
     {
       bucket,
       anchor: bucketUsesAnchor(bucket) ? anchor ?? null : null,
+      customStart: bucket === 'custom' ? customStart ?? null : null,
+      customEnd: bucket === 'custom' ? customEnd ?? null : null,
       liveWindowOffset: null,
     },
-    () => createMockOverview(bucket, anchor),
+    () => createMockOverview(bucket, anchor, customStart, customEnd),
   )
 }
 
@@ -209,17 +243,21 @@ export async function loadDashboard(
   anchor?: string | null,
   search?: string | null,
   liveWindowOffset?: number | null,
+  customStart?: string | null,
+  customEnd?: string | null,
 ): Promise<import('./types').DashboardSnapshot> {
   return invokeOrMock(
     'loadDashboard',
     {
       bucket,
       anchor: bucketUsesAnchor(bucket) ? anchor ?? null : null,
+      customStart: bucket === 'custom' ? customStart ?? null : null,
+      customEnd: bucket === 'custom' ? customEnd ?? null : null,
       search: search ?? null,
       liveWindowOffset: liveWindowOffset ?? null,
     },
     () => ({
-      overview: createMockOverview(bucket, anchor),
+      overview: createMockOverview(bucket, anchor, customStart, customEnd),
       conversations: [] as ConversationListItem[],
       syncSettings: createMockSyncSettings(),
       subscriptionProfile: createMockSubscriptionProfile(),

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -39,6 +39,7 @@ export type TranslationSet = {
     earlier: string
     newer: string
     start: string
+    end: string
     reset: string
     updated: string
     tokens: string
@@ -47,6 +48,8 @@ export type TranslationSet = {
     fast: string
     noData: string
     searchTitleOrSession: string
+    customRangeStartDate: string
+    customRangeEndDate: string
   }
   status: {
     waitingForFirstScan: string
@@ -277,6 +280,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       earlier: '更早',
       newer: '较新',
       start: '开始',
+      end: '结束',
       reset: '重置',
       updated: '更新于',
       tokens: 'Tokens',
@@ -285,6 +289,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       fast: 'Fast',
       noData: '暂无数据',
       searchTitleOrSession: '搜索标题或会话 ID',
+      customRangeStartDate: '自定义范围开始日期',
+      customRangeEndDate: '自定义范围结束日期',
     },
     status: {
       waitingForFirstScan: '等待首次扫描…',
@@ -304,6 +310,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       subscription_month: '订阅月',
       month: '月',
       year: '年',
+      custom: '自定义',
       total: '总计',
     },
     bucketDescriptions: {
@@ -518,6 +525,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       earlier: 'Earlier',
       newer: 'Newer',
       start: 'Start',
+      end: 'End',
       reset: 'Reset',
       updated: 'Updated',
       tokens: 'Tokens',
@@ -526,6 +534,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       fast: 'Fast',
       noData: 'No data',
       searchTitleOrSession: 'Search title or session id',
+      customRangeStartDate: 'Custom range start date',
+      customRangeEndDate: 'Custom range end date',
     },
     status: {
       waitingForFirstScan: 'Waiting for first scan…',
@@ -545,6 +555,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       subscription_month: 'Billing month',
       month: 'Month',
       year: 'Year',
+      custom: 'Custom',
       total: 'Total',
     },
     bucketDescriptions: {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -6,6 +6,7 @@ export type OverviewBucket =
   | 'subscription_month'
   | 'month'
   | 'year'
+  | 'custom'
   | 'total'
 
 export type ShareMode = 'value' | 'tokens'
@@ -197,6 +198,8 @@ export interface DashboardSnapshot {
 export interface ConversationFilters {
   bucket?: OverviewBucket | null
   anchor?: string | null
+  customStart?: string | null
+  customEnd?: string | null
   search?: string | null
   liveWindowOffset?: number | null
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -524,6 +524,41 @@ select:focus-visible {
   margin-left: auto;
 }
 
+.custom-range-controls {
+  display: inline-flex;
+  align-items: end;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: nowrap;
+  margin-left: auto;
+  max-width: 100%;
+}
+
+.custom-range-field {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.custom-range-field span {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.custom-range-input {
+  width: 176px;
+  flex: 0 1 176px;
+}
+
+.range-separator {
+  color: var(--text-muted);
+  font-family: 'Fira Code', monospace;
+  font-size: 0.9rem;
+  line-height: 48px;
+}
+
 .metric-grid {
   display: grid;
   gap: 14px;
@@ -1927,6 +1962,22 @@ select:focus-visible {
     margin-left: 0;
     justify-content: flex-start;
     flex-wrap: wrap;
+  }
+
+  .custom-range-controls {
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-start;
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .custom-range-input {
+    width: 100%;
+  }
+
+  .range-separator {
+    display: none;
   }
 
   .live-window-nav-copy {


### PR DESCRIPTION
## Summary
- Add a dashboard Custom range option with start/end date controls.
- Thread customStart/customEnd through the React API and Tauri commands into Rust window resolution.
- Add regression coverage for the custom range API/UI contract and inclusive end-date behavior.

## Test Plan
- [x] npm test
- [x] npm run lint
- [x] npm run build
- [x] cargo test --manifest-path src-tauri/Cargo.toml --locked
- [x] git diff --check
- [x] Playwright screenshots at desktop and mobile widths

Fixes #3
