### PR TITLE
[codex] Add subscription ledger payoff tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "npm run test:issue-1 && npm run test:issue-3",
+    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:subscription-ledger",
     "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
     "test:issue-3": "node scripts/test-issue-3-custom-range.mjs",
+    "test:subscription-ledger": "node scripts/test-subscription-ledger.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/scripts/test-subscription-ledger.mjs
+++ b/scripts/test-subscription-ledger.mjs
@@ -1,0 +1,39 @@
+import { readFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import assert from 'node:assert/strict'
+import ts from 'typescript'
+
+const repoRoot = join(import.meta.dirname, '..')
+const sourcePath = join(repoRoot, 'src/app/subscriptionDates.ts')
+const source = readFileSync(sourcePath, 'utf8')
+const output = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText
+
+const tempDir = mkdtempSync(join(tmpdir(), 'codex-pacer-subscription-dates-'))
+const modulePath = join(tempDir, 'subscriptionDates.mjs')
+writeFileSync(modulePath, output)
+
+try {
+  const { addOneCalendarMonth, todayLocalInputValue } = await import(pathToFileURL(modulePath))
+
+  assert.equal(addOneCalendarMonth('2026-01-31'), '2026-02-28')
+  assert.equal(addOneCalendarMonth('2028-01-31'), '2028-02-29')
+  assert.equal(addOneCalendarMonth('2026-03-31'), '2026-04-30')
+  assert.equal(addOneCalendarMonth('2026-12-31'), '2027-01-31')
+  assert.equal(addOneCalendarMonth('not-a-date'), 'not-a-date')
+
+  const singaporeLateNight = new Date('2026-05-05T00:30:00+08:00')
+  assert.equal(
+    todayLocalInputValue(singaporeLateNight),
+    '2026-05-05',
+    'ledger defaults should use local calendar date, not UTC ISO date',
+  )
+} finally {
+  rmSync(tempDir, { recursive: true, force: true })
+}

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -10,3 +10,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
   ON rate_limit_samples(
     bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
   );
+CREATE INDEX IF NOT EXISTS idx_subscription_records_service
+  ON subscription_records(service_start, service_end);

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -63,6 +63,18 @@ CREATE TABLE IF NOT EXISTS subscription_profile (
   updated_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS subscription_records (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  paid_at TEXT NOT NULL,
+  service_start TEXT NOT NULL,
+  service_end TEXT NOT NULL,
+  amount_usd REAL NOT NULL,
+  plan_type TEXT NOT NULL,
+  note TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS session_overrides (
   session_id TEXT PRIMARY KEY,
   fast_mode_override INTEGER,

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -65,14 +65,16 @@ CREATE TABLE IF NOT EXISTS subscription_profile (
 
 CREATE TABLE IF NOT EXISTS subscription_records (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  paid_at TEXT NOT NULL,
-  service_start TEXT NOT NULL,
-  service_end TEXT NOT NULL,
-  amount_usd REAL NOT NULL,
+  paid_at TEXT NOT NULL CHECK (paid_at GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  service_start TEXT NOT NULL CHECK (service_start GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  service_end TEXT NOT NULL CHECK (service_end GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  amount_usd REAL NOT NULL CHECK (amount_usd > 0),
+  billing_mode TEXT NOT NULL DEFAULT 'one_time' CHECK (billing_mode IN ('one_time', 'monthly_recurring')),
   plan_type TEXT NOT NULL,
   note TEXT,
   created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL
+  updated_at TEXT NOT NULL,
+  CHECK (service_end > service_start)
 );
 
 CREATE TABLE IF NOT EXISTS session_overrides (

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -10,7 +10,9 @@ mod sync_settings;
 
 pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
 pub use subscriptions::{
-    canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
+    canonical_subscription_currency, create_subscription_record, delete_subscription_record,
+    get_subscription_profile, list_subscription_records, save_subscription_profile,
+    update_subscription_record,
 };
 pub use sync_settings::{
     get_sync_settings, save_sync_settings, set_last_scan_completed, set_last_scan_started,

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -44,11 +44,31 @@ pub fn open_connection(db_path: &Path) -> rusqlite::Result<Connection> {
 }
 
 pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
+    let had_subscription_records_table = table_exists(conn, "subscription_records")?;
     conn.execute_batch(include_str!("../sql/schema.sql"))?;
+    subscriptions::ensure_subscription_records_schema(conn)?;
     sync_settings::ensure_sync_settings_schema(conn)?;
     ensure_singletons(conn)?;
+    subscriptions::migrate_subscription_profile_to_subscription_record(
+        conn,
+        had_subscription_records_table,
+    )?;
     conn.execute_batch(include_str!("../sql/indexes.sql"))?;
     Ok(())
+}
+
+fn table_exists(conn: &Connection, table_name: &str) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "
+        SELECT EXISTS(
+          SELECT 1
+          FROM sqlite_master
+          WHERE type = 'table' AND name = ?1
+        )
+        ",
+        params![table_name],
+        |row| row.get::<_, bool>(0),
+    )
 }
 
 fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {

--- a/src-tauri/src/database/subscriptions.rs
+++ b/src-tauri/src/database/subscriptions.rs
@@ -1,6 +1,7 @@
+use chrono::NaiveDate;
 use rusqlite::{params, Connection};
 
-use crate::models::SubscriptionProfile;
+use crate::models::{SubscriptionProfile, SubscriptionRecord, SubscriptionRecordInput};
 
 use super::now_utc_string;
 
@@ -58,4 +59,253 @@ pub fn save_subscription_profile(
         ],
     )?;
     get_subscription_profile(conn)
+}
+
+pub fn list_subscription_records(conn: &Connection) -> rusqlite::Result<Vec<SubscriptionRecord>> {
+    let mut stmt = conn.prepare(
+        "
+    SELECT id, paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+    FROM subscription_records
+    ORDER BY service_start DESC, paid_at DESC, id DESC
+    ",
+    )?;
+
+    let records = stmt
+        .query_map([], subscription_record_from_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(records)
+}
+
+pub fn create_subscription_record(
+    conn: &Connection,
+    input: &SubscriptionRecordInput,
+) -> Result<SubscriptionRecord, String> {
+    let normalized = normalize_subscription_record_input(input)?;
+    let now = now_utc_string();
+    conn.execute(
+        "
+      INSERT INTO subscription_records (
+        paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+      )
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)
+      ",
+        params![
+            normalized.paid_at,
+            normalized.service_start,
+            normalized.service_end,
+            normalized.amount_usd,
+            normalized.plan_type,
+            normalized.note,
+            now,
+        ],
+    )
+    .map_err(|error| error.to_string())?;
+
+    get_subscription_record(conn, conn.last_insert_rowid())
+}
+
+pub fn update_subscription_record(
+    conn: &Connection,
+    id: i64,
+    input: &SubscriptionRecordInput,
+) -> Result<SubscriptionRecord, String> {
+    let normalized = normalize_subscription_record_input(input)?;
+    let updated_at = now_utc_string();
+    let changed = conn
+        .execute(
+            "
+      UPDATE subscription_records
+      SET
+        paid_at = ?1,
+        service_start = ?2,
+        service_end = ?3,
+        amount_usd = ?4,
+        plan_type = ?5,
+        note = ?6,
+        updated_at = ?7
+      WHERE id = ?8
+      ",
+            params![
+                normalized.paid_at,
+                normalized.service_start,
+                normalized.service_end,
+                normalized.amount_usd,
+                normalized.plan_type,
+                normalized.note,
+                updated_at,
+                id,
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+
+    if changed == 0 {
+        return Err(format!("Subscription record {id} was not found."));
+    }
+
+    get_subscription_record(conn, id)
+}
+
+pub fn delete_subscription_record(conn: &Connection, id: i64) -> Result<bool, String> {
+    let changed = conn
+        .execute(
+            "DELETE FROM subscription_records WHERE id = ?1",
+            params![id],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(changed > 0)
+}
+
+fn get_subscription_record(conn: &Connection, id: i64) -> Result<SubscriptionRecord, String> {
+    conn.query_row(
+        "
+      SELECT id, paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+      FROM subscription_records
+      WHERE id = ?1
+      ",
+        params![id],
+        subscription_record_from_row,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn subscription_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SubscriptionRecord> {
+    Ok(SubscriptionRecord {
+        id: row.get(0)?,
+        paid_at: row.get(1)?,
+        service_start: row.get(2)?,
+        service_end: row.get(3)?,
+        amount_usd: row.get(4)?,
+        plan_type: row.get(5)?,
+        note: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
+}
+
+struct NormalizedSubscriptionRecordInput {
+    paid_at: String,
+    service_start: String,
+    service_end: String,
+    amount_usd: f64,
+    plan_type: String,
+    note: Option<String>,
+}
+
+fn normalize_subscription_record_input(
+    input: &SubscriptionRecordInput,
+) -> Result<NormalizedSubscriptionRecordInput, String> {
+    let paid_at = normalize_date_field("paidAt", &input.paid_at)?;
+    let service_start = normalize_date_field("serviceStart", &input.service_start)?;
+    let service_end = normalize_date_field("serviceEnd", &input.service_end)?;
+    let start_date = parse_date_field("serviceStart", &service_start)?;
+    let end_date = parse_date_field("serviceEnd", &service_end)?;
+    if end_date <= start_date {
+        return Err("serviceEnd must be later than serviceStart.".to_string());
+    }
+    if !input.amount_usd.is_finite() {
+        return Err("amountUsd must be a finite number.".to_string());
+    }
+
+    let plan_type = input.plan_type.trim();
+    let note = input
+        .note
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.chars().take(500).collect::<String>());
+
+    Ok(NormalizedSubscriptionRecordInput {
+        paid_at,
+        service_start,
+        service_end,
+        amount_usd: input.amount_usd.max(0.0),
+        plan_type: if plan_type.is_empty() {
+            "unknown".to_string()
+        } else {
+            plan_type.chars().take(64).collect()
+        },
+        note,
+    })
+}
+
+fn normalize_date_field(field_name: &str, value: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    parse_date_field(field_name, trimmed)?;
+    Ok(trimmed.to_string())
+}
+
+fn parse_date_field(field_name: &str, value: &str) -> Result<NaiveDate, String> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| format!("{field_name} must use YYYY-MM-DD format."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::init_db;
+
+    #[test]
+    fn subscription_records_round_trip() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+
+        init_db(&conn).expect("init database");
+        let created = create_subscription_record(
+            &conn,
+            &SubscriptionRecordInput {
+                paid_at: "2026-04-16".to_string(),
+                service_start: "2026-04-16".to_string(),
+                service_end: "2026-05-16".to_string(),
+                amount_usd: 19.99,
+                plan_type: "plus".to_string(),
+                note: Some("user@example.com".to_string()),
+            },
+        )
+        .expect("create record");
+
+        assert_eq!(created.plan_type, "plus");
+        assert_eq!(created.note.as_deref(), Some("user@example.com"));
+
+        let updated = update_subscription_record(
+            &conn,
+            created.id,
+            &SubscriptionRecordInput {
+                paid_at: "2026-04-17".to_string(),
+                service_start: "2026-04-17".to_string(),
+                service_end: "2026-05-17".to_string(),
+                amount_usd: 100.0,
+                plan_type: "pro_x5".to_string(),
+                note: Some("updated@example.com".to_string()),
+            },
+        )
+        .expect("update record");
+
+        assert_eq!(updated.amount_usd, 100.0);
+        assert_eq!(updated.plan_type, "pro_x5");
+        assert_eq!(list_subscription_records(&conn).expect("list records").len(), 1);
+        assert!(delete_subscription_record(&conn, created.id).expect("delete record"));
+        assert!(list_subscription_records(&conn)
+            .expect("list after delete")
+            .is_empty());
+    }
+
+    #[test]
+    fn subscription_record_rejects_invalid_dates() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+
+        init_db(&conn).expect("init database");
+        let error = create_subscription_record(
+            &conn,
+            &SubscriptionRecordInput {
+                paid_at: "2026-04-16".to_string(),
+                service_start: "2026-05-16".to_string(),
+                service_end: "2026-04-16".to_string(),
+                amount_usd: 19.99,
+                plan_type: "plus".to_string(),
+                note: None,
+            },
+        )
+        .expect_err("reject invalid date range");
+
+        assert!(error.contains("serviceEnd"));
+    }
 }

--- a/src-tauri/src/database/subscriptions.rs
+++ b/src-tauri/src/database/subscriptions.rs
@@ -1,9 +1,12 @@
-use chrono::NaiveDate;
-use rusqlite::{params, Connection};
+use chrono::{Datelike, Local, Months, NaiveDate};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::models::{SubscriptionProfile, SubscriptionRecord, SubscriptionRecordInput};
 
 use super::now_utc_string;
+
+const BILLING_MODE_ONE_TIME: &str = "one_time";
+const BILLING_MODE_MONTHLY_RECURRING: &str = "monthly_recurring";
 
 pub fn canonical_subscription_currency() -> &'static str {
     "USD"
@@ -64,7 +67,7 @@ pub fn save_subscription_profile(
 pub fn list_subscription_records(conn: &Connection) -> rusqlite::Result<Vec<SubscriptionRecord>> {
     let mut stmt = conn.prepare(
         "
-    SELECT id, paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+    SELECT id, paid_at, service_start, service_end, amount_usd, billing_mode, plan_type, note, created_at, updated_at
     FROM subscription_records
     ORDER BY service_start DESC, paid_at DESC, id DESC
     ",
@@ -85,15 +88,16 @@ pub fn create_subscription_record(
     conn.execute(
         "
       INSERT INTO subscription_records (
-        paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+        paid_at, service_start, service_end, amount_usd, billing_mode, plan_type, note, created_at, updated_at
       )
-      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)
       ",
         params![
             normalized.paid_at,
             normalized.service_start,
             normalized.service_end,
             normalized.amount_usd,
+            normalized.billing_mode,
             normalized.plan_type,
             normalized.note,
             now,
@@ -120,16 +124,18 @@ pub fn update_subscription_record(
         service_start = ?2,
         service_end = ?3,
         amount_usd = ?4,
-        plan_type = ?5,
-        note = ?6,
-        updated_at = ?7
-      WHERE id = ?8
+        billing_mode = ?5,
+        plan_type = ?6,
+        note = ?7,
+        updated_at = ?8
+      WHERE id = ?9
       ",
             params![
                 normalized.paid_at,
                 normalized.service_start,
                 normalized.service_end,
                 normalized.amount_usd,
+                normalized.billing_mode,
                 normalized.plan_type,
                 normalized.note,
                 updated_at,
@@ -158,7 +164,7 @@ pub fn delete_subscription_record(conn: &Connection, id: i64) -> Result<bool, St
 fn get_subscription_record(conn: &Connection, id: i64) -> Result<SubscriptionRecord, String> {
     conn.query_row(
         "
-      SELECT id, paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+      SELECT id, paid_at, service_start, service_end, amount_usd, billing_mode, plan_type, note, created_at, updated_at
       FROM subscription_records
       WHERE id = ?1
       ",
@@ -175,10 +181,11 @@ fn subscription_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Sub
         service_start: row.get(2)?,
         service_end: row.get(3)?,
         amount_usd: row.get(4)?,
-        plan_type: row.get(5)?,
-        note: row.get(6)?,
-        created_at: row.get(7)?,
-        updated_at: row.get(8)?,
+        billing_mode: row.get(5)?,
+        plan_type: row.get(6)?,
+        note: row.get(7)?,
+        created_at: row.get(8)?,
+        updated_at: row.get(9)?,
     })
 }
 
@@ -187,6 +194,7 @@ struct NormalizedSubscriptionRecordInput {
     service_start: String,
     service_end: String,
     amount_usd: f64,
+    billing_mode: String,
     plan_type: String,
     note: Option<String>,
 }
@@ -205,8 +213,12 @@ fn normalize_subscription_record_input(
     if !input.amount_usd.is_finite() {
         return Err("amountUsd must be a finite number.".to_string());
     }
+    if input.amount_usd <= 0.0 {
+        return Err("amountUsd must be greater than 0.".to_string());
+    }
 
     let plan_type = input.plan_type.trim();
+    let billing_mode = normalize_billing_mode(&input.billing_mode)?;
     let note = input
         .note
         .as_deref()
@@ -218,7 +230,8 @@ fn normalize_subscription_record_input(
         paid_at,
         service_start,
         service_end,
-        amount_usd: input.amount_usd.max(0.0),
+        amount_usd: input.amount_usd,
+        billing_mode,
         plan_type: if plan_type.is_empty() {
             "unknown".to_string()
         } else {
@@ -230,13 +243,165 @@ fn normalize_subscription_record_input(
 
 fn normalize_date_field(field_name: &str, value: &str) -> Result<String, String> {
     let trimmed = value.trim();
-    parse_date_field(field_name, trimmed)?;
-    Ok(trimmed.to_string())
+    let parsed = parse_date_field(field_name, trimmed)?;
+    Ok(parsed.format("%Y-%m-%d").to_string())
 }
 
 fn parse_date_field(field_name: &str, value: &str) -> Result<NaiveDate, String> {
-    NaiveDate::parse_from_str(value, "%Y-%m-%d")
-        .map_err(|_| format!("{field_name} must use YYYY-MM-DD format."))
+    let parts = value.split('-').collect::<Vec<_>>();
+    if parts.len() != 3 {
+        return Err(format!("{field_name} must use YYYY-MM-DD format."));
+    }
+    if parts[0].len() != 4 || parts[1].is_empty() || parts[2].is_empty() {
+        return Err(format!("{field_name} must use YYYY-MM-DD format."));
+    }
+    let year = parts[0]
+        .parse::<i32>()
+        .map_err(|_| format!("{field_name} must use YYYY-MM-DD format."))?;
+    let month = parts[1]
+        .parse::<u32>()
+        .map_err(|_| format!("{field_name} must use YYYY-MM-DD format."))?;
+    let day = parts[2]
+        .parse::<u32>()
+        .map_err(|_| format!("{field_name} must use YYYY-MM-DD format."))?;
+    NaiveDate::from_ymd_opt(year, month, day)
+        .ok_or_else(|| format!("{field_name} must use YYYY-MM-DD format."))
+}
+
+fn normalize_billing_mode(value: &str) -> Result<String, String> {
+    match value.trim() {
+        BILLING_MODE_ONE_TIME => Ok(BILLING_MODE_ONE_TIME.to_string()),
+        BILLING_MODE_MONTHLY_RECURRING => Ok(BILLING_MODE_MONTHLY_RECURRING.to_string()),
+        _ => Err("billingMode must be one_time or monthly_recurring.".to_string()),
+    }
+}
+
+pub(super) fn ensure_subscription_records_schema(conn: &Connection) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare("PRAGMA table_info(subscription_records)")?;
+    let column_names = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    if !column_names.iter().any(|name| name == "billing_mode") {
+        conn.execute(
+            "
+            ALTER TABLE subscription_records
+            ADD COLUMN billing_mode TEXT NOT NULL DEFAULT 'one_time'
+            ",
+            [],
+        )?;
+    }
+
+    Ok(())
+}
+
+pub(super) fn migrate_subscription_profile_to_subscription_record(
+    conn: &Connection,
+    had_subscription_records_table: bool,
+) -> rusqlite::Result<()> {
+    if had_subscription_records_table {
+        return Ok(());
+    }
+
+    let existing_count = conn.query_row(
+        "SELECT COUNT(*) FROM subscription_records",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    if existing_count > 0 {
+        return Ok(());
+    }
+
+    let profile = conn
+        .query_row(
+            "
+            SELECT plan_type, monthly_price, billing_anchor_day
+            FROM subscription_profile
+            WHERE singleton_id = 1
+            ",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, f64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((plan_type, monthly_price, billing_anchor_day)) = profile else {
+        return Ok(());
+    };
+    if monthly_price <= 0.0 || !monthly_price.is_finite() {
+        return Ok(());
+    }
+
+    let today = Local::now().date_naive();
+    let service_start = billing_cycle_start(today, billing_anchor_day as u32);
+    let service_end = add_months_clamped(service_start, 1);
+    let service_start = service_start.format("%Y-%m-%d").to_string();
+    let service_end = service_end.format("%Y-%m-%d").to_string();
+    let now = now_utc_string();
+
+    conn.execute(
+        "
+        INSERT INTO subscription_records (
+          paid_at, service_start, service_end, amount_usd, billing_mode, plan_type, note, created_at, updated_at
+        )
+        VALUES (?1, ?1, ?2, ?3, ?4, ?5, NULL, ?6, ?6)
+        ",
+        params![
+            service_start,
+            service_end,
+            monthly_price,
+            BILLING_MODE_MONTHLY_RECURRING,
+            if plan_type.trim().is_empty() {
+                "plus"
+            } else {
+                plan_type.trim()
+            },
+            now,
+        ],
+    )?;
+
+    Ok(())
+}
+
+fn billing_cycle_start(anchor_date: NaiveDate, billing_anchor_day: u32) -> NaiveDate {
+    let this_month_anchor = anchored_date(anchor_date.year(), anchor_date.month(), billing_anchor_day);
+    if anchor_date >= this_month_anchor {
+        this_month_anchor
+    } else {
+        add_months_clamped(this_month_anchor, -1)
+    }
+}
+
+fn add_months_clamped(date: NaiveDate, months: i32) -> NaiveDate {
+    if months >= 0 {
+        date.checked_add_months(Months::new(months as u32))
+            .expect("valid positive month offset")
+    } else {
+        date.checked_sub_months(Months::new(months.unsigned_abs()))
+            .expect("valid negative month offset")
+    }
+}
+
+fn anchored_date(year: i32, month: u32, billing_anchor_day: u32) -> NaiveDate {
+    let day = billing_anchor_day
+        .clamp(1, 31)
+        .min(days_in_month(year, month));
+    NaiveDate::from_ymd_opt(year, month, day).expect("valid anchored date")
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    let (next_year, next_month) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+    let first_next_month =
+        NaiveDate::from_ymd_opt(next_year, next_month, 1).expect("valid first day of next month");
+    first_next_month.pred_opt().expect("valid previous day").day()
 }
 
 #[cfg(test)]
@@ -256,6 +421,7 @@ mod tests {
                 service_start: "2026-04-16".to_string(),
                 service_end: "2026-05-16".to_string(),
                 amount_usd: 19.99,
+                billing_mode: "monthly_recurring".to_string(),
                 plan_type: "plus".to_string(),
                 note: Some("user@example.com".to_string()),
             },
@@ -273,6 +439,7 @@ mod tests {
                 service_start: "2026-04-17".to_string(),
                 service_end: "2026-05-17".to_string(),
                 amount_usd: 100.0,
+                billing_mode: "one_time".to_string(),
                 plan_type: "pro_x5".to_string(),
                 note: Some("updated@example.com".to_string()),
             },
@@ -281,11 +448,14 @@ mod tests {
 
         assert_eq!(updated.amount_usd, 100.0);
         assert_eq!(updated.plan_type, "pro_x5");
-        assert_eq!(list_subscription_records(&conn).expect("list records").len(), 1);
+        assert_eq!(list_subscription_records(&conn).expect("list records").len(), 2);
         assert!(delete_subscription_record(&conn, created.id).expect("delete record"));
-        assert!(list_subscription_records(&conn)
-            .expect("list after delete")
-            .is_empty());
+        assert_eq!(
+            list_subscription_records(&conn)
+                .expect("list after delete")
+                .len(),
+            1
+        );
     }
 
     #[test]
@@ -300,6 +470,7 @@ mod tests {
                 service_start: "2026-05-16".to_string(),
                 service_end: "2026-04-16".to_string(),
                 amount_usd: 19.99,
+                billing_mode: "one_time".to_string(),
                 plan_type: "plus".to_string(),
                 note: None,
             },
@@ -307,5 +478,59 @@ mod tests {
         .expect_err("reject invalid date range");
 
         assert!(error.contains("serviceEnd"));
+    }
+
+    #[test]
+    fn subscription_record_canonicalizes_dates_and_rejects_invalid_amounts() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+
+        init_db(&conn).expect("init database");
+        let created = create_subscription_record(
+            &conn,
+            &SubscriptionRecordInput {
+                paid_at: "2026-4-6".to_string(),
+                service_start: "2026-4-6".to_string(),
+                service_end: "2026-5-6".to_string(),
+                amount_usd: 19.99,
+                billing_mode: "monthly_recurring".to_string(),
+                plan_type: "plus".to_string(),
+                note: None,
+            },
+        )
+        .expect("create record");
+
+        assert_eq!(created.paid_at, "2026-04-06");
+        assert_eq!(created.service_start, "2026-04-06");
+        assert_eq!(created.service_end, "2026-05-06");
+        assert_eq!(created.billing_mode, "monthly_recurring");
+
+        let error = create_subscription_record(
+            &conn,
+            &SubscriptionRecordInput {
+                paid_at: "2026-04-06".to_string(),
+                service_start: "2026-04-06".to_string(),
+                service_end: "2026-05-06".to_string(),
+                amount_usd: -1.0,
+                billing_mode: "one_time".to_string(),
+                plan_type: "plus".to_string(),
+                note: None,
+            },
+        )
+        .expect_err("reject negative amount");
+
+        assert!(error.contains("amountUsd"));
+    }
+
+    #[test]
+    fn init_db_migrates_profile_to_monthly_recurring_record() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+
+        init_db(&conn).expect("init database");
+        let records = list_subscription_records(&conn).expect("list records");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].billing_mode, "monthly_recurring");
+        assert_eq!(records[0].amount_usd, 20.0);
+        assert_eq!(records[0].plan_type, "plus");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -219,8 +219,14 @@ async fn loadDashboard(
 fn getConversationDetail(
   state: State<'_, AppState>,
   root_session_id: String,
+  filters: Option<ConversationFilters>,
 ) -> Result<ConversationDetail, String> {
-  get_conversation_detail(&state.db_path, &root_session_id)
+  let live_rate_limits = maybe_live_rate_limits_for_bucket(
+    state.inner(),
+    filters.as_ref().and_then(|value| value.bucket.as_deref()),
+    filters.as_ref().and_then(|value| value.live_window_offset),
+  )?;
+  get_conversation_detail(&state.db_path, &root_session_id, filters, live_rate_limits)
 }
 
 #[allow(non_snake_case)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,15 +16,17 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Duration as ChronoDuration, Local};
 use rusqlite::params;
 use database::{
-  canonical_subscription_currency, get_subscription_profile, get_sync_settings, init_db,
-  insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
+  canonical_subscription_currency, create_subscription_record, delete_subscription_record,
+  get_subscription_profile, get_sync_settings, init_db, insert_live_rate_limit_snapshot,
+  list_subscription_records, open_connection, save_subscription_profile, save_sync_settings,
+  update_subscription_record,
 };
 use importer::{perform_scan, recalculate_all_session_values};
 use models::{
   ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
-  ScanResult, SubscriptionProfile, SyncSettings,
+  ScanResult, SubscriptionProfile, SubscriptionRecord, SubscriptionRecordInput, SyncSettings,
 };
 use pricing::{load_catalog, refresh_pricing_catalog_from_openai, seed_pricing_catalog};
 use queries::{get_conversation_detail, get_overview, get_quota_trend, list_conversations, load_dashboard_data};
@@ -204,6 +206,7 @@ async fn loadDashboard(
       conversations: snapshot.conversations,
       sync_settings,
       subscription_profile: snapshot.subscription_profile,
+      subscription_records: snapshot.subscription_records,
       live_rate_limits,
     })
   })
@@ -324,6 +327,41 @@ fn updateSubscriptionProfile(
     updated_at: payload.updated_at,
   };
   save_subscription_profile(&conn, &updated).map_err(|error| error.to_string())
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+fn listSubscriptionRecords(state: State<'_, AppState>) -> Result<Vec<SubscriptionRecord>, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  list_subscription_records(&conn).map_err(|error| error.to_string())
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn createSubscriptionRecord(
+  state: State<'_, AppState>,
+  payload: SubscriptionRecordInput,
+) -> Result<SubscriptionRecord, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  create_subscription_record(&conn, &payload)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn updateSubscriptionRecord(
+  state: State<'_, AppState>,
+  id: i64,
+  payload: SubscriptionRecordInput,
+) -> Result<SubscriptionRecord, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  update_subscription_record(&conn, id, &payload)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn deleteSubscriptionRecord(state: State<'_, AppState>, id: i64) -> Result<bool, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  delete_subscription_record(&conn, id)
 }
 
 fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
@@ -1669,6 +1707,10 @@ pub fn run() {
       updateSyncSettings,
       getSubscriptionProfile,
       updateSubscriptionProfile,
+      listSubscriptionRecords,
+      createSubscriptionRecord,
+      updateSubscriptionRecord,
+      deleteSubscriptionRecord,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -162,6 +162,7 @@ pub struct SubscriptionRecord {
   pub service_start: String,
   pub service_end: String,
   pub amount_usd: f64,
+  pub billing_mode: String,
   pub plan_type: String,
   pub note: Option<String>,
   pub created_at: String,
@@ -175,8 +176,14 @@ pub struct SubscriptionRecordInput {
   pub service_start: String,
   pub service_end: String,
   pub amount_usd: f64,
+  #[serde(default = "default_subscription_billing_mode")]
+  pub billing_mode: String,
   pub plan_type: String,
   pub note: Option<String>,
+}
+
+fn default_subscription_billing_mode() -> String {
+  "one_time".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -154,6 +154,31 @@ impl Default for SubscriptionProfile {
   }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionRecord {
+  pub id: i64,
+  pub paid_at: String,
+  pub service_start: String,
+  pub service_end: String,
+  pub amount_usd: f64,
+  pub plan_type: String,
+  pub note: Option<String>,
+  pub created_at: String,
+  pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionRecordInput {
+  pub paid_at: String,
+  pub service_start: String,
+  pub service_end: String,
+  pub amount_usd: f64,
+  pub plan_type: String,
+  pub note: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ConversationFilters {
@@ -323,6 +348,7 @@ pub struct DashboardSnapshot {
   pub conversations: Vec<ConversationListItem>,
   pub sync_settings: SyncSettings,
   pub subscription_profile: SubscriptionProfile,
+  pub subscription_records: Vec<SubscriptionRecord>,
   pub live_rate_limits: Option<LiveRateLimitSnapshot>,
 }
 

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -10,12 +10,12 @@ use chrono::{
 use rusqlite::Connection;
 use serde_json::Value;
 
-use crate::database::{get_subscription_profile, open_connection};
+use crate::database::{get_subscription_profile, list_subscription_records, open_connection};
 use crate::models::{
   CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem,
   ConversationSessionSummary, ConversationTurnPoint, LiveRateLimitSnapshot, ModelShare,
-  OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SubscriptionProfile, TokenUsage,
-  TrendPoint,
+  OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SubscriptionProfile,
+  SubscriptionRecord, TokenUsage, TrendPoint,
 };
 use crate::pricing::{
   calculate_value_usd, display_name_for_model, load_catalog_map, model_color, normalize_model_id,
@@ -97,6 +97,7 @@ pub struct DashboardData {
   pub overview: OverviewResponse,
   pub conversations: Vec<ConversationListItem>,
   pub subscription_profile: SubscriptionProfile,
+  pub subscription_records: Vec<SubscriptionRecord>,
 }
 
 pub fn get_overview(
@@ -112,12 +113,14 @@ pub fn get_overview(
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
   build_overview(
     &conn,
     &sessions,
     &events,
     &profile,
+    &subscription_records,
     &catalog,
     bucket,
     anchor,
@@ -171,7 +174,16 @@ pub fn list_conversations(
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
-  build_conversation_list(&conn, &sessions, &events, &profile, filters, live_rate_limits.as_ref())
+  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
+  build_conversation_list(
+    &conn,
+    &sessions,
+    &events,
+    &profile,
+    &subscription_records,
+    filters,
+    live_rate_limits.as_ref(),
+  )
 }
 
 pub fn load_dashboard_data(
@@ -188,6 +200,7 @@ pub fn load_dashboard_data(
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
 
   let overview = build_overview(
@@ -195,6 +208,7 @@ pub fn load_dashboard_data(
     &sessions,
     &events,
     &profile,
+    &subscription_records,
     &catalog,
     bucket.clone(),
     anchor.clone(),
@@ -208,6 +222,7 @@ pub fn load_dashboard_data(
     &sessions,
     &events,
     &profile,
+    &subscription_records,
     Some(ConversationFilters {
       bucket,
       anchor,
@@ -223,6 +238,7 @@ pub fn load_dashboard_data(
     overview,
     conversations,
     subscription_profile: profile,
+    subscription_records,
   })
 }
 
@@ -231,6 +247,7 @@ fn build_overview(
   sessions: &HashMap<String, SessionRow>,
   events: &[EventRow],
   profile: &SubscriptionProfile,
+  subscription_records: &[SubscriptionRecord],
   catalog: &HashMap<String, PricingCatalogEntry>,
   bucket: Option<String>,
   anchor: Option<String>,
@@ -274,8 +291,7 @@ fn build_overview(
     }
   }
 
-  let subscription_cost_usd =
-    subscription_cost_for_window(window, profile.monthly_price, profile.billing_anchor_day as u32);
+  let subscription_cost_usd = subscription_cost_for_overview(window, subscription_records);
   let payoff_ratio = if subscription_cost_usd > 0.0 {
     total_value_usd / subscription_cost_usd
   } else {
@@ -325,6 +341,7 @@ fn build_conversation_list(
   sessions: &HashMap<String, SessionRow>,
   events: &[EventRow],
   profile: &SubscriptionProfile,
+  subscription_records: &[SubscriptionRecord],
   filters: Option<ConversationFilters>,
   live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<Vec<ConversationListItem>, String> {
@@ -341,6 +358,7 @@ fn build_conversation_list(
     filters.live_window_offset,
   )?
   .window;
+  let subscription_cost_usd = subscription_cost_for_window(&window, subscription_records);
   let search = filters.search.unwrap_or_default().to_ascii_lowercase();
 
   let mut groups: BTreeMap<String, ConversationAccumulator> = BTreeMap::new();
@@ -431,8 +449,8 @@ fn build_conversation_list(
       subagent_count: group.session_ids.len().saturating_sub(1),
       has_fast_mode: !group.fast_session_ids.is_empty(),
       api_value_usd: group.api_value_usd,
-      subscription_share: if profile.monthly_price > 0.0 {
-        group.api_value_usd / profile.monthly_price
+      subscription_share: if subscription_cost_usd > 0.0 {
+        group.api_value_usd / subscription_cost_usd
       } else {
         0.0
       },
@@ -454,7 +472,7 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let sessions = load_sessions_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
   let events = load_events_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
-  let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
 
   let mut conversation_sessions = sessions.values().cloned().collect::<Vec<_>>();
@@ -598,6 +616,11 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
   if title.trim().is_empty() {
     title = root_session_id.to_string();
   }
+  let subscription_cost_usd = subscription_records
+    .iter()
+    .filter(|record| record.amount_usd > 0.0 && record.amount_usd.is_finite())
+    .map(|record| record.amount_usd)
+    .sum::<f64>();
 
   Ok(ConversationDetail {
     root_session_id: root_session_id.to_string(),
@@ -610,8 +633,8 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     reasoning_output_tokens: total_reasoning,
     total_tokens,
     api_value_usd: total_value_usd,
-    subscription_share: if profile.monthly_price > 0.0 {
-      total_value_usd / profile.monthly_price
+    subscription_share: if subscription_cost_usd > 0.0 {
+      total_value_usd / subscription_cost_usd
     } else {
       0.0
     },
@@ -1541,28 +1564,55 @@ fn custom_window_uses_monthly_bins(window: &Window) -> bool {
   window.end.signed_duration_since(window.start) > chrono::Duration::days(62)
 }
 
-fn subscription_cost_for_window(window: &Window, monthly_price: f64, billing_anchor_day: u32) -> f64 {
-  if window.bucket == "subscription_month" {
-    return monthly_price;
+fn subscription_cost_for_window(window: &Window, records: &[SubscriptionRecord]) -> f64 {
+  records
+    .iter()
+    .filter_map(|record| subscription_record_cost_for_window(record, window))
+    .sum()
+}
+
+fn subscription_cost_for_overview(window: &Window, records: &[SubscriptionRecord]) -> f64 {
+  if window.bucket == "total" {
+    return records
+      .iter()
+      .filter(|record| record.amount_usd > 0.0 && record.amount_usd.is_finite())
+      .map(|record| record.amount_usd)
+      .sum();
   }
 
-  let mut total = 0.0;
-  let mut cycle_start = billing_cycle_start(window.start.date_naive(), billing_anchor_day);
-  loop {
-    let cycle_end = billing_cycle_next_start(cycle_start, billing_anchor_day);
-    let overlap_start = window.start.date_naive().max(cycle_start);
-    let overlap_end = window.end.date_naive().min(cycle_end);
-    if overlap_start < overlap_end {
-      let cycle_days = (cycle_end - cycle_start).num_days().max(1) as f64;
-      let overlap_days = (overlap_end - overlap_start).num_days().max(0) as f64;
-      total += monthly_price * (overlap_days / cycle_days);
-    }
-    if cycle_end >= window.end.date_naive() {
-      break;
-    }
-    cycle_start = cycle_end;
+  subscription_cost_for_window(window, records)
+}
+
+fn subscription_record_cost_for_window(
+  record: &SubscriptionRecord,
+  window: &Window,
+) -> Option<f64> {
+  if record.amount_usd <= 0.0 || !record.amount_usd.is_finite() {
+    return None;
   }
-  total
+  let service_start = parse_date(&record.service_start)
+    .ok()
+    .and_then(|date| local_midnight(date).ok())?;
+  let service_end = parse_date(&record.service_end)
+    .ok()
+    .and_then(|date| local_midnight(date).ok())?;
+  if service_end <= service_start {
+    return None;
+  }
+  let overlap_start = window.start.max(service_start);
+  let overlap_end = window.end.min(service_end);
+  if overlap_end <= overlap_start {
+    return None;
+  }
+  let service_seconds = service_end
+    .signed_duration_since(service_start)
+    .num_seconds()
+    .max(1) as f64;
+  let overlap_seconds = overlap_end
+    .signed_duration_since(overlap_start)
+    .num_seconds()
+    .max(0) as f64;
+  Some(record.amount_usd * (overlap_seconds / service_seconds))
 }
 
 fn selected_rate_limit_window<'a>(
@@ -1837,6 +1887,12 @@ mod tests {
   use super::*;
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
+
+  fn local_time(value: &str) -> DateTime<Local> {
+    DateTime::parse_from_rfc3339(value)
+      .expect("parse local test timestamp")
+      .with_timezone(&Local)
+  }
 
   #[test]
   fn groups_modern_snapshots_into_one_turn() {
@@ -2190,6 +2246,96 @@ mod tests {
     .expect_err("custom end before start should fail");
 
     assert!(error.contains("Custom range end date cannot be before start date"));
+  }
+
+  #[test]
+  fn subscription_cost_uses_service_period_proration() {
+    let window = Window {
+      bucket: "month".to_string(),
+      anchor: "2026-04-01".to_string(),
+      start: local_time("2026-04-01T00:00:00+08:00"),
+      end: local_time("2026-05-01T00:00:00+08:00"),
+    };
+    let records = vec![
+      SubscriptionRecord {
+        id: 1,
+        paid_at: "2026-04-16".to_string(),
+        service_start: "2026-04-16".to_string(),
+        service_end: "2026-05-16".to_string(),
+        amount_usd: 20.0,
+        plan_type: "plus".to_string(),
+        note: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+      },
+      SubscriptionRecord {
+        id: 2,
+        paid_at: "2026-04-01".to_string(),
+        service_start: "2026-04-01".to_string(),
+        service_end: "2026-05-01".to_string(),
+        amount_usd: 200.0,
+        plan_type: "pro".to_string(),
+        note: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+      },
+    ];
+
+    let cost = subscription_cost_for_window(&window, &records);
+
+    assert!((cost - 210.0).abs() < 0.001);
+  }
+
+  #[test]
+  fn total_overview_subscription_cost_sums_full_records() {
+    let window = Window {
+      bucket: "total".to_string(),
+      anchor: "2026-03-19".to_string(),
+      start: local_time("2026-03-19T00:00:00+08:00"),
+      end: local_time("2026-05-01T00:00:00+08:00"),
+    };
+    let records = vec![
+      SubscriptionRecord {
+        id: 1,
+        paid_at: "2026-03-19".to_string(),
+        service_start: "2026-03-19".to_string(),
+        service_end: "2026-04-19".to_string(),
+        amount_usd: 19.99,
+        plan_type: "plus".to_string(),
+        note: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+      },
+      SubscriptionRecord {
+        id: 2,
+        paid_at: "2026-04-25".to_string(),
+        service_start: "2026-04-25".to_string(),
+        service_end: "2026-05-25".to_string(),
+        amount_usd: 100.0,
+        plan_type: "pro_x5".to_string(),
+        note: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+      },
+    ];
+
+    let prorated_cost = subscription_cost_for_window(&window, &records);
+    let total_cost = subscription_cost_for_overview(&window, &records);
+
+    assert!(prorated_cost < 119.99);
+    assert!((total_cost - 119.99).abs() < 0.001);
+  }
+
+  #[test]
+  fn subscription_cost_is_zero_without_records() {
+    let window = Window {
+      bucket: "day".to_string(),
+      anchor: "2026-04-16".to_string(),
+      start: local_time("2026-04-16T00:00:00+08:00"),
+      end: local_time("2026-04-17T00:00:00+08:00"),
+    };
+
+    assert_eq!(subscription_cost_for_window(&window, &[]), 0.0);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -358,7 +358,7 @@ fn build_conversation_list(
     filters.live_window_offset,
   )?
   .window;
-  let subscription_cost_usd = subscription_cost_for_window(&window, subscription_records);
+  let subscription_cost_usd = subscription_cost_for_overview(&window, subscription_records);
   let search = filters.search.unwrap_or_default().to_ascii_lowercase();
 
   let mut groups: BTreeMap<String, ConversationAccumulator> = BTreeMap::new();
@@ -468,12 +468,35 @@ fn build_conversation_list(
   Ok(items)
 }
 
-pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<ConversationDetail, String> {
+pub fn get_conversation_detail(
+  db_path: &Path,
+  root_session_id: &str,
+  filters: Option<ConversationFilters>,
+  live_rate_limits: Option<LiveRateLimitSnapshot>,
+) -> Result<ConversationDetail, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let sessions = load_sessions_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
   let events = load_events_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
+  let all_events = load_events(&conn).map_err(|error| error.to_string())?;
+  let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
+  let active_window = filters
+    .map(|filters| {
+      resolve_window(
+        &conn,
+        filters.bucket,
+        filters.anchor,
+        filters.custom_start,
+        filters.custom_end,
+        &all_events,
+        profile.billing_anchor_day,
+        live_rate_limits.as_ref(),
+        filters.live_window_offset,
+      )
+      .map(|resolved| resolved.window)
+    })
+    .transpose()?;
 
   let mut conversation_sessions = sessions.values().cloned().collect::<Vec<_>>();
 
@@ -531,6 +554,13 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
 
   for event in &events {
     if !sessions.contains_key(&event.session_id) {
+      continue;
+    }
+    if active_window
+      .as_ref()
+      .map(|window| !event_in_window(event, window))
+      .unwrap_or(false)
+    {
       continue;
     }
 
@@ -616,11 +646,10 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
   if title.trim().is_empty() {
     title = root_session_id.to_string();
   }
-  let subscription_cost_usd = subscription_records
-    .iter()
-    .filter(|record| record.amount_usd > 0.0 && record.amount_usd.is_finite())
-    .map(|record| record.amount_usd)
-    .sum::<f64>();
+  let subscription_cost_usd = active_window
+    .as_ref()
+    .map(|window| subscription_cost_for_overview(window, &subscription_records))
+    .unwrap_or_else(|| subscription_cost_for_detail_events(&conversation_events, &subscription_records));
 
   Ok(ConversationDetail {
     root_session_id: root_session_id.to_string(),
@@ -1567,7 +1596,7 @@ fn custom_window_uses_monthly_bins(window: &Window) -> bool {
 fn subscription_cost_for_window(window: &Window, records: &[SubscriptionRecord]) -> f64 {
   records
     .iter()
-    .filter_map(|record| subscription_record_cost_for_window(record, window))
+    .map(|record| subscription_record_cost_for_window(record, window))
     .sum()
 }
 
@@ -1575,34 +1604,117 @@ fn subscription_cost_for_overview(window: &Window, records: &[SubscriptionRecord
   if window.bucket == "total" {
     return records
       .iter()
-      .filter(|record| record.amount_usd > 0.0 && record.amount_usd.is_finite())
-      .map(|record| record.amount_usd)
+      .map(|record| subscription_record_total_cost_for_window(record, window))
       .sum();
   }
 
   subscription_cost_for_window(window, records)
 }
 
-fn subscription_record_cost_for_window(
+fn subscription_cost_for_detail_events(events: &[EventRow], records: &[SubscriptionRecord]) -> f64 {
+  let Some(first) = events
+    .iter()
+    .filter_map(|event| parse_rfc3339_local(&event.timestamp))
+    .min()
+  else {
+    return 0.0;
+  };
+  let Some(last) = events
+    .iter()
+    .filter_map(|event| parse_rfc3339_local(&event.timestamp))
+    .max()
+  else {
+    return 0.0;
+  };
+  let start_date = first.date_naive();
+  let end_date = last
+    .date_naive()
+    .checked_add_days(Days::new(1))
+    .unwrap_or(last.date_naive());
+  let (Ok(start), Ok(end)) = (local_midnight(start_date), local_midnight(end_date)) else {
+    return 0.0;
+  };
+  let window = Window {
+    bucket: "total".to_string(),
+    anchor: start_date.format("%Y-%m-%d").to_string(),
+    start,
+    end,
+  };
+  subscription_cost_for_overview(&window, records)
+}
+
+fn subscription_record_cost_for_window(record: &SubscriptionRecord, window: &Window) -> f64 {
+  subscription_record_cycles(record, window)
+    .into_iter()
+    .map(|(service_start, service_end)| prorated_subscription_cost(record.amount_usd, service_start, service_end, window))
+    .sum()
+}
+
+fn subscription_record_total_cost_for_window(record: &SubscriptionRecord, window: &Window) -> f64 {
+  subscription_record_cycles(record, window)
+    .into_iter()
+    .filter(|(service_start, service_end)| service_end > &window.start && service_start < &window.end)
+    .map(|_| record.amount_usd)
+    .sum()
+}
+
+fn subscription_record_cycles(
   record: &SubscriptionRecord,
   window: &Window,
-) -> Option<f64> {
+) -> Vec<(DateTime<Local>, DateTime<Local>)> {
   if record.amount_usd <= 0.0 || !record.amount_usd.is_finite() {
-    return None;
+    return Vec::new();
   }
   let service_start = parse_date(&record.service_start)
     .ok()
-    .and_then(|date| local_midnight(date).ok())?;
+    .and_then(|date| local_midnight(date).ok());
   let service_end = parse_date(&record.service_end)
     .ok()
-    .and_then(|date| local_midnight(date).ok())?;
+    .and_then(|date| local_midnight(date).ok());
+  let (Some(service_start), Some(service_end)) = (service_start, service_end) else {
+    return Vec::new();
+  };
   if service_end <= service_start {
-    return None;
+    return Vec::new();
   }
+  if record.billing_mode != "monthly_recurring" {
+    return vec![(service_start, service_end)];
+  }
+
+  let mut cycles = Vec::new();
+  let mut cycle_start_date = service_start.date_naive();
+  let mut cycle_end_date = service_end.date_naive();
+
+  while let (Ok(cycle_start), Ok(cycle_end)) = (
+    local_midnight(cycle_start_date),
+    local_midnight(cycle_end_date),
+  ) {
+    if cycle_end > window.start && cycle_start < window.end {
+      cycles.push((cycle_start, cycle_end));
+    }
+    if cycle_start >= window.end {
+      break;
+    }
+    cycle_start_date = add_months(cycle_start_date, 1);
+    cycle_end_date = add_months(cycle_end_date, 1);
+    if cycle_end_date <= cycle_start_date {
+      break;
+    }
+  }
+
+  cycles
+}
+
+fn prorated_subscription_cost(
+  amount_usd: f64,
+  service_start: DateTime<Local>,
+  service_end: DateTime<Local>,
+  window: &Window,
+) -> f64 {
   let overlap_start = window.start.max(service_start);
   let overlap_end = window.end.min(service_end);
   if overlap_end <= overlap_start {
-    return None;
+    return 0.0;
   }
   let service_seconds = service_end
     .signed_duration_since(service_start)
@@ -1612,7 +1724,7 @@ fn subscription_record_cost_for_window(
     .signed_duration_since(overlap_start)
     .num_seconds()
     .max(0) as f64;
-  Some(record.amount_usd * (overlap_seconds / service_seconds))
+  amount_usd * (overlap_seconds / service_seconds)
 }
 
 fn selected_rate_limit_window<'a>(
@@ -1885,13 +1997,35 @@ impl SourceTurnAccumulator {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::database::{init_db, insert_live_rate_limit_snapshot};
+  use crate::database::{create_subscription_record, init_db, insert_live_rate_limit_snapshot};
+  use crate::models::SubscriptionRecordInput;
   use tempfile::tempdir;
 
   fn local_time(value: &str) -> DateTime<Local> {
     DateTime::parse_from_rfc3339(value)
       .expect("parse local test timestamp")
       .with_timezone(&Local)
+  }
+
+  fn subscription_record(
+    id: i64,
+    service_start: &str,
+    service_end: &str,
+    amount_usd: f64,
+    billing_mode: &str,
+  ) -> SubscriptionRecord {
+    SubscriptionRecord {
+      id,
+      paid_at: service_start.to_string(),
+      service_start: service_start.to_string(),
+      service_end: service_end.to_string(),
+      amount_usd,
+      billing_mode: billing_mode.to_string(),
+      plan_type: "plus".to_string(),
+      note: None,
+      created_at: String::new(),
+      updated_at: String::new(),
+    }
   }
 
   #[test]
@@ -2257,28 +2391,8 @@ mod tests {
       end: local_time("2026-05-01T00:00:00+08:00"),
     };
     let records = vec![
-      SubscriptionRecord {
-        id: 1,
-        paid_at: "2026-04-16".to_string(),
-        service_start: "2026-04-16".to_string(),
-        service_end: "2026-05-16".to_string(),
-        amount_usd: 20.0,
-        plan_type: "plus".to_string(),
-        note: None,
-        created_at: String::new(),
-        updated_at: String::new(),
-      },
-      SubscriptionRecord {
-        id: 2,
-        paid_at: "2026-04-01".to_string(),
-        service_start: "2026-04-01".to_string(),
-        service_end: "2026-05-01".to_string(),
-        amount_usd: 200.0,
-        plan_type: "pro".to_string(),
-        note: None,
-        created_at: String::new(),
-        updated_at: String::new(),
-      },
+      subscription_record(1, "2026-04-16", "2026-05-16", 20.0, "one_time"),
+      subscription_record(2, "2026-04-01", "2026-05-01", 200.0, "one_time"),
     ];
 
     let cost = subscription_cost_for_window(&window, &records);
@@ -2295,28 +2409,8 @@ mod tests {
       end: local_time("2026-05-01T00:00:00+08:00"),
     };
     let records = vec![
-      SubscriptionRecord {
-        id: 1,
-        paid_at: "2026-03-19".to_string(),
-        service_start: "2026-03-19".to_string(),
-        service_end: "2026-04-19".to_string(),
-        amount_usd: 19.99,
-        plan_type: "plus".to_string(),
-        note: None,
-        created_at: String::new(),
-        updated_at: String::new(),
-      },
-      SubscriptionRecord {
-        id: 2,
-        paid_at: "2026-04-25".to_string(),
-        service_start: "2026-04-25".to_string(),
-        service_end: "2026-05-25".to_string(),
-        amount_usd: 100.0,
-        plan_type: "pro_x5".to_string(),
-        note: None,
-        created_at: String::new(),
-        updated_at: String::new(),
-      },
+      subscription_record(1, "2026-03-19", "2026-04-19", 19.99, "one_time"),
+      subscription_record(2, "2026-04-25", "2026-05-25", 100.0, "one_time"),
     ];
 
     let prorated_cost = subscription_cost_for_window(&window, &records);
@@ -2324,6 +2418,182 @@ mod tests {
 
     assert!(prorated_cost < 119.99);
     assert!((total_cost - 119.99).abs() < 0.001);
+  }
+
+  #[test]
+  fn recurring_subscription_cost_expands_monthly_periods() {
+    let window = Window {
+      bucket: "month".to_string(),
+      anchor: "2026-05-01".to_string(),
+      start: local_time("2026-05-01T00:00:00+08:00"),
+      end: local_time("2026-06-01T00:00:00+08:00"),
+    };
+    let records = vec![subscription_record(
+      1,
+      "2026-04-01",
+      "2026-05-01",
+      31.0,
+      "monthly_recurring",
+    )];
+
+    let cost = subscription_cost_for_window(&window, &records);
+
+    assert!((cost - 31.0).abs() < 0.001);
+  }
+
+  #[test]
+  fn total_list_and_overview_use_same_subscription_denominator() {
+    let conn = Connection::open_in_memory().expect("open in-memory database");
+    init_db(&conn).expect("init db");
+    let mut sessions = HashMap::new();
+    sessions.insert(
+      "session-1".to_string(),
+      SessionRow {
+        session_id: "session-1".to_string(),
+        root_session_id: "session-1".to_string(),
+        parent_session_id: None,
+        title: "Total check".to_string(),
+        source_state: "active".to_string(),
+        source_path: None,
+        started_at: Some("2026-04-20T09:00:00+08:00".to_string()),
+        updated_at: Some("2026-04-20T09:30:00+08:00".to_string()),
+        agent_nickname: None,
+        agent_role: None,
+      },
+    );
+    let events = vec![EventRow {
+      session_id: "session-1".to_string(),
+      timestamp: "2026-04-20T09:15:00+08:00".to_string(),
+      model_id: "gpt-5.4".to_string(),
+      input_tokens: 10,
+      cached_input_tokens: 0,
+      output_tokens: 10,
+      reasoning_output_tokens: 0,
+      total_tokens: 20,
+      value_usd: 10.0,
+      fast_mode_auto: false,
+      fast_mode_effective: false,
+    }];
+    let profile = SubscriptionProfile::default();
+    let records = vec![subscription_record(
+      1,
+      "2026-04-01",
+      "2026-05-01",
+      100.0,
+      "one_time",
+    )];
+
+    let overview = build_overview(
+      &conn,
+      &sessions,
+      &events,
+      &profile,
+      &records,
+      &HashMap::new(),
+      Some("total".to_string()),
+      None,
+      None,
+      None,
+      None,
+      None,
+    )
+    .expect("build overview");
+    let conversations = build_conversation_list(
+      &conn,
+      &sessions,
+      &events,
+      &profile,
+      &records,
+      Some(ConversationFilters {
+        bucket: Some("total".to_string()),
+        ..ConversationFilters::default()
+      }),
+      None,
+    )
+    .expect("build conversations");
+
+    assert!((overview.stats.payoff_ratio - 0.1).abs() < 0.001);
+    assert!((conversations[0].subscription_share - overview.stats.payoff_ratio).abs() < 0.001);
+  }
+
+  #[test]
+  fn conversation_detail_uses_active_window_subscription_denominator() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("detail-window.sqlite");
+    let conn = Connection::open(&db_path).expect("open test database");
+    init_db(&conn).expect("init db");
+    conn
+      .execute("DELETE FROM subscription_records", [])
+      .expect("clear migrated record");
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, title, source_state, started_at, updated_at, created_at, imported_at
+        )
+        VALUES (?1, ?1, ?2, 'active', ?3, ?4, ?3, ?4)
+        ",
+        rusqlite::params![
+          "session-1",
+          "Detail window check",
+          "2026-04-20T09:00:00+08:00",
+          "2026-04-20T09:30:00+08:00",
+        ],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
+          reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective
+        )
+        VALUES (?1, ?2, ?3, 10, 0, 10, 0, 20, 10.0, 0, 0)
+        ",
+        rusqlite::params!["session-1", "2026-04-20T09:15:00+08:00", "gpt-5.4"],
+      )
+      .expect("insert usage event");
+    create_subscription_record(
+      &conn,
+      &SubscriptionRecordInput {
+        paid_at: "2026-04-01".to_string(),
+        service_start: "2026-04-01".to_string(),
+        service_end: "2026-05-01".to_string(),
+        amount_usd: 100.0,
+        billing_mode: "one_time".to_string(),
+        plan_type: "plus".to_string(),
+        note: None,
+      },
+    )
+    .expect("create current subscription record");
+    create_subscription_record(
+      &conn,
+      &SubscriptionRecordInput {
+        paid_at: "2026-05-01".to_string(),
+        service_start: "2026-05-01".to_string(),
+        service_end: "2026-06-01".to_string(),
+        amount_usd: 900.0,
+        billing_mode: "one_time".to_string(),
+        plan_type: "pro_x10".to_string(),
+        note: None,
+      },
+    )
+    .expect("create future subscription record");
+    drop(conn);
+
+    let detail = get_conversation_detail(
+      &db_path,
+      "session-1",
+      Some(ConversationFilters {
+        bucket: Some("month".to_string()),
+        anchor: Some("2026-04-20".to_string()),
+        ..ConversationFilters::default()
+      }),
+      None,
+    )
+    .expect("load detail");
+
+    assert!((detail.subscription_share - 0.1).abs() < 0.001);
   }
 
   #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import type {
   AppView,
   CompositionShare,
   ConversationDetail,
+  ConversationFilters,
   ConversationListItem,
   ConversationSessionSummary,
   ConversationTurnPoint,
@@ -177,9 +178,14 @@ function App() {
       startTransition(() => {
         const nextDetailCache = new Map<string, ConversationDetail>()
         for (const conversation of snapshot.conversations) {
-          const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
+          const cachedDetail = detailCacheRef.current.get(
+            buildDetailCacheKey(conversation.rootSessionId, lastRequestedQueryKeyRef.current),
+          )
           if (cachedDetail && cachedDetail.updatedAt === conversation.updatedAt) {
-            nextDetailCache.set(conversation.rootSessionId, cachedDetail)
+            nextDetailCache.set(
+              buildDetailCacheKey(conversation.rootSessionId, lastRequestedQueryKeyRef.current),
+              cachedDetail,
+            )
           }
         }
 
@@ -276,37 +282,49 @@ function App() {
     void emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_LANGUAGE_EVENT, { language }).catch(() => {})
   }, [language])
 
-  const loadDetail = useCallback(async (rootSessionId: string | null) => {
-    const requestId = latestDetailRequestIdRef.current + 1
-    latestDetailRequestIdRef.current = requestId
-    if (!rootSessionId) {
+  const loadDetail = useCallback(
+    async (rootSessionId: string | null) => {
+      const requestId = latestDetailRequestIdRef.current + 1
+      latestDetailRequestIdRef.current = requestId
+      if (!rootSessionId) {
+        setDetail(null)
+        return
+      }
+
+      const filters = buildConversationFilters(
+        bucket,
+        anchor,
+        customStart,
+        customEnd,
+        deferredSearch || null,
+        liveWindowOffset,
+      )
+      const cacheKey = buildDetailCacheKey(rootSessionId, currentQueryKey)
+      const cachedDetail = detailCacheRef.current.get(cacheKey)
+      if (cachedDetail) {
+        setDetail(cachedDetail)
+        return
+      }
+
       setDetail(null)
-      return
-    }
-
-    const cachedDetail = detailCacheRef.current.get(rootSessionId)
-    if (cachedDetail) {
-      setDetail(cachedDetail)
-      return
-    }
-
-    setDetail(null)
-    try {
-      const nextDetail = await getConversationDetail(rootSessionId)
-      if (requestId !== latestDetailRequestIdRef.current) {
-        return
+      try {
+        const nextDetail = await getConversationDetail(rootSessionId, filters)
+        if (requestId !== latestDetailRequestIdRef.current) {
+          return
+        }
+        detailCacheRef.current.set(cacheKey, nextDetail)
+        startTransition(() => {
+          setDetail(nextDetail)
+        })
+      } catch (error) {
+        if (requestId !== latestDetailRequestIdRef.current) {
+          return
+        }
+        setStatusMessage(String(error))
       }
-      detailCacheRef.current.set(rootSessionId, nextDetail)
-      startTransition(() => {
-        setDetail(nextDetail)
-      })
-    } catch (error) {
-      if (requestId !== latestDetailRequestIdRef.current) {
-        return
-      }
-      setStatusMessage(String(error))
-    }
-  }, [])
+    },
+    [anchor, bucket, currentQueryKey, customEnd, customStart, deferredSearch, liveWindowOffset],
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -413,6 +431,9 @@ function App() {
     const nextRecords = await listSubscriptionRecords()
     setSubscriptionRecords(nextRecords)
     await loadShell(false)
+    if (isTauri()) {
+      await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
+    }
     setStatusMessage(t.status.subscriptionRecordSaved)
   }
 
@@ -421,6 +442,9 @@ function App() {
     const nextRecords = await listSubscriptionRecords()
     setSubscriptionRecords(nextRecords)
     await loadShell(false)
+    if (isTauri()) {
+      await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
+    }
     setStatusMessage(t.status.subscriptionRecordDeleted)
   }
 
@@ -990,6 +1014,24 @@ function bucketUsesAnchor(bucket: OverviewBucket) {
   return !['five_hour', 'seven_day', 'custom', 'total'].includes(bucket)
 }
 
+function buildConversationFilters(
+  bucket: OverviewBucket,
+  anchor: string,
+  customStart: string,
+  customEnd: string,
+  search: string | null,
+  liveWindowOffset: number,
+): ConversationFilters {
+  return {
+    bucket,
+    anchor: bucketUsesAnchor(bucket) ? anchor : null,
+    customStart: bucket === 'custom' ? customStart : null,
+    customEnd: bucket === 'custom' ? customEnd : null,
+    search,
+    liveWindowOffset: bucket === 'five_hour' || bucket === 'seven_day' ? liveWindowOffset : 0,
+  }
+}
+
 function buildQueryKey(
   bucket: OverviewBucket,
   anchor: string | null,
@@ -999,6 +1041,10 @@ function buildQueryKey(
   liveWindowOffset: number,
 ) {
   return [bucket, anchor ?? '', customStart ?? '', customEnd ?? '', search ?? '', String(liveWindowOffset)].join('::')
+}
+
+function buildDetailCacheKey(rootSessionId: string, queryKey: string | null) {
+  return `${queryKey ?? 'unloaded'}::${rootSessionId}`
 }
 
 function formatCustomRangeLabel(windowStart: string | null, windowEnd: string | null, language: 'zh-CN' | 'en') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,12 +13,16 @@ import {
 } from 'lucide-react'
 
 import {
+  createSubscriptionRecord,
+  deleteSubscriptionRecord,
   getScanInProgress,
   getConversationDetail,
   getLiveRateLimits,
+  listSubscriptionRecords,
   loadDashboard,
   refreshPricing,
   scanCodexUsage,
+  updateSubscriptionRecord,
   updateSubscriptionProfile,
   updateSyncSettings,
 } from './app/api'
@@ -49,6 +53,8 @@ import type {
   ShareMode,
   ShareSlice,
   SubscriptionProfile,
+  SubscriptionRecord,
+  SubscriptionRecordInput,
   SyncSettings,
 } from './app/types'
 import { ModelShareChart } from './components/ModelShareChart'
@@ -89,6 +95,7 @@ function App() {
   const [detail, setDetail] = useState<ConversationDetail | null>(null)
   const [syncSettings, setSyncSettings] = useState<SyncSettings | null>(null)
   const [subscriptionProfile, setSubscriptionProfile] = useState<SubscriptionProfile | null>(null)
+  const [subscriptionRecords, setSubscriptionRecords] = useState<SubscriptionRecord[]>([])
   const [liveRateLimits, setLiveRateLimits] = useState<LiveRateLimitSnapshot | null>(null)
   const [loadedQueryKey, setLoadedQueryKey] = useState<string | null>(null)
   const [dashboardRevision, setDashboardRevision] = useState(0)
@@ -180,6 +187,7 @@ function App() {
         setConversations(snapshot.conversations)
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
+        setSubscriptionRecords(snapshot.subscriptionRecords)
         setLiveRateLimits(snapshot.liveRateLimits)
         detailCacheRef.current = nextDetailCache
         setDashboardRevision((current) => current + 1)
@@ -394,6 +402,26 @@ function App() {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
     }
     setStatusMessage(t.status.settingsSaved)
+  }
+
+  async function handleSaveSubscriptionRecord(payload: SubscriptionRecordInput, id?: number | null) {
+    if (id) {
+      await updateSubscriptionRecord(id, payload)
+    } else {
+      await createSubscriptionRecord(payload)
+    }
+    const nextRecords = await listSubscriptionRecords()
+    setSubscriptionRecords(nextRecords)
+    await loadShell(false)
+    setStatusMessage(t.status.subscriptionRecordSaved)
+  }
+
+  async function handleDeleteSubscriptionRecord(id: number) {
+    await deleteSubscriptionRecord(id)
+    const nextRecords = await listSubscriptionRecords()
+    setSubscriptionRecords(nextRecords)
+    await loadShell(false)
+    setStatusMessage(t.status.subscriptionRecordDeleted)
   }
 
   const snapshotIsCurrent = loadedQueryKey === currentQueryKey
@@ -670,12 +698,9 @@ function App() {
                       tone="secondary"
                       value={formatUsd(activeOverview?.stats.subscriptionCostUsd ?? 0, language)}
                       note={
-                        subscriptionProfile
-                          ? t.metrics.planPerMonth(
-                              subscriptionProfile.planType,
-                              formatUsd(subscriptionProfile.monthlyPrice, language),
-                            )
-                          : undefined
+                        subscriptionRecords.length > 0
+                          ? t.metrics.subscriptionLedgerNote(subscriptionRecords.length)
+                          : t.metrics.noSubscriptionRecords
                       }
                     />
                     <MetricCard
@@ -900,9 +925,12 @@ function App() {
         language={language}
         liveRateLimits={liveRateLimits}
         onClose={() => setSettingsOpen(false)}
+        onDeleteSubscriptionRecord={handleDeleteSubscriptionRecord}
         onLanguageChange={setLanguage}
         onSave={handleSaveSettings}
+        onSaveSubscriptionRecord={handleSaveSubscriptionRecord}
         subscriptionProfile={subscriptionProfile}
+        subscriptionRecords={subscriptionRecords}
         syncSettings={syncSettings}
       />
     </div>

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -9,6 +9,8 @@ import type {
   OverviewResponse,
   QuotaTrendPoint,
   SubscriptionProfile,
+  SubscriptionRecord,
+  SubscriptionRecordInput,
   SyncSettings,
 } from './types'
 
@@ -57,6 +59,10 @@ function createMockSubscriptionProfile(): SubscriptionProfile {
     billingAnchorDay: 1,
     updatedAt: nowIso(),
   }
+}
+
+function createMockSubscriptionRecords(): SubscriptionRecord[] {
+  return []
 }
 
 function createMockLiveRateLimits(): LiveRateLimitSnapshot {
@@ -260,6 +266,7 @@ export async function loadDashboard(
       conversations: [] as ConversationListItem[],
       syncSettings: createMockSyncSettings(),
       subscriptionProfile: createMockSubscriptionProfile(),
+      subscriptionRecords: createMockSubscriptionRecords(),
       liveRateLimits: createMockLiveRateLimits(),
     }),
   )
@@ -312,4 +319,30 @@ export async function updateSubscriptionProfile(payload: SubscriptionProfile) {
     ...payload,
     currency: 'USD',
   }))
+}
+
+export async function listSubscriptionRecords() {
+  return invokeOrMock('listSubscriptionRecords', {}, createMockSubscriptionRecords)
+}
+
+export async function createSubscriptionRecord(payload: SubscriptionRecordInput) {
+  return invokeOrMock('createSubscriptionRecord', { payload }, () => ({
+    id: Date.now(),
+    ...payload,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  }))
+}
+
+export async function updateSubscriptionRecord(id: number, payload: SubscriptionRecordInput) {
+  return invokeOrMock('updateSubscriptionRecord', { id, payload }, () => ({
+    id,
+    ...payload,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  }))
+}
+
+export async function deleteSubscriptionRecord(id: number) {
+  return invokeOrMock('deleteSubscriptionRecord', { id }, () => true)
 }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -13,6 +13,7 @@ import type {
   SubscriptionRecordInput,
   SyncSettings,
 } from './types'
+import { todayLocalInputValue } from './subscriptionDates'
 
 function bucketUsesAnchor(bucket: OverviewBucket) {
   return !['five_hour', 'seven_day', 'custom', 'total'].includes(bucket)
@@ -77,19 +78,15 @@ function createMockLiveRateLimits(): LiveRateLimitSnapshot {
 }
 
 function localDateStartIso(value: string | null | undefined) {
-  const fallback = todayInputValue()
+  const fallback = todayLocalInputValue()
   return new Date(`${value ?? fallback}T00:00:00`).toISOString()
 }
 
 function localDateExclusiveEndIso(value: string | null | undefined) {
-  const fallback = todayInputValue()
+  const fallback = todayLocalInputValue()
   const date = new Date(`${value ?? fallback}T00:00:00`)
   date.setDate(date.getDate() + 1)
   return date.toISOString()
-}
-
-function todayInputValue() {
-  return new Date().toISOString().slice(0, 10)
 }
 
 function createMockOverview(
@@ -282,8 +279,9 @@ export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {
 
 export async function getConversationDetail(
   rootSessionId: string,
+  filters?: ConversationFilters | null,
 ): Promise<import('./types').ConversationDetail> {
-  return invokeOrMock('getConversationDetail', { rootSessionId }, () => {
+  return invokeOrMock('getConversationDetail', { rootSessionId, filters: filters ?? null }, () => {
     throw new Error(`Conversation ${rootSessionId} is unavailable in browser preview mode.`)
   })
 }

--- a/src/app/format.ts
+++ b/src/app/format.ts
@@ -1,5 +1,6 @@
 import type { AppLanguage } from './i18n'
 import { getDateTimeLocale, getNumberLocale, getRelativeTimeLocale } from './i18n'
+import { todayLocalInputValue } from './subscriptionDates'
 
 export function formatUsd(value: number, language: AppLanguage = 'zh-CN') {
   return new Intl.NumberFormat(getNumberLocale(language), {
@@ -92,5 +93,5 @@ export function formatRemainingDuration(endValue: string | null, language: AppLa
 }
 
 export function todayInputValue() {
-  return new Date().toISOString().slice(0, 10)
+  return todayLocalInputValue()
 }

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -59,6 +59,8 @@ export type TranslationSet = {
     failedToLoad: (bucketLabel: string, error: string) => string
     pricingRefreshed: string
     settingsSaved: string
+    subscriptionRecordSaved: string
+    subscriptionRecordDeleted: string
     waitingLiveQuota: string
   }
   buckets: Record<OverviewBucket, string>
@@ -82,6 +84,8 @@ export type TranslationSet = {
     subscriptionCost: string
     payoffRatio: string
     planPerMonth: (planType: string, price: string) => string
+    subscriptionLedgerNote: (count: number) => string
+    noSubscriptionRecords: string
     monthlyFeeShare: string
   }
   overview: {
@@ -236,6 +240,23 @@ export type TranslationSet = {
         monthlyPrice: string
         billingAnchorDay: string
         billingAnchorDayNote: string
+        planPlus: string
+        planPro5: string
+        planPro10: string
+        amountUsd: string
+        serviceStart: string
+        serviceEnd: string
+        addRecordTitle: string
+        editRecordTitle: string
+        addRecord: string
+        updateRecord: string
+        saveRecord: string
+        editRecord: string
+        removeRecord: string
+        cancelEditRecord: string
+        emptyRecords: string
+        accountEmail: string
+        accountEmailPlaceholder: string
       }
       liveQuota: {
         eyebrow: string
@@ -298,6 +319,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       failedToLoad: (bucketLabel, error) => `加载${bucketLabel}失败：${error}`,
       pricingRefreshed: '已按 OpenAI 标准短上下文定价刷新目录。',
       settingsSaved: '设置已保存。',
+      subscriptionRecordSaved: '订阅记录已保存。',
+      subscriptionRecordDeleted: '订阅记录已删除。',
       waitingLiveQuota: '等待 live quota',
     },
     buckets: {
@@ -331,7 +354,9 @@ const translations: Record<AppLanguage, TranslationSet> = {
       subscriptionCost: '订阅费',
       payoffRatio: '回本比例',
       planPerMonth: (planType, price) => `${planType} · ${price}/月`,
-      monthlyFeeShare: '占月费比例',
+      subscriptionLedgerNote: (count) => `${count} 条订阅记录`,
+      noSubscriptionRecords: '未添加订阅记录',
+      monthlyFeeShare: '订阅账本占比',
     },
     overview: {
       distribution: '分布',
@@ -485,6 +510,23 @@ const translations: Record<AppLanguage, TranslationSet> = {
           monthlyPrice: '月订阅价格',
           billingAnchorDay: '订阅月起始日',
           billingAnchorDayNote: '订阅月会按这个日期切分。例如设置为 23，则统计范围是每月 23 号到次月 22 号。',
+          planPlus: 'ChatGPT Plus',
+          planPro5: 'ChatGPT Pro 5x',
+          planPro10: 'ChatGPT Pro 10x',
+          amountUsd: '金额（USD）',
+          serviceStart: '服务开始',
+          serviceEnd: '服务结束',
+          addRecordTitle: '账本记录',
+          editRecordTitle: '编辑记录',
+          addRecord: '添加订阅记录',
+          updateRecord: '更新订阅记录',
+          saveRecord: '保存记录',
+          editRecord: '编辑',
+          removeRecord: '删除',
+          cancelEditRecord: '取消编辑',
+          emptyRecords: '还没有订阅账本记录。添加记录后，回本会按服务期重叠比例计算。',
+          accountEmail: '账号邮箱/备注',
+          accountEmailPlaceholder: '可选备注或邮箱',
         },
         liveQuota: {
           eyebrow: 'Live Quota',
@@ -540,6 +582,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       failedToLoad: (bucketLabel, error) => `Failed to load ${bucketLabel}: ${error}`,
       pricingRefreshed: 'Pricing catalog refreshed from OpenAI Standard short-context pricing.',
       settingsSaved: 'Settings saved.',
+      subscriptionRecordSaved: 'Subscription record saved.',
+      subscriptionRecordDeleted: 'Subscription record deleted.',
       waitingLiveQuota: 'Waiting for live quota',
     },
     buckets: {
@@ -573,7 +617,9 @@ const translations: Record<AppLanguage, TranslationSet> = {
       subscriptionCost: 'Subscription cost',
       payoffRatio: 'Payoff ratio',
       planPerMonth: (planType, price) => `${planType} · ${price}/mo`,
-      monthlyFeeShare: 'Share of monthly fee',
+      subscriptionLedgerNote: (count) => `${count} subscription records`,
+      noSubscriptionRecords: 'No subscription records',
+      monthlyFeeShare: 'Share of subscription ledger',
     },
     overview: {
       distribution: 'Distribution',
@@ -727,6 +773,23 @@ const translations: Record<AppLanguage, TranslationSet> = {
           monthlyPrice: 'Monthly subscription price',
           billingAnchorDay: 'Subscription month starts on',
           billingAnchorDayNote: 'The billing month is split by this day. For example, `23` means each window runs from the 23rd to the 22nd of the next month.',
+          planPlus: 'ChatGPT Plus',
+          planPro5: 'ChatGPT Pro 5x',
+          planPro10: 'ChatGPT Pro 10x',
+          amountUsd: 'Amount (USD)',
+          serviceStart: 'Service start',
+          serviceEnd: 'Service end',
+          addRecordTitle: 'Ledger record',
+          editRecordTitle: 'Edit record',
+          addRecord: 'Add subscription record',
+          updateRecord: 'Update subscription record',
+          saveRecord: 'Save record',
+          editRecord: 'Edit',
+          removeRecord: 'Delete',
+          cancelEditRecord: 'Cancel edit',
+          emptyRecords: 'No subscription ledger records yet. Add records to prorate payoff by service period overlap.',
+          accountEmail: 'Account email / note',
+          accountEmailPlaceholder: 'Optional note or email',
         },
         liveQuota: {
           eyebrow: 'Live Quota',

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -243,6 +243,9 @@ export type TranslationSet = {
         planPlus: string
         planPro5: string
         planPro10: string
+        billingMode: string
+        billingModeOneTime: string
+        billingModeMonthlyRecurring: string
         amountUsd: string
         serviceStart: string
         serviceEnd: string
@@ -513,6 +516,9 @@ const translations: Record<AppLanguage, TranslationSet> = {
           planPlus: 'ChatGPT Plus',
           planPro5: 'ChatGPT Pro 5x',
           planPro10: 'ChatGPT Pro 10x',
+          billingMode: '计费方式',
+          billingModeOneTime: '单次',
+          billingModeMonthlyRecurring: '每月重复',
           amountUsd: '金额（USD）',
           serviceStart: '服务开始',
           serviceEnd: '服务结束',
@@ -776,6 +782,9 @@ const translations: Record<AppLanguage, TranslationSet> = {
           planPlus: 'ChatGPT Plus',
           planPro5: 'ChatGPT Pro 5x',
           planPro10: 'ChatGPT Pro 10x',
+          billingMode: 'Billing mode',
+          billingModeOneTime: 'One-time',
+          billingModeMonthlyRecurring: 'Monthly recurring',
           amountUsd: 'Amount (USD)',
           serviceStart: 'Service start',
           serviceEnd: 'Service end',

--- a/src/app/subscriptionDates.ts
+++ b/src/app/subscriptionDates.ts
@@ -1,0 +1,37 @@
+function parseDateInput(value: string) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return null
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if (month < 1 || month > 12) return null
+
+  const lastDay = new Date(year, month, 0).getDate()
+  if (day < 1 || day > lastDay) return null
+
+  return { year, month, day }
+}
+
+function formatDateInput(year: number, month: number, day: number) {
+  return [
+    String(year).padStart(4, '0'),
+    String(month).padStart(2, '0'),
+    String(day).padStart(2, '0'),
+  ].join('-')
+}
+
+export function todayLocalInputValue(date = new Date()) {
+  return formatDateInput(date.getFullYear(), date.getMonth() + 1, date.getDate())
+}
+
+export function addOneCalendarMonth(value: string) {
+  const parsed = parseDateInput(value)
+  if (!parsed) return value
+
+  const targetMonthIndex = parsed.month
+  const targetYear = parsed.year + Math.floor(targetMonthIndex / 12)
+  const targetMonth = (targetMonthIndex % 12) + 1
+  const targetLastDay = new Date(targetYear, targetMonth, 0).getDate()
+  return formatDateInput(targetYear, targetMonth, Math.min(parsed.day, targetLastDay))
+}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -55,6 +55,27 @@ export interface SubscriptionProfile {
   updatedAt: string
 }
 
+export interface SubscriptionRecord {
+  id: number
+  paidAt: string
+  serviceStart: string
+  serviceEnd: string
+  amountUsd: number
+  planType: string
+  note: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SubscriptionRecordInput {
+  paidAt: string
+  serviceStart: string
+  serviceEnd: string
+  amountUsd: number
+  planType: string
+  note: string | null
+}
+
 export interface ScanResult {
   codexHome: string
   scannedFiles: number
@@ -191,6 +212,7 @@ export interface DashboardSnapshot {
   conversations: ConversationListItem[]
   syncSettings: SyncSettings
   subscriptionProfile: SubscriptionProfile
+  subscriptionRecords: SubscriptionRecord[]
   liveRateLimits: LiveRateLimitSnapshot | null
 }
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -12,6 +12,7 @@ export type OverviewBucket =
 export type ShareMode = 'value' | 'tokens'
 export type ShareDimension = 'model' | 'composition'
 export type AppView = 'overview' | 'conversations'
+export type SubscriptionBillingMode = 'one_time' | 'monthly_recurring'
 export type MenuBarPopupModuleId =
   | 'api_value'
   | 'token_count'
@@ -61,6 +62,7 @@ export interface SubscriptionRecord {
   serviceStart: string
   serviceEnd: string
   amountUsd: number
+  billingMode: SubscriptionBillingMode
   planType: string
   note: string | null
   createdAt: string
@@ -72,6 +74,7 @@ export interface SubscriptionRecordInput {
   serviceStart: string
   serviceEnd: string
   amountUsd: number
+  billingMode: SubscriptionBillingMode
   planType: string
   note: string | null
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,11 +3,13 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 
 import { formatPercent, formatRemainingDuration, formatUsd, todayInputValue } from '../app/format'
 import { SUPPORTED_LANGUAGES, type AppLanguage } from '../app/i18n'
+import { addOneCalendarMonth } from '../app/subscriptionDates'
 import { useI18n } from '../app/useI18n'
 import type {
   LiveRateLimitSnapshot,
   MenuBarPopupModuleId,
   OverviewBucket,
+  SubscriptionBillingMode,
   SubscriptionProfile,
   SubscriptionRecord,
   SubscriptionRecordInput,
@@ -57,22 +59,13 @@ function SwitchField({ label, checked, disabled = false, onChange }: SwitchField
   )
 }
 
-function addOneMonth(value: string) {
-  const date = new Date(`${value}T00:00:00`)
-  if (Number.isNaN(date.getTime())) return value
-  date.setMonth(date.getMonth() + 1)
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 type SubscriptionPlanOption = 'plus' | 'pro_x5' | 'pro_x10'
 
 interface SubscriptionRecordFormState {
   serviceStart: string
   serviceEnd: string
   amountUsd: number
+  billingMode: SubscriptionBillingMode
   planType: SubscriptionPlanOption
   accountEmail: string
 }
@@ -99,11 +92,12 @@ function createDefaultRecordForm(profile: SubscriptionProfile | null): Subscript
   const planType = normalizePlanOption(profile?.planType)
   return {
     serviceStart,
-    serviceEnd: addOneMonth(serviceStart),
+    serviceEnd: addOneCalendarMonth(serviceStart),
     amountUsd:
       profile?.monthlyPrice && profile.monthlyPrice > 0
         ? profile.monthlyPrice
         : defaultAmountForPlan(planType),
+    billingMode: 'monthly_recurring',
     planType,
     accountEmail: '',
   }
@@ -115,6 +109,7 @@ function recordToForm(record: SubscriptionRecord): SubscriptionRecordFormState {
     serviceStart: record.serviceStart,
     serviceEnd: record.serviceEnd,
     amountUsd: record.amountUsd,
+    billingMode: record.billingMode ?? 'one_time',
     planType,
     accountEmail: record.note ?? '',
   }
@@ -250,6 +245,16 @@ export function SettingsPanel({
       amountUsd: SUBSCRIPTION_PLAN_AMOUNTS.pro_x10,
     },
   ]
+  const billingModeOptions: Array<{ value: SubscriptionBillingMode; label: string }> = [
+    {
+      value: 'monthly_recurring',
+      label: t.settings.sections.subscription.billingModeMonthlyRecurring,
+    },
+    {
+      value: 'one_time',
+      label: t.settings.sections.subscription.billingModeOneTime,
+    },
+  ]
 
   function togglePopupModule(moduleId: MenuBarPopupModuleId, enabled: boolean) {
     setDraftSync((current) => {
@@ -308,7 +313,8 @@ export function SettingsPanel({
     setRecordForm((current) => ({
       ...current,
       serviceStart,
-      serviceEnd: current.serviceEnd <= serviceStart ? addOneMonth(serviceStart) : current.serviceEnd,
+      serviceEnd:
+        current.serviceEnd <= serviceStart ? addOneCalendarMonth(serviceStart) : current.serviceEnd,
     }))
   }
 
@@ -326,7 +332,8 @@ export function SettingsPanel({
           paidAt: recordForm.serviceStart,
           serviceStart: recordForm.serviceStart,
           serviceEnd: recordForm.serviceEnd,
-          amountUsd: Math.max(0, Number(recordForm.amountUsd || 0)),
+          amountUsd: Number(recordForm.amountUsd || 0),
+          billingMode: recordForm.billingMode,
           planType: recordForm.planType,
           note: accountEmail || null,
         },
@@ -932,6 +939,11 @@ export function SettingsPanel({
                         <span className="subscription-record-plan-badge">
                           {formatPlanLabel(record.planType, t.settings.sections.subscription)}
                         </span>
+                        <span className="subscription-record-mode-badge">
+                          {record.billingMode === 'monthly_recurring'
+                            ? t.settings.sections.subscription.billingModeMonthlyRecurring
+                            : t.settings.sections.subscription.billingModeOneTime}
+                        </span>
                         <strong className="subscription-record-amount">
                           {formatUsd(record.amountUsd, language)}
                         </strong>
@@ -1000,15 +1012,39 @@ export function SettingsPanel({
                     </select>
                   </label>
 
+                  <div className="field field-span-2">
+                    <span>{t.settings.sections.subscription.billingMode}</span>
+                    <div
+                      aria-label={t.settings.sections.subscription.billingMode}
+                      className="segmented-control"
+                      role="radiogroup"
+                    >
+                      {billingModeOptions.map((option) => (
+                        <button
+                          aria-checked={recordForm.billingMode === option.value}
+                          className={`segmented-control-button${
+                            recordForm.billingMode === option.value ? ' is-active' : ''
+                          }`}
+                          key={option.value}
+                          onClick={() => updateRecordForm({ billingMode: option.value })}
+                          role="radio"
+                          type="button"
+                        >
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
                   <label className="field">
                     <span>{t.settings.sections.subscription.amountUsd}</span>
                     <input
-                      min={0}
+                      min={0.01}
                       step={0.01}
                       type="number"
                       value={recordForm.amountUsd}
                       onChange={(event) =>
-                        updateRecordForm({ amountUsd: Math.max(0, Number(event.target.value || 0)) })
+                        updateRecordForm({ amountUsd: Number(event.target.value || 0) })
                       }
                     />
                   </label>
@@ -1056,6 +1092,8 @@ export function SettingsPanel({
                       className="accent-button"
                       disabled={
                         savingRecord ||
+                        !Number.isFinite(recordForm.amountUsd) ||
+                        recordForm.amountUsd <= 0 ||
                         !recordForm.serviceStart ||
                         !recordForm.serviceEnd ||
                         recordForm.serviceEnd <= recordForm.serviceStart

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 
-import { formatPercent, formatRemainingDuration } from '../app/format'
+import { formatPercent, formatRemainingDuration, formatUsd, todayInputValue } from '../app/format'
 import { SUPPORTED_LANGUAGES, type AppLanguage } from '../app/i18n'
 import { useI18n } from '../app/useI18n'
 import type {
@@ -9,6 +9,8 @@ import type {
   MenuBarPopupModuleId,
   OverviewBucket,
   SubscriptionProfile,
+  SubscriptionRecord,
+  SubscriptionRecordInput,
   SyncSettings,
 } from '../app/types'
 
@@ -18,12 +20,15 @@ interface SettingsPanelProps {
   liveRateLimits: LiveRateLimitSnapshot | null
   syncSettings: SyncSettings | null
   subscriptionProfile: SubscriptionProfile | null
+  subscriptionRecords: SubscriptionRecord[]
   onClose: () => void
   onLanguageChange: (language: AppLanguage) => void
   onSave: (payload: {
     syncSettings: SyncSettings
     subscriptionProfile: SubscriptionProfile
   }) => Promise<void>
+  onSaveSubscriptionRecord: (payload: SubscriptionRecordInput, id?: number | null) => Promise<void>
+  onDeleteSubscriptionRecord: (id: number) => Promise<void>
 }
 
 interface SwitchFieldProps {
@@ -52,6 +57,83 @@ function SwitchField({ label, checked, disabled = false, onChange }: SwitchField
   )
 }
 
+function addOneMonth(value: string) {
+  const date = new Date(`${value}T00:00:00`)
+  if (Number.isNaN(date.getTime())) return value
+  date.setMonth(date.getMonth() + 1)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+type SubscriptionPlanOption = 'plus' | 'pro_x5' | 'pro_x10'
+
+interface SubscriptionRecordFormState {
+  serviceStart: string
+  serviceEnd: string
+  amountUsd: number
+  planType: SubscriptionPlanOption
+  accountEmail: string
+}
+
+const SUBSCRIPTION_PLAN_AMOUNTS: Record<SubscriptionPlanOption, number> = {
+  plus: 19.99,
+  pro_x5: 100,
+  pro_x10: 200,
+}
+
+function normalizePlanOption(planType?: string | null): SubscriptionPlanOption {
+  const normalized = planType?.toLowerCase().replace(/[×*]/g, 'x').replace(/[\s-]+/g, '_') ?? ''
+  if (normalized.includes('pro') && normalized.includes('5')) return 'pro_x5'
+  if (normalized.includes('pro')) return 'pro_x10'
+  return 'plus'
+}
+
+function defaultAmountForPlan(planType?: string | null) {
+  return SUBSCRIPTION_PLAN_AMOUNTS[normalizePlanOption(planType)]
+}
+
+function createDefaultRecordForm(profile: SubscriptionProfile | null): SubscriptionRecordFormState {
+  const serviceStart = todayInputValue()
+  const planType = normalizePlanOption(profile?.planType)
+  return {
+    serviceStart,
+    serviceEnd: addOneMonth(serviceStart),
+    amountUsd:
+      profile?.monthlyPrice && profile.monthlyPrice > 0
+        ? profile.monthlyPrice
+        : defaultAmountForPlan(planType),
+    planType,
+    accountEmail: '',
+  }
+}
+
+function recordToForm(record: SubscriptionRecord): SubscriptionRecordFormState {
+  const planType = normalizePlanOption(record.planType)
+  return {
+    serviceStart: record.serviceStart,
+    serviceEnd: record.serviceEnd,
+    amountUsd: record.amountUsd,
+    planType,
+    accountEmail: record.note ?? '',
+  }
+}
+
+function formatPlanLabel(
+  planType: string,
+  labels: {
+    planPlus: string
+    planPro5: string
+    planPro10: string
+  },
+) {
+  const normalized = normalizePlanOption(planType)
+  if (normalized === 'pro_x5') return labels.planPro5
+  if (normalized === 'pro_x10') return labels.planPro10
+  return labels.planPlus
+}
+
 function refreshSecondsToMinutes(seconds: number) {
   return Math.max(1, Math.round(seconds / 60))
 }
@@ -70,16 +152,25 @@ export function SettingsPanel({
   liveRateLimits,
   syncSettings,
   subscriptionProfile,
+  subscriptionRecords,
   onClose,
   onLanguageChange,
   onSave,
+  onSaveSubscriptionRecord,
+  onDeleteSubscriptionRecord,
 }: SettingsPanelProps) {
   const { t } = useI18n()
   const [draftSync, setDraftSync] = useState<SyncSettings | null>(syncSettings)
   const [draftSubscription, setDraftSubscription] = useState<SubscriptionProfile | null>(
     subscriptionProfile,
   )
+  const [recordForm, setRecordForm] = useState<SubscriptionRecordFormState>(() =>
+    createDefaultRecordForm(subscriptionProfile),
+  )
+  const [editingRecordId, setEditingRecordId] = useState<number | null>(null)
   const [saving, setSaving] = useState(false)
+  const [savingRecord, setSavingRecord] = useState(false)
+  const [deletingRecordId, setDeletingRecordId] = useState<number | null>(null)
   const wasOpenRef = useRef(false)
   const showDockSettings = isMacOs()
 
@@ -89,11 +180,19 @@ export function SettingsPanel({
     if (justOpened || (!draftSync && syncSettings) || (!draftSubscription && subscriptionProfile)) {
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
+      setRecordForm(createDefaultRecordForm(subscriptionProfile))
+      setEditingRecordId(null)
       setSaving(false)
+      setSavingRecord(false)
+      setDeletingRecordId(null)
     } else if (!isOpen && wasOpenRef.current) {
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
+      setRecordForm(createDefaultRecordForm(subscriptionProfile))
+      setEditingRecordId(null)
       setSaving(false)
+      setSavingRecord(false)
+      setDeletingRecordId(null)
     }
 
     wasOpenRef.current = isOpen
@@ -134,6 +233,24 @@ export function SettingsPanel({
     { value: 'conversation_count', label: t.popup.modules.conversationCount },
   ]
 
+  const planOptions: Array<{ value: SubscriptionPlanOption; label: string; amountUsd: number }> = [
+    {
+      value: 'plus',
+      label: t.settings.sections.subscription.planPlus,
+      amountUsd: SUBSCRIPTION_PLAN_AMOUNTS.plus,
+    },
+    {
+      value: 'pro_x5',
+      label: t.settings.sections.subscription.planPro5,
+      amountUsd: SUBSCRIPTION_PLAN_AMOUNTS.pro_x5,
+    },
+    {
+      value: 'pro_x10',
+      label: t.settings.sections.subscription.planPro10,
+      amountUsd: SUBSCRIPTION_PLAN_AMOUNTS.pro_x10,
+    },
+  ]
+
   function togglePopupModule(moduleId: MenuBarPopupModuleId, enabled: boolean) {
     setDraftSync((current) => {
       if (!current) return current
@@ -168,6 +285,69 @@ export function SettingsPanel({
         menuBarPopupModules: nextModules,
       }
     })
+  }
+
+  function resetRecordForm() {
+    setRecordForm(createDefaultRecordForm(draftSubscription))
+    setEditingRecordId(null)
+  }
+
+  function updateRecordForm(patch: Partial<SubscriptionRecordFormState>) {
+    setRecordForm((current) => ({ ...current, ...patch }))
+  }
+
+  function updateRecordPlan(planType: SubscriptionPlanOption) {
+    setRecordForm((current) => ({
+      ...current,
+      planType,
+      amountUsd: SUBSCRIPTION_PLAN_AMOUNTS[planType],
+    }))
+  }
+
+  function updateRecordServiceStart(serviceStart: string) {
+    setRecordForm((current) => ({
+      ...current,
+      serviceStart,
+      serviceEnd: current.serviceEnd <= serviceStart ? addOneMonth(serviceStart) : current.serviceEnd,
+    }))
+  }
+
+  function editSubscriptionRecord(record: SubscriptionRecord) {
+    setEditingRecordId(record.id)
+    setRecordForm(recordToForm(record))
+  }
+
+  async function saveSubscriptionRecordForm() {
+    setSavingRecord(true)
+    try {
+      const accountEmail = recordForm.accountEmail.trim()
+      await onSaveSubscriptionRecord(
+        {
+          paidAt: recordForm.serviceStart,
+          serviceStart: recordForm.serviceStart,
+          serviceEnd: recordForm.serviceEnd,
+          amountUsd: Math.max(0, Number(recordForm.amountUsd || 0)),
+          planType: recordForm.planType,
+          note: accountEmail || null,
+        },
+        editingRecordId,
+      )
+      resetRecordForm()
+    } finally {
+      setSavingRecord(false)
+    }
+  }
+
+  async function removeSubscriptionRecord(id: number) {
+    setDeletingRecordId(id)
+    try {
+      await onDeleteSubscriptionRecord(id)
+      if (editingRecordId === id) {
+        resetRecordForm()
+      }
+    } finally {
+      setDeletingRecordId(null)
+    }
   }
 
   async function handleSubmit() {
@@ -738,6 +918,159 @@ export function SettingsPanel({
                     }
                   />
                 </label>
+              </div>
+
+              <div className="subscription-record-list">
+                {subscriptionRecords.length === 0 ? (
+                  <div className="empty-state subscription-empty-state">
+                    {t.settings.sections.subscription.emptyRecords}
+                  </div>
+                ) : (
+                  subscriptionRecords.map((record) => (
+                    <div className="subscription-record-card subscription-record-summary-card" key={record.id}>
+                      <div className="subscription-record-summary-main">
+                        <span className="subscription-record-plan-badge">
+                          {formatPlanLabel(record.planType, t.settings.sections.subscription)}
+                        </span>
+                        <strong className="subscription-record-amount">
+                          {formatUsd(record.amountUsd, language)}
+                        </strong>
+                        <span className="field-note">
+                          {record.serviceStart} → {record.serviceEnd}
+                        </span>
+                      </div>
+                      <div className="subscription-record-summary-meta">
+                        {record.note ? (
+                          <span>{record.note}</span>
+                        ) : (
+                          <span>{t.settings.sections.subscription.accountEmailPlaceholder}</span>
+                        )}
+                      </div>
+                      <div className="subscription-record-actions">
+                        <button
+                          className="ghost-button"
+                          disabled={savingRecord || deletingRecordId === record.id}
+                          onClick={() => editSubscriptionRecord(record)}
+                          type="button"
+                        >
+                          {t.settings.sections.subscription.editRecord}
+                        </button>
+                        <button
+                          className="ghost-button"
+                          disabled={savingRecord || deletingRecordId === record.id}
+                          onClick={() => removeSubscriptionRecord(record.id)}
+                          type="button"
+                        >
+                          {deletingRecordId === record.id
+                            ? t.actions.saving
+                            : t.settings.sections.subscription.removeRecord}
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              <div className="subscription-record-editor">
+                <div className="settings-section-head">
+                  <p className="eyebrow">
+                    {editingRecordId
+                      ? t.settings.sections.subscription.editRecordTitle
+                      : t.settings.sections.subscription.addRecordTitle}
+                  </p>
+                  <h4>
+                    {editingRecordId
+                      ? t.settings.sections.subscription.updateRecord
+                      : t.settings.sections.subscription.addRecord}
+                  </h4>
+                </div>
+
+                <div className="subscription-record-grid">
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.planType}</span>
+                    <select
+                      value={recordForm.planType}
+                      onChange={(event) => updateRecordPlan(event.target.value as SubscriptionPlanOption)}
+                    >
+                      {planOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label} · {formatUsd(option.amountUsd, language)}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.amountUsd}</span>
+                    <input
+                      min={0}
+                      step={0.01}
+                      type="number"
+                      value={recordForm.amountUsd}
+                      onChange={(event) =>
+                        updateRecordForm({ amountUsd: Math.max(0, Number(event.target.value || 0)) })
+                      }
+                    />
+                  </label>
+
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.accountEmail}</span>
+                    <input
+                      placeholder={t.settings.sections.subscription.accountEmailPlaceholder}
+                      type="email"
+                      value={recordForm.accountEmail}
+                      onChange={(event) => updateRecordForm({ accountEmail: event.target.value })}
+                    />
+                  </label>
+
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.serviceStart}</span>
+                    <input
+                      type="date"
+                      value={recordForm.serviceStart}
+                      onChange={(event) => updateRecordServiceStart(event.target.value)}
+                    />
+                  </label>
+
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.serviceEnd}</span>
+                    <input
+                      type="date"
+                      value={recordForm.serviceEnd}
+                      onChange={(event) => updateRecordForm({ serviceEnd: event.target.value })}
+                    />
+                  </label>
+
+                  <div className="subscription-record-form-actions">
+                    {editingRecordId ? (
+                      <button
+                        className="ghost-button"
+                        disabled={savingRecord}
+                        onClick={resetRecordForm}
+                        type="button"
+                      >
+                        {t.settings.sections.subscription.cancelEditRecord}
+                      </button>
+                    ) : null}
+                    <button
+                      className="accent-button"
+                      disabled={
+                        savingRecord ||
+                        !recordForm.serviceStart ||
+                        !recordForm.serviceEnd ||
+                        recordForm.serviceEnd <= recordForm.serviceStart
+                      }
+                      onClick={saveSubscriptionRecordForm}
+                      type="button"
+                    >
+                      {savingRecord
+                        ? t.actions.saving
+                        : editingRecordId
+                          ? t.settings.sections.subscription.updateRecord
+                          : t.settings.sections.subscription.saveRecord}
+                    </button>
+                  </div>
+                </div>
               </div>
             </section>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1879,6 +1879,96 @@ select:focus-visible {
   font-family: 'Fira Code', monospace;
 }
 
+.subscription-record-card {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid var(--line-subtle);
+  background: rgba(7, 13, 24, 0.48);
+}
+
+.subscription-record-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.subscription-record-list {
+  display: grid;
+  gap: 12px;
+}
+
+.subscription-record-summary-card {
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 14px;
+}
+
+.subscription-record-summary-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.subscription-record-plan-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 78px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 179, 237, 0.28);
+  background: rgba(38, 94, 145, 0.18);
+  color: var(--text-strong);
+  font-weight: 700;
+}
+
+.subscription-record-amount {
+  color: var(--text-strong);
+  font-family: 'Fira Code', monospace;
+}
+
+.subscription-record-summary-meta {
+  min-width: 140px;
+  max-width: 260px;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.subscription-record-editor {
+  display: grid;
+  gap: 14px;
+  margin-top: 4px;
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 35%),
+    rgba(7, 13, 24, 0.54);
+}
+
+.subscription-record-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subscription-record-form-actions {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.subscription-empty-state {
+  padding: 24px 16px;
+}
+
 .modal-actions {
   justify-content: flex-end;
   margin-top: 16px;
@@ -1910,8 +2000,15 @@ select:focus-visible {
   .conversation-layout,
   .share-layout,
   .settings-grid,
+  .subscription-record-grid,
+  .subscription-record-summary-card,
   .detail-metrics {
     grid-template-columns: 1fr;
+  }
+
+  .subscription-record-form-actions,
+  .subscription-record-summary-meta {
+    justify-content: flex-start;
   }
 
   .field-span-2,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1928,6 +1928,19 @@ select:focus-visible {
   font-weight: 700;
 }
 
+.subscription-record-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 158, 11, 0.28);
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--text-primary);
+  font-size: 0.84rem;
+  font-weight: 650;
+}
+
 .subscription-record-amount {
   color: var(--text-strong);
   font-family: 'Fira Code', monospace;
@@ -1956,6 +1969,49 @@ select:focus-visible {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
+}
+
+.segmented-control {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+  padding: 4px;
+  border-radius: 16px;
+  border: 1px solid var(--line-subtle);
+  background: rgba(4, 9, 16, 0.46);
+}
+
+.segmented-control-button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text-muted);
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease;
+}
+
+.segmented-control-button:hover {
+  color: var(--text-primary);
+  border-color: rgba(96, 165, 250, 0.22);
+}
+
+.segmented-control-button.is-active {
+  background: rgba(30, 64, 175, 0.28);
+  border-color: rgba(96, 165, 250, 0.34);
+  color: var(--text-strong);
+}
+
+.segmented-control-button:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.32);
+  outline-offset: 2px;
 }
 
 .subscription-record-form-actions {


### PR DESCRIPTION
## Summary
- add subscription ledger records with explicit monthly recurring vs one-time billing modes
- migrate existing subscription profile data into a monthly recurring ledger record when old databases first open
- align overview, conversation list, and detail payoff denominators across active filters/windows
- canonicalize ledger dates, reject non-positive amounts, and fix local calendar defaults/month-end date rollover
- refresh tray popup snapshots after ledger mutations and add regression coverage for the new behavior

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `git diff --check origin/develop...HEAD`