### PR TITLE
[codex] Split database modules and SQL files

### DIFF
--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -1,0 +1,12 @@
+CREATE INDEX IF NOT EXISTS idx_usage_events_session_id ON usage_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
+CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
+  ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
+  ON rate_limit_samples(
+    bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
+  );

--- a/src-tauri/sql/queries/quota_samples.sql
+++ b/src-tauri/sql/queries/quota_samples.sql
@@ -1,0 +1,4 @@
+SELECT sample_timestamp, used_percent, window_start, resets_at
+FROM rate_limit_samples
+WHERE bucket = ?1
+ORDER BY sample_timestamp ASC

--- a/src-tauri/sql/queries/rate_limit_windows.sql
+++ b/src-tauri/sql/queries/rate_limit_windows.sql
@@ -1,0 +1,5 @@
+SELECT window_start, resets_at
+FROM rate_limit_samples
+WHERE bucket = ?1
+GROUP BY window_start, resets_at
+ORDER BY window_start DESC, resets_at DESC

--- a/src-tauri/sql/queries/sessions.sql
+++ b/src-tauri/sql/queries/sessions.sql
@@ -1,0 +1,3 @@
+SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
+       started_at, updated_at, agent_nickname, agent_role
+FROM sessions

--- a/src-tauri/sql/queries/sessions_for_root.sql
+++ b/src-tauri/sql/queries/sessions_for_root.sql
@@ -1,0 +1,4 @@
+SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
+       started_at, updated_at, agent_nickname, agent_role
+FROM sessions
+WHERE root_session_id = ?1

--- a/src-tauri/sql/queries/usage_events.sql
+++ b/src-tauri/sql/queries/usage_events.sql
@@ -1,0 +1,5 @@
+SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+       output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+       fast_mode_auto, fast_mode_effective
+FROM usage_events
+ORDER BY timestamp ASC, id ASC

--- a/src-tauri/sql/queries/usage_events_for_root.sql
+++ b/src-tauri/sql/queries/usage_events_for_root.sql
@@ -1,0 +1,9 @@
+SELECT usage_events.session_id, usage_events.timestamp, usage_events.model_id,
+       usage_events.input_tokens, usage_events.cached_input_tokens,
+       usage_events.output_tokens, usage_events.reasoning_output_tokens,
+       usage_events.total_tokens, usage_events.value_usd,
+       usage_events.fast_mode_auto, usage_events.fast_mode_effective
+FROM usage_events
+INNER JOIN sessions ON sessions.session_id = usage_events.session_id
+WHERE sessions.root_session_id = ?1
+ORDER BY usage_events.timestamp ASC, usage_events.id ASC

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -1,0 +1,125 @@
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT PRIMARY KEY,
+  root_session_id TEXT NOT NULL,
+  parent_session_id TEXT,
+  title TEXT,
+  source_state TEXT NOT NULL DEFAULT 'missing',
+  source_path TEXT,
+  source_bucket TEXT,
+  started_at TEXT,
+  updated_at TEXT,
+  agent_nickname TEXT,
+  agent_role TEXT,
+  explicit_fast_mode INTEGER,
+  fast_mode_default INTEGER NOT NULL DEFAULT 0,
+  latest_plan_type TEXT,
+  last_model_id TEXT,
+  contains_subagents INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  imported_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS conversation_links (
+  session_id TEXT PRIMARY KEY,
+  root_session_id TEXT NOT NULL,
+  parent_session_id TEXT,
+  depth INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL,
+  cached_input_tokens INTEGER NOT NULL,
+  output_tokens INTEGER NOT NULL,
+  reasoning_output_tokens INTEGER NOT NULL,
+  total_tokens INTEGER NOT NULL,
+  value_usd REAL NOT NULL,
+  fast_mode_auto INTEGER NOT NULL,
+  fast_mode_effective INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pricing_catalog (
+  model_id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  input_price_per_million REAL NOT NULL,
+  cached_input_price_per_million REAL NOT NULL,
+  output_price_per_million REAL NOT NULL,
+  effective_model_id TEXT NOT NULL,
+  is_official INTEGER NOT NULL,
+  note TEXT,
+  source_url TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subscription_profile (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  plan_type TEXT NOT NULL,
+  currency TEXT NOT NULL,
+  monthly_price REAL NOT NULL,
+  billing_anchor_day INTEGER NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_overrides (
+  session_id TEXT PRIMARY KEY,
+  fast_mode_override INTEGER,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sync_settings (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
+  codex_home TEXT,
+  auto_scan_enabled INTEGER NOT NULL,
+  auto_scan_interval_minutes INTEGER NOT NULL,
+  live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
+  default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0,
+  hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0,
+  show_menu_bar_logo INTEGER NOT NULL DEFAULT 1,
+  show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1,
+  show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0,
+  menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent',
+  menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour',
+  menu_bar_bucket TEXT NOT NULL DEFAULT 'day',
+  menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1,
+  menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85,
+  menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115,
+  menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢',
+  menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥',
+  menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢',
+  menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1,
+  menu_bar_popup_modules TEXT NOT NULL DEFAULT '["api_value","scan_freshness"]',
+  menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1,
+  menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
+  last_scan_started_at TEXT,
+  last_scan_completed_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS import_state (
+  source_path TEXT PRIMARY KEY,
+  session_id TEXT,
+  source_bucket TEXT NOT NULL,
+  file_size INTEGER NOT NULL,
+  file_mtime_ms INTEGER NOT NULL,
+  last_imported_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS rate_limit_samples (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_kind TEXT NOT NULL,
+  source_session_id TEXT NOT NULL DEFAULT '',
+  bucket TEXT NOT NULL,
+  sample_timestamp TEXT NOT NULL,
+  limit_id TEXT NOT NULL DEFAULT '',
+  limit_name TEXT NOT NULL DEFAULT '',
+  plan_type TEXT NOT NULL DEFAULT '',
+  window_start TEXT NOT NULL,
+  resets_at TEXT NOT NULL,
+  used_percent INTEGER NOT NULL,
+  remaining_percent INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -2,507 +2,69 @@ use std::path::Path;
 use std::time::Duration;
 
 use chrono::Utc;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection};
 
-use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord, SubscriptionProfile, SyncSettings};
+mod rate_limit_samples;
+mod subscriptions;
+mod sync_settings;
+
+pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
+pub use subscriptions::{
+    canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
+};
+pub use sync_settings::{
+    get_sync_settings, save_sync_settings, set_last_scan_completed, set_last_scan_started,
+};
 
 pub fn now_utc_string() -> String {
-  Utc::now().to_rfc3339()
+    Utc::now().to_rfc3339()
 }
 
 pub fn bool_to_i64(value: bool) -> i64 {
-  if value { 1 } else { 0 }
+    if value {
+        1
+    } else {
+        0
+    }
 }
 
 pub fn i64_to_bool(value: i64) -> bool {
-  value != 0
-}
-
-pub fn canonical_subscription_currency() -> &'static str {
-  "USD"
-}
-
-pub fn default_menu_bar_popup_modules() -> Vec<String> {
-  vec![
-    "api_value".to_string(),
-    "scan_freshness".to_string(),
-  ]
-}
-
-fn is_supported_menu_bar_popup_module(module: &str) -> bool {
-  matches!(
-    module,
-    "api_value"
-      | "token_count"
-      | "scan_freshness"
-      | "live_quota_freshness"
-      | "payoff_ratio"
-      | "conversation_count"
-  )
-}
-
-fn default_menu_bar_popup_modules_json() -> String {
-  serde_json::to_string(&default_menu_bar_popup_modules()).expect("serialize default popup modules")
-}
-
-fn deserialize_menu_bar_popup_modules(value: String) -> Vec<String> {
-  serde_json::from_str::<Vec<String>>(&value)
-    .ok()
-    .map(|modules| {
-      modules
-        .into_iter()
-        .filter(|module| is_supported_menu_bar_popup_module(module))
-        .fold(Vec::new(), |mut deduped, module| {
-          if !deduped.iter().any(|existing| existing == &module) {
-            deduped.push(module);
-          }
-          deduped
-        })
-    })
-    .unwrap_or_else(default_menu_bar_popup_modules)
-}
-
-fn serialize_menu_bar_popup_modules(modules: &[String]) -> String {
-  serde_json::to_string(modules).unwrap_or_else(|_| default_menu_bar_popup_modules_json())
+    value != 0
 }
 
 pub fn open_connection(db_path: &Path) -> rusqlite::Result<Connection> {
-  let conn = Connection::open(db_path)?;
-  conn.busy_timeout(Duration::from_secs(10))?;
-  conn.pragma_update(None, "foreign_keys", "ON")?;
-  conn.pragma_update(None, "journal_mode", "WAL")?;
-  conn.pragma_update(None, "synchronous", "NORMAL")?;
-  Ok(conn)
+    let conn = Connection::open(db_path)?;
+    conn.busy_timeout(Duration::from_secs(10))?;
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "NORMAL")?;
+    Ok(conn)
 }
 
 pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
-  conn.execute_batch(
-    "
-    CREATE TABLE IF NOT EXISTS sessions (
-      session_id TEXT PRIMARY KEY,
-      root_session_id TEXT NOT NULL,
-      parent_session_id TEXT,
-      title TEXT,
-      source_state TEXT NOT NULL DEFAULT 'missing',
-      source_path TEXT,
-      source_bucket TEXT,
-      started_at TEXT,
-      updated_at TEXT,
-      agent_nickname TEXT,
-      agent_role TEXT,
-      explicit_fast_mode INTEGER,
-      fast_mode_default INTEGER NOT NULL DEFAULT 0,
-      latest_plan_type TEXT,
-      last_model_id TEXT,
-      contains_subagents INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL,
-      imported_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS conversation_links (
-      session_id TEXT PRIMARY KEY,
-      root_session_id TEXT NOT NULL,
-      parent_session_id TEXT,
-      depth INTEGER NOT NULL DEFAULT 0
-    );
-
-    CREATE TABLE IF NOT EXISTS usage_events (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      session_id TEXT NOT NULL,
-      timestamp TEXT NOT NULL,
-      model_id TEXT NOT NULL,
-      input_tokens INTEGER NOT NULL,
-      cached_input_tokens INTEGER NOT NULL,
-      output_tokens INTEGER NOT NULL,
-      reasoning_output_tokens INTEGER NOT NULL,
-      total_tokens INTEGER NOT NULL,
-      value_usd REAL NOT NULL,
-      fast_mode_auto INTEGER NOT NULL,
-      fast_mode_effective INTEGER NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS pricing_catalog (
-      model_id TEXT PRIMARY KEY,
-      display_name TEXT NOT NULL,
-      input_price_per_million REAL NOT NULL,
-      cached_input_price_per_million REAL NOT NULL,
-      output_price_per_million REAL NOT NULL,
-      effective_model_id TEXT NOT NULL,
-      is_official INTEGER NOT NULL,
-      note TEXT,
-      source_url TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS subscription_profile (
-      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
-      plan_type TEXT NOT NULL,
-      currency TEXT NOT NULL,
-      monthly_price REAL NOT NULL,
-      billing_anchor_day INTEGER NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS session_overrides (
-      session_id TEXT PRIMARY KEY,
-      fast_mode_override INTEGER,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS sync_settings (
-      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
-      sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
-      codex_home TEXT,
-      auto_scan_enabled INTEGER NOT NULL,
-      auto_scan_interval_minutes INTEGER NOT NULL,
-      live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
-      default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0,
-      hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0,
-      show_menu_bar_logo INTEGER NOT NULL DEFAULT 1,
-      show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1,
-      show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0,
-      menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent',
-      menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour',
-      menu_bar_bucket TEXT NOT NULL DEFAULT 'day',
-      menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1,
-      menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85,
-      menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115,
-      menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢',
-      menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥',
-      menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢',
-      menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1,
-      menu_bar_popup_modules TEXT NOT NULL DEFAULT '[\"api_value\",\"scan_freshness\"]',
-      menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1,
-      menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
-      last_scan_started_at TEXT,
-      last_scan_completed_at TEXT,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS import_state (
-      source_path TEXT PRIMARY KEY,
-      session_id TEXT,
-      source_bucket TEXT NOT NULL,
-      file_size INTEGER NOT NULL,
-      file_mtime_ms INTEGER NOT NULL,
-      last_imported_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS rate_limit_samples (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      source_kind TEXT NOT NULL,
-      source_session_id TEXT NOT NULL DEFAULT '',
-      bucket TEXT NOT NULL,
-      sample_timestamp TEXT NOT NULL,
-      limit_id TEXT NOT NULL DEFAULT '',
-      limit_name TEXT NOT NULL DEFAULT '',
-      plan_type TEXT NOT NULL DEFAULT '',
-      window_start TEXT NOT NULL,
-      resets_at TEXT NOT NULL,
-      used_percent INTEGER NOT NULL,
-      remaining_percent INTEGER NOT NULL,
-      created_at TEXT NOT NULL
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_usage_events_session_id ON usage_events(session_id);
-    CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp);
-    CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
-    CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
-    CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
-    CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
-    CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
-      ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
-      ON rate_limit_samples(
-        bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
-      );
-    ",
-  )?;
-
-  ensure_sync_settings_schema(conn)?;
-  ensure_singletons(conn)?;
-  Ok(())
-}
-
-fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare("PRAGMA table_info(sync_settings)")?;
-  let column_names = stmt
-    .query_map([], |row| row.get::<_, String>(1))?
-    .collect::<rusqlite::Result<Vec<_>>>()?;
-
-  if !column_names
-    .iter()
-    .any(|name| name == "sync_settings_schema_version")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN sync_settings_schema_version INTEGER NOT NULL DEFAULT 1
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "show_menu_bar_daily_api_value")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "show_menu_bar_logo")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN show_menu_bar_logo INTEGER NOT NULL DEFAULT 1
-      ",
-      [],
-    )?;
-    conn.execute(
-      "
-      UPDATE sync_settings
-      SET show_menu_bar_logo = show_menu_bar_daily_api_value
-      WHERE singleton_id = 1
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "show_menu_bar_live_quota_percent")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_live_quota_metric")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent'
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_live_quota_bucket")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour'
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_bucket") {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN menu_bar_bucket TEXT NOT NULL DEFAULT 'day'
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "live_quota_refresh_interval_seconds")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "default_fast_mode_for_new_gpt54_sessions")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "hide_dock_icon_when_menu_bar_visible")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_speed_show_emoji") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_speed_fast_threshold_percent")
-  {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_speed_slow_threshold_percent")
-  {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_speed_healthy_emoji")
-  {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢'",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_speed_fast_emoji") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥'",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_speed_slow_emoji") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢'",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_popup_enabled") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_popup_modules") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_modules TEXT NOT NULL DEFAULT '[\"api_value\",\"scan_freshness\"]'",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_popup_show_reset_timeline")
-  {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_popup_show_actions") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1",
-      [],
-    )?;
-  }
-
-  migrate_sync_settings_defaults_to_minutes(conn)?;
-
-  Ok(())
-}
-
-fn migrate_sync_settings_defaults_to_minutes(conn: &Connection) -> rusqlite::Result<()> {
-  let schema_version = conn
-    .query_row(
-      "SELECT sync_settings_schema_version FROM sync_settings WHERE singleton_id = 1",
-      [],
-      |row| row.get::<_, i64>(0),
-    )
-    .optional()?
-    .unwrap_or(2);
-
-  if schema_version >= 2 {
-    return Ok(());
-  }
-
-  conn.execute(
-    "
-    UPDATE sync_settings
-    SET
-      live_quota_refresh_interval_seconds = CASE
-        WHEN live_quota_refresh_interval_seconds = 60 THEN 300
-        ELSE live_quota_refresh_interval_seconds
-      END,
-      default_fast_mode_for_new_gpt54_sessions = CASE
-        WHEN default_fast_mode_for_new_gpt54_sessions = 1 THEN 0
-        ELSE default_fast_mode_for_new_gpt54_sessions
-      END,
-      sync_settings_schema_version = 2
-    WHERE singleton_id = 1
-    ",
-    [],
-  )?;
-
-  Ok(())
+    conn.execute_batch(include_str!("../sql/schema.sql"))?;
+    sync_settings::ensure_sync_settings_schema(conn)?;
+    ensure_singletons(conn)?;
+    conn.execute_batch(include_str!("../sql/indexes.sql"))?;
+    Ok(())
 }
 
 fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {
-  let now = now_utc_string();
-  conn.execute(
-    "
+    let now = now_utc_string();
+    conn.execute(
+        "
     INSERT INTO subscription_profile (
       singleton_id, plan_type, currency, monthly_price, billing_anchor_day, updated_at
     )
     VALUES (1, 'plus', ?2, 20.0, 1, ?1)
     ON CONFLICT(singleton_id) DO NOTHING
     ",
-    params![now, canonical_subscription_currency()],
-  )?;
+        params![now, canonical_subscription_currency()],
+    )?;
 
-  let now = now_utc_string();
-  conn.execute(
-    "
+    let now = now_utc_string();
+    conn.execute(
+        "
     INSERT INTO sync_settings (
       singleton_id, sync_settings_schema_version,
       codex_home, auto_scan_enabled, auto_scan_interval_minutes,
@@ -522,222 +84,23 @@ fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {
     VALUES (1, 2, NULL, 1, 5, 300, 0, 0, 1, 1, 0, 'remaining_percent', 'five_hour', 'day', 1, 85, 115, '🟢', '🔥', '🐢', 1, ?2, 1, 1, NULL, NULL, ?1)
     ON CONFLICT(singleton_id) DO NOTHING
     ",
-    params![now, default_menu_bar_popup_modules_json()],
-  )?;
+        params![now, sync_settings::default_menu_bar_popup_modules_json()],
+    )?;
 
-  Ok(())
-}
-
-pub fn get_sync_settings(conn: &Connection) -> rusqlite::Result<SyncSettings> {
-  conn.query_row(
-    "
-    SELECT codex_home, auto_scan_enabled, auto_scan_interval_minutes,
-           live_quota_refresh_interval_seconds,
-           hide_dock_icon_when_menu_bar_visible,
-           show_menu_bar_logo, show_menu_bar_daily_api_value,
-           show_menu_bar_live_quota_percent, menu_bar_live_quota_metric,
-           menu_bar_live_quota_bucket, menu_bar_bucket,
-           menu_bar_speed_show_emoji, menu_bar_speed_fast_threshold_percent,
-           menu_bar_speed_slow_threshold_percent, menu_bar_speed_healthy_emoji,
-           menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
-           menu_bar_popup_enabled, menu_bar_popup_modules,
-           menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
-           last_scan_started_at, last_scan_completed_at, updated_at
-    FROM sync_settings
-    WHERE singleton_id = 1
-    ",
-    [],
-    |row| {
-      Ok(SyncSettings {
-        codex_home: row.get(0)?,
-        auto_scan_enabled: i64_to_bool(row.get::<_, i64>(1)?),
-        auto_scan_interval_minutes: row.get(2)?,
-        live_quota_refresh_interval_seconds: row.get(3)?,
-        hide_dock_icon_when_menu_bar_visible: i64_to_bool(row.get::<_, i64>(4)?),
-        show_menu_bar_logo: i64_to_bool(row.get::<_, i64>(5)?),
-        show_menu_bar_daily_api_value: i64_to_bool(row.get::<_, i64>(6)?),
-        show_menu_bar_live_quota_percent: i64_to_bool(row.get::<_, i64>(7)?),
-        menu_bar_live_quota_metric: row.get(8)?,
-        menu_bar_live_quota_bucket: row.get(9)?,
-        menu_bar_bucket: row.get(10)?,
-        menu_bar_speed_show_emoji: i64_to_bool(row.get::<_, i64>(11)?),
-        menu_bar_speed_fast_threshold_percent: row.get(12)?,
-        menu_bar_speed_slow_threshold_percent: row.get(13)?,
-        menu_bar_speed_healthy_emoji: row.get(14)?,
-        menu_bar_speed_fast_emoji: row.get(15)?,
-        menu_bar_speed_slow_emoji: row.get(16)?,
-        menu_bar_popup_enabled: i64_to_bool(row.get::<_, i64>(17)?),
-        menu_bar_popup_modules: deserialize_menu_bar_popup_modules(row.get(18)?),
-        menu_bar_popup_show_reset_timeline: i64_to_bool(row.get::<_, i64>(19)?),
-        menu_bar_popup_show_actions: i64_to_bool(row.get::<_, i64>(20)?),
-        last_scan_started_at: row.get(21)?,
-        last_scan_completed_at: row.get(22)?,
-        updated_at: row.get(23)?,
-      })
-    },
-  )
-}
-
-pub fn save_sync_settings(conn: &Connection, settings: &SyncSettings) -> rusqlite::Result<SyncSettings> {
-  let updated_at = now_utc_string();
-  conn.execute(
-    "
-    INSERT INTO sync_settings (
-      singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
-      live_quota_refresh_interval_seconds,
-      hide_dock_icon_when_menu_bar_visible,
-      show_menu_bar_logo,
-      show_menu_bar_daily_api_value,
-      show_menu_bar_live_quota_percent, menu_bar_live_quota_metric,
-      menu_bar_live_quota_bucket, menu_bar_bucket,
-      menu_bar_speed_show_emoji, menu_bar_speed_fast_threshold_percent,
-      menu_bar_speed_slow_threshold_percent, menu_bar_speed_healthy_emoji,
-      menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
-      menu_bar_popup_enabled, menu_bar_popup_modules,
-      menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
-      last_scan_started_at, last_scan_completed_at, updated_at
-    )
-    VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)
-    ON CONFLICT(singleton_id) DO UPDATE SET
-      codex_home = excluded.codex_home,
-      auto_scan_enabled = excluded.auto_scan_enabled,
-      auto_scan_interval_minutes = excluded.auto_scan_interval_minutes,
-      live_quota_refresh_interval_seconds = excluded.live_quota_refresh_interval_seconds,
-      hide_dock_icon_when_menu_bar_visible = excluded.hide_dock_icon_when_menu_bar_visible,
-      show_menu_bar_logo = excluded.show_menu_bar_logo,
-      show_menu_bar_daily_api_value = excluded.show_menu_bar_daily_api_value,
-      show_menu_bar_live_quota_percent = excluded.show_menu_bar_live_quota_percent,
-      menu_bar_live_quota_metric = excluded.menu_bar_live_quota_metric,
-      menu_bar_live_quota_bucket = excluded.menu_bar_live_quota_bucket,
-      menu_bar_bucket = excluded.menu_bar_bucket,
-      menu_bar_speed_show_emoji = excluded.menu_bar_speed_show_emoji,
-      menu_bar_speed_fast_threshold_percent = excluded.menu_bar_speed_fast_threshold_percent,
-      menu_bar_speed_slow_threshold_percent = excluded.menu_bar_speed_slow_threshold_percent,
-      menu_bar_speed_healthy_emoji = excluded.menu_bar_speed_healthy_emoji,
-      menu_bar_speed_fast_emoji = excluded.menu_bar_speed_fast_emoji,
-      menu_bar_speed_slow_emoji = excluded.menu_bar_speed_slow_emoji,
-      menu_bar_popup_enabled = excluded.menu_bar_popup_enabled,
-      menu_bar_popup_modules = excluded.menu_bar_popup_modules,
-      menu_bar_popup_show_reset_timeline = excluded.menu_bar_popup_show_reset_timeline,
-      menu_bar_popup_show_actions = excluded.menu_bar_popup_show_actions,
-      last_scan_started_at = excluded.last_scan_started_at,
-      last_scan_completed_at = excluded.last_scan_completed_at,
-      updated_at = excluded.updated_at
-    ",
-    params![
-      settings.codex_home,
-      bool_to_i64(settings.auto_scan_enabled),
-      settings.auto_scan_interval_minutes.max(1),
-      settings.live_quota_refresh_interval_seconds.clamp(60, 3600),
-      bool_to_i64(settings.hide_dock_icon_when_menu_bar_visible),
-      bool_to_i64(settings.show_menu_bar_logo),
-      bool_to_i64(settings.show_menu_bar_daily_api_value),
-      bool_to_i64(settings.show_menu_bar_live_quota_percent),
-      settings.menu_bar_live_quota_metric,
-      settings.menu_bar_live_quota_bucket,
-      settings.menu_bar_bucket,
-      bool_to_i64(settings.menu_bar_speed_show_emoji),
-      settings.menu_bar_speed_fast_threshold_percent.clamp(0, 1000),
-      settings.menu_bar_speed_slow_threshold_percent.clamp(0, 1000),
-      settings.menu_bar_speed_healthy_emoji,
-      settings.menu_bar_speed_fast_emoji,
-      settings.menu_bar_speed_slow_emoji,
-      bool_to_i64(settings.menu_bar_popup_enabled),
-      serialize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
-      bool_to_i64(settings.menu_bar_popup_show_reset_timeline),
-      bool_to_i64(settings.menu_bar_popup_show_actions),
-      settings.last_scan_started_at,
-      settings.last_scan_completed_at,
-      updated_at,
-    ],
-  )?;
-  get_sync_settings(conn)
-}
-
-pub fn replace_session_rate_limit_samples(
-  conn: &Connection,
-  session_id: &str,
-  samples: &[RateLimitSampleRecord],
-) -> rusqlite::Result<()> {
-  conn.execute(
-    "
-    DELETE FROM rate_limit_samples
-    WHERE source_kind = 'session' AND source_session_id = ?1
-    ",
-    params![session_id],
-  )?;
-  insert_rate_limit_samples(conn, samples)
-}
-
-pub fn insert_rate_limit_samples(conn: &Connection, samples: &[RateLimitSampleRecord]) -> rusqlite::Result<()> {
-  let created_at = now_utc_string();
-  let mut stmt = conn.prepare(
-    "
-    INSERT OR IGNORE INTO rate_limit_samples (
-      source_kind, source_session_id, bucket, sample_timestamp, limit_id, limit_name, plan_type,
-      window_start, resets_at, used_percent, remaining_percent, created_at
-    )
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-    ",
-  )?;
-
-  for sample in samples {
-    stmt.execute(params![
-      sample.source_kind,
-      sample.source_session_id.clone().unwrap_or_default(),
-      sample.bucket,
-      sample.sample_timestamp,
-      sample.limit_id.clone().unwrap_or_default(),
-      sample.limit_name.clone().unwrap_or_default(),
-      sample.plan_type.clone().unwrap_or_default(),
-      sample.window_start,
-      sample.resets_at,
-      sample.used_percent.clamp(0, 100),
-      sample.remaining_percent.clamp(0, 100),
-      created_at,
-    ])?;
-  }
-
-  Ok(())
-}
-
-pub fn insert_live_rate_limit_snapshot(conn: &Connection, snapshot: &LiveRateLimitSnapshot) -> rusqlite::Result<()> {
-  let mut samples = Vec::new();
-  for (bucket, window) in [("five_hour", snapshot.primary.as_ref()), ("seven_day", snapshot.secondary.as_ref())] {
-    let Some(window) = window else {
-      continue;
-    };
-    let (Some(window_start), Some(resets_at)) = (window.window_start.clone(), window.resets_at.clone()) else {
-      continue;
-    };
-    samples.push(RateLimitSampleRecord {
-      source_kind: "live".to_string(),
-      source_session_id: None,
-      bucket: bucket.to_string(),
-      sample_timestamp: snapshot.fetched_at.clone(),
-      limit_id: snapshot.limit_id.clone(),
-      limit_name: snapshot.limit_name.clone(),
-      plan_type: snapshot.plan_type.clone(),
-      window_start,
-      resets_at,
-      used_percent: window.used_percent,
-      remaining_percent: window.remaining_percent,
-    });
-  }
-  insert_rate_limit_samples(conn, &samples)
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
+    use crate::models::{SubscriptionProfile, SyncSettings};
 
-  #[test]
-  fn init_db_adds_menu_bar_flag_to_existing_sync_settings() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
+    #[test]
+    fn init_db_adds_menu_bar_flag_to_existing_sync_settings() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
 
-    conn
-      .execute_batch(
-        "
+        conn.execute_batch(
+            "
         CREATE TABLE sync_settings (
           singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
           codex_home TEXT,
@@ -754,42 +117,41 @@ mod tests {
         )
         VALUES (1, NULL, 1, 5, NULL, NULL, '2026-03-26T00:00:00Z');
         ",
-      )
-      .expect("seed legacy schema");
+        )
+        .expect("seed legacy schema");
 
-    init_db(&conn).expect("migrate schema");
-    let settings = get_sync_settings(&conn).expect("load settings");
+        init_db(&conn).expect("migrate schema");
+        let settings = get_sync_settings(&conn).expect("load settings");
 
-    assert!(settings.show_menu_bar_daily_api_value);
-    assert!(settings.show_menu_bar_logo);
-    assert!(!settings.show_menu_bar_live_quota_percent);
-    assert_eq!(settings.menu_bar_live_quota_metric, "remaining_percent");
-    assert_eq!(settings.menu_bar_live_quota_bucket, "five_hour");
-    assert_eq!(settings.menu_bar_bucket, "day");
-    assert_eq!(settings.live_quota_refresh_interval_seconds, 300);
-    assert!(settings.menu_bar_speed_show_emoji);
-    assert_eq!(settings.menu_bar_speed_fast_threshold_percent, 85);
-    assert_eq!(settings.menu_bar_speed_slow_threshold_percent, 115);
-    assert_eq!(settings.menu_bar_speed_healthy_emoji, "🟢");
-    assert_eq!(settings.menu_bar_speed_fast_emoji, "🔥");
-    assert_eq!(settings.menu_bar_speed_slow_emoji, "🐢");
-    assert!(settings.menu_bar_popup_enabled);
-    assert_eq!(
-      settings.menu_bar_popup_modules,
-      default_menu_bar_popup_modules()
-    );
-    assert!(settings.menu_bar_popup_show_reset_timeline);
-    assert!(settings.menu_bar_popup_show_actions);
-    assert!(!settings.hide_dock_icon_when_menu_bar_visible);
-  }
+        assert!(settings.show_menu_bar_daily_api_value);
+        assert!(settings.show_menu_bar_logo);
+        assert!(!settings.show_menu_bar_live_quota_percent);
+        assert_eq!(settings.menu_bar_live_quota_metric, "remaining_percent");
+        assert_eq!(settings.menu_bar_live_quota_bucket, "five_hour");
+        assert_eq!(settings.menu_bar_bucket, "day");
+        assert_eq!(settings.live_quota_refresh_interval_seconds, 300);
+        assert!(settings.menu_bar_speed_show_emoji);
+        assert_eq!(settings.menu_bar_speed_fast_threshold_percent, 85);
+        assert_eq!(settings.menu_bar_speed_slow_threshold_percent, 115);
+        assert_eq!(settings.menu_bar_speed_healthy_emoji, "🟢");
+        assert_eq!(settings.menu_bar_speed_fast_emoji, "🔥");
+        assert_eq!(settings.menu_bar_speed_slow_emoji, "🐢");
+        assert!(settings.menu_bar_popup_enabled);
+        assert_eq!(
+            settings.menu_bar_popup_modules,
+            sync_settings::default_menu_bar_popup_modules()
+        );
+        assert!(settings.menu_bar_popup_show_reset_timeline);
+        assert!(settings.menu_bar_popup_show_actions);
+        assert!(!settings.hide_dock_icon_when_menu_bar_visible);
+    }
 
-  #[test]
-  fn init_db_copies_existing_menu_bar_visibility_into_logo_flag() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
+    #[test]
+    fn init_db_copies_existing_menu_bar_visibility_into_logo_flag() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
 
-    conn
-      .execute_batch(
-        "
+        conn.execute_batch(
+            "
         CREATE TABLE sync_settings (
           singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
           codex_home TEXT,
@@ -807,44 +169,43 @@ mod tests {
         )
         VALUES (1, NULL, 1, 5, 0, NULL, NULL, '2026-03-26T00:00:00Z');
         ",
-      )
-      .expect("seed pre-logo schema");
+        )
+        .expect("seed pre-logo schema");
 
-    init_db(&conn).expect("migrate schema");
-    let settings = get_sync_settings(&conn).expect("load settings");
+        init_db(&conn).expect("migrate schema");
+        let settings = get_sync_settings(&conn).expect("load settings");
 
-    assert!(!settings.show_menu_bar_daily_api_value);
-    assert!(!settings.show_menu_bar_logo);
-    assert!(!settings.hide_dock_icon_when_menu_bar_visible);
-  }
+        assert!(!settings.show_menu_bar_daily_api_value);
+        assert!(!settings.show_menu_bar_logo);
+        assert!(!settings.hide_dock_icon_when_menu_bar_visible);
+    }
 
-  #[test]
-  fn save_sync_settings_round_trips_dock_visibility_preference() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
-    init_db(&conn).expect("init database");
+    #[test]
+    fn save_sync_settings_round_trips_dock_visibility_preference() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
 
-    save_sync_settings(
-      &conn,
-      &SyncSettings {
-        hide_dock_icon_when_menu_bar_visible: true,
-        ..SyncSettings::default()
-      },
-    )
-    .expect("save settings");
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                hide_dock_icon_when_menu_bar_visible: true,
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save settings");
 
-    let settings = get_sync_settings(&conn).expect("load settings");
+        let settings = get_sync_settings(&conn).expect("load settings");
 
-    assert!(settings.hide_dock_icon_when_menu_bar_visible);
-  }
+        assert!(settings.hide_dock_icon_when_menu_bar_visible);
+    }
 
-  #[test]
-  fn init_db_migrates_old_default_refresh_and_disables_legacy_fast_mode_once() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
+    #[test]
+    fn init_db_migrates_old_default_refresh_and_disables_legacy_fast_mode_once() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
 
-    init_db(&conn).expect("init database");
-    conn
-      .execute(
-        "
+        init_db(&conn).expect("init database");
+        conn.execute(
+            "
         UPDATE sync_settings
         SET
           sync_settings_schema_version = 1,
@@ -852,20 +213,20 @@ mod tests {
           default_fast_mode_for_new_gpt54_sessions = 1
         WHERE singleton_id = 1
         ",
-        [],
-      )
-      .expect("seed old defaults");
+            [],
+        )
+        .expect("seed old defaults");
 
-    init_db(&conn).expect("migrate defaults");
-    let settings = get_sync_settings(&conn).expect("load settings");
-    let schema_version = conn
-      .query_row(
-        "SELECT sync_settings_schema_version FROM sync_settings WHERE singleton_id = 1",
-        [],
-        |row| row.get::<_, i64>(0),
-      )
-      .expect("load schema version");
-    let legacy_fast_mode_default = conn
+        init_db(&conn).expect("migrate defaults");
+        let settings = get_sync_settings(&conn).expect("load settings");
+        let schema_version = conn
+            .query_row(
+                "SELECT sync_settings_schema_version FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("load schema version");
+        let legacy_fast_mode_default = conn
       .query_row(
         "SELECT default_fast_mode_for_new_gpt54_sessions FROM sync_settings WHERE singleton_id = 1",
         [],
@@ -873,122 +234,46 @@ mod tests {
       )
       .expect("load legacy fast mode default");
 
-    assert_eq!(settings.live_quota_refresh_interval_seconds, 300);
-    assert_eq!(legacy_fast_mode_default, 0);
-    assert_eq!(schema_version, 2);
+        assert_eq!(settings.live_quota_refresh_interval_seconds, 300);
+        assert_eq!(legacy_fast_mode_default, 0);
+        assert_eq!(schema_version, 2);
 
-    save_sync_settings(
-      &conn,
-      &SyncSettings {
-        live_quota_refresh_interval_seconds: 600,
-        ..SyncSettings::default()
-      },
-    )
-    .expect("save user preferences");
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                live_quota_refresh_interval_seconds: 600,
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save user preferences");
 
-    init_db(&conn).expect("run init again");
-    let settings = get_sync_settings(&conn).expect("reload settings");
+        init_db(&conn).expect("run init again");
+        let settings = get_sync_settings(&conn).expect("reload settings");
 
-    assert_eq!(settings.live_quota_refresh_interval_seconds, 600);
-  }
+        assert_eq!(settings.live_quota_refresh_interval_seconds, 600);
+    }
 
-  #[test]
-  fn subscription_profile_is_normalized_to_usd() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
+    #[test]
+    fn subscription_profile_is_normalized_to_usd() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
 
-    init_db(&conn).expect("init database");
-    save_subscription_profile(
-      &conn,
-      &SubscriptionProfile {
-        plan_type: "pro".to_string(),
-        currency: "eur".to_string(),
-        monthly_price: 42.0,
-        billing_anchor_day: 9,
-        updated_at: "2026-04-07T00:00:00Z".to_string(),
-      },
-    )
-    .expect("save profile");
+        init_db(&conn).expect("init database");
+        save_subscription_profile(
+            &conn,
+            &SubscriptionProfile {
+                plan_type: "pro".to_string(),
+                currency: "eur".to_string(),
+                monthly_price: 42.0,
+                billing_anchor_day: 9,
+                updated_at: "2026-04-07T00:00:00Z".to_string(),
+            },
+        )
+        .expect("save profile");
 
-    let profile = get_subscription_profile(&conn).expect("load profile");
+        let profile = get_subscription_profile(&conn).expect("load profile");
 
-    assert_eq!(profile.currency, "USD");
-    assert_eq!(profile.monthly_price, 42.0);
-    assert_eq!(profile.billing_anchor_day, 9);
-  }
-}
-
-pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
-  conn.execute(
-    "
-    UPDATE sync_settings
-    SET last_scan_started_at = ?1, updated_at = ?1
-    WHERE singleton_id = 1
-    ",
-    params![timestamp],
-  )?;
-  Ok(())
-}
-
-pub fn set_last_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
-  conn.execute(
-    "
-    UPDATE sync_settings
-    SET last_scan_completed_at = ?1, updated_at = ?1
-    WHERE singleton_id = 1
-    ",
-    params![timestamp],
-  )?;
-  Ok(())
-}
-
-pub fn get_subscription_profile(conn: &Connection) -> rusqlite::Result<SubscriptionProfile> {
-  conn.query_row(
-    "
-    SELECT plan_type, currency, monthly_price, billing_anchor_day, updated_at
-    FROM subscription_profile
-    WHERE singleton_id = 1
-    ",
-    [],
-    |row| {
-      Ok(SubscriptionProfile {
-        plan_type: row.get(0)?,
-        currency: {
-          let _: String = row.get(1)?;
-          canonical_subscription_currency().to_string()
-        },
-        monthly_price: row.get(2)?,
-        billing_anchor_day: row.get(3)?,
-        updated_at: row.get(4)?,
-      })
-    },
-  )
-}
-
-pub fn save_subscription_profile(
-  conn: &Connection,
-  profile: &SubscriptionProfile,
-) -> rusqlite::Result<SubscriptionProfile> {
-  let updated_at = now_utc_string();
-  conn.execute(
-    "
-    INSERT INTO subscription_profile (
-      singleton_id, plan_type, currency, monthly_price, billing_anchor_day, updated_at
-    )
-    VALUES (1, ?1, ?2, ?3, ?4, ?5)
-    ON CONFLICT(singleton_id) DO UPDATE SET
-      plan_type = excluded.plan_type,
-      currency = excluded.currency,
-      monthly_price = excluded.monthly_price,
-      billing_anchor_day = excluded.billing_anchor_day,
-      updated_at = excluded.updated_at
-    ",
-    params![
-      profile.plan_type,
-      canonical_subscription_currency(),
-      profile.monthly_price.max(0.0),
-      profile.billing_anchor_day.clamp(1, 28),
-      updated_at,
-    ],
-  )?;
-  get_subscription_profile(conn)
+        assert_eq!(profile.currency, "USD");
+        assert_eq!(profile.monthly_price, 42.0);
+        assert_eq!(profile.billing_anchor_day, 9);
+    }
 }

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -1,0 +1,89 @@
+use rusqlite::{params, Connection};
+
+use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord};
+
+use super::now_utc_string;
+
+pub fn replace_session_rate_limit_samples(
+    conn: &Connection,
+    session_id: &str,
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    DELETE FROM rate_limit_samples
+    WHERE source_kind = 'session' AND source_session_id = ?1
+    ",
+        params![session_id],
+    )?;
+    insert_rate_limit_samples(conn, samples)
+}
+
+pub fn insert_rate_limit_samples(
+    conn: &Connection,
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<()> {
+    let created_at = now_utc_string();
+    let mut stmt = conn.prepare(
+        "
+    INSERT OR IGNORE INTO rate_limit_samples (
+      source_kind, source_session_id, bucket, sample_timestamp, limit_id, limit_name, plan_type,
+      window_start, resets_at, used_percent, remaining_percent, created_at
+    )
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+    ",
+    )?;
+
+    for sample in samples {
+        stmt.execute(params![
+            sample.source_kind,
+            sample.source_session_id.clone().unwrap_or_default(),
+            sample.bucket,
+            sample.sample_timestamp,
+            sample.limit_id.clone().unwrap_or_default(),
+            sample.limit_name.clone().unwrap_or_default(),
+            sample.plan_type.clone().unwrap_or_default(),
+            sample.window_start,
+            sample.resets_at,
+            sample.used_percent.clamp(0, 100),
+            sample.remaining_percent.clamp(0, 100),
+            created_at,
+        ])?;
+    }
+
+    Ok(())
+}
+
+pub fn insert_live_rate_limit_snapshot(
+    conn: &Connection,
+    snapshot: &LiveRateLimitSnapshot,
+) -> rusqlite::Result<()> {
+    let mut samples = Vec::new();
+    for (bucket, window) in [
+        ("five_hour", snapshot.primary.as_ref()),
+        ("seven_day", snapshot.secondary.as_ref()),
+    ] {
+        let Some(window) = window else {
+            continue;
+        };
+        let (Some(window_start), Some(resets_at)) =
+            (window.window_start.clone(), window.resets_at.clone())
+        else {
+            continue;
+        };
+        samples.push(RateLimitSampleRecord {
+            source_kind: "live".to_string(),
+            source_session_id: None,
+            bucket: bucket.to_string(),
+            sample_timestamp: snapshot.fetched_at.clone(),
+            limit_id: snapshot.limit_id.clone(),
+            limit_name: snapshot.limit_name.clone(),
+            plan_type: snapshot.plan_type.clone(),
+            window_start,
+            resets_at,
+            used_percent: window.used_percent,
+            remaining_percent: window.remaining_percent,
+        });
+    }
+    insert_rate_limit_samples(conn, &samples)
+}

--- a/src-tauri/src/database/subscriptions.rs
+++ b/src-tauri/src/database/subscriptions.rs
@@ -1,0 +1,61 @@
+use rusqlite::{params, Connection};
+
+use crate::models::SubscriptionProfile;
+
+use super::now_utc_string;
+
+pub fn canonical_subscription_currency() -> &'static str {
+    "USD"
+}
+
+pub fn get_subscription_profile(conn: &Connection) -> rusqlite::Result<SubscriptionProfile> {
+    conn.query_row(
+        "
+    SELECT plan_type, currency, monthly_price, billing_anchor_day, updated_at
+    FROM subscription_profile
+    WHERE singleton_id = 1
+    ",
+        [],
+        |row| {
+            Ok(SubscriptionProfile {
+                plan_type: row.get(0)?,
+                currency: {
+                    let _: String = row.get(1)?;
+                    canonical_subscription_currency().to_string()
+                },
+                monthly_price: row.get(2)?,
+                billing_anchor_day: row.get(3)?,
+                updated_at: row.get(4)?,
+            })
+        },
+    )
+}
+
+pub fn save_subscription_profile(
+    conn: &Connection,
+    profile: &SubscriptionProfile,
+) -> rusqlite::Result<SubscriptionProfile> {
+    let updated_at = now_utc_string();
+    conn.execute(
+        "
+    INSERT INTO subscription_profile (
+      singleton_id, plan_type, currency, monthly_price, billing_anchor_day, updated_at
+    )
+    VALUES (1, ?1, ?2, ?3, ?4, ?5)
+    ON CONFLICT(singleton_id) DO UPDATE SET
+      plan_type = excluded.plan_type,
+      currency = excluded.currency,
+      monthly_price = excluded.monthly_price,
+      billing_anchor_day = excluded.billing_anchor_day,
+      updated_at = excluded.updated_at
+    ",
+        params![
+            profile.plan_type,
+            canonical_subscription_currency(),
+            profile.monthly_price.max(0.0),
+            profile.billing_anchor_day.clamp(1, 28),
+            updated_at,
+        ],
+    )?;
+    get_subscription_profile(conn)
+}

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -1,0 +1,478 @@
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::models::SyncSettings;
+
+use super::{bool_to_i64, i64_to_bool, now_utc_string};
+
+pub fn default_menu_bar_popup_modules() -> Vec<String> {
+    vec!["api_value".to_string(), "scan_freshness".to_string()]
+}
+
+fn is_supported_menu_bar_popup_module(module: &str) -> bool {
+    matches!(
+        module,
+        "api_value"
+            | "token_count"
+            | "scan_freshness"
+            | "live_quota_freshness"
+            | "payoff_ratio"
+            | "conversation_count"
+    )
+}
+
+pub(super) fn default_menu_bar_popup_modules_json() -> String {
+    serde_json::to_string(&default_menu_bar_popup_modules())
+        .expect("serialize default popup modules")
+}
+
+fn deserialize_menu_bar_popup_modules(value: String) -> Vec<String> {
+    serde_json::from_str::<Vec<String>>(&value)
+        .ok()
+        .map(|modules| {
+            modules
+                .into_iter()
+                .filter(|module| is_supported_menu_bar_popup_module(module))
+                .fold(Vec::new(), |mut deduped, module| {
+                    if !deduped.iter().any(|existing| existing == &module) {
+                        deduped.push(module);
+                    }
+                    deduped
+                })
+        })
+        .unwrap_or_else(default_menu_bar_popup_modules)
+}
+
+fn serialize_menu_bar_popup_modules(modules: &[String]) -> String {
+    serde_json::to_string(modules).unwrap_or_else(|_| default_menu_bar_popup_modules_json())
+}
+
+pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare("PRAGMA table_info(sync_settings)")?;
+    let column_names = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    if !column_names
+        .iter()
+        .any(|name| name == "sync_settings_schema_version")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN sync_settings_schema_version INTEGER NOT NULL DEFAULT 1
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "show_menu_bar_daily_api_value")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names.iter().any(|name| name == "show_menu_bar_logo") {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN show_menu_bar_logo INTEGER NOT NULL DEFAULT 1
+      ",
+            [],
+        )?;
+        conn.execute(
+            "
+      UPDATE sync_settings
+      SET show_menu_bar_logo = show_menu_bar_daily_api_value
+      WHERE singleton_id = 1
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "show_menu_bar_live_quota_percent")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_live_quota_metric")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent'
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_live_quota_bucket")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour'
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names.iter().any(|name| name == "menu_bar_bucket") {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN menu_bar_bucket TEXT NOT NULL DEFAULT 'day'
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "live_quota_refresh_interval_seconds")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "default_fast_mode_for_new_gpt54_sessions")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "hide_dock_icon_when_menu_bar_visible")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_show_emoji")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_fast_threshold_percent")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_slow_threshold_percent")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_healthy_emoji")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢'",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_fast_emoji")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥'",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_slow_emoji")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢'",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_popup_enabled")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_popup_modules")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_modules TEXT NOT NULL DEFAULT '[\"api_value\",\"scan_freshness\"]'",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_popup_show_reset_timeline")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_popup_show_actions")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1",
+      [],
+    )?;
+    }
+
+    migrate_sync_settings_defaults_to_minutes(conn)?;
+
+    Ok(())
+}
+
+fn migrate_sync_settings_defaults_to_minutes(conn: &Connection) -> rusqlite::Result<()> {
+    let schema_version = conn
+        .query_row(
+            "SELECT sync_settings_schema_version FROM sync_settings WHERE singleton_id = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .unwrap_or(2);
+
+    if schema_version >= 2 {
+        return Ok(());
+    }
+
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET
+      live_quota_refresh_interval_seconds = CASE
+        WHEN live_quota_refresh_interval_seconds = 60 THEN 300
+        ELSE live_quota_refresh_interval_seconds
+      END,
+      default_fast_mode_for_new_gpt54_sessions = CASE
+        WHEN default_fast_mode_for_new_gpt54_sessions = 1 THEN 0
+        ELSE default_fast_mode_for_new_gpt54_sessions
+      END,
+      sync_settings_schema_version = 2
+    WHERE singleton_id = 1
+    ",
+        [],
+    )?;
+
+    Ok(())
+}
+
+pub fn get_sync_settings(conn: &Connection) -> rusqlite::Result<SyncSettings> {
+    conn.query_row(
+        "
+    SELECT codex_home, auto_scan_enabled, auto_scan_interval_minutes,
+           live_quota_refresh_interval_seconds,
+           hide_dock_icon_when_menu_bar_visible,
+           show_menu_bar_logo, show_menu_bar_daily_api_value,
+           show_menu_bar_live_quota_percent, menu_bar_live_quota_metric,
+           menu_bar_live_quota_bucket, menu_bar_bucket,
+           menu_bar_speed_show_emoji, menu_bar_speed_fast_threshold_percent,
+           menu_bar_speed_slow_threshold_percent, menu_bar_speed_healthy_emoji,
+           menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
+           menu_bar_popup_enabled, menu_bar_popup_modules,
+           menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
+           last_scan_started_at, last_scan_completed_at, updated_at
+    FROM sync_settings
+    WHERE singleton_id = 1
+    ",
+        [],
+        |row| {
+            Ok(SyncSettings {
+                codex_home: row.get(0)?,
+                auto_scan_enabled: i64_to_bool(row.get::<_, i64>(1)?),
+                auto_scan_interval_minutes: row.get(2)?,
+                live_quota_refresh_interval_seconds: row.get(3)?,
+                hide_dock_icon_when_menu_bar_visible: i64_to_bool(row.get::<_, i64>(4)?),
+                show_menu_bar_logo: i64_to_bool(row.get::<_, i64>(5)?),
+                show_menu_bar_daily_api_value: i64_to_bool(row.get::<_, i64>(6)?),
+                show_menu_bar_live_quota_percent: i64_to_bool(row.get::<_, i64>(7)?),
+                menu_bar_live_quota_metric: row.get(8)?,
+                menu_bar_live_quota_bucket: row.get(9)?,
+                menu_bar_bucket: row.get(10)?,
+                menu_bar_speed_show_emoji: i64_to_bool(row.get::<_, i64>(11)?),
+                menu_bar_speed_fast_threshold_percent: row.get(12)?,
+                menu_bar_speed_slow_threshold_percent: row.get(13)?,
+                menu_bar_speed_healthy_emoji: row.get(14)?,
+                menu_bar_speed_fast_emoji: row.get(15)?,
+                menu_bar_speed_slow_emoji: row.get(16)?,
+                menu_bar_popup_enabled: i64_to_bool(row.get::<_, i64>(17)?),
+                menu_bar_popup_modules: deserialize_menu_bar_popup_modules(row.get(18)?),
+                menu_bar_popup_show_reset_timeline: i64_to_bool(row.get::<_, i64>(19)?),
+                menu_bar_popup_show_actions: i64_to_bool(row.get::<_, i64>(20)?),
+                last_scan_started_at: row.get(21)?,
+                last_scan_completed_at: row.get(22)?,
+                updated_at: row.get(23)?,
+            })
+        },
+    )
+}
+
+pub fn save_sync_settings(
+    conn: &Connection,
+    settings: &SyncSettings,
+) -> rusqlite::Result<SyncSettings> {
+    let updated_at = now_utc_string();
+    conn.execute(
+    "
+    INSERT INTO sync_settings (
+      singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
+      live_quota_refresh_interval_seconds,
+      hide_dock_icon_when_menu_bar_visible,
+      show_menu_bar_logo,
+      show_menu_bar_daily_api_value,
+      show_menu_bar_live_quota_percent, menu_bar_live_quota_metric,
+      menu_bar_live_quota_bucket, menu_bar_bucket,
+      menu_bar_speed_show_emoji, menu_bar_speed_fast_threshold_percent,
+      menu_bar_speed_slow_threshold_percent, menu_bar_speed_healthy_emoji,
+      menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
+      menu_bar_popup_enabled, menu_bar_popup_modules,
+      menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
+      last_scan_started_at, last_scan_completed_at, updated_at
+    )
+    VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)
+    ON CONFLICT(singleton_id) DO UPDATE SET
+      codex_home = excluded.codex_home,
+      auto_scan_enabled = excluded.auto_scan_enabled,
+      auto_scan_interval_minutes = excluded.auto_scan_interval_minutes,
+      live_quota_refresh_interval_seconds = excluded.live_quota_refresh_interval_seconds,
+      hide_dock_icon_when_menu_bar_visible = excluded.hide_dock_icon_when_menu_bar_visible,
+      show_menu_bar_logo = excluded.show_menu_bar_logo,
+      show_menu_bar_daily_api_value = excluded.show_menu_bar_daily_api_value,
+      show_menu_bar_live_quota_percent = excluded.show_menu_bar_live_quota_percent,
+      menu_bar_live_quota_metric = excluded.menu_bar_live_quota_metric,
+      menu_bar_live_quota_bucket = excluded.menu_bar_live_quota_bucket,
+      menu_bar_bucket = excluded.menu_bar_bucket,
+      menu_bar_speed_show_emoji = excluded.menu_bar_speed_show_emoji,
+      menu_bar_speed_fast_threshold_percent = excluded.menu_bar_speed_fast_threshold_percent,
+      menu_bar_speed_slow_threshold_percent = excluded.menu_bar_speed_slow_threshold_percent,
+      menu_bar_speed_healthy_emoji = excluded.menu_bar_speed_healthy_emoji,
+      menu_bar_speed_fast_emoji = excluded.menu_bar_speed_fast_emoji,
+      menu_bar_speed_slow_emoji = excluded.menu_bar_speed_slow_emoji,
+      menu_bar_popup_enabled = excluded.menu_bar_popup_enabled,
+      menu_bar_popup_modules = excluded.menu_bar_popup_modules,
+      menu_bar_popup_show_reset_timeline = excluded.menu_bar_popup_show_reset_timeline,
+      menu_bar_popup_show_actions = excluded.menu_bar_popup_show_actions,
+      last_scan_started_at = excluded.last_scan_started_at,
+      last_scan_completed_at = excluded.last_scan_completed_at,
+      updated_at = excluded.updated_at
+    ",
+    params![
+      settings.codex_home,
+      bool_to_i64(settings.auto_scan_enabled),
+      settings.auto_scan_interval_minutes.max(1),
+      settings.live_quota_refresh_interval_seconds.clamp(60, 3600),
+      bool_to_i64(settings.hide_dock_icon_when_menu_bar_visible),
+      bool_to_i64(settings.show_menu_bar_logo),
+      bool_to_i64(settings.show_menu_bar_daily_api_value),
+      bool_to_i64(settings.show_menu_bar_live_quota_percent),
+      settings.menu_bar_live_quota_metric,
+      settings.menu_bar_live_quota_bucket,
+      settings.menu_bar_bucket,
+      bool_to_i64(settings.menu_bar_speed_show_emoji),
+      settings.menu_bar_speed_fast_threshold_percent.clamp(0, 1000),
+      settings.menu_bar_speed_slow_threshold_percent.clamp(0, 1000),
+      settings.menu_bar_speed_healthy_emoji,
+      settings.menu_bar_speed_fast_emoji,
+      settings.menu_bar_speed_slow_emoji,
+      bool_to_i64(settings.menu_bar_popup_enabled),
+      serialize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
+      bool_to_i64(settings.menu_bar_popup_show_reset_timeline),
+      bool_to_i64(settings.menu_bar_popup_show_actions),
+      settings.last_scan_started_at,
+      settings.last_scan_completed_at,
+      updated_at,
+    ],
+    )?;
+    get_sync_settings(conn)
+}
+
+pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET last_scan_started_at = ?1, updated_at = ?1
+    WHERE singleton_id = 1
+    ",
+        params![timestamp],
+    )?;
+    Ok(())
+}
+
+pub fn set_last_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET last_scan_completed_at = ?1, updated_at = ?1
+    WHERE singleton_id = 1
+    ",
+        params![timestamp],
+    )?;
+    Ok(())
+}

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -22,6 +22,13 @@ use crate::pricing::{
   resolve_pricing,
 };
 
+const SQL_SESSIONS: &str = include_str!("../sql/queries/sessions.sql");
+const SQL_SESSIONS_FOR_ROOT: &str = include_str!("../sql/queries/sessions_for_root.sql");
+const SQL_USAGE_EVENTS: &str = include_str!("../sql/queries/usage_events.sql");
+const SQL_USAGE_EVENTS_FOR_ROOT: &str = include_str!("../sql/queries/usage_events_for_root.sql");
+const SQL_RATE_LIMIT_WINDOWS: &str = include_str!("../sql/queries/rate_limit_windows.sql");
+const SQL_QUOTA_SAMPLES: &str = include_str!("../sql/queries/quota_samples.sql");
+
 #[derive(Debug, Clone)]
 struct SessionRow {
   session_id: String,
@@ -1059,13 +1066,7 @@ fn build_composition_breakdown(
 }
 
 fn load_sessions(conn: &Connection) -> rusqlite::Result<HashMap<String, SessionRow>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
-           started_at, updated_at, agent_nickname, agent_role
-    FROM sessions
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_SESSIONS)?;
   let rows = stmt.query_map([], |row| {
     Ok(SessionRow {
       session_id: row.get(0)?,
@@ -1093,14 +1094,7 @@ fn load_sessions_for_root_session(
   conn: &Connection,
   root_session_id: &str,
 ) -> rusqlite::Result<HashMap<String, SessionRow>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
-           started_at, updated_at, agent_nickname, agent_role
-    FROM sessions
-    WHERE root_session_id = ?1
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_SESSIONS_FOR_ROOT)?;
   let rows = stmt.query_map([root_session_id], |row| {
     Ok(SessionRow {
       session_id: row.get(0)?,
@@ -1125,15 +1119,7 @@ fn load_sessions_for_root_session(
 }
 
 fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
-           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
-           fast_mode_auto, fast_mode_effective
-    FROM usage_events
-    ORDER BY timestamp ASC, id ASC
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_USAGE_EVENTS)?;
   let rows = stmt.query_map([], |row| {
     Ok(EventRow {
       session_id: row.get(0)?,
@@ -1154,19 +1140,7 @@ fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
 }
 
 fn load_events_for_root_session(conn: &Connection, root_session_id: &str) -> rusqlite::Result<Vec<EventRow>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT usage_events.session_id, usage_events.timestamp, usage_events.model_id,
-           usage_events.input_tokens, usage_events.cached_input_tokens,
-           usage_events.output_tokens, usage_events.reasoning_output_tokens,
-           usage_events.total_tokens, usage_events.value_usd,
-           usage_events.fast_mode_auto, usage_events.fast_mode_effective
-    FROM usage_events
-    INNER JOIN sessions ON sessions.session_id = usage_events.session_id
-    WHERE sessions.root_session_id = ?1
-    ORDER BY usage_events.timestamp ASC, usage_events.id ASC
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_USAGE_EVENTS_FOR_ROOT)?;
   let rows = stmt.query_map([root_session_id], |row| {
     Ok(EventRow {
       session_id: row.get(0)?,
@@ -1340,15 +1314,7 @@ fn load_live_rate_limit_windows(
   bucket: &str,
   current_window: Option<RateLimitWindowSummary>,
 ) -> rusqlite::Result<Vec<RateLimitWindowSummary>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT window_start, resets_at
-    FROM rate_limit_samples
-    WHERE bucket = ?1
-    GROUP BY window_start, resets_at
-    ORDER BY window_start DESC, resets_at DESC
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_RATE_LIMIT_WINDOWS)?;
   let rows = stmt.query_map(rusqlite::params![bucket], |row| {
     Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
   })?;
@@ -1620,14 +1586,7 @@ fn live_sample(live_rate_limits: &LiveRateLimitSnapshot, bucket: &str) -> Option
 }
 
 fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
-  let mut stmt = match conn.prepare(
-    "
-    SELECT sample_timestamp, used_percent, window_start, resets_at
-    FROM rate_limit_samples
-    WHERE bucket = ?1
-    ORDER BY sample_timestamp ASC
-    ",
-  ) {
+  let mut stmt = match conn.prepare(SQL_QUOTA_SAMPLES) {
     Ok(stmt) => stmt,
     Err(_) => return Vec::new(),
   };


### PR DESCRIPTION
## Summary
- Move the SQLite schema and indexes out of the Rust database module into `src-tauri/sql/` files loaded with `include_str!`.
- Split the monolithic database module into focused Rust modules for sync settings, subscription profile persistence, and rate-limit samples.
- Move high-traffic dashboard/conversation SQL statements into `src-tauri/sql/queries/` and reference them from `queries.rs`.
- Preserve existing Tauri command behavior and database shape; this PR is intended as a structure-only refactor for easier follow-up feature PRs.

## Compatibility
- No database shape or stored-data format changes are intended.
- Existing initialization and legacy `sync_settings` migration paths are preserved.
- SQL files are embedded at compile time via `include_str!`, so packaged apps do not depend on runtime SQL file lookup.

## Review status
- Rebased onto latest `develop` after #7 landed.
- GitHub merge state is clean.
- Codex review passed.
- Additional Superpowers subagent review found no behavior regression; one non-blocking P2 recommendation remains to add seeded public-query coverage for the extracted SQL files.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `npm test`
- `npm run build`
- `git diff --check origin/develop...HEAD`