### PR TITLE
[codex] Harden menu bar quota popup

### DIFF
--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -1,0 +1,12 @@
+CREATE INDEX IF NOT EXISTS idx_usage_events_session_id ON usage_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
+CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
+  ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
+  ON rate_limit_samples(
+    bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
+  );

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -3,12 +3,14 @@ CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp)
 CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
+CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source_id);
 CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
+CREATE INDEX IF NOT EXISTS idx_import_state_source_id ON import_state(source_id);
 CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
   ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
   ON rate_limit_samples(
-    bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
+    source_id, bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
   );
 CREATE INDEX IF NOT EXISTS idx_subscription_records_service
   ON subscription_records(service_start, service_end);

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -10,3 +10,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
   ON rate_limit_samples(
     bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
   );
+CREATE INDEX IF NOT EXISTS idx_subscription_records_service
+  ON subscription_records(service_start, service_end);

--- a/src-tauri/sql/queries/quota_samples.sql
+++ b/src-tauri/sql/queries/quota_samples.sql
@@ -1,0 +1,4 @@
+SELECT sample_timestamp, used_percent, window_start, resets_at
+FROM rate_limit_samples
+WHERE bucket = ?1
+ORDER BY sample_timestamp ASC

--- a/src-tauri/sql/queries/rate_limit_windows.sql
+++ b/src-tauri/sql/queries/rate_limit_windows.sql
@@ -1,0 +1,5 @@
+SELECT window_start, resets_at
+FROM rate_limit_samples
+WHERE bucket = ?1
+GROUP BY window_start, resets_at
+ORDER BY window_start DESC, resets_at DESC

--- a/src-tauri/sql/queries/session_source_memberships.sql
+++ b/src-tauri/sql/queries/session_source_memberships.sql
@@ -1,0 +1,3 @@
+SELECT session_id, source_id
+FROM import_state
+WHERE session_id IS NOT NULL AND source_id IS NOT NULL

--- a/src-tauri/sql/queries/sessions.sql
+++ b/src-tauri/sql/queries/sessions.sql
@@ -1,3 +1,3 @@
-SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
+SELECT session_id, source_id, root_session_id, parent_session_id, title, source_state, source_path,
        started_at, updated_at, agent_nickname, agent_role
 FROM sessions

--- a/src-tauri/sql/queries/sessions.sql
+++ b/src-tauri/sql/queries/sessions.sql
@@ -1,0 +1,3 @@
+SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
+       started_at, updated_at, agent_nickname, agent_role
+FROM sessions

--- a/src-tauri/sql/queries/sessions_for_root.sql
+++ b/src-tauri/sql/queries/sessions_for_root.sql
@@ -1,4 +1,4 @@
-SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
+SELECT session_id, source_id, root_session_id, parent_session_id, title, source_state, source_path,
        started_at, updated_at, agent_nickname, agent_role
 FROM sessions
 WHERE root_session_id = ?1

--- a/src-tauri/sql/queries/sessions_for_root.sql
+++ b/src-tauri/sql/queries/sessions_for_root.sql
@@ -1,0 +1,4 @@
+SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
+       started_at, updated_at, agent_nickname, agent_role
+FROM sessions
+WHERE root_session_id = ?1

--- a/src-tauri/sql/queries/usage_events.sql
+++ b/src-tauri/sql/queries/usage_events.sql
@@ -1,0 +1,5 @@
+SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+       output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+       fast_mode_auto, fast_mode_effective
+FROM usage_events
+ORDER BY timestamp ASC, id ASC

--- a/src-tauri/sql/queries/usage_events_for_root.sql
+++ b/src-tauri/sql/queries/usage_events_for_root.sql
@@ -1,0 +1,9 @@
+SELECT usage_events.session_id, usage_events.timestamp, usage_events.model_id,
+       usage_events.input_tokens, usage_events.cached_input_tokens,
+       usage_events.output_tokens, usage_events.reasoning_output_tokens,
+       usage_events.total_tokens, usage_events.value_usd,
+       usage_events.fast_mode_auto, usage_events.fast_mode_effective
+FROM usage_events
+INNER JOIN sessions ON sessions.session_id = usage_events.session_id
+WHERE sessions.root_session_id = ?1
+ORDER BY usage_events.timestamp ASC, usage_events.id ASC

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -1,0 +1,125 @@
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT PRIMARY KEY,
+  root_session_id TEXT NOT NULL,
+  parent_session_id TEXT,
+  title TEXT,
+  source_state TEXT NOT NULL DEFAULT 'missing',
+  source_path TEXT,
+  source_bucket TEXT,
+  started_at TEXT,
+  updated_at TEXT,
+  agent_nickname TEXT,
+  agent_role TEXT,
+  explicit_fast_mode INTEGER,
+  fast_mode_default INTEGER NOT NULL DEFAULT 0,
+  latest_plan_type TEXT,
+  last_model_id TEXT,
+  contains_subagents INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  imported_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS conversation_links (
+  session_id TEXT PRIMARY KEY,
+  root_session_id TEXT NOT NULL,
+  parent_session_id TEXT,
+  depth INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL,
+  cached_input_tokens INTEGER NOT NULL,
+  output_tokens INTEGER NOT NULL,
+  reasoning_output_tokens INTEGER NOT NULL,
+  total_tokens INTEGER NOT NULL,
+  value_usd REAL NOT NULL,
+  fast_mode_auto INTEGER NOT NULL,
+  fast_mode_effective INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pricing_catalog (
+  model_id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  input_price_per_million REAL NOT NULL,
+  cached_input_price_per_million REAL NOT NULL,
+  output_price_per_million REAL NOT NULL,
+  effective_model_id TEXT NOT NULL,
+  is_official INTEGER NOT NULL,
+  note TEXT,
+  source_url TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subscription_profile (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  plan_type TEXT NOT NULL,
+  currency TEXT NOT NULL,
+  monthly_price REAL NOT NULL,
+  billing_anchor_day INTEGER NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_overrides (
+  session_id TEXT PRIMARY KEY,
+  fast_mode_override INTEGER,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sync_settings (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
+  codex_home TEXT,
+  auto_scan_enabled INTEGER NOT NULL,
+  auto_scan_interval_minutes INTEGER NOT NULL,
+  live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
+  default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0,
+  hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0,
+  show_menu_bar_logo INTEGER NOT NULL DEFAULT 1,
+  show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1,
+  show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0,
+  menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent',
+  menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour',
+  menu_bar_bucket TEXT NOT NULL DEFAULT 'day',
+  menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1,
+  menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85,
+  menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115,
+  menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢',
+  menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥',
+  menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢',
+  menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1,
+  menu_bar_popup_modules TEXT NOT NULL DEFAULT '["api_value","scan_freshness"]',
+  menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1,
+  menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
+  last_scan_started_at TEXT,
+  last_scan_completed_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS import_state (
+  source_path TEXT PRIMARY KEY,
+  session_id TEXT,
+  source_bucket TEXT NOT NULL,
+  file_size INTEGER NOT NULL,
+  file_mtime_ms INTEGER NOT NULL,
+  last_imported_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS rate_limit_samples (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_kind TEXT NOT NULL,
+  source_session_id TEXT NOT NULL DEFAULT '',
+  bucket TEXT NOT NULL,
+  sample_timestamp TEXT NOT NULL,
+  limit_id TEXT NOT NULL DEFAULT '',
+  limit_name TEXT NOT NULL DEFAULT '',
+  plan_type TEXT NOT NULL DEFAULT '',
+  window_start TEXT NOT NULL,
+  resets_at TEXT NOT NULL,
+  used_percent INTEGER NOT NULL,
+  remaining_percent INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -63,6 +63,18 @@ CREATE TABLE IF NOT EXISTS subscription_profile (
   updated_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS subscription_records (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  paid_at TEXT NOT NULL,
+  service_start TEXT NOT NULL,
+  service_end TEXT NOT NULL,
+  amount_usd REAL NOT NULL,
+  plan_type TEXT NOT NULL,
+  note TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS session_overrides (
   session_id TEXT PRIMARY KEY,
   fast_mode_override INTEGER,

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS sessions (
   session_id TEXT PRIMARY KEY,
+  source_id TEXT NOT NULL DEFAULT 'local',
   root_session_id TEXT NOT NULL,
   parent_session_id TEXT,
   title TEXT,
@@ -113,6 +114,7 @@ CREATE TABLE IF NOT EXISTS sync_settings (
 
 CREATE TABLE IF NOT EXISTS import_state (
   source_path TEXT PRIMARY KEY,
+  source_id TEXT NOT NULL DEFAULT 'local',
   session_id TEXT,
   source_bucket TEXT NOT NULL,
   file_size INTEGER NOT NULL,
@@ -122,6 +124,7 @@ CREATE TABLE IF NOT EXISTS import_state (
 
 CREATE TABLE IF NOT EXISTS rate_limit_samples (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_id TEXT NOT NULL DEFAULT 'local',
   source_kind TEXT NOT NULL,
   source_session_id TEXT NOT NULL DEFAULT '',
   bucket TEXT NOT NULL,
@@ -134,4 +137,24 @@ CREATE TABLE IF NOT EXISTS rate_limit_samples (
   used_percent INTEGER NOT NULL,
   remaining_percent INTEGER NOT NULL,
   created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS codex_sources (
+  id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  label TEXT NOT NULL,
+  ssh_alias TEXT,
+  host_name TEXT,
+  user TEXT,
+  port INTEGER,
+  remote_codex_home TEXT,
+  local_codex_home TEXT,
+  selected INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'idle',
+  last_discovered_at TEXT,
+  last_downloaded_at TEXT,
+  last_scanned_at TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
 );

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -10,7 +10,9 @@ mod sync_settings;
 
 pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
 pub use subscriptions::{
-    canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
+    canonical_subscription_currency, create_subscription_record, delete_subscription_record,
+    get_subscription_profile, list_subscription_records, save_subscription_profile,
+    update_subscription_record,
 };
 pub use sync_settings::{
     get_sync_settings, save_sync_settings, set_last_scan_completed, set_last_scan_started,

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -5,10 +5,15 @@ use chrono::Utc;
 use rusqlite::{params, Connection};
 
 mod rate_limit_samples;
+mod sources;
 mod subscriptions;
 mod sync_settings;
 
 pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
+pub use sources::{
+    delete_codex_source, ensure_local_codex_source, get_codex_source, list_codex_sources,
+    set_codex_source_selected, update_codex_source_download_state, upsert_ssh_codex_source,
+};
 pub use subscriptions::{
     canonical_subscription_currency, create_subscription_record, delete_subscription_record,
     get_subscription_profile, list_subscription_records, save_subscription_profile,
@@ -45,9 +50,49 @@ pub fn open_connection(db_path: &Path) -> rusqlite::Result<Connection> {
 
 pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(include_str!("../sql/schema.sql"))?;
+    ensure_source_schema(conn)?;
     sync_settings::ensure_sync_settings_schema(conn)?;
     ensure_singletons(conn)?;
+    ensure_local_codex_source(conn, None)?;
     conn.execute_batch(include_str!("../sql/indexes.sql"))?;
+    Ok(())
+}
+
+fn ensure_source_schema(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_column(
+        conn,
+        "sessions",
+        "source_id",
+        "ALTER TABLE sessions ADD COLUMN source_id TEXT NOT NULL DEFAULT 'local'",
+    )?;
+    ensure_column(
+        conn,
+        "import_state",
+        "source_id",
+        "ALTER TABLE import_state ADD COLUMN source_id TEXT NOT NULL DEFAULT 'local'",
+    )?;
+    ensure_column(
+        conn,
+        "rate_limit_samples",
+        "source_id",
+        "ALTER TABLE rate_limit_samples ADD COLUMN source_id TEXT NOT NULL DEFAULT 'local'",
+    )?;
+    Ok(())
+}
+
+fn ensure_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    alter_sql: &str,
+) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if !columns.iter().any(|name| name == column) {
+        conn.execute(alter_sql, [])?;
+    }
     Ok(())
 }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -2,507 +2,69 @@ use std::path::Path;
 use std::time::Duration;
 
 use chrono::Utc;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection};
 
-use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord, SubscriptionProfile, SyncSettings};
+mod rate_limit_samples;
+mod subscriptions;
+mod sync_settings;
+
+pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
+pub use subscriptions::{
+    canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
+};
+pub use sync_settings::{
+    get_sync_settings, save_sync_settings, set_last_scan_completed, set_last_scan_started,
+};
 
 pub fn now_utc_string() -> String {
-  Utc::now().to_rfc3339()
+    Utc::now().to_rfc3339()
 }
 
 pub fn bool_to_i64(value: bool) -> i64 {
-  if value { 1 } else { 0 }
+    if value {
+        1
+    } else {
+        0
+    }
 }
 
 pub fn i64_to_bool(value: i64) -> bool {
-  value != 0
-}
-
-pub fn canonical_subscription_currency() -> &'static str {
-  "USD"
-}
-
-pub fn default_menu_bar_popup_modules() -> Vec<String> {
-  vec![
-    "api_value".to_string(),
-    "scan_freshness".to_string(),
-  ]
-}
-
-fn is_supported_menu_bar_popup_module(module: &str) -> bool {
-  matches!(
-    module,
-    "api_value"
-      | "token_count"
-      | "scan_freshness"
-      | "live_quota_freshness"
-      | "payoff_ratio"
-      | "conversation_count"
-  )
-}
-
-fn default_menu_bar_popup_modules_json() -> String {
-  serde_json::to_string(&default_menu_bar_popup_modules()).expect("serialize default popup modules")
-}
-
-fn deserialize_menu_bar_popup_modules(value: String) -> Vec<String> {
-  serde_json::from_str::<Vec<String>>(&value)
-    .ok()
-    .map(|modules| {
-      modules
-        .into_iter()
-        .filter(|module| is_supported_menu_bar_popup_module(module))
-        .fold(Vec::new(), |mut deduped, module| {
-          if !deduped.iter().any(|existing| existing == &module) {
-            deduped.push(module);
-          }
-          deduped
-        })
-    })
-    .unwrap_or_else(default_menu_bar_popup_modules)
-}
-
-fn serialize_menu_bar_popup_modules(modules: &[String]) -> String {
-  serde_json::to_string(modules).unwrap_or_else(|_| default_menu_bar_popup_modules_json())
+    value != 0
 }
 
 pub fn open_connection(db_path: &Path) -> rusqlite::Result<Connection> {
-  let conn = Connection::open(db_path)?;
-  conn.busy_timeout(Duration::from_secs(10))?;
-  conn.pragma_update(None, "foreign_keys", "ON")?;
-  conn.pragma_update(None, "journal_mode", "WAL")?;
-  conn.pragma_update(None, "synchronous", "NORMAL")?;
-  Ok(conn)
+    let conn = Connection::open(db_path)?;
+    conn.busy_timeout(Duration::from_secs(10))?;
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "NORMAL")?;
+    Ok(conn)
 }
 
 pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
-  conn.execute_batch(
-    "
-    CREATE TABLE IF NOT EXISTS sessions (
-      session_id TEXT PRIMARY KEY,
-      root_session_id TEXT NOT NULL,
-      parent_session_id TEXT,
-      title TEXT,
-      source_state TEXT NOT NULL DEFAULT 'missing',
-      source_path TEXT,
-      source_bucket TEXT,
-      started_at TEXT,
-      updated_at TEXT,
-      agent_nickname TEXT,
-      agent_role TEXT,
-      explicit_fast_mode INTEGER,
-      fast_mode_default INTEGER NOT NULL DEFAULT 0,
-      latest_plan_type TEXT,
-      last_model_id TEXT,
-      contains_subagents INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL,
-      imported_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS conversation_links (
-      session_id TEXT PRIMARY KEY,
-      root_session_id TEXT NOT NULL,
-      parent_session_id TEXT,
-      depth INTEGER NOT NULL DEFAULT 0
-    );
-
-    CREATE TABLE IF NOT EXISTS usage_events (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      session_id TEXT NOT NULL,
-      timestamp TEXT NOT NULL,
-      model_id TEXT NOT NULL,
-      input_tokens INTEGER NOT NULL,
-      cached_input_tokens INTEGER NOT NULL,
-      output_tokens INTEGER NOT NULL,
-      reasoning_output_tokens INTEGER NOT NULL,
-      total_tokens INTEGER NOT NULL,
-      value_usd REAL NOT NULL,
-      fast_mode_auto INTEGER NOT NULL,
-      fast_mode_effective INTEGER NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS pricing_catalog (
-      model_id TEXT PRIMARY KEY,
-      display_name TEXT NOT NULL,
-      input_price_per_million REAL NOT NULL,
-      cached_input_price_per_million REAL NOT NULL,
-      output_price_per_million REAL NOT NULL,
-      effective_model_id TEXT NOT NULL,
-      is_official INTEGER NOT NULL,
-      note TEXT,
-      source_url TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS subscription_profile (
-      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
-      plan_type TEXT NOT NULL,
-      currency TEXT NOT NULL,
-      monthly_price REAL NOT NULL,
-      billing_anchor_day INTEGER NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS session_overrides (
-      session_id TEXT PRIMARY KEY,
-      fast_mode_override INTEGER,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS sync_settings (
-      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
-      sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
-      codex_home TEXT,
-      auto_scan_enabled INTEGER NOT NULL,
-      auto_scan_interval_minutes INTEGER NOT NULL,
-      live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
-      default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0,
-      hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0,
-      show_menu_bar_logo INTEGER NOT NULL DEFAULT 1,
-      show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1,
-      show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0,
-      menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent',
-      menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour',
-      menu_bar_bucket TEXT NOT NULL DEFAULT 'day',
-      menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1,
-      menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85,
-      menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115,
-      menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢',
-      menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥',
-      menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢',
-      menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1,
-      menu_bar_popup_modules TEXT NOT NULL DEFAULT '[\"api_value\",\"scan_freshness\"]',
-      menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1,
-      menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
-      last_scan_started_at TEXT,
-      last_scan_completed_at TEXT,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS import_state (
-      source_path TEXT PRIMARY KEY,
-      session_id TEXT,
-      source_bucket TEXT NOT NULL,
-      file_size INTEGER NOT NULL,
-      file_mtime_ms INTEGER NOT NULL,
-      last_imported_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS rate_limit_samples (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      source_kind TEXT NOT NULL,
-      source_session_id TEXT NOT NULL DEFAULT '',
-      bucket TEXT NOT NULL,
-      sample_timestamp TEXT NOT NULL,
-      limit_id TEXT NOT NULL DEFAULT '',
-      limit_name TEXT NOT NULL DEFAULT '',
-      plan_type TEXT NOT NULL DEFAULT '',
-      window_start TEXT NOT NULL,
-      resets_at TEXT NOT NULL,
-      used_percent INTEGER NOT NULL,
-      remaining_percent INTEGER NOT NULL,
-      created_at TEXT NOT NULL
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_usage_events_session_id ON usage_events(session_id);
-    CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp);
-    CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
-    CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
-    CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
-    CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
-    CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
-      ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
-      ON rate_limit_samples(
-        bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
-      );
-    ",
-  )?;
-
-  ensure_sync_settings_schema(conn)?;
-  ensure_singletons(conn)?;
-  Ok(())
-}
-
-fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare("PRAGMA table_info(sync_settings)")?;
-  let column_names = stmt
-    .query_map([], |row| row.get::<_, String>(1))?
-    .collect::<rusqlite::Result<Vec<_>>>()?;
-
-  if !column_names
-    .iter()
-    .any(|name| name == "sync_settings_schema_version")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN sync_settings_schema_version INTEGER NOT NULL DEFAULT 1
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "show_menu_bar_daily_api_value")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "show_menu_bar_logo")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN show_menu_bar_logo INTEGER NOT NULL DEFAULT 1
-      ",
-      [],
-    )?;
-    conn.execute(
-      "
-      UPDATE sync_settings
-      SET show_menu_bar_logo = show_menu_bar_daily_api_value
-      WHERE singleton_id = 1
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "show_menu_bar_live_quota_percent")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_live_quota_metric")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent'
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_live_quota_bucket")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour'
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_bucket") {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN menu_bar_bucket TEXT NOT NULL DEFAULT 'day'
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "live_quota_refresh_interval_seconds")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "default_fast_mode_for_new_gpt54_sessions")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "hide_dock_icon_when_menu_bar_visible")
-  {
-    conn.execute(
-      "
-      ALTER TABLE sync_settings
-      ADD COLUMN hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0
-      ",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_speed_show_emoji") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_speed_fast_threshold_percent")
-  {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_speed_slow_threshold_percent")
-  {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_speed_healthy_emoji")
-  {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢'",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_speed_fast_emoji") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥'",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_speed_slow_emoji") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢'",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_popup_enabled") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_popup_modules") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_modules TEXT NOT NULL DEFAULT '[\"api_value\",\"scan_freshness\"]'",
-      [],
-    )?;
-  }
-
-  if !column_names
-    .iter()
-    .any(|name| name == "menu_bar_popup_show_reset_timeline")
-  {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1",
-      [],
-    )?;
-  }
-
-  if !column_names.iter().any(|name| name == "menu_bar_popup_show_actions") {
-    conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1",
-      [],
-    )?;
-  }
-
-  migrate_sync_settings_defaults_to_minutes(conn)?;
-
-  Ok(())
-}
-
-fn migrate_sync_settings_defaults_to_minutes(conn: &Connection) -> rusqlite::Result<()> {
-  let schema_version = conn
-    .query_row(
-      "SELECT sync_settings_schema_version FROM sync_settings WHERE singleton_id = 1",
-      [],
-      |row| row.get::<_, i64>(0),
-    )
-    .optional()?
-    .unwrap_or(2);
-
-  if schema_version >= 2 {
-    return Ok(());
-  }
-
-  conn.execute(
-    "
-    UPDATE sync_settings
-    SET
-      live_quota_refresh_interval_seconds = CASE
-        WHEN live_quota_refresh_interval_seconds = 60 THEN 300
-        ELSE live_quota_refresh_interval_seconds
-      END,
-      default_fast_mode_for_new_gpt54_sessions = CASE
-        WHEN default_fast_mode_for_new_gpt54_sessions = 1 THEN 0
-        ELSE default_fast_mode_for_new_gpt54_sessions
-      END,
-      sync_settings_schema_version = 2
-    WHERE singleton_id = 1
-    ",
-    [],
-  )?;
-
-  Ok(())
+    conn.execute_batch(include_str!("../sql/schema.sql"))?;
+    sync_settings::ensure_sync_settings_schema(conn)?;
+    ensure_singletons(conn)?;
+    conn.execute_batch(include_str!("../sql/indexes.sql"))?;
+    Ok(())
 }
 
 fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {
-  let now = now_utc_string();
-  conn.execute(
-    "
+    let now = now_utc_string();
+    conn.execute(
+        "
     INSERT INTO subscription_profile (
       singleton_id, plan_type, currency, monthly_price, billing_anchor_day, updated_at
     )
     VALUES (1, 'plus', ?2, 20.0, 1, ?1)
     ON CONFLICT(singleton_id) DO NOTHING
     ",
-    params![now, canonical_subscription_currency()],
-  )?;
+        params![now, canonical_subscription_currency()],
+    )?;
 
-  let now = now_utc_string();
-  conn.execute(
-    "
+    let now = now_utc_string();
+    conn.execute(
+        "
     INSERT INTO sync_settings (
       singleton_id, sync_settings_schema_version,
       codex_home, auto_scan_enabled, auto_scan_interval_minutes,
@@ -522,222 +84,23 @@ fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {
     VALUES (1, 2, NULL, 1, 5, 300, 0, 0, 1, 1, 0, 'remaining_percent', 'five_hour', 'day', 1, 85, 115, '🟢', '🔥', '🐢', 1, ?2, 1, 1, NULL, NULL, ?1)
     ON CONFLICT(singleton_id) DO NOTHING
     ",
-    params![now, default_menu_bar_popup_modules_json()],
-  )?;
+        params![now, sync_settings::default_menu_bar_popup_modules_json()],
+    )?;
 
-  Ok(())
-}
-
-pub fn get_sync_settings(conn: &Connection) -> rusqlite::Result<SyncSettings> {
-  conn.query_row(
-    "
-    SELECT codex_home, auto_scan_enabled, auto_scan_interval_minutes,
-           live_quota_refresh_interval_seconds,
-           hide_dock_icon_when_menu_bar_visible,
-           show_menu_bar_logo, show_menu_bar_daily_api_value,
-           show_menu_bar_live_quota_percent, menu_bar_live_quota_metric,
-           menu_bar_live_quota_bucket, menu_bar_bucket,
-           menu_bar_speed_show_emoji, menu_bar_speed_fast_threshold_percent,
-           menu_bar_speed_slow_threshold_percent, menu_bar_speed_healthy_emoji,
-           menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
-           menu_bar_popup_enabled, menu_bar_popup_modules,
-           menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
-           last_scan_started_at, last_scan_completed_at, updated_at
-    FROM sync_settings
-    WHERE singleton_id = 1
-    ",
-    [],
-    |row| {
-      Ok(SyncSettings {
-        codex_home: row.get(0)?,
-        auto_scan_enabled: i64_to_bool(row.get::<_, i64>(1)?),
-        auto_scan_interval_minutes: row.get(2)?,
-        live_quota_refresh_interval_seconds: row.get(3)?,
-        hide_dock_icon_when_menu_bar_visible: i64_to_bool(row.get::<_, i64>(4)?),
-        show_menu_bar_logo: i64_to_bool(row.get::<_, i64>(5)?),
-        show_menu_bar_daily_api_value: i64_to_bool(row.get::<_, i64>(6)?),
-        show_menu_bar_live_quota_percent: i64_to_bool(row.get::<_, i64>(7)?),
-        menu_bar_live_quota_metric: row.get(8)?,
-        menu_bar_live_quota_bucket: row.get(9)?,
-        menu_bar_bucket: row.get(10)?,
-        menu_bar_speed_show_emoji: i64_to_bool(row.get::<_, i64>(11)?),
-        menu_bar_speed_fast_threshold_percent: row.get(12)?,
-        menu_bar_speed_slow_threshold_percent: row.get(13)?,
-        menu_bar_speed_healthy_emoji: row.get(14)?,
-        menu_bar_speed_fast_emoji: row.get(15)?,
-        menu_bar_speed_slow_emoji: row.get(16)?,
-        menu_bar_popup_enabled: i64_to_bool(row.get::<_, i64>(17)?),
-        menu_bar_popup_modules: deserialize_menu_bar_popup_modules(row.get(18)?),
-        menu_bar_popup_show_reset_timeline: i64_to_bool(row.get::<_, i64>(19)?),
-        menu_bar_popup_show_actions: i64_to_bool(row.get::<_, i64>(20)?),
-        last_scan_started_at: row.get(21)?,
-        last_scan_completed_at: row.get(22)?,
-        updated_at: row.get(23)?,
-      })
-    },
-  )
-}
-
-pub fn save_sync_settings(conn: &Connection, settings: &SyncSettings) -> rusqlite::Result<SyncSettings> {
-  let updated_at = now_utc_string();
-  conn.execute(
-    "
-    INSERT INTO sync_settings (
-      singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
-      live_quota_refresh_interval_seconds,
-      hide_dock_icon_when_menu_bar_visible,
-      show_menu_bar_logo,
-      show_menu_bar_daily_api_value,
-      show_menu_bar_live_quota_percent, menu_bar_live_quota_metric,
-      menu_bar_live_quota_bucket, menu_bar_bucket,
-      menu_bar_speed_show_emoji, menu_bar_speed_fast_threshold_percent,
-      menu_bar_speed_slow_threshold_percent, menu_bar_speed_healthy_emoji,
-      menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
-      menu_bar_popup_enabled, menu_bar_popup_modules,
-      menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
-      last_scan_started_at, last_scan_completed_at, updated_at
-    )
-    VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)
-    ON CONFLICT(singleton_id) DO UPDATE SET
-      codex_home = excluded.codex_home,
-      auto_scan_enabled = excluded.auto_scan_enabled,
-      auto_scan_interval_minutes = excluded.auto_scan_interval_minutes,
-      live_quota_refresh_interval_seconds = excluded.live_quota_refresh_interval_seconds,
-      hide_dock_icon_when_menu_bar_visible = excluded.hide_dock_icon_when_menu_bar_visible,
-      show_menu_bar_logo = excluded.show_menu_bar_logo,
-      show_menu_bar_daily_api_value = excluded.show_menu_bar_daily_api_value,
-      show_menu_bar_live_quota_percent = excluded.show_menu_bar_live_quota_percent,
-      menu_bar_live_quota_metric = excluded.menu_bar_live_quota_metric,
-      menu_bar_live_quota_bucket = excluded.menu_bar_live_quota_bucket,
-      menu_bar_bucket = excluded.menu_bar_bucket,
-      menu_bar_speed_show_emoji = excluded.menu_bar_speed_show_emoji,
-      menu_bar_speed_fast_threshold_percent = excluded.menu_bar_speed_fast_threshold_percent,
-      menu_bar_speed_slow_threshold_percent = excluded.menu_bar_speed_slow_threshold_percent,
-      menu_bar_speed_healthy_emoji = excluded.menu_bar_speed_healthy_emoji,
-      menu_bar_speed_fast_emoji = excluded.menu_bar_speed_fast_emoji,
-      menu_bar_speed_slow_emoji = excluded.menu_bar_speed_slow_emoji,
-      menu_bar_popup_enabled = excluded.menu_bar_popup_enabled,
-      menu_bar_popup_modules = excluded.menu_bar_popup_modules,
-      menu_bar_popup_show_reset_timeline = excluded.menu_bar_popup_show_reset_timeline,
-      menu_bar_popup_show_actions = excluded.menu_bar_popup_show_actions,
-      last_scan_started_at = excluded.last_scan_started_at,
-      last_scan_completed_at = excluded.last_scan_completed_at,
-      updated_at = excluded.updated_at
-    ",
-    params![
-      settings.codex_home,
-      bool_to_i64(settings.auto_scan_enabled),
-      settings.auto_scan_interval_minutes.max(1),
-      settings.live_quota_refresh_interval_seconds.clamp(60, 3600),
-      bool_to_i64(settings.hide_dock_icon_when_menu_bar_visible),
-      bool_to_i64(settings.show_menu_bar_logo),
-      bool_to_i64(settings.show_menu_bar_daily_api_value),
-      bool_to_i64(settings.show_menu_bar_live_quota_percent),
-      settings.menu_bar_live_quota_metric,
-      settings.menu_bar_live_quota_bucket,
-      settings.menu_bar_bucket,
-      bool_to_i64(settings.menu_bar_speed_show_emoji),
-      settings.menu_bar_speed_fast_threshold_percent.clamp(0, 1000),
-      settings.menu_bar_speed_slow_threshold_percent.clamp(0, 1000),
-      settings.menu_bar_speed_healthy_emoji,
-      settings.menu_bar_speed_fast_emoji,
-      settings.menu_bar_speed_slow_emoji,
-      bool_to_i64(settings.menu_bar_popup_enabled),
-      serialize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
-      bool_to_i64(settings.menu_bar_popup_show_reset_timeline),
-      bool_to_i64(settings.menu_bar_popup_show_actions),
-      settings.last_scan_started_at,
-      settings.last_scan_completed_at,
-      updated_at,
-    ],
-  )?;
-  get_sync_settings(conn)
-}
-
-pub fn replace_session_rate_limit_samples(
-  conn: &Connection,
-  session_id: &str,
-  samples: &[RateLimitSampleRecord],
-) -> rusqlite::Result<()> {
-  conn.execute(
-    "
-    DELETE FROM rate_limit_samples
-    WHERE source_kind = 'session' AND source_session_id = ?1
-    ",
-    params![session_id],
-  )?;
-  insert_rate_limit_samples(conn, samples)
-}
-
-pub fn insert_rate_limit_samples(conn: &Connection, samples: &[RateLimitSampleRecord]) -> rusqlite::Result<()> {
-  let created_at = now_utc_string();
-  let mut stmt = conn.prepare(
-    "
-    INSERT OR IGNORE INTO rate_limit_samples (
-      source_kind, source_session_id, bucket, sample_timestamp, limit_id, limit_name, plan_type,
-      window_start, resets_at, used_percent, remaining_percent, created_at
-    )
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-    ",
-  )?;
-
-  for sample in samples {
-    stmt.execute(params![
-      sample.source_kind,
-      sample.source_session_id.clone().unwrap_or_default(),
-      sample.bucket,
-      sample.sample_timestamp,
-      sample.limit_id.clone().unwrap_or_default(),
-      sample.limit_name.clone().unwrap_or_default(),
-      sample.plan_type.clone().unwrap_or_default(),
-      sample.window_start,
-      sample.resets_at,
-      sample.used_percent.clamp(0, 100),
-      sample.remaining_percent.clamp(0, 100),
-      created_at,
-    ])?;
-  }
-
-  Ok(())
-}
-
-pub fn insert_live_rate_limit_snapshot(conn: &Connection, snapshot: &LiveRateLimitSnapshot) -> rusqlite::Result<()> {
-  let mut samples = Vec::new();
-  for (bucket, window) in [("five_hour", snapshot.primary.as_ref()), ("seven_day", snapshot.secondary.as_ref())] {
-    let Some(window) = window else {
-      continue;
-    };
-    let (Some(window_start), Some(resets_at)) = (window.window_start.clone(), window.resets_at.clone()) else {
-      continue;
-    };
-    samples.push(RateLimitSampleRecord {
-      source_kind: "live".to_string(),
-      source_session_id: None,
-      bucket: bucket.to_string(),
-      sample_timestamp: snapshot.fetched_at.clone(),
-      limit_id: snapshot.limit_id.clone(),
-      limit_name: snapshot.limit_name.clone(),
-      plan_type: snapshot.plan_type.clone(),
-      window_start,
-      resets_at,
-      used_percent: window.used_percent,
-      remaining_percent: window.remaining_percent,
-    });
-  }
-  insert_rate_limit_samples(conn, &samples)
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
+    use crate::models::{SubscriptionProfile, SyncSettings};
 
-  #[test]
-  fn init_db_adds_menu_bar_flag_to_existing_sync_settings() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
+    #[test]
+    fn init_db_adds_menu_bar_flag_to_existing_sync_settings() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
 
-    conn
-      .execute_batch(
-        "
+        conn.execute_batch(
+            "
         CREATE TABLE sync_settings (
           singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
           codex_home TEXT,
@@ -754,42 +117,41 @@ mod tests {
         )
         VALUES (1, NULL, 1, 5, NULL, NULL, '2026-03-26T00:00:00Z');
         ",
-      )
-      .expect("seed legacy schema");
+        )
+        .expect("seed legacy schema");
 
-    init_db(&conn).expect("migrate schema");
-    let settings = get_sync_settings(&conn).expect("load settings");
+        init_db(&conn).expect("migrate schema");
+        let settings = get_sync_settings(&conn).expect("load settings");
 
-    assert!(settings.show_menu_bar_daily_api_value);
-    assert!(settings.show_menu_bar_logo);
-    assert!(!settings.show_menu_bar_live_quota_percent);
-    assert_eq!(settings.menu_bar_live_quota_metric, "remaining_percent");
-    assert_eq!(settings.menu_bar_live_quota_bucket, "five_hour");
-    assert_eq!(settings.menu_bar_bucket, "day");
-    assert_eq!(settings.live_quota_refresh_interval_seconds, 300);
-    assert!(settings.menu_bar_speed_show_emoji);
-    assert_eq!(settings.menu_bar_speed_fast_threshold_percent, 85);
-    assert_eq!(settings.menu_bar_speed_slow_threshold_percent, 115);
-    assert_eq!(settings.menu_bar_speed_healthy_emoji, "🟢");
-    assert_eq!(settings.menu_bar_speed_fast_emoji, "🔥");
-    assert_eq!(settings.menu_bar_speed_slow_emoji, "🐢");
-    assert!(settings.menu_bar_popup_enabled);
-    assert_eq!(
-      settings.menu_bar_popup_modules,
-      default_menu_bar_popup_modules()
-    );
-    assert!(settings.menu_bar_popup_show_reset_timeline);
-    assert!(settings.menu_bar_popup_show_actions);
-    assert!(!settings.hide_dock_icon_when_menu_bar_visible);
-  }
+        assert!(settings.show_menu_bar_daily_api_value);
+        assert!(settings.show_menu_bar_logo);
+        assert!(!settings.show_menu_bar_live_quota_percent);
+        assert_eq!(settings.menu_bar_live_quota_metric, "remaining_percent");
+        assert_eq!(settings.menu_bar_live_quota_bucket, "five_hour");
+        assert_eq!(settings.menu_bar_bucket, "day");
+        assert_eq!(settings.live_quota_refresh_interval_seconds, 300);
+        assert!(settings.menu_bar_speed_show_emoji);
+        assert_eq!(settings.menu_bar_speed_fast_threshold_percent, 85);
+        assert_eq!(settings.menu_bar_speed_slow_threshold_percent, 115);
+        assert_eq!(settings.menu_bar_speed_healthy_emoji, "🟢");
+        assert_eq!(settings.menu_bar_speed_fast_emoji, "🔥");
+        assert_eq!(settings.menu_bar_speed_slow_emoji, "🐢");
+        assert!(settings.menu_bar_popup_enabled);
+        assert_eq!(
+            settings.menu_bar_popup_modules,
+            sync_settings::default_menu_bar_popup_modules()
+        );
+        assert!(settings.menu_bar_popup_show_reset_timeline);
+        assert!(settings.menu_bar_popup_show_actions);
+        assert!(!settings.hide_dock_icon_when_menu_bar_visible);
+    }
 
-  #[test]
-  fn init_db_copies_existing_menu_bar_visibility_into_logo_flag() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
+    #[test]
+    fn init_db_copies_existing_menu_bar_visibility_into_logo_flag() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
 
-    conn
-      .execute_batch(
-        "
+        conn.execute_batch(
+            "
         CREATE TABLE sync_settings (
           singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
           codex_home TEXT,
@@ -807,44 +169,43 @@ mod tests {
         )
         VALUES (1, NULL, 1, 5, 0, NULL, NULL, '2026-03-26T00:00:00Z');
         ",
-      )
-      .expect("seed pre-logo schema");
+        )
+        .expect("seed pre-logo schema");
 
-    init_db(&conn).expect("migrate schema");
-    let settings = get_sync_settings(&conn).expect("load settings");
+        init_db(&conn).expect("migrate schema");
+        let settings = get_sync_settings(&conn).expect("load settings");
 
-    assert!(!settings.show_menu_bar_daily_api_value);
-    assert!(!settings.show_menu_bar_logo);
-    assert!(!settings.hide_dock_icon_when_menu_bar_visible);
-  }
+        assert!(!settings.show_menu_bar_daily_api_value);
+        assert!(!settings.show_menu_bar_logo);
+        assert!(!settings.hide_dock_icon_when_menu_bar_visible);
+    }
 
-  #[test]
-  fn save_sync_settings_round_trips_dock_visibility_preference() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
-    init_db(&conn).expect("init database");
+    #[test]
+    fn save_sync_settings_round_trips_dock_visibility_preference() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
 
-    save_sync_settings(
-      &conn,
-      &SyncSettings {
-        hide_dock_icon_when_menu_bar_visible: true,
-        ..SyncSettings::default()
-      },
-    )
-    .expect("save settings");
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                hide_dock_icon_when_menu_bar_visible: true,
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save settings");
 
-    let settings = get_sync_settings(&conn).expect("load settings");
+        let settings = get_sync_settings(&conn).expect("load settings");
 
-    assert!(settings.hide_dock_icon_when_menu_bar_visible);
-  }
+        assert!(settings.hide_dock_icon_when_menu_bar_visible);
+    }
 
-  #[test]
-  fn init_db_migrates_old_default_refresh_and_disables_legacy_fast_mode_once() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
+    #[test]
+    fn init_db_migrates_old_default_refresh_and_disables_legacy_fast_mode_once() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
 
-    init_db(&conn).expect("init database");
-    conn
-      .execute(
-        "
+        init_db(&conn).expect("init database");
+        conn.execute(
+            "
         UPDATE sync_settings
         SET
           sync_settings_schema_version = 1,
@@ -852,20 +213,20 @@ mod tests {
           default_fast_mode_for_new_gpt54_sessions = 1
         WHERE singleton_id = 1
         ",
-        [],
-      )
-      .expect("seed old defaults");
+            [],
+        )
+        .expect("seed old defaults");
 
-    init_db(&conn).expect("migrate defaults");
-    let settings = get_sync_settings(&conn).expect("load settings");
-    let schema_version = conn
-      .query_row(
-        "SELECT sync_settings_schema_version FROM sync_settings WHERE singleton_id = 1",
-        [],
-        |row| row.get::<_, i64>(0),
-      )
-      .expect("load schema version");
-    let legacy_fast_mode_default = conn
+        init_db(&conn).expect("migrate defaults");
+        let settings = get_sync_settings(&conn).expect("load settings");
+        let schema_version = conn
+            .query_row(
+                "SELECT sync_settings_schema_version FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("load schema version");
+        let legacy_fast_mode_default = conn
       .query_row(
         "SELECT default_fast_mode_for_new_gpt54_sessions FROM sync_settings WHERE singleton_id = 1",
         [],
@@ -873,122 +234,46 @@ mod tests {
       )
       .expect("load legacy fast mode default");
 
-    assert_eq!(settings.live_quota_refresh_interval_seconds, 300);
-    assert_eq!(legacy_fast_mode_default, 0);
-    assert_eq!(schema_version, 2);
+        assert_eq!(settings.live_quota_refresh_interval_seconds, 300);
+        assert_eq!(legacy_fast_mode_default, 0);
+        assert_eq!(schema_version, 2);
 
-    save_sync_settings(
-      &conn,
-      &SyncSettings {
-        live_quota_refresh_interval_seconds: 600,
-        ..SyncSettings::default()
-      },
-    )
-    .expect("save user preferences");
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                live_quota_refresh_interval_seconds: 600,
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save user preferences");
 
-    init_db(&conn).expect("run init again");
-    let settings = get_sync_settings(&conn).expect("reload settings");
+        init_db(&conn).expect("run init again");
+        let settings = get_sync_settings(&conn).expect("reload settings");
 
-    assert_eq!(settings.live_quota_refresh_interval_seconds, 600);
-  }
+        assert_eq!(settings.live_quota_refresh_interval_seconds, 600);
+    }
 
-  #[test]
-  fn subscription_profile_is_normalized_to_usd() {
-    let conn = Connection::open_in_memory().expect("open in-memory database");
+    #[test]
+    fn subscription_profile_is_normalized_to_usd() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
 
-    init_db(&conn).expect("init database");
-    save_subscription_profile(
-      &conn,
-      &SubscriptionProfile {
-        plan_type: "pro".to_string(),
-        currency: "eur".to_string(),
-        monthly_price: 42.0,
-        billing_anchor_day: 9,
-        updated_at: "2026-04-07T00:00:00Z".to_string(),
-      },
-    )
-    .expect("save profile");
+        init_db(&conn).expect("init database");
+        save_subscription_profile(
+            &conn,
+            &SubscriptionProfile {
+                plan_type: "pro".to_string(),
+                currency: "eur".to_string(),
+                monthly_price: 42.0,
+                billing_anchor_day: 9,
+                updated_at: "2026-04-07T00:00:00Z".to_string(),
+            },
+        )
+        .expect("save profile");
 
-    let profile = get_subscription_profile(&conn).expect("load profile");
+        let profile = get_subscription_profile(&conn).expect("load profile");
 
-    assert_eq!(profile.currency, "USD");
-    assert_eq!(profile.monthly_price, 42.0);
-    assert_eq!(profile.billing_anchor_day, 9);
-  }
-}
-
-pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
-  conn.execute(
-    "
-    UPDATE sync_settings
-    SET last_scan_started_at = ?1, updated_at = ?1
-    WHERE singleton_id = 1
-    ",
-    params![timestamp],
-  )?;
-  Ok(())
-}
-
-pub fn set_last_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
-  conn.execute(
-    "
-    UPDATE sync_settings
-    SET last_scan_completed_at = ?1, updated_at = ?1
-    WHERE singleton_id = 1
-    ",
-    params![timestamp],
-  )?;
-  Ok(())
-}
-
-pub fn get_subscription_profile(conn: &Connection) -> rusqlite::Result<SubscriptionProfile> {
-  conn.query_row(
-    "
-    SELECT plan_type, currency, monthly_price, billing_anchor_day, updated_at
-    FROM subscription_profile
-    WHERE singleton_id = 1
-    ",
-    [],
-    |row| {
-      Ok(SubscriptionProfile {
-        plan_type: row.get(0)?,
-        currency: {
-          let _: String = row.get(1)?;
-          canonical_subscription_currency().to_string()
-        },
-        monthly_price: row.get(2)?,
-        billing_anchor_day: row.get(3)?,
-        updated_at: row.get(4)?,
-      })
-    },
-  )
-}
-
-pub fn save_subscription_profile(
-  conn: &Connection,
-  profile: &SubscriptionProfile,
-) -> rusqlite::Result<SubscriptionProfile> {
-  let updated_at = now_utc_string();
-  conn.execute(
-    "
-    INSERT INTO subscription_profile (
-      singleton_id, plan_type, currency, monthly_price, billing_anchor_day, updated_at
-    )
-    VALUES (1, ?1, ?2, ?3, ?4, ?5)
-    ON CONFLICT(singleton_id) DO UPDATE SET
-      plan_type = excluded.plan_type,
-      currency = excluded.currency,
-      monthly_price = excluded.monthly_price,
-      billing_anchor_day = excluded.billing_anchor_day,
-      updated_at = excluded.updated_at
-    ",
-    params![
-      profile.plan_type,
-      canonical_subscription_currency(),
-      profile.monthly_price.max(0.0),
-      profile.billing_anchor_day.clamp(1, 28),
-      updated_at,
-    ],
-  )?;
-  get_subscription_profile(conn)
+        assert_eq!(profile.currency, "USD");
+        assert_eq!(profile.monthly_price, 42.0);
+        assert_eq!(profile.billing_anchor_day, 9);
+    }
 }

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -6,36 +6,46 @@ use super::now_utc_string;
 
 pub fn replace_session_rate_limit_samples(
     conn: &Connection,
+    source_id: &str,
     session_id: &str,
     samples: &[RateLimitSampleRecord],
 ) -> rusqlite::Result<()> {
     conn.execute(
         "
     DELETE FROM rate_limit_samples
-    WHERE source_kind = 'session' AND source_session_id = ?1
+    WHERE source_id = ?1 AND source_kind = 'session' AND source_session_id = ?2
     ",
-        params![session_id],
+        params![source_id, session_id],
     )?;
-    insert_rate_limit_samples(conn, samples)
+    insert_rate_limit_samples_for_source(conn, source_id, samples)
 }
 
 pub fn insert_rate_limit_samples(
     conn: &Connection,
     samples: &[RateLimitSampleRecord],
 ) -> rusqlite::Result<()> {
+    insert_rate_limit_samples_for_source(conn, "local", samples)
+}
+
+fn insert_rate_limit_samples_for_source(
+    conn: &Connection,
+    source_id: &str,
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<()> {
     let created_at = now_utc_string();
     let mut stmt = conn.prepare(
         "
     INSERT OR IGNORE INTO rate_limit_samples (
-      source_kind, source_session_id, bucket, sample_timestamp, limit_id, limit_name, plan_type,
+      source_id, source_kind, source_session_id, bucket, sample_timestamp, limit_id, limit_name, plan_type,
       window_start, resets_at, used_percent, remaining_percent, created_at
     )
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
     ",
     )?;
 
     for sample in samples {
         stmt.execute(params![
+            source_id,
             sample.source_kind,
             sample.source_session_id.clone().unwrap_or_default(),
             sample.bucket,

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -1,0 +1,89 @@
+use rusqlite::{params, Connection};
+
+use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord};
+
+use super::now_utc_string;
+
+pub fn replace_session_rate_limit_samples(
+    conn: &Connection,
+    session_id: &str,
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    DELETE FROM rate_limit_samples
+    WHERE source_kind = 'session' AND source_session_id = ?1
+    ",
+        params![session_id],
+    )?;
+    insert_rate_limit_samples(conn, samples)
+}
+
+pub fn insert_rate_limit_samples(
+    conn: &Connection,
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<()> {
+    let created_at = now_utc_string();
+    let mut stmt = conn.prepare(
+        "
+    INSERT OR IGNORE INTO rate_limit_samples (
+      source_kind, source_session_id, bucket, sample_timestamp, limit_id, limit_name, plan_type,
+      window_start, resets_at, used_percent, remaining_percent, created_at
+    )
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+    ",
+    )?;
+
+    for sample in samples {
+        stmt.execute(params![
+            sample.source_kind,
+            sample.source_session_id.clone().unwrap_or_default(),
+            sample.bucket,
+            sample.sample_timestamp,
+            sample.limit_id.clone().unwrap_or_default(),
+            sample.limit_name.clone().unwrap_or_default(),
+            sample.plan_type.clone().unwrap_or_default(),
+            sample.window_start,
+            sample.resets_at,
+            sample.used_percent.clamp(0, 100),
+            sample.remaining_percent.clamp(0, 100),
+            created_at,
+        ])?;
+    }
+
+    Ok(())
+}
+
+pub fn insert_live_rate_limit_snapshot(
+    conn: &Connection,
+    snapshot: &LiveRateLimitSnapshot,
+) -> rusqlite::Result<()> {
+    let mut samples = Vec::new();
+    for (bucket, window) in [
+        ("five_hour", snapshot.primary.as_ref()),
+        ("seven_day", snapshot.secondary.as_ref()),
+    ] {
+        let Some(window) = window else {
+            continue;
+        };
+        let (Some(window_start), Some(resets_at)) =
+            (window.window_start.clone(), window.resets_at.clone())
+        else {
+            continue;
+        };
+        samples.push(RateLimitSampleRecord {
+            source_kind: "live".to_string(),
+            source_session_id: None,
+            bucket: bucket.to_string(),
+            sample_timestamp: snapshot.fetched_at.clone(),
+            limit_id: snapshot.limit_id.clone(),
+            limit_name: snapshot.limit_name.clone(),
+            plan_type: snapshot.plan_type.clone(),
+            window_start,
+            resets_at,
+            used_percent: window.used_percent,
+            remaining_percent: window.remaining_percent,
+        });
+    }
+    insert_rate_limit_samples(conn, &samples)
+}

--- a/src-tauri/src/database/sources.rs
+++ b/src-tauri/src/database/sources.rs
@@ -1,0 +1,333 @@
+use rusqlite::{params, Connection};
+
+use crate::models::{CodexSource, CodexSourceInput};
+
+use super::{bool_to_i64, i64_to_bool, now_utc_string};
+
+pub fn ensure_local_codex_source(
+    conn: &Connection,
+    local_codex_home: Option<&str>,
+) -> rusqlite::Result<()> {
+    let now = now_utc_string();
+    conn.execute(
+        "
+    INSERT INTO codex_sources (
+      id, kind, label, local_codex_home, selected, status, created_at, updated_at
+    )
+    VALUES ('local', 'local', 'localhost', ?1, 1, 'ready', ?2, ?2)
+    ON CONFLICT(id) DO UPDATE SET
+      local_codex_home = COALESCE(?1, codex_sources.local_codex_home),
+      updated_at = excluded.updated_at
+    ",
+        params![local_codex_home, now],
+    )?;
+    Ok(())
+}
+
+pub fn list_codex_sources(conn: &Connection) -> rusqlite::Result<Vec<CodexSource>> {
+    ensure_local_codex_source(conn, None)?;
+    let mut stmt = conn.prepare(
+        "
+    SELECT id, kind, label, ssh_alias, host_name, user, port, remote_codex_home, local_codex_home,
+           selected, status, last_discovered_at, last_downloaded_at, last_scanned_at,
+           last_error, created_at, updated_at
+    FROM codex_sources
+    ORDER BY CASE WHEN id = 'local' THEN 0 ELSE 1 END, label COLLATE NOCASE ASC, id ASC
+    ",
+    )?;
+    let rows = stmt
+        .query_map([], codex_source_from_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+pub fn get_codex_source(conn: &Connection, id: &str) -> rusqlite::Result<CodexSource> {
+    conn.query_row(
+        "
+    SELECT id, kind, label, ssh_alias, host_name, user, port, remote_codex_home, local_codex_home,
+           selected, status, last_discovered_at, last_downloaded_at, last_scanned_at,
+           last_error, created_at, updated_at
+    FROM codex_sources
+    WHERE id = ?1
+    ",
+        params![id],
+        codex_source_from_row,
+    )
+}
+
+pub fn upsert_ssh_codex_source(
+    conn: &Connection,
+    id: &str,
+    input: &CodexSourceInput,
+    local_codex_home: &str,
+) -> rusqlite::Result<CodexSource> {
+    let now = now_utc_string();
+    conn.execute(
+        "
+    INSERT INTO codex_sources (
+      id, kind, label, ssh_alias, host_name, user, port, remote_codex_home, local_codex_home,
+      selected, status, last_discovered_at, created_at, updated_at
+    )
+    VALUES (?1, 'ssh', ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'idle', ?10, ?10, ?10)
+    ON CONFLICT(id) DO UPDATE SET
+      label = excluded.label,
+      ssh_alias = excluded.ssh_alias,
+      host_name = excluded.host_name,
+      user = excluded.user,
+      port = excluded.port,
+      remote_codex_home = excluded.remote_codex_home,
+      local_codex_home = excluded.local_codex_home,
+      selected = excluded.selected,
+      last_discovered_at = excluded.last_discovered_at,
+      updated_at = excluded.updated_at
+    ",
+        params![
+            id,
+            normalize_label(&input.label, &input.ssh_alias),
+            input.ssh_alias.trim(),
+            input
+                .host_name
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty()),
+            input
+                .user
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty()),
+            input.port,
+            normalize_remote_codex_home(&input.remote_codex_home),
+            local_codex_home,
+            bool_to_i64(input.selected),
+            now,
+        ],
+    )?;
+    get_codex_source(conn, id)
+}
+
+pub fn set_codex_source_selected(
+    conn: &Connection,
+    id: &str,
+    selected: bool,
+) -> rusqlite::Result<CodexSource> {
+    let now = now_utc_string();
+    conn.execute(
+        "UPDATE codex_sources SET selected = ?1, updated_at = ?2 WHERE id = ?3",
+        params![bool_to_i64(selected), now, id],
+    )?;
+    get_codex_source(conn, id)
+}
+
+pub fn update_codex_source_download_state(
+    conn: &Connection,
+    id: &str,
+    status: &str,
+    last_downloaded_at: Option<&str>,
+    last_scanned_at: Option<&str>,
+    error: Option<&str>,
+) -> rusqlite::Result<CodexSource> {
+    let now = now_utc_string();
+    conn.execute(
+        "
+    UPDATE codex_sources
+    SET status = ?1,
+        last_downloaded_at = COALESCE(?2, last_downloaded_at),
+        last_scanned_at = COALESCE(?3, last_scanned_at),
+        last_error = ?4,
+        updated_at = ?5
+    WHERE id = ?6
+    ",
+        params![status, last_downloaded_at, last_scanned_at, error, now, id],
+    )?;
+    get_codex_source(conn, id)
+}
+
+pub fn delete_codex_source(conn: &mut Connection, id: &str) -> rusqlite::Result<bool> {
+    if id == "local" {
+        return Ok(false);
+    }
+
+    let tx = conn.transaction()?;
+    tx.execute(
+        "
+    DELETE FROM usage_events
+    WHERE session_id IN (SELECT session_id FROM sessions WHERE source_id = ?1)
+    ",
+        params![id],
+    )?;
+    tx.execute(
+        "
+    DELETE FROM session_overrides
+    WHERE session_id IN (SELECT session_id FROM sessions WHERE source_id = ?1)
+    ",
+        params![id],
+    )?;
+    tx.execute(
+        "
+    DELETE FROM conversation_links
+    WHERE session_id IN (SELECT session_id FROM sessions WHERE source_id = ?1)
+       OR root_session_id IN (SELECT session_id FROM sessions WHERE source_id = ?1)
+       OR parent_session_id IN (SELECT session_id FROM sessions WHERE source_id = ?1)
+    ",
+        params![id],
+    )?;
+    tx.execute("DELETE FROM sessions WHERE source_id = ?1", params![id])?;
+    tx.execute("DELETE FROM import_state WHERE source_id = ?1", params![id])?;
+    tx.execute(
+        "DELETE FROM rate_limit_samples WHERE source_id = ?1",
+        params![id],
+    )?;
+    let deleted = tx.execute(
+        "DELETE FROM codex_sources WHERE id = ?1 AND kind <> 'local'",
+        params![id],
+    )?;
+    tx.commit()?;
+    Ok(deleted > 0)
+}
+
+fn codex_source_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CodexSource> {
+    Ok(CodexSource {
+        id: row.get(0)?,
+        kind: row.get(1)?,
+        label: row.get(2)?,
+        ssh_alias: row.get(3)?,
+        host_name: row.get(4)?,
+        user: row.get(5)?,
+        port: row.get(6)?,
+        remote_codex_home: row.get(7)?,
+        local_codex_home: row.get(8)?,
+        selected: i64_to_bool(row.get::<_, i64>(9)?),
+        status: row.get(10)?,
+        last_discovered_at: row.get(11)?,
+        last_downloaded_at: row.get(12)?,
+        last_scanned_at: row.get(13)?,
+        last_error: row.get(14)?,
+        created_at: row.get(15)?,
+        updated_at: row.get(16)?,
+    })
+}
+
+fn normalize_label(label: &str, fallback: &str) -> String {
+    let trimmed = label.trim();
+    if trimmed.is_empty() {
+        fallback.trim().chars().take(80).collect()
+    } else {
+        trimmed.chars().take(80).collect()
+    }
+}
+
+fn normalize_remote_codex_home(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        "~/.codex".to_string()
+    } else {
+        trimmed.chars().take(500).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::init_db;
+
+    #[test]
+    fn delete_codex_source_removes_imported_source_data() {
+        let mut conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+        upsert_ssh_codex_source(
+            &conn,
+            "ssh_test_box",
+            &CodexSourceInput {
+                label: "test_box".to_string(),
+                ssh_alias: "test_box".to_string(),
+                host_name: Some("10.0.0.2".to_string()),
+                user: Some("me".to_string()),
+                port: Some(22),
+                remote_codex_home: "~/.codex".to_string(),
+                selected: true,
+            },
+            "/tmp/codex-source",
+        )
+        .expect("create source");
+
+        conn.execute_batch(
+            "
+        INSERT INTO sessions (
+          session_id, source_id, root_session_id, parent_session_id, title, source_state,
+          source_path, source_bucket, started_at, updated_at, agent_nickname, agent_role,
+          explicit_fast_mode, fast_mode_default, latest_plan_type, last_model_id,
+          contains_subagents, created_at, imported_at
+        )
+        VALUES (
+          'session-1', 'ssh_test_box', 'session-1', NULL, 'remote session', 'present',
+          '/tmp/one.jsonl', 'sessions', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z',
+          NULL, NULL, NULL, 0, NULL, 'gpt-5.1', 0, '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z'
+        );
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
+          reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('session-1', '2026-04-01T00:00:00Z', 'gpt-5.1', 10, 0, 10, 0, 20, 0.1, 0, 0);
+        INSERT INTO import_state (
+          source_path, source_id, session_id, source_bucket, file_size, file_mtime_ms, last_imported_at
+        )
+        VALUES ('/tmp/one.jsonl', 'ssh_test_box', 'session-1', 'sessions', 1, 1, '2026-04-01T00:00:00Z');
+        INSERT INTO rate_limit_samples (
+          source_id, source_kind, source_session_id, bucket, sample_timestamp, limit_id,
+          limit_name, plan_type, window_start, resets_at, used_percent, remaining_percent, created_at
+        )
+        VALUES (
+          'ssh_test_box', 'session', 'session-1', 'five_hour', '2026-04-01T00:00:00Z',
+          'limit', 'Limit', 'pro', '2026-04-01T00:00:00Z', '2026-04-01T05:00:00Z',
+          10, 90, '2026-04-01T00:00:00Z'
+        );
+        ",
+        )
+        .expect("seed source data");
+
+        assert!(delete_codex_source(&mut conn, "ssh_test_box").expect("delete source"));
+        assert!(!delete_codex_source(&mut conn, "local").expect("cannot delete local"));
+
+        let source_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM codex_sources WHERE id = 'ssh_test_box'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("source count");
+        let session_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE source_id = 'ssh_test_box'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("session count");
+        let usage_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM usage_events WHERE session_id = 'session-1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("usage count");
+        let import_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM import_state WHERE source_id = 'ssh_test_box'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("import count");
+        let sample_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM rate_limit_samples WHERE source_id = 'ssh_test_box'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("sample count");
+
+        assert_eq!(source_count, 0);
+        assert_eq!(session_count, 0);
+        assert_eq!(usage_count, 0);
+        assert_eq!(import_count, 0);
+        assert_eq!(sample_count, 0);
+    }
+}

--- a/src-tauri/src/database/subscriptions.rs
+++ b/src-tauri/src/database/subscriptions.rs
@@ -1,6 +1,7 @@
+use chrono::NaiveDate;
 use rusqlite::{params, Connection};
 
-use crate::models::SubscriptionProfile;
+use crate::models::{SubscriptionProfile, SubscriptionRecord, SubscriptionRecordInput};
 
 use super::now_utc_string;
 
@@ -58,4 +59,253 @@ pub fn save_subscription_profile(
         ],
     )?;
     get_subscription_profile(conn)
+}
+
+pub fn list_subscription_records(conn: &Connection) -> rusqlite::Result<Vec<SubscriptionRecord>> {
+    let mut stmt = conn.prepare(
+        "
+    SELECT id, paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+    FROM subscription_records
+    ORDER BY service_start DESC, paid_at DESC, id DESC
+    ",
+    )?;
+
+    let records = stmt
+        .query_map([], subscription_record_from_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(records)
+}
+
+pub fn create_subscription_record(
+    conn: &Connection,
+    input: &SubscriptionRecordInput,
+) -> Result<SubscriptionRecord, String> {
+    let normalized = normalize_subscription_record_input(input)?;
+    let now = now_utc_string();
+    conn.execute(
+        "
+      INSERT INTO subscription_records (
+        paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+      )
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)
+      ",
+        params![
+            normalized.paid_at,
+            normalized.service_start,
+            normalized.service_end,
+            normalized.amount_usd,
+            normalized.plan_type,
+            normalized.note,
+            now,
+        ],
+    )
+    .map_err(|error| error.to_string())?;
+
+    get_subscription_record(conn, conn.last_insert_rowid())
+}
+
+pub fn update_subscription_record(
+    conn: &Connection,
+    id: i64,
+    input: &SubscriptionRecordInput,
+) -> Result<SubscriptionRecord, String> {
+    let normalized = normalize_subscription_record_input(input)?;
+    let updated_at = now_utc_string();
+    let changed = conn
+        .execute(
+            "
+      UPDATE subscription_records
+      SET
+        paid_at = ?1,
+        service_start = ?2,
+        service_end = ?3,
+        amount_usd = ?4,
+        plan_type = ?5,
+        note = ?6,
+        updated_at = ?7
+      WHERE id = ?8
+      ",
+            params![
+                normalized.paid_at,
+                normalized.service_start,
+                normalized.service_end,
+                normalized.amount_usd,
+                normalized.plan_type,
+                normalized.note,
+                updated_at,
+                id,
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+
+    if changed == 0 {
+        return Err(format!("Subscription record {id} was not found."));
+    }
+
+    get_subscription_record(conn, id)
+}
+
+pub fn delete_subscription_record(conn: &Connection, id: i64) -> Result<bool, String> {
+    let changed = conn
+        .execute(
+            "DELETE FROM subscription_records WHERE id = ?1",
+            params![id],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(changed > 0)
+}
+
+fn get_subscription_record(conn: &Connection, id: i64) -> Result<SubscriptionRecord, String> {
+    conn.query_row(
+        "
+      SELECT id, paid_at, service_start, service_end, amount_usd, plan_type, note, created_at, updated_at
+      FROM subscription_records
+      WHERE id = ?1
+      ",
+        params![id],
+        subscription_record_from_row,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn subscription_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SubscriptionRecord> {
+    Ok(SubscriptionRecord {
+        id: row.get(0)?,
+        paid_at: row.get(1)?,
+        service_start: row.get(2)?,
+        service_end: row.get(3)?,
+        amount_usd: row.get(4)?,
+        plan_type: row.get(5)?,
+        note: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
+}
+
+struct NormalizedSubscriptionRecordInput {
+    paid_at: String,
+    service_start: String,
+    service_end: String,
+    amount_usd: f64,
+    plan_type: String,
+    note: Option<String>,
+}
+
+fn normalize_subscription_record_input(
+    input: &SubscriptionRecordInput,
+) -> Result<NormalizedSubscriptionRecordInput, String> {
+    let paid_at = normalize_date_field("paidAt", &input.paid_at)?;
+    let service_start = normalize_date_field("serviceStart", &input.service_start)?;
+    let service_end = normalize_date_field("serviceEnd", &input.service_end)?;
+    let start_date = parse_date_field("serviceStart", &service_start)?;
+    let end_date = parse_date_field("serviceEnd", &service_end)?;
+    if end_date <= start_date {
+        return Err("serviceEnd must be later than serviceStart.".to_string());
+    }
+    if !input.amount_usd.is_finite() {
+        return Err("amountUsd must be a finite number.".to_string());
+    }
+
+    let plan_type = input.plan_type.trim();
+    let note = input
+        .note
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.chars().take(500).collect::<String>());
+
+    Ok(NormalizedSubscriptionRecordInput {
+        paid_at,
+        service_start,
+        service_end,
+        amount_usd: input.amount_usd.max(0.0),
+        plan_type: if plan_type.is_empty() {
+            "unknown".to_string()
+        } else {
+            plan_type.chars().take(64).collect()
+        },
+        note,
+    })
+}
+
+fn normalize_date_field(field_name: &str, value: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    parse_date_field(field_name, trimmed)?;
+    Ok(trimmed.to_string())
+}
+
+fn parse_date_field(field_name: &str, value: &str) -> Result<NaiveDate, String> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| format!("{field_name} must use YYYY-MM-DD format."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::init_db;
+
+    #[test]
+    fn subscription_records_round_trip() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+
+        init_db(&conn).expect("init database");
+        let created = create_subscription_record(
+            &conn,
+            &SubscriptionRecordInput {
+                paid_at: "2026-04-16".to_string(),
+                service_start: "2026-04-16".to_string(),
+                service_end: "2026-05-16".to_string(),
+                amount_usd: 19.99,
+                plan_type: "plus".to_string(),
+                note: Some("user@example.com".to_string()),
+            },
+        )
+        .expect("create record");
+
+        assert_eq!(created.plan_type, "plus");
+        assert_eq!(created.note.as_deref(), Some("user@example.com"));
+
+        let updated = update_subscription_record(
+            &conn,
+            created.id,
+            &SubscriptionRecordInput {
+                paid_at: "2026-04-17".to_string(),
+                service_start: "2026-04-17".to_string(),
+                service_end: "2026-05-17".to_string(),
+                amount_usd: 100.0,
+                plan_type: "pro_x5".to_string(),
+                note: Some("updated@example.com".to_string()),
+            },
+        )
+        .expect("update record");
+
+        assert_eq!(updated.amount_usd, 100.0);
+        assert_eq!(updated.plan_type, "pro_x5");
+        assert_eq!(list_subscription_records(&conn).expect("list records").len(), 1);
+        assert!(delete_subscription_record(&conn, created.id).expect("delete record"));
+        assert!(list_subscription_records(&conn)
+            .expect("list after delete")
+            .is_empty());
+    }
+
+    #[test]
+    fn subscription_record_rejects_invalid_dates() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+
+        init_db(&conn).expect("init database");
+        let error = create_subscription_record(
+            &conn,
+            &SubscriptionRecordInput {
+                paid_at: "2026-04-16".to_string(),
+                service_start: "2026-05-16".to_string(),
+                service_end: "2026-04-16".to_string(),
+                amount_usd: 19.99,
+                plan_type: "plus".to_string(),
+                note: None,
+            },
+        )
+        .expect_err("reject invalid date range");
+
+        assert!(error.contains("serviceEnd"));
+    }
 }

--- a/src-tauri/src/database/subscriptions.rs
+++ b/src-tauri/src/database/subscriptions.rs
@@ -1,0 +1,61 @@
+use rusqlite::{params, Connection};
+
+use crate::models::SubscriptionProfile;
+
+use super::now_utc_string;
+
+pub fn canonical_subscription_currency() -> &'static str {
+    "USD"
+}
+
+pub fn get_subscription_profile(conn: &Connection) -> rusqlite::Result<SubscriptionProfile> {
+    conn.query_row(
+        "
+    SELECT plan_type, currency, monthly_price, billing_anchor_day, updated_at
+    FROM subscription_profile
+    WHERE singleton_id = 1
+    ",
+        [],
+        |row| {
+            Ok(SubscriptionProfile {
+                plan_type: row.get(0)?,
+                currency: {
+                    let _: String = row.get(1)?;
+                    canonical_subscription_currency().to_string()
+                },
+                monthly_price: row.get(2)?,
+                billing_anchor_day: row.get(3)?,
+                updated_at: row.get(4)?,
+            })
+        },
+    )
+}
+
+pub fn save_subscription_profile(
+    conn: &Connection,
+    profile: &SubscriptionProfile,
+) -> rusqlite::Result<SubscriptionProfile> {
+    let updated_at = now_utc_string();
+    conn.execute(
+        "
+    INSERT INTO subscription_profile (
+      singleton_id, plan_type, currency, monthly_price, billing_anchor_day, updated_at
+    )
+    VALUES (1, ?1, ?2, ?3, ?4, ?5)
+    ON CONFLICT(singleton_id) DO UPDATE SET
+      plan_type = excluded.plan_type,
+      currency = excluded.currency,
+      monthly_price = excluded.monthly_price,
+      billing_anchor_day = excluded.billing_anchor_day,
+      updated_at = excluded.updated_at
+    ",
+        params![
+            profile.plan_type,
+            canonical_subscription_currency(),
+            profile.monthly_price.max(0.0),
+            profile.billing_anchor_day.clamp(1, 28),
+            updated_at,
+        ],
+    )?;
+    get_subscription_profile(conn)
+}

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -1,0 +1,478 @@
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::models::SyncSettings;
+
+use super::{bool_to_i64, i64_to_bool, now_utc_string};
+
+pub fn default_menu_bar_popup_modules() -> Vec<String> {
+    vec!["api_value".to_string(), "scan_freshness".to_string()]
+}
+
+fn is_supported_menu_bar_popup_module(module: &str) -> bool {
+    matches!(
+        module,
+        "api_value"
+            | "token_count"
+            | "scan_freshness"
+            | "live_quota_freshness"
+            | "payoff_ratio"
+            | "conversation_count"
+    )
+}
+
+pub(super) fn default_menu_bar_popup_modules_json() -> String {
+    serde_json::to_string(&default_menu_bar_popup_modules())
+        .expect("serialize default popup modules")
+}
+
+fn deserialize_menu_bar_popup_modules(value: String) -> Vec<String> {
+    serde_json::from_str::<Vec<String>>(&value)
+        .ok()
+        .map(|modules| {
+            modules
+                .into_iter()
+                .filter(|module| is_supported_menu_bar_popup_module(module))
+                .fold(Vec::new(), |mut deduped, module| {
+                    if !deduped.iter().any(|existing| existing == &module) {
+                        deduped.push(module);
+                    }
+                    deduped
+                })
+        })
+        .unwrap_or_else(default_menu_bar_popup_modules)
+}
+
+fn serialize_menu_bar_popup_modules(modules: &[String]) -> String {
+    serde_json::to_string(modules).unwrap_or_else(|_| default_menu_bar_popup_modules_json())
+}
+
+pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare("PRAGMA table_info(sync_settings)")?;
+    let column_names = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    if !column_names
+        .iter()
+        .any(|name| name == "sync_settings_schema_version")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN sync_settings_schema_version INTEGER NOT NULL DEFAULT 1
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "show_menu_bar_daily_api_value")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names.iter().any(|name| name == "show_menu_bar_logo") {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN show_menu_bar_logo INTEGER NOT NULL DEFAULT 1
+      ",
+            [],
+        )?;
+        conn.execute(
+            "
+      UPDATE sync_settings
+      SET show_menu_bar_logo = show_menu_bar_daily_api_value
+      WHERE singleton_id = 1
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "show_menu_bar_live_quota_percent")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_live_quota_metric")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent'
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_live_quota_bucket")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour'
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names.iter().any(|name| name == "menu_bar_bucket") {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN menu_bar_bucket TEXT NOT NULL DEFAULT 'day'
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "live_quota_refresh_interval_seconds")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "default_fast_mode_for_new_gpt54_sessions")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "hide_dock_icon_when_menu_bar_visible")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_show_emoji")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_fast_threshold_percent")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_slow_threshold_percent")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_healthy_emoji")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢'",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_fast_emoji")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥'",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_speed_slow_emoji")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢'",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_popup_enabled")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_popup_modules")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_modules TEXT NOT NULL DEFAULT '[\"api_value\",\"scan_freshness\"]'",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_popup_show_reset_timeline")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1",
+      [],
+    )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "menu_bar_popup_show_actions")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1",
+      [],
+    )?;
+    }
+
+    migrate_sync_settings_defaults_to_minutes(conn)?;
+
+    Ok(())
+}
+
+fn migrate_sync_settings_defaults_to_minutes(conn: &Connection) -> rusqlite::Result<()> {
+    let schema_version = conn
+        .query_row(
+            "SELECT sync_settings_schema_version FROM sync_settings WHERE singleton_id = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .unwrap_or(2);
+
+    if schema_version >= 2 {
+        return Ok(());
+    }
+
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET
+      live_quota_refresh_interval_seconds = CASE
+        WHEN live_quota_refresh_interval_seconds = 60 THEN 300
+        ELSE live_quota_refresh_interval_seconds
+      END,
+      default_fast_mode_for_new_gpt54_sessions = CASE
+        WHEN default_fast_mode_for_new_gpt54_sessions = 1 THEN 0
+        ELSE default_fast_mode_for_new_gpt54_sessions
+      END,
+      sync_settings_schema_version = 2
+    WHERE singleton_id = 1
+    ",
+        [],
+    )?;
+
+    Ok(())
+}
+
+pub fn get_sync_settings(conn: &Connection) -> rusqlite::Result<SyncSettings> {
+    conn.query_row(
+        "
+    SELECT codex_home, auto_scan_enabled, auto_scan_interval_minutes,
+           live_quota_refresh_interval_seconds,
+           hide_dock_icon_when_menu_bar_visible,
+           show_menu_bar_logo, show_menu_bar_daily_api_value,
+           show_menu_bar_live_quota_percent, menu_bar_live_quota_metric,
+           menu_bar_live_quota_bucket, menu_bar_bucket,
+           menu_bar_speed_show_emoji, menu_bar_speed_fast_threshold_percent,
+           menu_bar_speed_slow_threshold_percent, menu_bar_speed_healthy_emoji,
+           menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
+           menu_bar_popup_enabled, menu_bar_popup_modules,
+           menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
+           last_scan_started_at, last_scan_completed_at, updated_at
+    FROM sync_settings
+    WHERE singleton_id = 1
+    ",
+        [],
+        |row| {
+            Ok(SyncSettings {
+                codex_home: row.get(0)?,
+                auto_scan_enabled: i64_to_bool(row.get::<_, i64>(1)?),
+                auto_scan_interval_minutes: row.get(2)?,
+                live_quota_refresh_interval_seconds: row.get(3)?,
+                hide_dock_icon_when_menu_bar_visible: i64_to_bool(row.get::<_, i64>(4)?),
+                show_menu_bar_logo: i64_to_bool(row.get::<_, i64>(5)?),
+                show_menu_bar_daily_api_value: i64_to_bool(row.get::<_, i64>(6)?),
+                show_menu_bar_live_quota_percent: i64_to_bool(row.get::<_, i64>(7)?),
+                menu_bar_live_quota_metric: row.get(8)?,
+                menu_bar_live_quota_bucket: row.get(9)?,
+                menu_bar_bucket: row.get(10)?,
+                menu_bar_speed_show_emoji: i64_to_bool(row.get::<_, i64>(11)?),
+                menu_bar_speed_fast_threshold_percent: row.get(12)?,
+                menu_bar_speed_slow_threshold_percent: row.get(13)?,
+                menu_bar_speed_healthy_emoji: row.get(14)?,
+                menu_bar_speed_fast_emoji: row.get(15)?,
+                menu_bar_speed_slow_emoji: row.get(16)?,
+                menu_bar_popup_enabled: i64_to_bool(row.get::<_, i64>(17)?),
+                menu_bar_popup_modules: deserialize_menu_bar_popup_modules(row.get(18)?),
+                menu_bar_popup_show_reset_timeline: i64_to_bool(row.get::<_, i64>(19)?),
+                menu_bar_popup_show_actions: i64_to_bool(row.get::<_, i64>(20)?),
+                last_scan_started_at: row.get(21)?,
+                last_scan_completed_at: row.get(22)?,
+                updated_at: row.get(23)?,
+            })
+        },
+    )
+}
+
+pub fn save_sync_settings(
+    conn: &Connection,
+    settings: &SyncSettings,
+) -> rusqlite::Result<SyncSettings> {
+    let updated_at = now_utc_string();
+    conn.execute(
+    "
+    INSERT INTO sync_settings (
+      singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
+      live_quota_refresh_interval_seconds,
+      hide_dock_icon_when_menu_bar_visible,
+      show_menu_bar_logo,
+      show_menu_bar_daily_api_value,
+      show_menu_bar_live_quota_percent, menu_bar_live_quota_metric,
+      menu_bar_live_quota_bucket, menu_bar_bucket,
+      menu_bar_speed_show_emoji, menu_bar_speed_fast_threshold_percent,
+      menu_bar_speed_slow_threshold_percent, menu_bar_speed_healthy_emoji,
+      menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
+      menu_bar_popup_enabled, menu_bar_popup_modules,
+      menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
+      last_scan_started_at, last_scan_completed_at, updated_at
+    )
+    VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)
+    ON CONFLICT(singleton_id) DO UPDATE SET
+      codex_home = excluded.codex_home,
+      auto_scan_enabled = excluded.auto_scan_enabled,
+      auto_scan_interval_minutes = excluded.auto_scan_interval_minutes,
+      live_quota_refresh_interval_seconds = excluded.live_quota_refresh_interval_seconds,
+      hide_dock_icon_when_menu_bar_visible = excluded.hide_dock_icon_when_menu_bar_visible,
+      show_menu_bar_logo = excluded.show_menu_bar_logo,
+      show_menu_bar_daily_api_value = excluded.show_menu_bar_daily_api_value,
+      show_menu_bar_live_quota_percent = excluded.show_menu_bar_live_quota_percent,
+      menu_bar_live_quota_metric = excluded.menu_bar_live_quota_metric,
+      menu_bar_live_quota_bucket = excluded.menu_bar_live_quota_bucket,
+      menu_bar_bucket = excluded.menu_bar_bucket,
+      menu_bar_speed_show_emoji = excluded.menu_bar_speed_show_emoji,
+      menu_bar_speed_fast_threshold_percent = excluded.menu_bar_speed_fast_threshold_percent,
+      menu_bar_speed_slow_threshold_percent = excluded.menu_bar_speed_slow_threshold_percent,
+      menu_bar_speed_healthy_emoji = excluded.menu_bar_speed_healthy_emoji,
+      menu_bar_speed_fast_emoji = excluded.menu_bar_speed_fast_emoji,
+      menu_bar_speed_slow_emoji = excluded.menu_bar_speed_slow_emoji,
+      menu_bar_popup_enabled = excluded.menu_bar_popup_enabled,
+      menu_bar_popup_modules = excluded.menu_bar_popup_modules,
+      menu_bar_popup_show_reset_timeline = excluded.menu_bar_popup_show_reset_timeline,
+      menu_bar_popup_show_actions = excluded.menu_bar_popup_show_actions,
+      last_scan_started_at = excluded.last_scan_started_at,
+      last_scan_completed_at = excluded.last_scan_completed_at,
+      updated_at = excluded.updated_at
+    ",
+    params![
+      settings.codex_home,
+      bool_to_i64(settings.auto_scan_enabled),
+      settings.auto_scan_interval_minutes.max(1),
+      settings.live_quota_refresh_interval_seconds.clamp(60, 3600),
+      bool_to_i64(settings.hide_dock_icon_when_menu_bar_visible),
+      bool_to_i64(settings.show_menu_bar_logo),
+      bool_to_i64(settings.show_menu_bar_daily_api_value),
+      bool_to_i64(settings.show_menu_bar_live_quota_percent),
+      settings.menu_bar_live_quota_metric,
+      settings.menu_bar_live_quota_bucket,
+      settings.menu_bar_bucket,
+      bool_to_i64(settings.menu_bar_speed_show_emoji),
+      settings.menu_bar_speed_fast_threshold_percent.clamp(0, 1000),
+      settings.menu_bar_speed_slow_threshold_percent.clamp(0, 1000),
+      settings.menu_bar_speed_healthy_emoji,
+      settings.menu_bar_speed_fast_emoji,
+      settings.menu_bar_speed_slow_emoji,
+      bool_to_i64(settings.menu_bar_popup_enabled),
+      serialize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
+      bool_to_i64(settings.menu_bar_popup_show_reset_timeline),
+      bool_to_i64(settings.menu_bar_popup_show_actions),
+      settings.last_scan_started_at,
+      settings.last_scan_completed_at,
+      updated_at,
+    ],
+    )?;
+    get_sync_settings(conn)
+}
+
+pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET last_scan_started_at = ?1, updated_at = ?1
+    WHERE singleton_id = 1
+    ",
+        params![timestamp],
+    )?;
+    Ok(())
+}
+
+pub fn set_last_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET last_scan_completed_at = ?1, updated_at = ?1
+    WHERE singleton_id = 1
+    ",
+        params![timestamp],
+    )?;
+    Ok(())
+}

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -14,7 +14,8 @@ use crate::database::{
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
-  calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing, seed_pricing_catalog,
+    calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing,
+    seed_pricing_catalog,
 };
 
 #[derive(Debug, Clone)]
@@ -61,7 +62,18 @@ enum SessionParseError {
   Fatal(String),
 }
 
-pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
+pub fn perform_scan(
+    db_path: &Path,
+    codex_home_override: Option<String>,
+) -> Result<ScanResult, String> {
+    perform_scan_for_source(db_path, "local", codex_home_override)
+}
+
+pub fn perform_scan_for_source(
+    db_path: &Path,
+    source_id: &str,
+    codex_home_override: Option<String>,
+) -> Result<ScanResult, String> {
   let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
@@ -76,8 +88,9 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
     .map(|item| item.path.to_string_lossy().to_string())
     .collect();
 
-  let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
-  let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
+    let import_state = load_import_state(&conn, source_id).map_err(|error| error.to_string())?;
+    let needs_rate_limit_backfill =
+        needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
 
   let mut changed_sessions = 0usize;
   let mut imported_session_ids = HashSet::new();
@@ -109,7 +122,8 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
   if !changed_files.is_empty() {
     let titles = load_session_index(&codex_home);
     let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
-    let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
+        let existing_relations =
+            load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
 
     for session_file in changed_files {
       let parsed = match parse_session_file(session_file, &titles) {
@@ -127,7 +141,10 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
 
       match classify_topology_maintenance(
         existing_relations.get(&parsed.raw_session.session_id),
-        existing_relations.get(&parsed.raw_session.session_id).map(|item| item.child_count).unwrap_or_default(),
+                existing_relations
+                    .get(&parsed.raw_session.session_id)
+                    .map(|item| item.child_count)
+                    .unwrap_or_default(),
         parsed.raw_session.parent_session_id.as_deref(),
       ) {
         TopologyMaintenance::None => {}
@@ -139,23 +156,25 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
         }
       }
 
-      persist_session(&mut conn, session_file, &parsed, &catalog).map_err(|error| error.to_string())?;
+            persist_session(&mut conn, source_id, session_file, &parsed, &catalog)
+                .map_err(|error| error.to_string())?;
       changed_sessions += 1;
     }
   }
 
-  mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
-  prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
+    mark_missing_sources(&conn, source_id, &present_paths).map_err(|error| error.to_string())?;
+    prune_import_state(&conn, source_id, &present_paths).map_err(|error| error.to_string())?;
   if topology_dirty {
     recompute_conversation_links(&conn).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
-    upsert_root_conversation_links(&conn, &new_root_session_ids).map_err(|error| error.to_string())?;
+        upsert_root_conversation_links(&conn, &new_root_session_ids)
+            .map_err(|error| error.to_string())?;
   }
 
   let missing_sessions = conn
     .query_row(
-      "SELECT COUNT(*) FROM sessions WHERE source_state = 'missing'",
-      [],
+            "SELECT COUNT(*) FROM sessions WHERE source_id = ?1 AND source_state = 'missing'",
+            params![source_id],
       |row| row.get::<_, i64>(0),
     )
     .map_err(|error| error.to_string())? as usize;
@@ -231,7 +250,10 @@ fn classify_topology_maintenance(
   existing_child_count: usize,
   parent_session_id: Option<&str>,
 ) -> TopologyMaintenance {
-  match (existing_relation.filter(|item| item.exists), parent_session_id) {
+    match (
+        existing_relation.filter(|item| item.exists),
+        parent_session_id,
+    ) {
     (Some(existing_relation), next_parent_session_id) => {
       if existing_relation.parent_session_id.as_deref() == next_parent_session_id {
         TopologyMaintenance::None
@@ -263,7 +285,10 @@ pub fn recalculate_all_session_values(conn: &Connection) -> rusqlite::Result<()>
   Ok(())
 }
 
-fn resolve_codex_home(conn: &Connection, override_value: Option<String>) -> Result<PathBuf, String> {
+fn resolve_codex_home(
+    conn: &Connection,
+    override_value: Option<String>,
+) -> Result<PathBuf, String> {
   if let Some(path) = override_value {
     return Ok(PathBuf::from(path));
   }
@@ -367,8 +392,12 @@ fn parse_session_file_once(
   session_file: &SessionFile,
   titles: &HashMap<String, String>,
 ) -> Result<ParsedSession, SessionParseError> {
-  let file = File::open(&session_file.path)
-    .map_err(|error| SessionParseError::Fatal(format!("Failed to open {}: {error}", session_file.path.display())))?;
+    let file = File::open(&session_file.path).map_err(|error| {
+        SessionParseError::Fatal(format!(
+            "Failed to open {}: {error}",
+            session_file.path.display()
+        ))
+    })?;
   let expected_session_id = fallback_session_id_from_filename(&session_file.path);
 
   let mut session_id = String::new();
@@ -416,7 +445,11 @@ fn parse_session_file_once(
       updated_at = timestamp.clone();
     }
 
-    match value.get("type").and_then(Value::as_str).unwrap_or_default() {
+        match value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+        {
       "session_meta" => {
         let payload = value.get("payload").unwrap_or(&Value::Null);
         let parent = payload
@@ -525,7 +558,9 @@ fn parse_session_file_once(
         let sample_timestamp = timestamp.unwrap_or_else(now_utc_string);
         rate_limit_samples.extend(extract_rate_limit_samples(&sample_timestamp, payload));
 
-        let model_id = current_model.clone().unwrap_or_else(|| "unknown".to_string());
+                let model_id = current_model
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string());
         seen_models.insert(model_id.clone());
 
         snapshots.push(UsageSnapshot {
@@ -618,12 +653,16 @@ fn looks_like_session_id(value: &str) -> bool {
     .iter()
     .zip(expected_lengths.iter())
     .all(|(segment, expected_len)| {
-      segment.len() == *expected_len && segment.chars().all(|character| character.is_ascii_hexdigit())
+            segment.len() == *expected_len
+                && segment
+                    .chars()
+                    .all(|character| character.is_ascii_hexdigit())
     })
 }
 
 fn persist_session(
   conn: &mut Connection,
+    source_id: &str,
   session_file: &SessionFile,
   parsed: &ParsedSession,
   catalog: &HashMap<String, crate::models::PricingCatalogEntry>,
@@ -636,12 +675,13 @@ fn persist_session(
   tx.execute(
     "
     INSERT INTO sessions (
-      session_id, root_session_id, parent_session_id, title, source_state, source_path,
+      session_id, source_id, root_session_id, parent_session_id, title, source_state, source_path,
       source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
       fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
     )
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, 0, ?16, ?17)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, 0, ?17, ?18)
     ON CONFLICT(session_id) DO UPDATE SET
+      source_id = excluded.source_id,
       root_session_id = sessions.root_session_id,
       parent_session_id = excluded.parent_session_id,
       title = COALESCE(excluded.title, sessions.title),
@@ -660,6 +700,7 @@ fn persist_session(
     ",
     params![
       parsed.raw_session.session_id,
+      source_id,
       parsed.raw_session.root_session_id,
       parsed.raw_session.parent_session_id,
       parsed.raw_session.title,
@@ -683,7 +724,12 @@ fn persist_session(
     "DELETE FROM usage_events WHERE session_id = ?1",
     params![parsed.raw_session.session_id],
   )?;
-  replace_session_rate_limit_samples(&tx, &parsed.raw_session.session_id, &parsed.rate_limit_samples)?;
+    replace_session_rate_limit_samples(
+        &tx,
+        source_id,
+        &parsed.raw_session.session_id,
+        &parsed.rate_limit_samples,
+    )?;
 
   let mut previous_usage: Option<TokenUsage> = None;
 
@@ -733,9 +779,10 @@ fn persist_session(
 
   tx.execute(
     "
-    INSERT INTO import_state (source_path, session_id, source_bucket, file_size, file_mtime_ms, last_imported_at)
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+    INSERT INTO import_state (source_path, source_id, session_id, source_bucket, file_size, file_mtime_ms, last_imported_at)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
     ON CONFLICT(source_path) DO UPDATE SET
+      source_id = excluded.source_id,
       session_id = excluded.session_id,
       source_bucket = excluded.source_bucket,
       file_size = excluded.file_size,
@@ -744,6 +791,7 @@ fn persist_session(
     ",
     params![
       session_file.path.to_string_lossy().to_string(),
+      source_id,
       parsed.raw_session.session_id,
       session_file.bucket,
       session_file.file_size,
@@ -755,9 +803,10 @@ fn persist_session(
   tx.execute(
     "
     DELETE FROM import_state
-    WHERE session_id = ?1 AND source_path <> ?2
+    WHERE source_id = ?1 AND session_id = ?2 AND source_path <> ?3
     ",
     params![
+            source_id,
       parsed.raw_session.session_id,
       session_file.path.to_string_lossy().to_string(),
     ],
@@ -829,7 +878,9 @@ fn extract_rate_limit_samples(timestamp: &str, payload: &Value) -> Vec<RateLimit
     let Some(resets_at) = unix_seconds_to_rfc3339_local(resets_at_seconds) else {
       continue;
     };
-    let Some(window_start) = unix_seconds_to_rfc3339_local(resets_at_seconds - window_duration_mins * 60) else {
+        let Some(window_start) =
+            unix_seconds_to_rfc3339_local(resets_at_seconds - window_duration_mins * 60)
+        else {
       continue;
     };
 
@@ -858,7 +909,9 @@ fn extract_rate_limit_samples(timestamp: &str, payload: &Value) -> Vec<RateLimit
 fn unix_seconds_to_rfc3339_local(value: i64) -> Option<String> {
   match Local.timestamp_opt(value, 0) {
     LocalResult::Single(timestamp) => Some(normalize_local_timestamp(timestamp).to_rfc3339()),
-    LocalResult::Ambiguous(timestamp, _) => Some(normalize_local_timestamp(timestamp).to_rfc3339()),
+        LocalResult::Ambiguous(timestamp, _) => {
+            Some(normalize_local_timestamp(timestamp).to_rfc3339())
+        }
     LocalResult::None => None,
   }
 }
@@ -870,15 +923,19 @@ fn normalize_local_timestamp(timestamp: chrono::DateTime<Local>) -> chrono::Date
     .unwrap_or(timestamp)
 }
 
-fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, ImportState>> {
+fn load_import_state(
+    conn: &Connection,
+    source_id: &str,
+) -> rusqlite::Result<HashMap<String, ImportState>> {
   let mut stmt = conn.prepare(
     "
     SELECT source_path, session_id, file_size, file_mtime_ms
     FROM import_state
+    WHERE source_id = ?1
     ",
   )?;
 
-  let rows = stmt.query_map([], |row| {
+    let rows = stmt.query_map(params![source_id], |row| {
     Ok(ImportState {
       source_path: row.get(0)?,
       session_id: row.get(1)?,
@@ -908,7 +965,9 @@ fn needs_rate_limit_sample_backfill(conn: &Connection) -> rusqlite::Result<bool>
   Ok(count == 0)
 }
 
-fn load_existing_session_relations(conn: &Connection) -> rusqlite::Result<HashMap<String, ExistingSessionRelation>> {
+fn load_existing_session_relations(
+    conn: &Connection,
+) -> rusqlite::Result<HashMap<String, ExistingSessionRelation>> {
   let mut stmt = conn.prepare("SELECT session_id, parent_session_id FROM sessions")?;
   let rows = stmt.query_map([], |row| {
     Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
@@ -928,7 +987,10 @@ fn load_existing_session_relations(conn: &Connection) -> rusqlite::Result<HashMa
   Ok(relations)
 }
 
-fn upsert_root_conversation_links(conn: &Connection, session_ids: &[String]) -> rusqlite::Result<()> {
+fn upsert_root_conversation_links(
+    conn: &Connection,
+    session_ids: &[String],
+) -> rusqlite::Result<()> {
   for session_id in session_ids {
     conn.execute(
       "
@@ -946,9 +1008,17 @@ fn upsert_root_conversation_links(conn: &Connection, session_ids: &[String]) -> 
   Ok(())
 }
 
-fn mark_missing_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare("SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL")?;
-  let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
+fn mark_missing_sources(
+    conn: &Connection,
+    source_id: &str,
+    present_paths: &HashSet<String>,
+) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare(
+    "SELECT session_id, source_path FROM sessions WHERE source_id = ?1 AND source_path IS NOT NULL",
+  )?;
+    let rows = stmt.query_map(params![source_id], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
 
   for row in rows {
     let (session_id, source_path) = row?;
@@ -966,15 +1036,19 @@ fn mark_missing_sources(conn: &Connection, present_paths: &HashSet<String>) -> r
   Ok(())
 }
 
-fn prune_import_state(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare("SELECT source_path FROM import_state")?;
-  let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+fn prune_import_state(
+    conn: &Connection,
+    source_id: &str,
+    present_paths: &HashSet<String>,
+) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare("SELECT source_path FROM import_state WHERE source_id = ?1")?;
+    let rows = stmt.query_map(params![source_id], |row| row.get::<_, String>(0))?;
   for row in rows {
     let source_path = row?;
     if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
       conn.execute(
-        "DELETE FROM import_state WHERE source_path = ?1",
-        params![source_path],
+                "DELETE FROM import_state WHERE source_id = ?1 AND source_path = ?2",
+                params![source_id, source_path],
       )?;
     }
   }
@@ -1009,7 +1083,12 @@ fn recompute_conversation_links(conn: &Connection) -> rusqlite::Result<()> {
         parent_session_id = excluded.parent_session_id,
         depth = excluded.depth
       ",
-      params![session_id, root_session_id, parents.get(session_id).cloned().flatten(), depth as i64],
+            params![
+                session_id,
+                root_session_id,
+                parents.get(session_id).cloned().flatten(),
+                depth as i64
+            ],
     )?;
 
     conn.execute(
@@ -1064,15 +1143,18 @@ fn read_i64(value: &Value, key: &str) -> i64 {
 }
 
 fn read_total_tokens(value: &Value) -> i64 {
-  value.get("total_tokens").and_then(Value::as_i64).unwrap_or_else(|| {
-    read_i64(value, "input_tokens") + read_i64(value, "output_tokens")
-  })
+    value
+        .get("total_tokens")
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| read_i64(value, "input_tokens") + read_i64(value, "output_tokens"))
 }
 
 fn read_percent(value: &Value, key: &str) -> Option<i64> {
-  value
-    .get(key)
-    .and_then(|field| field.as_i64().or_else(|| field.as_f64().map(|number| number.round() as i64)))
+    value.get(key).and_then(|field| {
+        field
+            .as_i64()
+            .or_else(|| field.as_f64().map(|number| number.round() as i64))
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -1166,9 +1248,8 @@ mod tests {
       )
       .expect("query usage");
 
-    let standard = (75.0 / 1_000_000.0) * 5.0
-      + (25.0 / 1_000_000.0) * 0.5
-      + (40.0 / 1_000_000.0) * 30.0;
+        let standard =
+            (75.0 / 1_000_000.0) * 5.0 + (25.0 / 1_000_000.0) * 0.5 + (40.0 / 1_000_000.0) * 30.0;
     assert!((value_usd - standard).abs() < 1e-9);
     assert_eq!(fast_mode_auto, 0);
     assert_eq!(fast_mode_effective, 0);
@@ -1183,7 +1264,9 @@ mod tests {
 
     let child_session_id = "019d4f72-a2ee-77a0-bd4a-76f43b7b299b";
     let wrong_session_id = "019d4d7c-457e-7020-8b5f-7940eb5e3716";
-    let session_path = sessions_dir.join(format!("rollout-2026-04-03T02-26-46-{child_session_id}.jsonl"));
+        let session_path = sessions_dir.join(format!(
+            "rollout-2026-04-03T02-26-46-{child_session_id}.jsonl"
+        ));
     write_session_file_with_parent(
       &session_path,
       child_session_id,
@@ -1232,7 +1315,10 @@ mod tests {
       .optional()
       .expect("query repaired import state");
     assert_eq!(repaired_session_id.as_deref(), Some(child_session_id));
-    assert_eq!(session_usage_totals(&conn, child_session_id), (100, 20, 25, 125, 1));
+        assert_eq!(
+            session_usage_totals(&conn, child_session_id),
+            (100, 20, 25, 125, 1)
+        );
   }
 
   #[test]
@@ -1261,7 +1347,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.parent_session_id.as_deref(), Some("root-parent"));
+        assert_eq!(
+            parsed.raw_session.parent_session_id.as_deref(),
+            Some("root-parent")
+        );
     assert_eq!(parsed.raw_session.agent_nickname.as_deref(), Some("Hume"));
     assert_eq!(parsed.snapshots.len(), 2);
     assert_eq!(parsed.latest_plan_type.as_deref(), Some("pro"));
@@ -1270,8 +1359,7 @@ mod tests {
   #[test]
   fn parser_prefers_file_matching_session_meta_when_fork_file_replays_parent_meta() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
+        let session_path = directory
         .path()
         .join("rollout-2026-03-24T00-00-00-55555555-5555-5555-5555-555555555555.jsonl");
     std::fs::write(
@@ -1296,7 +1384,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "55555555-5555-5555-5555-555555555555");
+        assert_eq!(
+            parsed.raw_session.session_id,
+            "55555555-5555-5555-5555-555555555555"
+        );
     assert_eq!(
       parsed.raw_session.parent_session_id.as_deref(),
       Some("44444444-4444-4444-4444-444444444444")
@@ -1363,8 +1454,7 @@ mod tests {
   #[test]
   fn parser_supports_legacy_top_level_id_format() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
+        let session_path = directory
         .path()
         .join("rollout-2025-09-09T16-29-03-0df0be29-d74d-468f-8dda-0630fc6e989e.jsonl");
     std::fs::write(
@@ -1388,15 +1478,20 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "0df0be29-d74d-468f-8dda-0630fc6e989e");
-    assert_eq!(parsed.raw_session.started_at.as_deref(), Some("2025-09-09T08:29:03.118Z"));
+        assert_eq!(
+            parsed.raw_session.session_id,
+            "0df0be29-d74d-468f-8dda-0630fc6e989e"
+        );
+        assert_eq!(
+            parsed.raw_session.started_at.as_deref(),
+            Some("2025-09-09T08:29:03.118Z")
+        );
   }
 
   #[test]
   fn parser_falls_back_to_session_id_from_filename() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
+        let session_path = directory
         .path()
         .join("rollout-2026-03-17T18-00-21-019cfb3d-415c-7623-aab0-22e73abcec2e.jsonl");
     std::fs::write(
@@ -1419,7 +1514,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "019cfb3d-415c-7623-aab0-22e73abcec2e");
+        assert_eq!(
+            parsed.raw_session.session_id,
+            "019cfb3d-415c-7623-aab0-22e73abcec2e"
+        );
   }
 
   #[test]
@@ -1430,11 +1528,19 @@ mod tests {
       child_count: 0,
     };
     assert_eq!(
-      classify_topology_maintenance(Some(&existing_child), existing_child.child_count, Some("root-parent")),
+            classify_topology_maintenance(
+                Some(&existing_child),
+                existing_child.child_count,
+                Some("root-parent")
+            ),
       TopologyMaintenance::None
     );
     assert_eq!(
-      classify_topology_maintenance(Some(&existing_child), existing_child.child_count, Some("other-parent")),
+            classify_topology_maintenance(
+                Some(&existing_child),
+                existing_child.child_count,
+                Some("other-parent")
+            ),
       TopologyMaintenance::RecomputeAll
     );
 
@@ -1444,7 +1550,11 @@ mod tests {
       child_count: 2,
     };
     assert_eq!(
-      classify_topology_maintenance(Some(&missing_parent_placeholder), missing_parent_placeholder.child_count, None),
+            classify_topology_maintenance(
+                Some(&missing_parent_placeholder),
+                missing_parent_placeholder.child_count,
+                None
+            ),
       TopologyMaintenance::RecomputeAll
     );
     assert_eq!(
@@ -1466,7 +1576,11 @@ mod tests {
 
     let parent_session_id = "44444444-4444-4444-4444-444444444444";
     let child_session_id = "55555555-5555-5555-5555-555555555555";
-    write_session_file(&sessions_dir.join("parent.jsonl"), parent_session_id, &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)]);
+        write_session_file(
+            &sessions_dir.join("parent.jsonl"),
+            parent_session_id,
+            &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)],
+        );
     write_session_file_with_parent(
       &sessions_dir.join("child.jsonl"),
       child_session_id,
@@ -1486,7 +1600,8 @@ mod tests {
         ("2026-03-24T00:10:02Z", 160, 20, 25, 185),
       ],
     );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+        perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+            .expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(
@@ -1499,7 +1614,11 @@ mod tests {
     );
     assert_eq!(
       conversation_link(&conn, child_session_id),
-      Some((parent_session_id.to_string(), Some(parent_session_id.to_string()), 1))
+            Some((
+                parent_session_id.to_string(),
+                Some(parent_session_id.to_string()),
+                1
+            ))
     );
   }
 
@@ -1527,7 +1646,8 @@ mod tests {
       parent_session_id,
       &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)],
     );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+        perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+            .expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(
@@ -1540,7 +1660,11 @@ mod tests {
     );
     assert_eq!(
       conversation_link(&conn, child_session_id),
-      Some((parent_session_id.to_string(), Some(parent_session_id.to_string()), 1))
+            Some((
+                parent_session_id.to_string(),
+                Some(parent_session_id.to_string()),
+                1
+            ))
     );
   }
 
@@ -1558,24 +1682,35 @@ mod tests {
     write_session_file(
       &active_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+            &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("active".to_string()));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (100, 20, 25, 125, 1)
+        );
+        assert_eq!(
+            session_source_state(&conn, session_id),
+            Some("active".to_string())
+        );
 
     let archived_path = archived_dir.join("sample.jsonl");
     std::fs::rename(&active_path, &archived_path).expect("move to archived");
 
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+        perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+            .expect("second scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("archived".to_string()));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (100, 20, 25, 125, 1)
+        );
+        assert_eq!(
+            session_source_state(&conn, session_id),
+            Some("archived".to_string())
+        );
   }
 
   #[test]
@@ -1590,19 +1725,24 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 150, 30, 40, 190),
-      ],
+            &[("2026-03-24T00:00:01Z", 150, 30, 40, 190)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
     std::fs::remove_file(&session_path).expect("delete source");
 
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+        perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+            .expect("second scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (150, 30, 40, 190, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("missing".to_string()));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (150, 30, 40, 190, 1)
+        );
+        assert_eq!(
+            session_source_state(&conn, session_id),
+            Some("missing".to_string())
+        );
   }
 
   #[test]
@@ -1617,15 +1757,14 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+            &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
     std::fs::remove_file(&session_path).expect("delete source");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+        perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+            .expect("second scan");
 
     write_session_file(
       &session_path,
@@ -1638,8 +1777,14 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("third scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
-    assert_eq!(session_source_state(&conn, session_id), Some("active".to_string()));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (180, 40, 45, 225, 2)
+        );
+        assert_eq!(
+            session_source_state(&conn, session_id),
+            Some("active".to_string())
+        );
   }
 
   #[test]
@@ -1654,16 +1799,17 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+            &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
     let conn = open_connection(&db_path).expect("open db after first scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (100, 20, 25, 125, 1)
+        );
     drop(conn);
 
     write_session_file(
@@ -1674,10 +1820,14 @@ mod tests {
         ("2026-03-24T00:00:10Z", 180, 40, 45, 225),
       ],
     );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+        perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+            .expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after second scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (180, 40, 45, 225, 2)
+        );
   }
 
   #[test]
@@ -1692,16 +1842,17 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+            &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
     let conn = open_connection(&db_path).expect("open db after first scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (100, 20, 25, 125, 1)
+        );
     drop(conn);
 
     std::fs::write(
@@ -1715,10 +1866,14 @@ mod tests {
     )
     .expect("write incomplete session");
 
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+        perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+            .expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after incomplete rescan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (100, 20, 25, 125, 1)
+        );
     drop(conn);
 
     write_session_file(
@@ -1732,7 +1887,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("third scan");
 
     let conn = open_connection(&db_path).expect("open db after third scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (180, 40, 45, 225, 2)
+        );
   }
 
   #[test]
@@ -1765,10 +1923,14 @@ mod tests {
     )
     .expect("write active session with incomplete tail");
 
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+        perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+            .expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after second scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+        assert_eq!(
+            session_usage_totals(&conn, session_id),
+            (180, 40, 45, 225, 2)
+        );
   }
 
   #[test]
@@ -1780,10 +1942,12 @@ mod tests {
 
     let parent_session_id = "77777777-7777-7777-7777-777777777777";
     let child_session_id = "88888888-8888-8888-8888-888888888888";
-    let parent_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"));
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-05-00-{child_session_id}.jsonl"));
+        let parent_path = sessions_dir.join(format!(
+            "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+        ));
+        let child_path = sessions_dir.join(format!(
+            "rollout-2026-03-24T00-05-00-{child_session_id}.jsonl"
+        ));
 
     write_session_file(
       &parent_path,
@@ -1808,8 +1972,14 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, parent_session_id), (260, 60, 65, 325, 3));
-    assert_eq!(session_usage_totals(&conn, child_session_id), (140, 20, 25, 165, 2));
+        assert_eq!(
+            session_usage_totals(&conn, parent_session_id),
+            (260, 60, 65, 325, 3)
+        );
+        assert_eq!(
+            session_usage_totals(&conn, child_session_id),
+            (140, 20, 25, 165, 2)
+        );
     assert_eq!(
       session_root_and_subagents(&conn, parent_session_id),
       Some((parent_session_id.to_string(), true))
@@ -1857,7 +2027,8 @@ mod tests {
       "{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n",
     );
 
-    for (timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens) in snapshots {
+        for (timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens) in snapshots
+        {
       body.push_str(&format!(
         concat!(
           "{{\"timestamp\":\"{}\",\"type\":\"event_msg\",\"payload\":{{",
@@ -1869,11 +2040,7 @@ mod tests {
           "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
           "}}}}\n"
         ),
-        timestamp,
-        input_tokens,
-        cached_input_tokens,
-        output_tokens,
-        total_tokens
+                timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens
       ));
     }
 
@@ -1886,7 +2053,10 @@ mod tests {
     parent_session_id: &str,
     snapshots: &[(&str, i64, i64, i64, i64)],
   ) {
-    let first_timestamp = snapshots.first().map(|item| item.0).unwrap_or("2026-03-24T00:00:00Z");
+        let first_timestamp = snapshots
+            .first()
+            .map(|item| item.0)
+            .unwrap_or("2026-03-24T00:00:00Z");
     let mut body = format!(
       concat!(
         "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
@@ -1906,7 +2076,8 @@ mod tests {
       parent_session_id,
     );
 
-    for (timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens) in snapshots {
+        for (timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens) in snapshots
+        {
       body.push_str(&format!(
         concat!(
           "{{\"timestamp\":\"{}\",\"type\":\"event_msg\",\"payload\":{{",
@@ -1918,11 +2089,7 @@ mod tests {
           "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
           "}}}}\n"
         ),
-        timestamp,
-        input_tokens,
-        cached_input_tokens,
-        output_tokens,
-        total_tokens
+                timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens
       ));
     }
 
@@ -1930,8 +2097,7 @@ mod tests {
   }
 
   fn session_root_and_subagents(conn: &Connection, session_id: &str) -> Option<(String, bool)> {
-    conn
-      .query_row(
+        conn.query_row(
         "SELECT root_session_id, contains_subagents FROM sessions WHERE session_id = ?1",
         params![session_id],
         |row| Ok((row.get(0)?, row.get::<_, i64>(1)? != 0)),
@@ -1940,9 +2106,11 @@ mod tests {
       .expect("query root and subagents")
   }
 
-  fn conversation_link(conn: &Connection, session_id: &str) -> Option<(String, Option<String>, i64)> {
-    conn
-      .query_row(
+    fn conversation_link(
+        conn: &Connection,
+        session_id: &str,
+    ) -> Option<(String, Option<String>, i64)> {
+        conn.query_row(
         "
         SELECT root_session_id, parent_session_id, depth
         FROM conversation_links
@@ -1956,8 +2124,7 @@ mod tests {
   }
 
   fn session_usage_totals(conn: &Connection, session_id: &str) -> (i64, i64, i64, i64, i64) {
-    conn
-      .query_row(
+        conn.query_row(
         "
         SELECT
           COALESCE(SUM(input_tokens), 0),
@@ -1969,14 +2136,21 @@ mod tests {
         WHERE session_id = ?1
         ",
         params![session_id],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
       )
       .expect("query usage totals")
   }
 
   fn session_source_state(conn: &Connection, session_id: &str) -> Option<String> {
-    conn
-      .query_row(
+        conn.query_row(
         "SELECT source_state FROM sessions WHERE session_id = ?1",
         params![session_id],
         |row| row.get(0),
@@ -1986,8 +2160,7 @@ mod tests {
   }
 
   fn import_state_session_id(conn: &Connection, path: &Path) -> Option<String> {
-    conn
-      .query_row(
+        conn.query_row(
         "SELECT session_id FROM import_state WHERE source_path = ?1",
         params![path.to_string_lossy().to_string()],
         |row| row.get(0),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,15 +16,17 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Duration as ChronoDuration, Local};
 use rusqlite::params;
 use database::{
-  canonical_subscription_currency, get_subscription_profile, get_sync_settings, init_db,
-  insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
+  canonical_subscription_currency, create_subscription_record, delete_subscription_record,
+  get_subscription_profile, get_sync_settings, init_db, insert_live_rate_limit_snapshot,
+  list_subscription_records, open_connection, save_subscription_profile, save_sync_settings,
+  update_subscription_record,
 };
 use importer::{perform_scan, recalculate_all_session_values};
 use models::{
   ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
-  ScanResult, SubscriptionProfile, SyncSettings,
+  ScanResult, SubscriptionProfile, SubscriptionRecord, SubscriptionRecordInput, SyncSettings,
 };
 use pricing::{load_catalog, refresh_pricing_catalog_from_openai, seed_pricing_catalog};
 use queries::{get_conversation_detail, get_overview, get_quota_trend, list_conversations, load_dashboard_data};
@@ -204,6 +206,7 @@ async fn loadDashboard(
       conversations: snapshot.conversations,
       sync_settings,
       subscription_profile: snapshot.subscription_profile,
+      subscription_records: snapshot.subscription_records,
       live_rate_limits,
     })
   })
@@ -324,6 +327,41 @@ fn updateSubscriptionProfile(
     updated_at: payload.updated_at,
   };
   save_subscription_profile(&conn, &updated).map_err(|error| error.to_string())
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+fn listSubscriptionRecords(state: State<'_, AppState>) -> Result<Vec<SubscriptionRecord>, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  list_subscription_records(&conn).map_err(|error| error.to_string())
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn createSubscriptionRecord(
+  state: State<'_, AppState>,
+  payload: SubscriptionRecordInput,
+) -> Result<SubscriptionRecord, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  create_subscription_record(&conn, &payload)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn updateSubscriptionRecord(
+  state: State<'_, AppState>,
+  id: i64,
+  payload: SubscriptionRecordInput,
+) -> Result<SubscriptionRecord, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  update_subscription_record(&conn, id, &payload)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn deleteSubscriptionRecord(state: State<'_, AppState>, id: i64) -> Result<bool, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  delete_subscription_record(&conn, id)
 }
 
 fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
@@ -1669,6 +1707,10 @@ pub fn run() {
       updateSyncSettings,
       getSubscriptionProfile,
       updateSubscriptionProfile,
+      listSubscriptionRecords,
+      createSubscriptionRecord,
+      updateSubscriptionRecord,
+      deleteSubscriptionRecord,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ use database::{
 };
 use importer::{perform_scan, perform_scan_for_source, recalculate_all_session_values};
 use models::{
-    CodexSource, CodexSourceCandidate, CodexSourceDownloadResult, CodexSourceInput,
+    CodexAccountStatus, CodexSource, CodexSourceCandidate, CodexSourceDownloadResult, CodexSourceInput,
   ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
@@ -35,7 +35,7 @@ use pricing::{load_catalog, refresh_pricing_catalog_from_openai, seed_pricing_ca
 use queries::{
     get_conversation_detail, get_overview, get_quota_trend, list_conversations, load_dashboard_data,
 };
-use rate_limits::query_live_rate_limits;
+use rate_limits::{query_codex_account_status, query_live_rate_limits};
 use rusqlite::params;
 use sources::{discover_ssh_codex_sources, download_codex_source, source_cache_codex_home};
 use tauri::{
@@ -247,6 +247,7 @@ async fn loadDashboard(
       sync_settings,
       subscription_profile: snapshot.subscription_profile,
       subscription_records: snapshot.subscription_records,
+      account_status: safe_codex_account_status(),
       live_rate_limits,
     })
   })
@@ -519,6 +520,17 @@ fn updateSubscriptionRecord(
 fn deleteSubscriptionRecord(state: State<'_, AppState>, id: i64) -> Result<bool, String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   delete_subscription_record(&conn, id)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+fn getCodexAccountStatus() -> CodexAccountStatus {
+  safe_codex_account_status()
+}
+
+fn safe_codex_account_status() -> CodexAccountStatus {
+  query_codex_account_status()
+    .unwrap_or_else(|error| CodexAccountStatus::unavailable(error, Local::now().to_rfc3339()))
 }
 
 fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
@@ -2051,6 +2063,7 @@ pub fn run() {
       createSubscriptionRecord,
       updateSubscriptionRecord,
       deleteSubscriptionRecord,
+      getCodexAccountStatus,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod models;
 mod pricing;
 mod queries;
 mod rate_limits;
+mod sources;
 
 use std::fs;
 use std::path::PathBuf;
@@ -14,29 +15,34 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, Local};
-use rusqlite::params;
 use database::{
-  canonical_subscription_currency, create_subscription_record, delete_subscription_record,
+    canonical_subscription_currency, create_subscription_record,
+    delete_codex_source as delete_codex_source_record, delete_subscription_record,
   get_subscription_profile, get_sync_settings, init_db, insert_live_rate_limit_snapshot,
-  list_subscription_records, open_connection, save_subscription_profile, save_sync_settings,
-  update_subscription_record,
+    list_codex_sources, list_subscription_records, open_connection, save_subscription_profile,
+    save_sync_settings, set_codex_source_selected, update_subscription_record,
+    upsert_ssh_codex_source,
 };
-use importer::{perform_scan, recalculate_all_session_values};
+use importer::{perform_scan, perform_scan_for_source, recalculate_all_session_values};
 use models::{
+    CodexSource, CodexSourceCandidate, CodexSourceDownloadResult, CodexSourceInput,
   ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
   ScanResult, SubscriptionProfile, SubscriptionRecord, SubscriptionRecordInput, SyncSettings,
 };
 use pricing::{load_catalog, refresh_pricing_catalog_from_openai, seed_pricing_catalog};
-use queries::{get_conversation_detail, get_overview, get_quota_trend, list_conversations, load_dashboard_data};
+use queries::{
+    get_conversation_detail, get_overview, get_quota_trend, list_conversations, load_dashboard_data,
+};
 use rate_limits::query_live_rate_limits;
+use rusqlite::params;
+use sources::{discover_ssh_codex_sources, download_codex_source, source_cache_codex_home};
 use tauri::{
-  Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
-  WebviewWindowBuilder,
   menu::{Menu, MenuItem, PredefinedMenuItem},
   tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
-  AppHandle, State,
+    AppHandle, Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, State,
+    WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
 
 const DAILY_VALUE_TRAY_ID: &str = "daily-api-value";
@@ -68,6 +74,7 @@ struct MenuBarPopupAnchor {
 #[derive(Clone)]
 struct AppState {
   db_path: PathBuf,
+    app_data_dir: PathBuf,
   scan_in_progress: Arc<AtomicBool>,
   daily_value_tray: Option<TrayIcon>,
   live_rate_limits: Arc<Mutex<Option<CachedRateLimitSnapshot>>>,
@@ -76,8 +83,20 @@ struct AppState {
 
 #[allow(non_snake_case)]
 #[tauri::command(rename_all = "camelCase")]
-fn scanCodexUsage(state: State<'_, AppState>, codex_home: Option<String>) -> Result<ScanResult, String> {
+fn scanCodexUsage(
+    state: State<'_, AppState>,
+    codex_home: Option<String>,
+) -> Result<ScanResult, String> {
   run_scan_if_idle(state.inner().clone(), codex_home)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn scanCodexSources(
+    state: State<'_, AppState>,
+    source_ids: Option<Vec<String>>,
+) -> Result<Vec<ScanResult>, String> {
+    run_source_scan_if_idle(state.inner().clone(), source_ids)
 }
 
 #[allow(non_snake_case)]
@@ -106,8 +125,10 @@ fn getOverview(
   custom_start: Option<String>,
   custom_end: Option<String>,
   live_window_offset: Option<i64>,
+    source_ids: Option<Vec<String>>,
 ) -> Result<OverviewResponse, String> {
-  let live_rate_limits = maybe_live_rate_limits_for_bucket(state.inner(), bucket.as_deref(), live_window_offset)?;
+    let live_rate_limits =
+        maybe_live_rate_limits_for_bucket(state.inner(), bucket.as_deref(), live_window_offset)?;
   get_overview(
     &state.db_path,
     bucket,
@@ -116,6 +137,7 @@ fn getOverview(
     custom_end,
     live_rate_limits,
     live_window_offset,
+        source_ids,
   )
 }
 
@@ -150,13 +172,22 @@ fn getMenuBarPopupSnapshot(
 
 #[allow(non_snake_case)]
 #[tauri::command(rename_all = "camelCase")]
-fn resizeMenuBarPopup(app: AppHandle, state: State<'_, AppState>, height: f64) -> Result<bool, String> {
+fn resizeMenuBarPopup(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    height: f64,
+) -> Result<bool, String> {
   let Some(window) = app.get_webview_window(MENU_BAR_POPUP_WINDOW_LABEL) else {
     return Ok(false);
   };
   let (height, position) = match latest_menu_bar_popup_anchor(state.inner()) {
-    Some(anchor) => menu_bar_popup_geometry(&window, anchor.rect, anchor.click_position, height)?,
-    None => (height.clamp(MENU_BAR_POPUP_MIN_HEIGHT, MENU_BAR_POPUP_MAX_HEIGHT), None),
+        Some(anchor) => {
+            menu_bar_popup_geometry(&window, anchor.rect, anchor.click_position, height)?
+        }
+        None => (
+            height.clamp(MENU_BAR_POPUP_MIN_HEIGHT, MENU_BAR_POPUP_MAX_HEIGHT),
+            None,
+        ),
   };
   window
     .set_size(tauri::Size::Logical(tauri::LogicalSize::new(
@@ -182,12 +213,18 @@ async fn loadDashboard(
   custom_end: Option<String>,
   search: Option<String>,
   live_window_offset: Option<i64>,
+    source_ids: Option<Vec<String>>,
 ) -> Result<DashboardSnapshot, String> {
   let state = state.inner().clone();
   tauri::async_runtime::spawn_blocking(move || {
-    let normalized_bucket = bucket.clone().unwrap_or_else(|| "subscription_month".to_string());
-    let live_rate_limits =
-      maybe_live_rate_limits_for_bucket(&state, Some(&normalized_bucket), live_window_offset)?;
+        let normalized_bucket = bucket
+            .clone()
+            .unwrap_or_else(|| "subscription_month".to_string());
+        let live_rate_limits = maybe_live_rate_limits_for_bucket(
+            &state,
+            Some(&normalized_bucket),
+            live_window_offset,
+        )?;
     let snapshot = load_dashboard_data(
       &state.db_path,
       Some(normalized_bucket.clone()),
@@ -197,13 +234,16 @@ async fn loadDashboard(
       search,
       live_rate_limits.clone(),
       live_window_offset,
+            source_ids,
     )?;
     let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
     let sync_settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+        let codex_sources = list_codex_sources(&conn).map_err(|error| error.to_string())?;
 
     Ok(DashboardSnapshot {
       overview: snapshot.overview,
       conversations: snapshot.conversations,
+            codex_sources,
       sync_settings,
       subscription_profile: snapshot.subscription_profile,
       subscription_records: snapshot.subscription_records,
@@ -212,6 +252,105 @@ async fn loadDashboard(
   })
   .await
   .map_err(|error| format!("Failed to load dashboard: {error}"))?
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+fn discoverSshCodexSources() -> Vec<CodexSourceCandidate> {
+    discover_ssh_codex_sources()
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+fn listCodexSources(state: State<'_, AppState>) -> Result<Vec<CodexSource>, String> {
+    let conn = open_connection(&state.inner().db_path).map_err(|error| error.to_string())?;
+    list_codex_sources(&conn).map_err(|error| error.to_string())
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn upsertCodexSource(
+    state: State<'_, AppState>,
+    payload: CodexSourceInput,
+) -> Result<CodexSource, String> {
+    let source_id = format!(
+        "ssh_{}",
+        payload
+            .ssh_alias
+            .chars()
+            .map(|character| {
+                if character.is_ascii_alphanumeric() {
+                    character.to_ascii_lowercase()
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>()
+            .split('_')
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>()
+            .join("_")
+    );
+    let cache_home = source_cache_codex_home(&state.inner().app_data_dir, &source_id)
+        .to_string_lossy()
+        .to_string();
+    let conn = open_connection(&state.inner().db_path).map_err(|error| error.to_string())?;
+    upsert_ssh_codex_source(&conn, &source_id, &payload, &cache_home)
+        .map_err(|error| error.to_string())
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn setCodexSourceSelected(
+    state: State<'_, AppState>,
+    source_id: String,
+    selected: bool,
+) -> Result<CodexSource, String> {
+    let conn = open_connection(&state.inner().db_path).map_err(|error| error.to_string())?;
+    set_codex_source_selected(&conn, &source_id, selected).map_err(|error| error.to_string())
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn deleteCodexSource(
+    state: State<'_, AppState>,
+    source_id: String,
+) -> Result<Vec<CodexSource>, String> {
+    if source_id == "local" {
+        return Err("localhost cannot be deleted.".to_string());
+    }
+
+    let source_root = source_cache_codex_home(&state.inner().app_data_dir, &source_id)
+        .parent()
+        .map(|path| path.to_path_buf());
+    let mut conn = open_connection(&state.inner().db_path).map_err(|error| error.to_string())?;
+    let deleted =
+        delete_codex_source_record(&mut conn, &source_id).map_err(|error| error.to_string())?;
+    if !deleted {
+        return Err("Source not found.".to_string());
+    }
+    if let Some(path) = source_root {
+        if path.exists() {
+            fs::remove_dir_all(&path)
+                .map_err(|error| format!("Deleted source but failed to remove cache: {error}"))?;
+        }
+    }
+    list_codex_sources(&conn).map_err(|error| error.to_string())
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+async fn downloadCodexSource(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    source_id: String,
+) -> Result<CodexSourceDownloadResult, String> {
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        download_codex_source(&app, &state.db_path, &state.app_data_dir, &source_id)
+    })
+    .await
+    .map_err(|error| format!("Failed to download Codex source: {error}"))?
 }
 
 #[allow(non_snake_case)]
@@ -239,8 +378,7 @@ fn handleMenuBarPopupAction(
     "open_settings" => {
       hide_menu_bar_popup(&app);
       show_main_window(&app);
-      app
-        .emit_to(MAIN_WINDOW_LABEL, MENU_BAR_POPUP_OPEN_SETTINGS_EVENT, ())
+            app.emit_to(MAIN_WINDOW_LABEL, MENU_BAR_POPUP_OPEN_SETTINGS_EVENT, ())
         .map_err(|error| error.to_string())?;
       Ok(true)
     }
@@ -277,20 +415,39 @@ fn updateSyncSettings(
     codex_home: payload.codex_home,
     auto_scan_enabled: payload.auto_scan_enabled,
     auto_scan_interval_minutes: payload.auto_scan_interval_minutes.max(1),
-    live_quota_refresh_interval_seconds: payload.live_quota_refresh_interval_seconds.clamp(60, 3600),
+        live_quota_refresh_interval_seconds: payload
+            .live_quota_refresh_interval_seconds
+            .clamp(60, 3600),
     hide_dock_icon_when_menu_bar_visible: payload.hide_dock_icon_when_menu_bar_visible,
     show_menu_bar_logo: payload.show_menu_bar_logo,
     show_menu_bar_daily_api_value: payload.show_menu_bar_daily_api_value,
     show_menu_bar_live_quota_percent: payload.show_menu_bar_live_quota_percent,
-    menu_bar_live_quota_metric: normalize_menu_bar_live_quota_metric(&payload.menu_bar_live_quota_metric),
-    menu_bar_live_quota_bucket: normalize_menu_bar_live_quota_bucket(&payload.menu_bar_live_quota_bucket),
+        menu_bar_live_quota_metric: normalize_menu_bar_live_quota_metric(
+            &payload.menu_bar_live_quota_metric,
+        ),
+        menu_bar_live_quota_bucket: normalize_menu_bar_live_quota_bucket(
+            &payload.menu_bar_live_quota_bucket,
+        ),
     menu_bar_bucket: normalize_menu_bar_bucket(&payload.menu_bar_bucket),
     menu_bar_speed_show_emoji: payload.menu_bar_speed_show_emoji,
-    menu_bar_speed_fast_threshold_percent: payload.menu_bar_speed_fast_threshold_percent.clamp(0, 1000),
-    menu_bar_speed_slow_threshold_percent: payload.menu_bar_speed_slow_threshold_percent.clamp(0, 1000),
-    menu_bar_speed_healthy_emoji: normalize_menu_bar_speed_emoji(&payload.menu_bar_speed_healthy_emoji, "🟢"),
-    menu_bar_speed_fast_emoji: normalize_menu_bar_speed_emoji(&payload.menu_bar_speed_fast_emoji, "🔥"),
-    menu_bar_speed_slow_emoji: normalize_menu_bar_speed_emoji(&payload.menu_bar_speed_slow_emoji, "🐢"),
+        menu_bar_speed_fast_threshold_percent: payload
+            .menu_bar_speed_fast_threshold_percent
+            .clamp(0, 1000),
+        menu_bar_speed_slow_threshold_percent: payload
+            .menu_bar_speed_slow_threshold_percent
+            .clamp(0, 1000),
+        menu_bar_speed_healthy_emoji: normalize_menu_bar_speed_emoji(
+            &payload.menu_bar_speed_healthy_emoji,
+            "🟢",
+        ),
+        menu_bar_speed_fast_emoji: normalize_menu_bar_speed_emoji(
+            &payload.menu_bar_speed_fast_emoji,
+            "🔥",
+        ),
+        menu_bar_speed_slow_emoji: normalize_menu_bar_speed_emoji(
+            &payload.menu_bar_speed_slow_emoji,
+            "🐢",
+        ),
     menu_bar_popup_enabled: payload.menu_bar_popup_enabled,
     menu_bar_popup_modules: normalize_menu_bar_popup_modules(&payload.menu_bar_popup_modules),
     menu_bar_popup_show_reset_timeline: payload.menu_bar_popup_show_reset_timeline,
@@ -379,6 +536,60 @@ fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanR
   result
 }
 
+fn run_source_scan_if_idle(
+    state: AppState,
+    source_ids: Option<Vec<String>>,
+) -> Result<Vec<ScanResult>, String> {
+    if state
+        .scan_in_progress
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err("A scan is already running.".to_string());
+    }
+
+    let result = (|| {
+        let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+        let sources = list_codex_sources(&conn).map_err(|error| error.to_string())?;
+        let requested = source_ids.unwrap_or_else(|| {
+            sources
+                .iter()
+                .filter(|source| source.selected)
+                .map(|source| source.id.clone())
+                .collect()
+        });
+        let requested = requested
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
+        let mut results = Vec::new();
+        for source in sources {
+            if !requested.contains(&source.id) {
+                continue;
+            }
+            let codex_home = if source.id == "local" {
+                None
+            } else {
+                source.local_codex_home.clone()
+            };
+            if source.id != "local" && codex_home.is_none() {
+                continue;
+            }
+            results.push(perform_scan_for_source(
+                &state.db_path,
+                &source.id,
+                codex_home,
+            )?);
+        }
+        Ok(results)
+    })();
+
+    state.scan_in_progress.store(false, Ordering::SeqCst);
+    if result.is_ok() {
+        refresh_daily_value_menu_bar(&state);
+    }
+    result
+}
+
 fn refresh_daily_value_menu_bar(state: &AppState) {
   if let Err(error) = update_daily_value_menu_bar(state) {
     log::warn!("Failed to update menu bar display: {error}");
@@ -400,13 +611,18 @@ fn update_daily_value_menu_bar(state: &AppState) -> Result<(), String> {
   apply_menu_bar_icon(tray, settings.show_menu_bar_logo)?;
   let (api_value_title, live_metric_title) = current_menu_bar_title_parts(state, &settings)?;
   match menu_bar_title(api_value_title.as_deref(), live_metric_title.as_deref()) {
-    Some(title) => tray.set_title(Some(&title)).map_err(|error| error.to_string())?,
+        Some(title) => tray
+            .set_title(Some(&title))
+            .map_err(|error| error.to_string())?,
     None => tray
       .set_title(None::<String>)
       .map_err(|error| error.to_string())?,
   }
-  tray
-    .set_tooltip(Some(menu_bar_tooltip(&settings, api_value_title.as_deref(), state)?))
+    tray.set_tooltip(Some(menu_bar_tooltip(
+        &settings,
+        api_value_title.as_deref(),
+        state,
+    )?))
     .map_err(|error| error.to_string())?;
   tray.set_visible(true).map_err(|error| error.to_string())?;
   Ok(())
@@ -441,10 +657,10 @@ fn apply_dock_icon_visibility(_: &AppHandle, _: &SyncSettings, _: bool) {}
 fn apply_menu_bar_icon(tray: &TrayIcon, show_logo: bool) -> Result<(), String> {
   if show_logo {
     if let Some(icon) = tray.app_handle().default_window_icon().cloned() {
-      tray.set_icon(Some(icon)).map_err(|error| error.to_string())?;
+            tray.set_icon(Some(icon))
+                .map_err(|error| error.to_string())?;
       #[cfg(target_os = "macos")]
-      tray
-        .set_icon_as_template(true)
+            tray.set_icon_as_template(true)
         .map_err(|error| error.to_string())?;
     }
   } else {
@@ -470,11 +686,16 @@ fn current_menu_bar_title_parts(
     let overview = get_overview(
       &state.db_path,
       Some(bucket.clone()),
-      if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
+            if bucket_uses_anchor(&bucket) {
+                Some(anchor)
+            } else {
+                None
+            },
       None,
       None,
       live_rate_limits.clone(),
       None,
+            None,
     )?;
     Some(format!("${:.1}", overview.stats.api_value_usd))
   } else {
@@ -495,7 +716,10 @@ fn current_menu_bar_title_parts(
   Ok((api_value_title, live_metric_title))
 }
 
-fn menu_bar_title(api_value_title: Option<&str>, live_metric_title: Option<&str>) -> Option<String> {
+fn menu_bar_title(
+    api_value_title: Option<&str>,
+    live_metric_title: Option<&str>,
+) -> Option<String> {
   let mut segments = Vec::new();
   if let Some(value) = api_value_title.filter(|value| !value.trim().is_empty()) {
     segments.push(value.to_string());
@@ -512,9 +736,8 @@ fn menu_bar_title(api_value_title: Option<&str>, live_metric_title: Option<&str>
 
 fn normalize_menu_bar_bucket(bucket: &str) -> String {
   match bucket {
-    "day" | "week" | "five_hour" | "seven_day" | "subscription_month" | "month" | "year" | "total" => {
-      bucket.to_string()
-    }
+        "day" | "week" | "five_hour" | "seven_day" | "subscription_month" | "month" | "year"
+        | "total" => bucket.to_string(),
     _ => "day".to_string(),
   }
 }
@@ -570,7 +793,10 @@ fn menu_bar_tooltip(
   let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let mut fragments = Vec::new();
   if let Some(title) = api_value_title.filter(|value| !value.trim().is_empty()) {
-    fragments.push(format!("{}累计 API 价值：{title}", menu_bar_bucket_label(&bucket)));
+        fragments.push(format!(
+            "{}累计 API 价值：{title}",
+            menu_bar_bucket_label(&bucket)
+        ));
   }
   if settings.show_menu_bar_live_quota_percent {
     let snapshot = get_live_rate_limits_cached(state)?;
@@ -624,7 +850,9 @@ fn menu_bar_live_quota_snapshot(
     Some(snapshot) => snapshot,
     None => get_live_rate_limits_cached(state)?,
   };
-  Ok(menu_bar_live_quota_title(&snapshot, settings, bucket, metric, now))
+    Ok(menu_bar_live_quota_title(
+        &snapshot, settings, bucket, metric, now,
+    ))
 }
 
 fn selected_menu_bar_live_quota_window<'a>(
@@ -673,7 +901,10 @@ fn menu_bar_live_quota_tooltip(
         velocity.remaining_time_percent,
       ))
     }
-    _ => Some(format!("{label}剩余 {}%", window.remaining_percent.clamp(0, 100))),
+        _ => Some(format!(
+            "{label}剩余 {}%",
+            window.remaining_percent.clamp(0, 100)
+        )),
   }
 }
 
@@ -706,10 +937,15 @@ fn suggested_usage_velocity(
   }
 
   let remaining_seconds = reset_at.signed_duration_since(now).num_seconds() as f64;
-  let remaining_time_percent = ((remaining_seconds / total_seconds as f64) * 100.0).clamp(0.0, 100.0);
+    let remaining_time_percent =
+        ((remaining_seconds / total_seconds as f64) * 100.0).clamp(0.0, 100.0);
   let remaining_percent = window.remaining_percent.clamp(0, 100) as f64;
   let ratio = if remaining_time_percent <= 0.0 {
-    if remaining_percent <= 0.0 { 1.0 } else { 10.0 }
+        if remaining_percent <= 0.0 {
+            1.0
+        } else {
+            10.0
+        }
   } else {
     remaining_percent / remaining_time_percent
   };
@@ -721,11 +957,17 @@ fn suggested_usage_velocity(
     format!("{percent:.0}%")
   };
 
-  let fast_threshold = settings.menu_bar_speed_fast_threshold_percent.clamp(0, 1000) as f64;
+    let fast_threshold = settings
+        .menu_bar_speed_fast_threshold_percent
+        .clamp(0, 1000) as f64;
   let slow_threshold = settings
     .menu_bar_speed_slow_threshold_percent
     .clamp(0, 1000)
-    .max(settings.menu_bar_speed_fast_threshold_percent.clamp(0, 1000)) as f64;
+        .max(
+            settings
+                .menu_bar_speed_fast_threshold_percent
+                .clamp(0, 1000),
+        ) as f64;
 
   Some(SuggestedUsageVelocityDisplay {
     emoji: usage_velocity_emoji(percent, fast_threshold, slow_threshold, settings),
@@ -751,7 +993,9 @@ fn usage_velocity_emoji(
   }
 }
 
-fn quota_window_bounds(window: &RateLimitWindowSnapshot) -> Option<(DateTime<Local>, DateTime<Local>)> {
+fn quota_window_bounds(
+    window: &RateLimitWindowSnapshot,
+) -> Option<(DateTime<Local>, DateTime<Local>)> {
   let reset_at = window.resets_at.as_deref().and_then(parse_rfc3339_local)?;
   let window_start = match window.window_start.as_deref().and_then(parse_rfc3339_local) {
     Some(timestamp) => timestamp,
@@ -787,7 +1031,10 @@ fn get_live_rate_limits_cached(state: &AppState) -> Result<LiveRateLimitSnapshot
   get_live_rate_limits(state, false)
 }
 
-fn get_live_rate_limits(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
+fn get_live_rate_limits(
+    state: &AppState,
+    force_refresh: bool,
+) -> Result<LiveRateLimitSnapshot, String> {
   let ttl = live_rate_limit_cache_ttl(state);
 
   if !force_refresh {
@@ -929,15 +1176,27 @@ fn load_persisted_live_rate_limits_for_source(
     limit_id: primary
       .as_ref()
       .and_then(|window| window.limit_id.clone())
-      .or_else(|| secondary.as_ref().and_then(|window| window.limit_id.clone())),
+            .or_else(|| {
+                secondary
+                    .as_ref()
+                    .and_then(|window| window.limit_id.clone())
+            }),
     limit_name: primary
       .as_ref()
       .and_then(|window| window.limit_name.clone())
-      .or_else(|| secondary.as_ref().and_then(|window| window.limit_name.clone())),
+            .or_else(|| {
+                secondary
+                    .as_ref()
+                    .and_then(|window| window.limit_name.clone())
+            }),
     plan_type: primary
       .as_ref()
       .and_then(|window| window.plan_type.clone())
-      .or_else(|| secondary.as_ref().and_then(|window| window.plan_type.clone())),
+            .or_else(|| {
+                secondary
+                    .as_ref()
+                    .and_then(|window| window.plan_type.clone())
+            }),
     primary: primary.map(|window| window.snapshot),
     secondary: secondary.map(|window| window.snapshot),
     fetched_at,
@@ -979,7 +1238,10 @@ fn get_cached_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot
     .and_then(|cache| cache.as_ref().map(|snapshot| snapshot.snapshot.clone()))
 }
 
-fn store_live_rate_limits_cache(state: &AppState, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
+fn store_live_rate_limits_cache(
+    state: &AppState,
+    snapshot: &LiveRateLimitSnapshot,
+) -> Result<(), String> {
   let mut cache = state
     .live_rate_limits
     .lock()
@@ -991,7 +1253,10 @@ fn store_live_rate_limits_cache(state: &AppState, snapshot: &LiveRateLimitSnapsh
   Ok(())
 }
 
-fn best_effort_live_rate_limits(state: &AppState, force_refresh: bool) -> Option<LiveRateLimitSnapshot> {
+fn best_effort_live_rate_limits(
+    state: &AppState,
+    force_refresh: bool,
+) -> Option<LiveRateLimitSnapshot> {
   match get_live_rate_limits(state, force_refresh) {
     Ok(snapshot) => Some(snapshot),
     Err(error) => {
@@ -1013,7 +1278,8 @@ fn build_menu_bar_popup_snapshot(
     get_live_rate_limits_local(state)
   };
   let selected_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
-  let anchor = bucket_uses_anchor(&selected_bucket).then(|| Local::now().format("%Y-%m-%d").to_string());
+    let anchor =
+        bucket_uses_anchor(&selected_bucket).then(|| Local::now().format("%Y-%m-%d").to_string());
   let overview = get_overview(
     &state.db_path,
     Some(selected_bucket.clone()),
@@ -1026,6 +1292,7 @@ fn build_menu_bar_popup_snapshot(
       None
     },
     None,
+        None,
   )
   .ok();
   let quota_trend_7d = if selected_bucket == "seven_day" {
@@ -1034,7 +1301,12 @@ fn build_menu_bar_popup_snapshot(
       .map(|value| value.quota_trend.clone())
       .unwrap_or_default()
   } else {
-    get_quota_trend(&state.db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
+        get_quota_trend(
+            &state.db_path,
+            "seven_day".to_string(),
+            live_rate_limits.clone(),
+        )
+        .unwrap_or_default()
   };
 
   Ok(MenuBarPopupSnapshot {
@@ -1044,9 +1316,12 @@ fn build_menu_bar_popup_snapshot(
     quota_5h: live_rate_limits
       .as_ref()
       .and_then(|snapshot| snapshot.primary.as_ref().map(menu_bar_popup_quota_snapshot)),
-    quota_7d: live_rate_limits
+        quota_7d: live_rate_limits.as_ref().and_then(|snapshot| {
+            snapshot
+                .secondary
       .as_ref()
-      .and_then(|snapshot| snapshot.secondary.as_ref().map(menu_bar_popup_quota_snapshot)),
+                .map(menu_bar_popup_quota_snapshot)
+        }),
     quota_trend_7d,
     suggested_speed_7d: live_rate_limits
       .as_ref()
@@ -1054,15 +1329,26 @@ fn build_menu_bar_popup_snapshot(
       .and_then(|window| menu_bar_popup_suggested_speed(window, &settings, Local::now())),
     speed_fast_threshold_percent: settings.menu_bar_speed_fast_threshold_percent,
     speed_slow_threshold_percent: settings.menu_bar_speed_slow_threshold_percent,
-    api_value_selected_bucket: overview.as_ref().map(|value| value.stats.api_value_usd).unwrap_or(0.0),
-    total_tokens_selected_bucket: overview.as_ref().map(|value| value.stats.total_tokens).unwrap_or(0),
+        api_value_selected_bucket: overview
+            .as_ref()
+            .map(|value| value.stats.api_value_usd)
+            .unwrap_or(0.0),
+        total_tokens_selected_bucket: overview
+            .as_ref()
+            .map(|value| value.stats.total_tokens)
+            .unwrap_or(0),
     conversation_count_selected_bucket: overview
       .as_ref()
       .map(|value| value.stats.conversation_count)
       .unwrap_or(0),
-    payoff_ratio: overview.as_ref().map(|value| value.stats.payoff_ratio).unwrap_or(0.0),
+        payoff_ratio: overview
+            .as_ref()
+            .map(|value| value.stats.payoff_ratio)
+            .unwrap_or(0.0),
     last_scan_completed_at: settings.last_scan_completed_at,
-    live_quota_fetched_at: live_rate_limits.as_ref().map(|snapshot| snapshot.fetched_at.clone()),
+        live_quota_fetched_at: live_rate_limits
+            .as_ref()
+            .map(|snapshot| snapshot.fetched_at.clone()),
     visible_modules: normalize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
     show_reset_timeline: settings.menu_bar_popup_show_reset_timeline,
     show_actions: settings.menu_bar_popup_show_actions,
@@ -1085,11 +1371,17 @@ fn menu_bar_popup_suggested_speed(
   now: DateTime<Local>,
 ) -> Option<MenuBarPopupSuggestedSpeed> {
   let velocity = suggested_usage_velocity(window, now, settings)?;
-  let fast_threshold = settings.menu_bar_speed_fast_threshold_percent.clamp(0, 1000) as f64;
+    let fast_threshold = settings
+        .menu_bar_speed_fast_threshold_percent
+        .clamp(0, 1000) as f64;
   let slow_threshold = settings
     .menu_bar_speed_slow_threshold_percent
     .clamp(0, 1000)
-    .max(settings.menu_bar_speed_fast_threshold_percent.clamp(0, 1000)) as f64;
+        .max(
+            settings
+                .menu_bar_speed_fast_threshold_percent
+                .clamp(0, 1000),
+        ) as f64;
   let percent = velocity_ratio_percent(window, now);
 
   Some(MenuBarPopupSuggestedSpeed {
@@ -1112,11 +1404,17 @@ fn velocity_ratio_percent(window: &RateLimitWindowSnapshot, now: DateTime<Local>
   }
 
   let remaining_seconds = reset_at.signed_duration_since(now).num_seconds() as f64;
-  let remaining_time_percent = ((remaining_seconds / total_seconds as f64) * 100.0).clamp(0.0, 100.0);
+    let remaining_time_percent =
+        ((remaining_seconds / total_seconds as f64) * 100.0).clamp(0.0, 100.0);
   if remaining_time_percent <= 0.0 {
-    if window.remaining_percent <= 0 { 100.0 } else { 1000.0 }
+        if window.remaining_percent <= 0 {
+            100.0
   } else {
-    ((window.remaining_percent.clamp(0, 100) as f64 / remaining_time_percent) * 100.0).clamp(0.0, 1000.0)
+            1000.0
+        }
+    } else {
+        ((window.remaining_percent.clamp(0, 100) as f64 / remaining_time_percent) * 100.0)
+            .clamp(0.0, 1000.0)
   }
 }
 
@@ -1134,7 +1432,9 @@ fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
   open_connection(&state.db_path)
     .ok()
     .and_then(|conn| get_sync_settings(&conn).ok())
-    .map(|settings| Duration::from_secs(settings.live_quota_refresh_interval_seconds.clamp(60, 3600) as u64))
+        .map(|settings| {
+            Duration::from_secs(settings.live_quota_refresh_interval_seconds.clamp(60, 3600) as u64)
+        })
     .unwrap_or(Duration::from_secs(300))
 }
 
@@ -1143,7 +1443,11 @@ fn build_menu_bar_popup_window(app: &AppHandle) -> Result<WebviewWindow, String>
     return Ok(window);
   }
 
-  WebviewWindowBuilder::new(app, MENU_BAR_POPUP_WINDOW_LABEL, WebviewUrl::App("index.html".into()))
+    WebviewWindowBuilder::new(
+        app,
+        MENU_BAR_POPUP_WINDOW_LABEL,
+        WebviewUrl::App("index.html".into()),
+    )
     .title("Codex Pacer Popup")
     .inner_size(MENU_BAR_POPUP_WIDTH, MENU_BAR_POPUP_INITIAL_HEIGHT)
     .resizable(false)
@@ -1201,7 +1505,9 @@ fn position_menu_bar_popup(
   rect: Rect,
   click_position: PhysicalPosition<f64>,
 ) -> Result<(), String> {
-  if let (_, Some(position)) = menu_bar_popup_geometry(window, rect, click_position, MENU_BAR_POPUP_INITIAL_HEIGHT)? {
+    if let (_, Some(position)) =
+        menu_bar_popup_geometry(window, rect, click_position, MENU_BAR_POPUP_INITIAL_HEIGHT)?
+    {
     return window
       .set_position(Position::Physical(position))
       .map_err(|error| error.to_string());
@@ -1241,10 +1547,17 @@ fn menu_bar_popup_geometry(
   Ok((geometry.height, Some(geometry.position)))
 }
 
-fn store_menu_bar_popup_anchor(state: &AppState, rect: Rect, click_position: PhysicalPosition<f64>) {
+fn store_menu_bar_popup_anchor(
+    state: &AppState,
+    rect: Rect,
+    click_position: PhysicalPosition<f64>,
+) {
   match state.menu_bar_popup_anchor.lock() {
     Ok(mut anchor) => {
-      *anchor = Some(MenuBarPopupAnchor { rect, click_position });
+            *anchor = Some(MenuBarPopupAnchor {
+                rect,
+                click_position,
+            });
     }
     Err(_) => {
       log::warn!("Failed to store tray popup anchor.");
@@ -1279,7 +1592,9 @@ fn tray_event_monitor(
   rect: Rect,
   click_position: PhysicalPosition<f64>,
 ) -> Result<Option<Monitor>, String> {
-  let monitors = window.available_monitors().map_err(|error| error.to_string())?;
+    let monitors = window
+        .available_monitors()
+        .map_err(|error| error.to_string())?;
   let mut best_match: Option<(Monitor, f64)> = None;
 
   for monitor in monitors {
@@ -1417,8 +1732,12 @@ fn menu_bar_popup_geometry_for_monitor(
   } else {
     monitor_position.y + monitor_size.height as i32 - anchor.y.round() as i32 - offset_y
   };
-  let available_height = (available_height_physical.max(0) as f64 / scale_factor).max(MENU_BAR_POPUP_MIN_HEIGHT);
-  let height = requested_height.clamp(MENU_BAR_POPUP_MIN_HEIGHT, MENU_BAR_POPUP_MAX_HEIGHT.min(available_height));
+    let available_height =
+        (available_height_physical.max(0) as f64 / scale_factor).max(MENU_BAR_POPUP_MIN_HEIGHT);
+    let height = requested_height.clamp(
+        MENU_BAR_POPUP_MIN_HEIGHT,
+        MENU_BAR_POPUP_MAX_HEIGHT.min(available_height),
+    );
   let popup_height = logical_to_physical_i32(height, scale_factor);
   let mut y = if opens_above {
     tray_top - offset_y - popup_height
@@ -1453,10 +1772,16 @@ fn tray_rect_anchor_physical(
 }
 
 fn logical_to_physical_i32(value: f64, scale_factor: f64) -> i32 {
-  (value * normalized_scale_factor(scale_factor)).round().max(1.0) as i32
+    (value * normalized_scale_factor(scale_factor))
+        .round()
+        .max(1.0) as i32
 }
 
-fn tray_rect_top_physical(rect: Rect, click_position: PhysicalPosition<f64>, scale_factor: f64) -> i32 {
+fn tray_rect_top_physical(
+    rect: Rect,
+    click_position: PhysicalPosition<f64>,
+    scale_factor: f64,
+) -> i32 {
   let rect_position = tray_rect_position_to_physical(rect.position, scale_factor);
   let rect_size = tray_rect_size_to_physical(rect.size, scale_factor);
   if rect_size.height > 0 {
@@ -1496,7 +1821,8 @@ fn build_daily_value_menu_bar(app: &AppHandle, db_path: &PathBuf) -> Result<Tray
   let separator = PredefinedMenuItem::separator(app).map_err(|error| error.to_string())?;
   let quit = MenuItem::with_id(app, DAILY_VALUE_QUIT_MENU_ID, "Quit", true, None::<&str>)
     .map_err(|error| error.to_string())?;
-  let menu = Menu::with_items(app, &[&show_window, &separator, &quit]).map_err(|error| error.to_string())?;
+    let menu = Menu::with_items(app, &[&show_window, &separator, &quit])
+        .map_err(|error| error.to_string())?;
 
   let mut builder = TrayIconBuilder::with_id(DAILY_VALUE_TRAY_ID)
     .menu(&menu)
@@ -1538,8 +1864,7 @@ fn build_daily_value_menu_bar(app: &AppHandle, db_path: &PathBuf) -> Result<Tray
   }
 
   let tray = builder.build(app).map_err(|error| error.to_string())?;
-  tray
-    .set_visible(menu_bar_has_visible_content(&settings))
+    tray.set_visible(menu_bar_has_visible_content(&settings))
     .map_err(|error| error.to_string())?;
   Ok(tray)
 }
@@ -1581,15 +1906,14 @@ fn spawn_scheduler(state: AppState) {
       }
 
       let should_scan = match settings.last_scan_completed_at.as_deref() {
-        Some(last_completed_at) => {
-          chrono::DateTime::parse_from_rfc3339(last_completed_at)
+                Some(last_completed_at) => chrono::DateTime::parse_from_rfc3339(last_completed_at)
             .ok()
             .map(|last| {
-              let elapsed = chrono::Utc::now().signed_duration_since(last.with_timezone(&chrono::Utc));
+                        let elapsed = chrono::Utc::now()
+                            .signed_duration_since(last.with_timezone(&chrono::Utc));
               elapsed.num_minutes() >= settings.auto_scan_interval_minutes.max(1)
             })
-            .unwrap_or(true)
-        }
+                    .unwrap_or(true),
         None => true,
       };
 
@@ -1654,8 +1978,12 @@ pub fn run() {
         .path()
         .app_data_dir()
         .map_err(|error| format!("Failed to resolve app data dir: {error}"))?;
-      fs::create_dir_all(&app_data_dir)
-        .map_err(|error| format!("Failed to create app data dir {}: {error}", app_data_dir.display()))?;
+            fs::create_dir_all(&app_data_dir).map_err(|error| {
+                format!(
+                    "Failed to create app data dir {}: {error}",
+                    app_data_dir.display()
+                )
+            })?;
       let db_path = app_data_dir.join("codex-counter.sqlite");
 
       let conn = open_connection(&db_path).map_err(|error| error.to_string())?;
@@ -1673,6 +2001,7 @@ pub fn run() {
       };
       let state = AppState {
         db_path,
+                app_data_dir,
         scan_in_progress: Arc::new(AtomicBool::new(false)),
         daily_value_tray,
         live_rate_limits: Arc::new(Mutex::new(None)),
@@ -1680,7 +2009,11 @@ pub fn run() {
       };
       app.manage(state.clone());
       if let Ok(settings) = get_sync_settings(&conn) {
-        apply_dock_icon_visibility(&app_handle, &settings, state.daily_value_tray.is_some());
+                apply_dock_icon_visibility(
+                    &app_handle,
+                    &settings,
+                    state.daily_value_tray.is_some(),
+                );
       }
       if let Err(error) = build_menu_bar_popup_window(&app_handle) {
         log::warn!("Failed to set up menu bar popup window: {error}");
@@ -1693,6 +2026,7 @@ pub fn run() {
     })
     .invoke_handler(tauri::generate_handler![
       scanCodexUsage,
+            scanCodexSources,
       getScanInProgress,
       refreshPricing,
       getOverview,
@@ -1701,6 +2035,12 @@ pub fn run() {
       getMenuBarPopupSnapshot,
       resizeMenuBarPopup,
       loadDashboard,
+            discoverSshCodexSources,
+            listCodexSources,
+            upsertCodexSource,
+            setCodexSourceSelected,
+            deleteCodexSource,
+            downloadCodexSource,
       getConversationDetail,
       handleMenuBarPopupAction,
       getSyncSettings,
@@ -1827,7 +2167,10 @@ mod tests {
   #[test]
   fn menu_bar_title_joins_visible_segments_without_extra_spacing() {
     assert_eq!(menu_bar_title(None, None), None);
-    assert_eq!(menu_bar_title(Some("$12.4"), None), Some("$12.4".to_string()));
+        assert_eq!(
+            menu_bar_title(Some("$12.4"), None),
+            Some("$12.4".to_string())
+        );
     assert_eq!(menu_bar_title(None, Some("67%")), Some("67%".to_string()));
     assert_eq!(
       menu_bar_title(Some("$12.4"), Some("67%")),
@@ -1893,7 +2236,8 @@ mod tests {
 
   #[test]
   fn tray_popup_position_keeps_physical_tray_coordinates_unscaled() {
-    let position = tray_rect_position_to_physical(Position::Physical((1440.0, 12.0).into()), 2.0);
+        let position =
+            tray_rect_position_to_physical(Position::Physical((1440.0, 12.0).into()), 2.0);
     let size = tray_rect_size_to_physical(tauri::Size::Physical((24u32, 24u32).into()), 2.0);
 
     assert_eq!(position, PhysicalPosition::new(1440, 12));
@@ -1918,7 +2262,8 @@ mod tests {
       size: tauri::Size::Physical((48u32, 48u32).into()),
     };
 
-    let lookup_point = tray_event_monitor_lookup_point(rect, PhysicalPosition::new(4024.0, 24.0), 2.0);
+        let lookup_point =
+            tray_event_monitor_lookup_point(rect, PhysicalPosition::new(4024.0, 24.0), 2.0);
 
     assert_eq!(lookup_point, PhysicalPosition::new(2012.0, 29.0));
   }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -154,6 +154,31 @@ impl Default for SubscriptionProfile {
   }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionRecord {
+  pub id: i64,
+  pub paid_at: String,
+  pub service_start: String,
+  pub service_end: String,
+  pub amount_usd: f64,
+  pub plan_type: String,
+  pub note: Option<String>,
+  pub created_at: String,
+  pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionRecordInput {
+  pub paid_at: String,
+  pub service_start: String,
+  pub service_end: String,
+  pub amount_usd: f64,
+  pub plan_type: String,
+  pub note: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ConversationFilters {
@@ -323,6 +348,7 @@ pub struct DashboardSnapshot {
   pub conversations: Vec<ConversationListItem>,
   pub sync_settings: SyncSettings,
   pub subscription_profile: SubscriptionProfile,
+  pub subscription_records: Vec<SubscriptionRecord>,
   pub live_rate_limits: Option<LiveRateLimitSnapshot>,
 }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -242,6 +242,34 @@ pub struct SubscriptionRecordInput {
   pub note: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexAccountStatus {
+  pub available: bool,
+  pub requires_openai_auth: bool,
+  pub auth_mode: Option<String>,
+  pub account_type: Option<String>,
+  pub email: Option<String>,
+  pub plan_type: Option<String>,
+  pub error: Option<String>,
+  pub fetched_at: String,
+}
+
+impl CodexAccountStatus {
+  pub fn unavailable(error: String, fetched_at: String) -> Self {
+    Self {
+      available: false,
+      requires_openai_auth: false,
+      auth_mode: None,
+      account_type: None,
+      email: None,
+      plan_type: None,
+      error: Some(error),
+      fetched_at,
+    }
+  }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ConversationFilters {
@@ -422,10 +450,11 @@ pub struct OverviewResponse {
 pub struct DashboardSnapshot {
   pub overview: OverviewResponse,
   pub conversations: Vec<ConversationListItem>,
-    pub codex_sources: Vec<CodexSource>,
+  pub codex_sources: Vec<CodexSource>,
   pub sync_settings: SyncSettings,
   pub subscription_profile: SubscriptionProfile,
   pub subscription_records: Vec<SubscriptionRecord>,
+  pub account_status: CodexAccountStatus,
   pub live_rate_limits: Option<LiveRateLimitSnapshot>,
 }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -134,6 +134,69 @@ impl Default for SyncSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct CodexSource {
+    pub id: String,
+    pub kind: String,
+    pub label: String,
+    pub ssh_alias: Option<String>,
+    pub host_name: Option<String>,
+    pub user: Option<String>,
+    pub port: Option<i64>,
+    pub remote_codex_home: Option<String>,
+    pub local_codex_home: Option<String>,
+    pub selected: bool,
+    pub status: String,
+    pub last_discovered_at: Option<String>,
+    pub last_downloaded_at: Option<String>,
+    pub last_scanned_at: Option<String>,
+    pub last_error: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSourceCandidate {
+    pub id: String,
+    pub label: String,
+    pub ssh_alias: String,
+    pub host_name: Option<String>,
+    pub user: Option<String>,
+    pub port: Option<i64>,
+    pub remote_codex_home: String,
+    pub ignored_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSourceInput {
+    pub label: String,
+    pub ssh_alias: String,
+    pub host_name: Option<String>,
+    pub user: Option<String>,
+    pub port: Option<i64>,
+    pub remote_codex_home: String,
+    pub selected: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSourceDownloadProgress {
+    pub source_id: String,
+    pub stage: String,
+    pub progress: Option<f64>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSourceDownloadResult {
+    pub source: CodexSource,
+    pub scan_result: ScanResult,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SubscriptionProfile {
   pub plan_type: String,
   pub currency: String,
@@ -188,6 +251,7 @@ pub struct ConversationFilters {
   pub custom_end: Option<String>,
   pub search: Option<String>,
   pub live_window_offset: Option<i64>,
+    pub source_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -326,6 +390,17 @@ pub struct CompositionShare {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SourceShare {
+    pub source_id: String,
+    pub display_name: String,
+    pub api_value_usd: f64,
+    pub total_tokens: i64,
+    pub conversation_count: usize,
+    pub color: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OverviewResponse {
   pub bucket: String,
   pub anchor: String,
@@ -338,6 +413,7 @@ pub struct OverviewResponse {
   pub quota_trend: Vec<QuotaTrendPoint>,
   pub model_shares: Vec<ModelShare>,
   pub composition_shares: Vec<CompositionShare>,
+    pub source_shares: Vec<SourceShare>,
   pub live_rate_limits: Option<LiveRateLimitSnapshot>,
 }
 
@@ -346,6 +422,7 @@ pub struct OverviewResponse {
 pub struct DashboardSnapshot {
   pub overview: OverviewResponse,
   pub conversations: Vec<ConversationListItem>,
+    pub codex_sources: Vec<CodexSource>,
   pub sync_settings: SyncSettings,
   pub subscription_profile: SubscriptionProfile,
   pub subscription_records: Vec<SubscriptionRecord>,
@@ -438,6 +515,7 @@ pub struct ConversationDetail {
   pub turns: Vec<ConversationTurnPoint>,
   pub model_breakdown: Vec<ModelShare>,
   pub composition_breakdown: Vec<CompositionShare>,
+    pub source_breakdown: Vec<SourceShare>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -10,12 +10,12 @@ use chrono::{
 use rusqlite::Connection;
 use serde_json::Value;
 
-use crate::database::{get_subscription_profile, open_connection};
+use crate::database::{get_subscription_profile, list_subscription_records, open_connection};
 use crate::models::{
   CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem,
   ConversationSessionSummary, ConversationTurnPoint, LiveRateLimitSnapshot, ModelShare,
-  OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SubscriptionProfile, TokenUsage,
-  TrendPoint,
+  OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SubscriptionProfile,
+  SubscriptionRecord, TokenUsage, TrendPoint,
 };
 use crate::pricing::{
   calculate_value_usd, display_name_for_model, load_catalog_map, model_color, normalize_model_id,
@@ -97,6 +97,7 @@ pub struct DashboardData {
   pub overview: OverviewResponse,
   pub conversations: Vec<ConversationListItem>,
   pub subscription_profile: SubscriptionProfile,
+  pub subscription_records: Vec<SubscriptionRecord>,
 }
 
 pub fn get_overview(
@@ -112,12 +113,14 @@ pub fn get_overview(
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
   build_overview(
     &conn,
     &sessions,
     &events,
     &profile,
+    &subscription_records,
     &catalog,
     bucket,
     anchor,
@@ -171,7 +174,16 @@ pub fn list_conversations(
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
-  build_conversation_list(&conn, &sessions, &events, &profile, filters, live_rate_limits.as_ref())
+  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
+  build_conversation_list(
+    &conn,
+    &sessions,
+    &events,
+    &profile,
+    &subscription_records,
+    filters,
+    live_rate_limits.as_ref(),
+  )
 }
 
 pub fn load_dashboard_data(
@@ -188,6 +200,7 @@ pub fn load_dashboard_data(
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
 
   let overview = build_overview(
@@ -195,6 +208,7 @@ pub fn load_dashboard_data(
     &sessions,
     &events,
     &profile,
+    &subscription_records,
     &catalog,
     bucket.clone(),
     anchor.clone(),
@@ -208,6 +222,7 @@ pub fn load_dashboard_data(
     &sessions,
     &events,
     &profile,
+    &subscription_records,
     Some(ConversationFilters {
       bucket,
       anchor,
@@ -223,6 +238,7 @@ pub fn load_dashboard_data(
     overview,
     conversations,
     subscription_profile: profile,
+    subscription_records,
   })
 }
 
@@ -231,6 +247,7 @@ fn build_overview(
   sessions: &HashMap<String, SessionRow>,
   events: &[EventRow],
   profile: &SubscriptionProfile,
+  subscription_records: &[SubscriptionRecord],
   catalog: &HashMap<String, PricingCatalogEntry>,
   bucket: Option<String>,
   anchor: Option<String>,
@@ -274,8 +291,7 @@ fn build_overview(
     }
   }
 
-  let subscription_cost_usd =
-    subscription_cost_for_window(window, profile.monthly_price, profile.billing_anchor_day as u32);
+  let subscription_cost_usd = subscription_cost_for_overview(window, subscription_records);
   let payoff_ratio = if subscription_cost_usd > 0.0 {
     total_value_usd / subscription_cost_usd
   } else {
@@ -325,6 +341,7 @@ fn build_conversation_list(
   sessions: &HashMap<String, SessionRow>,
   events: &[EventRow],
   profile: &SubscriptionProfile,
+  subscription_records: &[SubscriptionRecord],
   filters: Option<ConversationFilters>,
   live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<Vec<ConversationListItem>, String> {
@@ -341,6 +358,7 @@ fn build_conversation_list(
     filters.live_window_offset,
   )?
   .window;
+  let subscription_cost_usd = subscription_cost_for_window(&window, subscription_records);
   let search = filters.search.unwrap_or_default().to_ascii_lowercase();
 
   let mut groups: BTreeMap<String, ConversationAccumulator> = BTreeMap::new();
@@ -431,8 +449,8 @@ fn build_conversation_list(
       subagent_count: group.session_ids.len().saturating_sub(1),
       has_fast_mode: !group.fast_session_ids.is_empty(),
       api_value_usd: group.api_value_usd,
-      subscription_share: if profile.monthly_price > 0.0 {
-        group.api_value_usd / profile.monthly_price
+      subscription_share: if subscription_cost_usd > 0.0 {
+        group.api_value_usd / subscription_cost_usd
       } else {
         0.0
       },
@@ -454,7 +472,7 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let sessions = load_sessions_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
   let events = load_events_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
-  let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
 
   let mut conversation_sessions = sessions.values().cloned().collect::<Vec<_>>();
@@ -598,6 +616,11 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
   if title.trim().is_empty() {
     title = root_session_id.to_string();
   }
+  let subscription_cost_usd = subscription_records
+    .iter()
+    .filter(|record| record.amount_usd > 0.0 && record.amount_usd.is_finite())
+    .map(|record| record.amount_usd)
+    .sum::<f64>();
 
   Ok(ConversationDetail {
     root_session_id: root_session_id.to_string(),
@@ -610,8 +633,8 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     reasoning_output_tokens: total_reasoning,
     total_tokens,
     api_value_usd: total_value_usd,
-    subscription_share: if profile.monthly_price > 0.0 {
-      total_value_usd / profile.monthly_price
+    subscription_share: if subscription_cost_usd > 0.0 {
+      total_value_usd / subscription_cost_usd
     } else {
       0.0
     },
@@ -1541,28 +1564,55 @@ fn custom_window_uses_monthly_bins(window: &Window) -> bool {
   window.end.signed_duration_since(window.start) > chrono::Duration::days(62)
 }
 
-fn subscription_cost_for_window(window: &Window, monthly_price: f64, billing_anchor_day: u32) -> f64 {
-  if window.bucket == "subscription_month" {
-    return monthly_price;
+fn subscription_cost_for_window(window: &Window, records: &[SubscriptionRecord]) -> f64 {
+  records
+    .iter()
+    .filter_map(|record| subscription_record_cost_for_window(record, window))
+    .sum()
+}
+
+fn subscription_cost_for_overview(window: &Window, records: &[SubscriptionRecord]) -> f64 {
+  if window.bucket == "total" {
+    return records
+      .iter()
+      .filter(|record| record.amount_usd > 0.0 && record.amount_usd.is_finite())
+      .map(|record| record.amount_usd)
+      .sum();
   }
 
-  let mut total = 0.0;
-  let mut cycle_start = billing_cycle_start(window.start.date_naive(), billing_anchor_day);
-  loop {
-    let cycle_end = billing_cycle_next_start(cycle_start, billing_anchor_day);
-    let overlap_start = window.start.date_naive().max(cycle_start);
-    let overlap_end = window.end.date_naive().min(cycle_end);
-    if overlap_start < overlap_end {
-      let cycle_days = (cycle_end - cycle_start).num_days().max(1) as f64;
-      let overlap_days = (overlap_end - overlap_start).num_days().max(0) as f64;
-      total += monthly_price * (overlap_days / cycle_days);
-    }
-    if cycle_end >= window.end.date_naive() {
-      break;
-    }
-    cycle_start = cycle_end;
+  subscription_cost_for_window(window, records)
+}
+
+fn subscription_record_cost_for_window(
+  record: &SubscriptionRecord,
+  window: &Window,
+) -> Option<f64> {
+  if record.amount_usd <= 0.0 || !record.amount_usd.is_finite() {
+    return None;
   }
-  total
+  let service_start = parse_date(&record.service_start)
+    .ok()
+    .and_then(|date| local_midnight(date).ok())?;
+  let service_end = parse_date(&record.service_end)
+    .ok()
+    .and_then(|date| local_midnight(date).ok())?;
+  if service_end <= service_start {
+    return None;
+  }
+  let overlap_start = window.start.max(service_start);
+  let overlap_end = window.end.min(service_end);
+  if overlap_end <= overlap_start {
+    return None;
+  }
+  let service_seconds = service_end
+    .signed_duration_since(service_start)
+    .num_seconds()
+    .max(1) as f64;
+  let overlap_seconds = overlap_end
+    .signed_duration_since(overlap_start)
+    .num_seconds()
+    .max(0) as f64;
+  Some(record.amount_usd * (overlap_seconds / service_seconds))
 }
 
 fn selected_rate_limit_window<'a>(
@@ -1837,6 +1887,12 @@ mod tests {
   use super::*;
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
+
+  fn local_time(value: &str) -> DateTime<Local> {
+    DateTime::parse_from_rfc3339(value)
+      .expect("parse local test timestamp")
+      .with_timezone(&Local)
+  }
 
   #[test]
   fn groups_modern_snapshots_into_one_turn() {
@@ -2190,6 +2246,96 @@ mod tests {
     .expect_err("custom end before start should fail");
 
     assert!(error.contains("Custom range end date cannot be before start date"));
+  }
+
+  #[test]
+  fn subscription_cost_uses_service_period_proration() {
+    let window = Window {
+      bucket: "month".to_string(),
+      anchor: "2026-04-01".to_string(),
+      start: local_time("2026-04-01T00:00:00+08:00"),
+      end: local_time("2026-05-01T00:00:00+08:00"),
+    };
+    let records = vec![
+      SubscriptionRecord {
+        id: 1,
+        paid_at: "2026-04-16".to_string(),
+        service_start: "2026-04-16".to_string(),
+        service_end: "2026-05-16".to_string(),
+        amount_usd: 20.0,
+        plan_type: "plus".to_string(),
+        note: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+      },
+      SubscriptionRecord {
+        id: 2,
+        paid_at: "2026-04-01".to_string(),
+        service_start: "2026-04-01".to_string(),
+        service_end: "2026-05-01".to_string(),
+        amount_usd: 200.0,
+        plan_type: "pro".to_string(),
+        note: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+      },
+    ];
+
+    let cost = subscription_cost_for_window(&window, &records);
+
+    assert!((cost - 210.0).abs() < 0.001);
+  }
+
+  #[test]
+  fn total_overview_subscription_cost_sums_full_records() {
+    let window = Window {
+      bucket: "total".to_string(),
+      anchor: "2026-03-19".to_string(),
+      start: local_time("2026-03-19T00:00:00+08:00"),
+      end: local_time("2026-05-01T00:00:00+08:00"),
+    };
+    let records = vec![
+      SubscriptionRecord {
+        id: 1,
+        paid_at: "2026-03-19".to_string(),
+        service_start: "2026-03-19".to_string(),
+        service_end: "2026-04-19".to_string(),
+        amount_usd: 19.99,
+        plan_type: "plus".to_string(),
+        note: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+      },
+      SubscriptionRecord {
+        id: 2,
+        paid_at: "2026-04-25".to_string(),
+        service_start: "2026-04-25".to_string(),
+        service_end: "2026-05-25".to_string(),
+        amount_usd: 100.0,
+        plan_type: "pro_x5".to_string(),
+        note: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+      },
+    ];
+
+    let prorated_cost = subscription_cost_for_window(&window, &records);
+    let total_cost = subscription_cost_for_overview(&window, &records);
+
+    assert!(prorated_cost < 119.99);
+    assert!((total_cost - 119.99).abs() < 0.001);
+  }
+
+  #[test]
+  fn subscription_cost_is_zero_without_records() {
+    let window = Window {
+      bucket: "day".to_string(),
+      anchor: "2026-04-16".to_string(),
+      start: local_time("2026-04-16T00:00:00+08:00"),
+      end: local_time("2026-04-17T00:00:00+08:00"),
+    };
+
+    assert_eq!(subscription_cost_for_window(&window, &[]), 0.0);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -22,6 +22,13 @@ use crate::pricing::{
   resolve_pricing,
 };
 
+const SQL_SESSIONS: &str = include_str!("../sql/queries/sessions.sql");
+const SQL_SESSIONS_FOR_ROOT: &str = include_str!("../sql/queries/sessions_for_root.sql");
+const SQL_USAGE_EVENTS: &str = include_str!("../sql/queries/usage_events.sql");
+const SQL_USAGE_EVENTS_FOR_ROOT: &str = include_str!("../sql/queries/usage_events_for_root.sql");
+const SQL_RATE_LIMIT_WINDOWS: &str = include_str!("../sql/queries/rate_limit_windows.sql");
+const SQL_QUOTA_SAMPLES: &str = include_str!("../sql/queries/quota_samples.sql");
+
 #[derive(Debug, Clone)]
 struct SessionRow {
   session_id: String,
@@ -1059,13 +1066,7 @@ fn build_composition_breakdown(
 }
 
 fn load_sessions(conn: &Connection) -> rusqlite::Result<HashMap<String, SessionRow>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
-           started_at, updated_at, agent_nickname, agent_role
-    FROM sessions
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_SESSIONS)?;
   let rows = stmt.query_map([], |row| {
     Ok(SessionRow {
       session_id: row.get(0)?,
@@ -1093,14 +1094,7 @@ fn load_sessions_for_root_session(
   conn: &Connection,
   root_session_id: &str,
 ) -> rusqlite::Result<HashMap<String, SessionRow>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT session_id, root_session_id, parent_session_id, title, source_state, source_path,
-           started_at, updated_at, agent_nickname, agent_role
-    FROM sessions
-    WHERE root_session_id = ?1
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_SESSIONS_FOR_ROOT)?;
   let rows = stmt.query_map([root_session_id], |row| {
     Ok(SessionRow {
       session_id: row.get(0)?,
@@ -1125,15 +1119,7 @@ fn load_sessions_for_root_session(
 }
 
 fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
-           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
-           fast_mode_auto, fast_mode_effective
-    FROM usage_events
-    ORDER BY timestamp ASC, id ASC
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_USAGE_EVENTS)?;
   let rows = stmt.query_map([], |row| {
     Ok(EventRow {
       session_id: row.get(0)?,
@@ -1154,19 +1140,7 @@ fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
 }
 
 fn load_events_for_root_session(conn: &Connection, root_session_id: &str) -> rusqlite::Result<Vec<EventRow>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT usage_events.session_id, usage_events.timestamp, usage_events.model_id,
-           usage_events.input_tokens, usage_events.cached_input_tokens,
-           usage_events.output_tokens, usage_events.reasoning_output_tokens,
-           usage_events.total_tokens, usage_events.value_usd,
-           usage_events.fast_mode_auto, usage_events.fast_mode_effective
-    FROM usage_events
-    INNER JOIN sessions ON sessions.session_id = usage_events.session_id
-    WHERE sessions.root_session_id = ?1
-    ORDER BY usage_events.timestamp ASC, usage_events.id ASC
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_USAGE_EVENTS_FOR_ROOT)?;
   let rows = stmt.query_map([root_session_id], |row| {
     Ok(EventRow {
       session_id: row.get(0)?,
@@ -1340,15 +1314,7 @@ fn load_live_rate_limit_windows(
   bucket: &str,
   current_window: Option<RateLimitWindowSummary>,
 ) -> rusqlite::Result<Vec<RateLimitWindowSummary>> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT window_start, resets_at
-    FROM rate_limit_samples
-    WHERE bucket = ?1
-    GROUP BY window_start, resets_at
-    ORDER BY window_start DESC, resets_at DESC
-    ",
-  )?;
+  let mut stmt = conn.prepare(SQL_RATE_LIMIT_WINDOWS)?;
   let rows = stmt.query_map(rusqlite::params![bucket], |row| {
     Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
   })?;
@@ -1620,14 +1586,7 @@ fn live_sample(live_rate_limits: &LiveRateLimitSnapshot, bucket: &str) -> Option
 }
 
 fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
-  let mut stmt = match conn.prepare(
-    "
-    SELECT sample_timestamp, used_percent, window_start, resets_at
-    FROM rate_limit_samples
-    WHERE bucket = ?1
-    ORDER BY sample_timestamp ASC
-    ",
-  ) {
+  let mut stmt = match conn.prepare(SQL_QUOTA_SAMPLES) {
     Ok(stmt) => stmt,
     Err(_) => return Vec::new(),
   };

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -10,12 +10,14 @@ use chrono::{
 use rusqlite::Connection;
 use serde_json::Value;
 
-use crate::database::{get_subscription_profile, list_subscription_records, open_connection};
+use crate::database::{
+    get_subscription_profile, list_codex_sources, list_subscription_records, open_connection,
+};
 use crate::models::{
   CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem,
   ConversationSessionSummary, ConversationTurnPoint, LiveRateLimitSnapshot, ModelShare,
-  OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SubscriptionProfile,
-  SubscriptionRecord, TokenUsage, TrendPoint,
+    OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SourceShare,
+    SubscriptionProfile, SubscriptionRecord, TokenUsage, TrendPoint,
 };
 use crate::pricing::{
   calculate_value_usd, display_name_for_model, load_catalog_map, model_color, normalize_model_id,
@@ -24,6 +26,8 @@ use crate::pricing::{
 
 const SQL_SESSIONS: &str = include_str!("../sql/queries/sessions.sql");
 const SQL_SESSIONS_FOR_ROOT: &str = include_str!("../sql/queries/sessions_for_root.sql");
+const SQL_SESSION_SOURCE_MEMBERSHIPS: &str =
+    include_str!("../sql/queries/session_source_memberships.sql");
 const SQL_USAGE_EVENTS: &str = include_str!("../sql/queries/usage_events.sql");
 const SQL_USAGE_EVENTS_FOR_ROOT: &str = include_str!("../sql/queries/usage_events_for_root.sql");
 const SQL_RATE_LIMIT_WINDOWS: &str = include_str!("../sql/queries/rate_limit_windows.sql");
@@ -32,6 +36,8 @@ const SQL_QUOTA_SAMPLES: &str = include_str!("../sql/queries/quota_samples.sql")
 #[derive(Debug, Clone)]
 struct SessionRow {
   session_id: String,
+    source_id: String,
+    source_ids: HashSet<String>,
   root_session_id: String,
   parent_session_id: Option<String>,
   title: String,
@@ -108,12 +114,14 @@ pub fn get_overview(
   custom_end: Option<String>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
+    source_ids: Option<Vec<String>>,
 ) -> Result<OverviewResponse, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
-  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
+    let subscription_records =
+        list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
   build_overview(
     &conn,
@@ -128,6 +136,7 @@ pub fn get_overview(
     custom_end,
     live_rate_limits,
     live_window_offset,
+        source_ids.as_deref(),
   )
 }
 
@@ -174,7 +183,8 @@ pub fn list_conversations(
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
-  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
+    let subscription_records =
+        list_subscription_records(&conn).map_err(|error| error.to_string())?;
   build_conversation_list(
     &conn,
     &sessions,
@@ -195,12 +205,14 @@ pub fn load_dashboard_data(
   search: Option<String>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
+    source_ids: Option<Vec<String>>,
 ) -> Result<DashboardData, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
   let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
-  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
+    let subscription_records =
+        list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
 
   let overview = build_overview(
@@ -216,6 +228,7 @@ pub fn load_dashboard_data(
     custom_end.clone(),
     live_rate_limits.clone(),
     live_window_offset,
+        source_ids.as_deref(),
   )?;
   let conversations = build_conversation_list(
     &conn,
@@ -230,6 +243,7 @@ pub fn load_dashboard_data(
       custom_end,
       search,
       live_window_offset,
+            source_ids,
     }),
     live_rate_limits.as_ref(),
   )?;
@@ -255,14 +269,17 @@ fn build_overview(
   custom_end: Option<String>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
+    source_ids: Option<&[String]>,
 ) -> Result<OverviewResponse, String> {
+    let source_filter = normalize_source_filter(source_ids);
+    let source_events = filter_events_by_source(events, sessions, source_filter.as_ref());
   let resolved_window = resolve_window(
     conn,
     bucket,
     anchor,
     custom_start,
     custom_end,
-    events,
+        &source_events,
     profile.billing_anchor_day,
     live_rate_limits.as_ref(),
     live_window_offset,
@@ -270,6 +287,7 @@ fn build_overview(
   let window = &resolved_window.window;
   let filtered_events: Vec<_> = events
     .iter()
+        .filter(|event| event_source_allowed(event, sessions, source_filter.as_ref()))
     .filter(|event| event_in_window(event, window))
     .cloned()
     .collect();
@@ -278,6 +296,8 @@ fn build_overview(
   let mut total_value_usd = 0.0;
   let mut total_tokens = 0i64;
   let mut model_shares: HashMap<String, ModelShareAccumulator> = HashMap::new();
+    let mut source_shares: HashMap<String, SourceShareAccumulator> = HashMap::new();
+    let source_labels = load_source_label_map(conn).map_err(|error| error.to_string())?;
 
   for event in &filtered_events {
     total_value_usd += event.value_usd;
@@ -287,7 +307,17 @@ fn build_overview(
       let model = model_shares.entry(event.model_id.clone()).or_default();
       model.api_value_usd += event.value_usd;
       model.total_tokens += event.total_tokens;
-      model.conversation_ids.insert(session.root_session_id.clone());
+            model
+                .conversation_ids
+                .insert(session.root_session_id.clone());
+
+            let source_id = source_id_for_session(session, source_filter.as_ref());
+            let source = source_shares.entry(source_id).or_default();
+            source.api_value_usd += event.value_usd;
+            source.total_tokens += event.total_tokens;
+            source
+                .conversation_ids
+                .insert(session.root_session_id.clone());
     }
   }
 
@@ -313,6 +343,13 @@ fn build_overview(
     })
     .collect::<Vec<_>>();
   model_breakdown.sort_by(|left, right| right.api_value_usd.total_cmp(&left.api_value_usd));
+    let mut source_breakdown = build_source_breakdown(source_shares, &source_labels);
+    source_breakdown.sort_by(|left, right| {
+        right
+            .api_value_usd
+            .total_cmp(&left.api_value_usd)
+            .then_with(|| right.total_tokens.cmp(&left.total_tokens))
+    });
 
   Ok(OverviewResponse {
     bucket: window.bucket.clone(),
@@ -332,6 +369,7 @@ fn build_overview(
     quota_trend,
     model_shares: model_breakdown,
     composition_shares: composition_breakdown,
+        source_shares: source_breakdown,
     live_rate_limits,
   })
 }
@@ -346,13 +384,15 @@ fn build_conversation_list(
   live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<Vec<ConversationListItem>, String> {
   let filters = filters.unwrap_or_default();
+    let source_filter = normalize_source_filter(filters.source_ids.as_deref());
+    let source_events = filter_events_by_source(events, sessions, source_filter.as_ref());
   let window = resolve_window(
     conn,
     filters.bucket.clone(),
     filters.anchor.clone(),
     filters.custom_start.clone(),
     filters.custom_end.clone(),
-    events,
+        &source_events,
     profile.billing_anchor_day,
     live_rate_limits,
     filters.live_window_offset,
@@ -364,6 +404,9 @@ fn build_conversation_list(
   let mut groups: BTreeMap<String, ConversationAccumulator> = BTreeMap::new();
 
   for session in sessions.values() {
+        if !session_source_allowed(session, source_filter.as_ref()) {
+            continue;
+        }
     let group = groups
       .entry(session.root_session_id.clone())
       .or_insert_with(|| ConversationAccumulator {
@@ -392,6 +435,9 @@ fn build_conversation_list(
   }
 
   for event in events {
+        if !event_source_allowed(event, sessions, source_filter.as_ref()) {
+            continue;
+        }
     if !event_in_window(event, &window) {
       continue;
     }
@@ -468,12 +514,94 @@ fn build_conversation_list(
   Ok(items)
 }
 
-pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<ConversationDetail, String> {
+fn normalize_source_filter(source_ids: Option<&[String]>) -> Option<HashSet<String>> {
+    let ids = source_ids?
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .collect::<HashSet<_>>();
+    if ids.is_empty() {
+        None
+    } else {
+        Some(ids)
+    }
+}
+
+fn session_source_allowed(session: &SessionRow, source_filter: Option<&HashSet<String>>) -> bool {
+    source_filter
+        .map(|ids| {
+            session
+                .source_ids
+                .iter()
+                .any(|source_id| ids.contains(source_id))
+        })
+        .unwrap_or(true)
+}
+
+fn source_id_for_session(session: &SessionRow, source_filter: Option<&HashSet<String>>) -> String {
+    if let Some(filter) = source_filter {
+        if filter.contains(&session.source_id) {
+            return session.source_id.clone();
+        }
+        let mut matching_ids = session
+            .source_ids
+            .iter()
+            .filter(|source_id| filter.contains(*source_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        matching_ids.sort();
+        if let Some(source_id) = matching_ids.into_iter().next() {
+            return source_id;
+        }
+    }
+
+    session.source_id.clone()
+}
+
+fn event_source_allowed(
+    event: &EventRow,
+    sessions: &HashMap<String, SessionRow>,
+    source_filter: Option<&HashSet<String>>,
+) -> bool {
+    let Some(session) = sessions.get(&event.session_id) else {
+        return false;
+    };
+    session_source_allowed(session, source_filter)
+}
+
+fn filter_events_by_source(
+    events: &[EventRow],
+    sessions: &HashMap<String, SessionRow>,
+    source_filter: Option<&HashSet<String>>,
+) -> Vec<EventRow> {
+    events
+        .iter()
+        .filter(|event| event_source_allowed(event, sessions, source_filter))
+        .cloned()
+        .collect()
+}
+
+fn load_source_label_map(conn: &Connection) -> rusqlite::Result<HashMap<String, String>> {
+    Ok(list_codex_sources(conn)?
+        .into_iter()
+        .map(|source| (source.id, source.label))
+        .collect())
+}
+
+pub fn get_conversation_detail(
+    db_path: &Path,
+    root_session_id: &str,
+) -> Result<ConversationDetail, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
-  let events = load_events_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
-  let subscription_records = list_subscription_records(&conn).map_err(|error| error.to_string())?;
+    let sessions = load_sessions_for_root_session(&conn, root_session_id)
+        .map_err(|error| error.to_string())?;
+    let events =
+        load_events_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
+    let subscription_records =
+        list_subscription_records(&conn).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
+    let source_labels = load_source_label_map(&conn).map_err(|error| error.to_string())?;
 
   let mut conversation_sessions = sessions.values().cloned().collect::<Vec<_>>();
 
@@ -494,6 +622,7 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
   let mut total_tokens = 0i64;
   let mut total_value_usd = 0.0;
   let mut model_breakdown: HashMap<String, ModelShareAccumulator> = HashMap::new();
+    let mut source_breakdown: HashMap<String, SourceShareAccumulator> = HashMap::new();
   let mut per_session: HashMap<String, ConversationSessionAccumulator> = HashMap::new();
   let mut detail_turns = Vec::new();
   let mut conversation_events = Vec::new();
@@ -548,6 +677,14 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     model.total_tokens += event.total_tokens;
     model.conversation_ids.insert(root_session_id.to_string());
 
+        if let Some(session) = sessions.get(&event.session_id) {
+            let source_id = source_id_for_session(session, None);
+            let source = source_breakdown.entry(source_id).or_default();
+            source.api_value_usd += event.value_usd;
+            source.total_tokens += event.total_tokens;
+            source.conversation_ids.insert(root_session_id.to_string());
+        }
+
     if let Some(summary) = per_session.get_mut(&event.session_id) {
       summary.model_ids.insert(event.model_id.clone());
       summary.input_tokens += event.input_tokens;
@@ -567,8 +704,7 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     detail_turns.append(&mut turns);
   }
   detail_turns.sort_by(|left, right| {
-    left
-      .last_activity_at
+        left.last_activity_at
       .cmp(&right.last_activity_at)
       .then_with(|| left.session_id.cmp(&right.session_id))
       .then_with(|| left.turn_id.cmp(&right.turn_id))
@@ -612,6 +748,13 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     .collect::<Vec<_>>();
   model_breakdown.sort_by(|left, right| right.api_value_usd.total_cmp(&left.api_value_usd));
   let composition_breakdown = build_composition_breakdown(&conversation_events, &catalog);
+    let mut source_breakdown = build_source_breakdown(source_breakdown, &source_labels);
+    source_breakdown.sort_by(|left, right| {
+        right
+            .api_value_usd
+            .total_cmp(&left.api_value_usd)
+            .then_with(|| right.total_tokens.cmp(&left.total_tokens))
+    });
 
   if title.trim().is_empty() {
     title = root_session_id.to_string();
@@ -644,6 +787,7 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     turns: detail_turns,
     model_breakdown,
     composition_breakdown,
+        source_breakdown,
   })
 }
 
@@ -676,7 +820,11 @@ fn build_turns_for_session(
       .and_then(Value::as_str)
       .map(ToString::to_string);
 
-    match value.get("type").and_then(Value::as_str).unwrap_or_default() {
+        match value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+        {
       "turn_context" => {
         if let Some(model) = value
           .get("payload")
@@ -688,9 +836,18 @@ fn build_turns_for_session(
       }
       "event_msg" => {
         let payload = value.get("payload").unwrap_or(&Value::Null);
-        match payload.get("type").and_then(Value::as_str).unwrap_or_default() {
+                match payload
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                {
           "task_started" => {
-            close_active_turn(&mut turns, &mut active_turn_index, timestamp.as_deref(), None);
+                        close_active_turn(
+                            &mut turns,
+                            &mut active_turn_index,
+                            timestamp.as_deref(),
+                            None,
+                        );
             let turn_id = payload.get("turn_id").and_then(Value::as_str);
             start_turn(
               &mut turns,
@@ -758,7 +915,10 @@ fn build_turns_for_session(
               input_tokens: read_i64(total_usage, "input_tokens"),
               cached_input_tokens: read_i64(total_usage, "cached_input_tokens"),
               output_tokens: read_i64(total_usage, "output_tokens"),
-              reasoning_output_tokens: read_i64(total_usage, "reasoning_output_tokens"),
+                            reasoning_output_tokens: read_i64(
+                                total_usage,
+                                "reasoning_output_tokens",
+                            ),
               total_tokens: read_total_tokens(total_usage),
             };
 
@@ -784,8 +944,13 @@ fn build_turns_for_session(
               &mut turn_sequence,
               session.session_id.clone(),
             );
-            let model_id = current_model.clone().unwrap_or_else(|| "unknown".to_string());
-            let value_usd = calculate_value_usd(&delta, resolve_pricing(catalog, &model_id).as_ref());
+                        let model_id = current_model
+                            .clone()
+                            .unwrap_or_else(|| "unknown".to_string());
+                        let value_usd = calculate_value_usd(
+                            &delta,
+                            resolve_pricing(catalog, &model_id).as_ref(),
+                        );
             let turn = &mut turns[turn_index];
             turn.model_ids.insert(model_id);
             turn.input_tokens += delta.input_tokens;
@@ -806,16 +971,19 @@ fn build_turns_for_session(
 
   if let Some(index) = active_turn_index {
     let inferred_status = infer_turn_status(&turns[index]);
-    close_active_turn(&mut turns, &mut active_turn_index, None, Some(inferred_status));
+        close_active_turn(
+            &mut turns,
+            &mut active_turn_index,
+            None,
+            Some(inferred_status),
+        );
   }
 
-  Ok(
-    turns
+    Ok(turns
       .into_iter()
       .filter(|turn| turn.total_tokens > 0)
       .map(|turn| turn.into_point())
-      .collect(),
-  )
+        .collect())
 }
 
 fn filter_replayed_turns_for_session(
@@ -827,8 +995,9 @@ fn filter_replayed_turns_for_session(
 
   for turn in turns {
     let is_real_turn_id = !is_synthetic_turn_id(&turn.turn_id);
-    let is_replayed_duplicate =
-      session.parent_session_id.is_some() && is_real_turn_id && seen_real_turn_ids.contains(&turn.turn_id);
+        let is_replayed_duplicate = session.parent_session_id.is_some()
+            && is_real_turn_id
+            && seen_real_turn_ids.contains(&turn.turn_id);
 
     if is_replayed_duplicate {
       continue;
@@ -845,7 +1014,9 @@ fn filter_replayed_turns_for_session(
 
 fn is_synthetic_turn_id(turn_id: &str) -> bool {
   turn_id.starts_with("turn-")
-    && turn_id[5..].chars().all(|character| character.is_ascii_digit())
+        && turn_id[5..]
+            .chars()
+            .all(|character| character.is_ascii_digit())
 }
 
 fn attach_user_message(
@@ -867,10 +1038,24 @@ fn attach_user_message(
       index
     } else {
       close_active_turn(turns, active_turn_index, timestamp, None);
-      start_turn(turns, active_turn_index, timestamp, None, turn_sequence, session_id)
+            start_turn(
+                turns,
+                active_turn_index,
+                timestamp,
+                None,
+                turn_sequence,
+                session_id,
+            )
     }
   } else {
-    start_turn(turns, active_turn_index, timestamp, None, turn_sequence, session_id)
+        start_turn(
+            turns,
+            active_turn_index,
+            timestamp,
+            None,
+            turn_sequence,
+            session_id,
+        )
   };
 
   if let Some(message) = message {
@@ -891,7 +1076,14 @@ fn attach_assistant_message(
   let turn_index = if let Some(index) = *active_turn_index {
     index
   } else {
-    start_turn(turns, active_turn_index, timestamp, None, turn_sequence, session_id)
+        start_turn(
+            turns,
+            active_turn_index,
+            timestamp,
+            None,
+            turn_sequence,
+            session_id,
+        )
   };
 
   if let Some(message) = message {
@@ -917,7 +1109,14 @@ fn ensure_active_turn(
 ) -> usize {
   match *active_turn_index {
     Some(index) => index,
-    None => start_turn(turns, active_turn_index, timestamp, None, turn_sequence, session_id),
+        None => start_turn(
+            turns,
+            active_turn_index,
+            timestamp,
+            None,
+            turn_sequence,
+            session_id,
+        ),
   }
 }
 
@@ -1045,9 +1244,10 @@ fn read_i64(value: &Value, key: &str) -> i64 {
 }
 
 fn read_total_tokens(value: &Value) -> i64 {
-  value.get("total_tokens").and_then(Value::as_i64).unwrap_or_else(|| {
-    read_i64(value, "input_tokens") + read_i64(value, "output_tokens")
-  })
+    value
+        .get("total_tokens")
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| read_i64(value, "input_tokens") + read_i64(value, "output_tokens"))
 }
 
 fn build_composition_breakdown(
@@ -1071,9 +1271,10 @@ fn build_composition_breakdown(
     breakdown[0].api_value_usd +=
       ((event.input_tokens - event.cached_input_tokens).max(0) as f64 / 1_000_000.0)
         * pricing.input_price_per_million;
-    breakdown[1].api_value_usd +=
-      (event.cached_input_tokens as f64 / 1_000_000.0) * pricing.cached_input_price_per_million;
-    breakdown[2].api_value_usd += (event.output_tokens as f64 / 1_000_000.0) * pricing.output_price_per_million;
+        breakdown[1].api_value_usd += (event.cached_input_tokens as f64 / 1_000_000.0)
+            * pricing.cached_input_price_per_million;
+        breakdown[2].api_value_usd +=
+            (event.output_tokens as f64 / 1_000_000.0) * pricing.output_price_per_million;
   }
 
   breakdown
@@ -1088,20 +1289,56 @@ fn build_composition_breakdown(
     .collect()
 }
 
+fn build_source_breakdown(
+    source_shares: HashMap<String, SourceShareAccumulator>,
+    labels: &HashMap<String, String>,
+) -> Vec<SourceShare> {
+    source_shares
+        .into_iter()
+        .map(|(source_id, aggregate)| SourceShare {
+            display_name: labels
+                .get(&source_id)
+                .cloned()
+                .unwrap_or_else(|| source_id.clone()),
+            color: source_color(&source_id).to_string(),
+            source_id,
+            api_value_usd: aggregate.api_value_usd,
+            total_tokens: aggregate.total_tokens,
+            conversation_count: aggregate.conversation_ids.len(),
+        })
+        .collect()
+}
+
+fn source_color(source_id: &str) -> &'static str {
+    const COLORS: [&str; 10] = [
+        "#60a5fa", "#ff7f45", "#d946ef", "#ffd166", "#34d399", "#a78bfa", "#f472b6", "#2dd4bf",
+        "#f87171", "#93c5fd",
+    ];
+    let hash = source_id.bytes().fold(0usize, |accumulator, byte| {
+        accumulator.wrapping_mul(31).wrapping_add(byte as usize)
+    });
+    COLORS[hash % COLORS.len()]
+}
+
 fn load_sessions(conn: &Connection) -> rusqlite::Result<HashMap<String, SessionRow>> {
   let mut stmt = conn.prepare(SQL_SESSIONS)?;
   let rows = stmt.query_map([], |row| {
+        let source_id: String = row.get(1)?;
+        let mut source_ids = HashSet::new();
+        source_ids.insert(source_id.clone());
     Ok(SessionRow {
       session_id: row.get(0)?,
-      root_session_id: row.get(1)?,
-      parent_session_id: row.get(2)?,
-      title: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
-      source_state: row.get(4)?,
-      source_path: row.get(5)?,
-      started_at: row.get(6)?,
-      updated_at: row.get(7)?,
-      agent_nickname: row.get(8)?,
-      agent_role: row.get(9)?,
+            source_id,
+            source_ids,
+            root_session_id: row.get(2)?,
+            parent_session_id: row.get(3)?,
+            title: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+            source_state: row.get(5)?,
+            source_path: row.get(6)?,
+            started_at: row.get(7)?,
+            updated_at: row.get(8)?,
+            agent_nickname: row.get(9)?,
+            agent_role: row.get(10)?,
     })
   })?;
 
@@ -1110,6 +1347,7 @@ fn load_sessions(conn: &Connection) -> rusqlite::Result<HashMap<String, SessionR
     let session = row?;
     sessions.insert(session.session_id.clone(), session);
   }
+    enrich_session_source_memberships(conn, &mut sessions)?;
   Ok(sessions)
 }
 
@@ -1119,17 +1357,22 @@ fn load_sessions_for_root_session(
 ) -> rusqlite::Result<HashMap<String, SessionRow>> {
   let mut stmt = conn.prepare(SQL_SESSIONS_FOR_ROOT)?;
   let rows = stmt.query_map([root_session_id], |row| {
+        let source_id: String = row.get(1)?;
+        let mut source_ids = HashSet::new();
+        source_ids.insert(source_id.clone());
     Ok(SessionRow {
       session_id: row.get(0)?,
-      root_session_id: row.get(1)?,
-      parent_session_id: row.get(2)?,
-      title: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
-      source_state: row.get(4)?,
-      source_path: row.get(5)?,
-      started_at: row.get(6)?,
-      updated_at: row.get(7)?,
-      agent_nickname: row.get(8)?,
-      agent_role: row.get(9)?,
+            source_id,
+            source_ids,
+            root_session_id: row.get(2)?,
+            parent_session_id: row.get(3)?,
+            title: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+            source_state: row.get(5)?,
+            source_path: row.get(6)?,
+            started_at: row.get(7)?,
+            updated_at: row.get(8)?,
+            agent_nickname: row.get(9)?,
+            agent_role: row.get(10)?,
     })
   })?;
 
@@ -1138,7 +1381,29 @@ fn load_sessions_for_root_session(
     let session = row?;
     sessions.insert(session.session_id.clone(), session);
   }
+    enrich_session_source_memberships(conn, &mut sessions)?;
   Ok(sessions)
+}
+
+fn enrich_session_source_memberships(
+    conn: &Connection,
+    sessions: &mut HashMap<String, SessionRow>,
+) -> rusqlite::Result<()> {
+    if sessions.is_empty() {
+        return Ok(());
+    }
+
+    let mut stmt = conn.prepare(SQL_SESSION_SOURCE_MEMBERSHIPS)?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (session_id, source_id) = row?;
+        if let Some(session) = sessions.get_mut(&session_id) {
+            session.source_ids.insert(source_id);
+        }
+    }
+    Ok(())
 }
 
 fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
@@ -1162,7 +1427,10 @@ fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
   rows.collect()
 }
 
-fn load_events_for_root_session(conn: &Connection, root_session_id: &str) -> rusqlite::Result<Vec<EventRow>> {
+fn load_events_for_root_session(
+    conn: &Connection,
+    root_session_id: &str,
+) -> rusqlite::Result<Vec<EventRow>> {
   let mut stmt = conn.prepare(SQL_USAGE_EVENTS_FOR_ROOT)?;
   let rows = stmt.query_map([root_session_id], |row| {
     Ok(EventRow {
@@ -1308,11 +1576,22 @@ fn resolve_live_rate_limit_window(
     .and_then(|snapshot| selected_rate_limit_window(snapshot, bucket))
     .and_then(|active_window| {
       Some(RateLimitWindowSummary {
-        start: normalize_local_timestamp(active_window.window_start.as_deref().and_then(parse_rfc3339_local)?),
-        end: normalize_local_timestamp(active_window.resets_at.as_deref().and_then(parse_rfc3339_local)?),
+                start: normalize_local_timestamp(
+                    active_window
+                        .window_start
+                        .as_deref()
+                        .and_then(parse_rfc3339_local)?,
+                ),
+                end: normalize_local_timestamp(
+                    active_window
+                        .resets_at
+                        .as_deref()
+                        .and_then(parse_rfc3339_local)?,
+                ),
       })
     });
-  let windows = load_live_rate_limit_windows(conn, bucket, current_window).map_err(|error| error.to_string())?;
+    let windows = load_live_rate_limit_windows(conn, bucket, current_window)
+        .map_err(|error| error.to_string())?;
 
   if windows.is_empty() {
     return Err(format!(
@@ -1359,21 +1638,29 @@ fn load_live_rate_limit_windows(
     windows.push(RateLimitWindowSummary { start, end });
   }
 
-  windows.sort_by(|left, right| right.end.cmp(&left.end).then_with(|| right.start.cmp(&left.start)));
+    windows.sort_by(|left, right| {
+        right
+            .end
+            .cmp(&left.end)
+            .then_with(|| right.start.cmp(&left.start))
+    });
 
   let mut ordered = Vec::new();
   let mut cursor = current_window.or_else(|| windows.first().cloned());
   while let Some(window) = cursor {
-    if !ordered
-      .iter()
-      .any(|existing: &RateLimitWindowSummary| existing.start == window.start && existing.end == window.end)
-    {
+        if !ordered.iter().any(|existing: &RateLimitWindowSummary| {
+            existing.start == window.start && existing.end == window.end
+        }) {
       ordered.push(window.clone());
     }
     cursor = windows
       .iter()
       .filter(|candidate| candidate.end <= window.start)
-      .max_by(|left, right| left.end.cmp(&right.end).then_with(|| left.start.cmp(&right.start)))
+            .max_by(|left, right| {
+                left.end
+                    .cmp(&right.end)
+                    .then_with(|| left.start.cmp(&right.start))
+            })
       .cloned();
   }
 
@@ -1433,7 +1720,9 @@ fn build_quota_trend(
     }
   }
   samples.sort_by_key(|sample| sample.timestamp);
-  samples.dedup_by(|right, left| right.timestamp == left.timestamp && right.used_percent == left.used_percent);
+    samples.dedup_by(|right, left| {
+        right.timestamp == left.timestamp && right.used_percent == left.used_percent
+    });
 
   let bins = build_elapsed_bins(window, window.end);
   let mut trend = Vec::new();
@@ -1522,7 +1811,9 @@ fn build_bins(window: &Window) -> Vec<TrendBin> {
       "five_hour" => current + chrono::Duration::minutes(15),
       "week" | "subscription_month" | "month" => current + chrono::Duration::days(1),
       "seven_day" => current + chrono::Duration::hours(1),
-      "custom" if custom_window_uses_hourly_bins(window) => current + chrono::Duration::hours(1),
+            "custom" if custom_window_uses_hourly_bins(window) => {
+                current + chrono::Duration::hours(1)
+            }
       "custom" if custom_window_uses_monthly_bins(window) => {
         let current_date = current.date_naive();
         let next_date = add_months(current_date, 1);
@@ -1540,8 +1831,12 @@ fn build_bins(window: &Window) -> Vec<TrendBin> {
     let label = match window.bucket.as_str() {
       "day" | "five_hour" => current.format("%H:%M").to_string(),
       "seven_day" => current.format("%b %d %H:%M").to_string(),
-      "custom" if custom_window_uses_hourly_bins(window) => current.format("%H:%M").to_string(),
-      "custom" if custom_window_uses_monthly_bins(window) => current.format("%b %Y").to_string(),
+            "custom" if custom_window_uses_hourly_bins(window) => {
+                current.format("%H:%M").to_string()
+            }
+            "custom" if custom_window_uses_monthly_bins(window) => {
+                current.format("%b %Y").to_string()
+            }
       "year" | "total" => current.format("%b %Y").to_string(),
       _ => current.format("%b %d").to_string(),
     };
@@ -1656,11 +1951,12 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
   let target_start = normalize_local_timestamp(window.start);
   let target_end = normalize_local_timestamp(window.end);
 
-  rows
-    .filter_map(Result::ok)
+    rows.filter_map(Result::ok)
     .filter_map(|(timestamp, used_percent, window_start, resets_at)| {
-      let sample_window_start = parse_rfc3339_local(&window_start).map(normalize_local_timestamp)?;
-      let sample_window_end = parse_rfc3339_local(&resets_at).map(normalize_local_timestamp)?;
+            let sample_window_start =
+                parse_rfc3339_local(&window_start).map(normalize_local_timestamp)?;
+            let sample_window_end =
+                parse_rfc3339_local(&resets_at).map(normalize_local_timestamp)?;
       if sample_window_start != target_start || sample_window_end != target_end {
         return None;
       }
@@ -1672,7 +1968,10 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     .collect()
 }
 
-fn live_snapshot_cutoff(live_rate_limits: &LiveRateLimitSnapshot, window: &Window) -> Option<DateTime<Local>> {
+fn live_snapshot_cutoff(
+    live_rate_limits: &LiveRateLimitSnapshot,
+    window: &Window,
+) -> Option<DateTime<Local>> {
   let active_window = selected_rate_limit_window(live_rate_limits, &window.bucket)?;
   let live_start = active_window
     .window_start
@@ -1684,7 +1983,9 @@ fn live_snapshot_cutoff(live_rate_limits: &LiveRateLimitSnapshot, window: &Windo
     .as_deref()
     .and_then(parse_rfc3339_local)
     .map(normalize_local_timestamp)?;
-  if live_start != normalize_local_timestamp(window.start) || live_end != normalize_local_timestamp(window.end) {
+    if live_start != normalize_local_timestamp(window.start)
+        || live_end != normalize_local_timestamp(window.end)
+    {
     return None;
   }
   parse_rfc3339_local(&live_rate_limits.fetched_at).map(|timestamp| timestamp.min(window.end))
@@ -1698,7 +1999,8 @@ fn normalize_local_timestamp(timestamp: DateTime<Local>) -> DateTime<Local> {
 }
 
 fn billing_cycle_start(anchor_date: NaiveDate, billing_anchor_day: u32) -> NaiveDate {
-  let this_month_anchor = anchored_date(anchor_date.year(), anchor_date.month(), billing_anchor_day);
+    let this_month_anchor =
+        anchored_date(anchor_date.year(), anchor_date.month(), billing_anchor_day);
   if anchor_date >= this_month_anchor {
     this_month_anchor
   } else {
@@ -1721,9 +2023,11 @@ fn anchored_date(year: i32, month: u32, billing_anchor_day: u32) -> NaiveDate {
 
 fn add_months(date: NaiveDate, months: i32) -> NaiveDate {
   if months >= 0 {
-    date.checked_add_months(Months::new(months as u32)).unwrap_or(date)
+        date.checked_add_months(Months::new(months as u32))
+            .unwrap_or(date)
   } else {
-    date.checked_sub_months(Months::new((-months) as u32)).unwrap_or(date)
+        date.checked_sub_months(Months::new((-months) as u32))
+            .unwrap_or(date)
   }
 }
 
@@ -1741,12 +2045,15 @@ fn parse_rfc3339_local(value: &str) -> Option<DateTime<Local>> {
 fn local_midnight(date: NaiveDate) -> Result<DateTime<Local>, String> {
   let naive = NaiveDateTime::new(
     date,
-    chrono::NaiveTime::from_hms_opt(0, 0, 0).ok_or_else(|| "Invalid local midnight.".to_string())?,
+        chrono::NaiveTime::from_hms_opt(0, 0, 0)
+            .ok_or_else(|| "Invalid local midnight.".to_string())?,
   );
   match Local.from_local_datetime(&naive) {
     LocalResult::Single(value) => Ok(value),
     LocalResult::Ambiguous(first, _) => Ok(first),
-    LocalResult::None => Err("Could not localize midnight in the current timezone.".to_string()),
+        LocalResult::None => {
+            Err("Could not localize midnight in the current timezone.".to_string())
+        }
   }
 }
 
@@ -1779,6 +2086,13 @@ struct ModelShareAccumulator {
   api_value_usd: f64,
   total_tokens: i64,
   conversation_ids: HashSet<String>,
+}
+
+#[derive(Debug, Default)]
+struct SourceShareAccumulator {
+    api_value_usd: f64,
+    total_tokens: i64,
+    conversation_ids: HashSet<String>,
 }
 
 #[derive(Debug)]
@@ -1915,6 +2229,8 @@ mod tests {
     let turns = build_turns_for_session(
       &SessionRow {
         session_id: "session-1".to_string(),
+                source_id: "local".to_string(),
+                source_ids: HashSet::from(["local".to_string()]),
         root_session_id: "session-1".to_string(),
         parent_session_id: None,
         title: String::new(),
@@ -1960,6 +2276,8 @@ mod tests {
     let turns = build_turns_for_session(
       &SessionRow {
         session_id: "session-2".to_string(),
+                source_id: "local".to_string(),
+                source_ids: HashSet::from(["local".to_string()]),
         root_session_id: "session-2".to_string(),
         parent_session_id: None,
         title: String::new(),
@@ -1995,6 +2313,8 @@ mod tests {
   fn child_session_turns_drop_replayed_parent_turn_ids() {
     let root_session = SessionRow {
       session_id: "root-session".to_string(),
+            source_id: "local".to_string(),
+            source_ids: HashSet::from(["local".to_string()]),
       root_session_id: "root-session".to_string(),
       parent_session_id: None,
       title: String::new(),
@@ -2007,6 +2327,8 @@ mod tests {
     };
     let child_session = SessionRow {
       session_id: "child-session".to_string(),
+            source_id: "local".to_string(),
+            source_ids: HashSet::from(["local".to_string()]),
       root_session_id: "root-session".to_string(),
       parent_session_id: Some("root-session".to_string()),
       title: String::new(),
@@ -2074,8 +2396,11 @@ mod tests {
     };
 
     let mut seen_real_turn_ids = HashSet::new();
-    let root_filtered =
-      filter_replayed_turns_for_session(&root_session, vec![root_turn.clone()], &mut seen_real_turn_ids);
+        let root_filtered = filter_replayed_turns_for_session(
+            &root_session,
+            vec![root_turn.clone()],
+            &mut seen_real_turn_ids,
+        );
     let child_filtered = filter_replayed_turns_for_session(
       &child_session,
       vec![replayed_root_turn, child_turn.clone()],
@@ -2091,6 +2416,8 @@ mod tests {
   fn synthetic_turn_ids_are_not_deduped_across_sessions() {
     let root_session = SessionRow {
       session_id: "root-session".to_string(),
+            source_id: "local".to_string(),
+            source_ids: HashSet::from(["local".to_string()]),
       root_session_id: "root-session".to_string(),
       parent_session_id: None,
       title: String::new(),
@@ -2103,6 +2430,8 @@ mod tests {
     };
     let child_session = SessionRow {
       session_id: "child-session".to_string(),
+            source_id: "local".to_string(),
+            source_ids: HashSet::from(["local".to_string()]),
       root_session_id: "root-session".to_string(),
       parent_session_id: Some("root-session".to_string()),
       title: String::new(),
@@ -2152,10 +2481,16 @@ mod tests {
     };
 
     let mut seen_real_turn_ids = HashSet::new();
-    let root_filtered =
-      filter_replayed_turns_for_session(&root_session, vec![root_turn], &mut seen_real_turn_ids);
-    let child_filtered =
-      filter_replayed_turns_for_session(&child_session, vec![child_turn], &mut seen_real_turn_ids);
+        let root_filtered = filter_replayed_turns_for_session(
+            &root_session,
+            vec![root_turn],
+            &mut seen_real_turn_ids,
+        );
+        let child_filtered = filter_replayed_turns_for_session(
+            &child_session,
+            vec![child_turn],
+            &mut seen_real_turn_ids,
+        );
 
     assert_eq!(root_filtered.len(), 1);
     assert_eq!(child_filtered.len(), 1);
@@ -2179,8 +2514,14 @@ mod tests {
     .expect("resolve window");
 
     assert_eq!(window.window.anchor, "2026-03-23");
-    assert_eq!(window.window.start.date_naive(), NaiveDate::from_ymd_opt(2026, 3, 23).unwrap());
-    assert_eq!(window.window.end.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 23).unwrap());
+        assert_eq!(
+            window.window.start.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 3, 23).unwrap()
+        );
+        assert_eq!(
+            window.window.end.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 4, 23).unwrap()
+        );
   }
 
   #[test]
@@ -2201,8 +2542,14 @@ mod tests {
     .expect("resolve window");
 
     assert_eq!(window.window.anchor, "2026-02-23");
-    assert_eq!(window.window.start.date_naive(), NaiveDate::from_ymd_opt(2026, 2, 23).unwrap());
-    assert_eq!(window.window.end.date_naive(), NaiveDate::from_ymd_opt(2026, 3, 23).unwrap());
+        assert_eq!(
+            window.window.start.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 2, 23).unwrap()
+        );
+        assert_eq!(
+            window.window.end.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 3, 23).unwrap()
+        );
   }
 
   #[test]
@@ -2224,8 +2571,14 @@ mod tests {
 
     assert_eq!(window.window.bucket, "custom");
     assert_eq!(window.window.anchor, "2026-04-10");
-    assert_eq!(window.window.start.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 10).unwrap());
-    assert_eq!(window.window.end.date_naive(), NaiveDate::from_ymd_opt(2026, 4, 13).unwrap());
+        assert_eq!(
+            window.window.start.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 4, 10).unwrap()
+        );
+        assert_eq!(
+            window.window.end.date_naive(),
+            NaiveDate::from_ymd_opt(2026, 4, 13).unwrap()
+        );
   }
 
   #[test]
@@ -2356,14 +2709,27 @@ mod tests {
       secondary: None,
       fetched_at: "2026-03-26T14:33:00+08:00".to_string(),
     };
-    insert_live_rate_limit_snapshot(&conn, &live_rate_limits).expect("insert live rate limit snapshot");
+        insert_live_rate_limit_snapshot(&conn, &live_rate_limits)
+            .expect("insert live rate limit snapshot");
 
-    let window =
-      resolve_window(&conn, Some("five_hour".to_string()), None, None, None, &[], 1, Some(&live_rate_limits), None)
+        let window = resolve_window(
+            &conn,
+            Some("five_hour".to_string()),
+            None,
+            None,
+            None,
+            &[],
+            1,
+            Some(&live_rate_limits),
+            None,
+        )
         .expect("resolve live window");
 
     assert_eq!(window.window.anchor, "2026-03-26");
-    assert_eq!(window.window.start.to_rfc3339(), "2026-03-26T11:27:00+08:00");
+        assert_eq!(
+            window.window.start.to_rfc3339(),
+            "2026-03-26T11:27:00+08:00"
+        );
     assert_eq!(window.window.end.to_rfc3339(), "2026-03-26T16:27:00+08:00");
   }
 
@@ -2403,13 +2769,25 @@ mod tests {
     insert_live_rate_limit_snapshot(&conn, &previous).expect("insert previous live window");
     insert_live_rate_limit_snapshot(&conn, &current).expect("insert current live window");
 
-    let window =
-      resolve_window(&conn, Some("five_hour".to_string()), None, None, None, &[], 1, Some(&current), Some(1))
+        let window = resolve_window(
+            &conn,
+            Some("five_hour".to_string()),
+            None,
+            None,
+            None,
+            &[],
+            1,
+            Some(&current),
+            Some(1),
+        )
         .expect("resolve historical live window");
 
     assert_eq!(window.live_window_offset, 1);
     assert!(window.live_window_count >= 2);
-    assert_eq!(window.window.start.to_rfc3339(), "2026-03-26T06:27:00+08:00");
+        assert_eq!(
+            window.window.start.to_rfc3339(),
+            "2026-03-26T06:27:00+08:00"
+        );
     assert_eq!(window.window.end.to_rfc3339(), "2026-03-26T11:27:00+08:00");
   }
 }

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -9,11 +9,12 @@ use chrono::{Local, LocalResult, TimeZone, Timelike};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use crate::models::{LiveRateLimitSnapshot, RateLimitWindowSnapshot};
+use crate::models::{CodexAccountStatus, LiveRateLimitSnapshot, RateLimitWindowSnapshot};
 
 const APP_SERVER_TIMEOUT: Duration = Duration::from_secs(5);
 const INIT_REQUEST_ID: &str = "codex-counter.init";
 const READ_REQUEST_ID: &str = "codex-counter.rate-limits";
+const ACCOUNT_READ_REQUEST_ID: &str = "codex-counter.account-read";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -42,6 +43,7 @@ struct AppServerRateLimitReadResponse {
 enum AppServerMessage {
   Initialized(Result<(), String>),
   RateLimits(Result<LiveRateLimitSnapshot, String>),
+  Account(Result<CodexAccountStatus, String>),
   Closed,
 }
 
@@ -52,6 +54,35 @@ struct AppServerCommandSpec {
 }
 
 pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
+  query_app_server(AppServerQuery::RateLimits).and_then(|message| match message {
+    AppServerQueryResult::RateLimits(snapshot) => Ok(snapshot),
+    AppServerQueryResult::Account(_) => {
+      Err("Codex app-server returned account status for a rate-limit query.".to_string())
+    }
+  })
+}
+
+pub fn query_codex_account_status() -> Result<CodexAccountStatus, String> {
+  query_app_server(AppServerQuery::Account).and_then(|message| match message {
+    AppServerQueryResult::Account(status) => Ok(status),
+    AppServerQueryResult::RateLimits(_) => {
+      Err("Codex app-server returned rate limits for an account query.".to_string())
+    }
+  })
+}
+
+#[derive(Clone, Copy)]
+enum AppServerQuery {
+  RateLimits,
+  Account,
+}
+
+enum AppServerQueryResult {
+  RateLimits(LiveRateLimitSnapshot),
+  Account(CodexAccountStatus),
+}
+
+fn query_app_server(query: AppServerQuery) -> Result<AppServerQueryResult, String> {
   let codex_binary = resolve_codex_binary();
   let command_spec = app_server_command_spec(&codex_binary);
   let mut command = app_server_command(&command_spec);
@@ -99,37 +130,49 @@ pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
         continue;
       }
 
-      if response_id != READ_REQUEST_ID {
+      if response_id != READ_REQUEST_ID && response_id != ACCOUNT_READ_REQUEST_ID {
         continue;
       }
 
       if !init_ok {
-        let _ = sender.send(AppServerMessage::RateLimits(Err(
-          "Codex app-server returned rate limits before initialization completed.".to_string(),
-        )));
+        let error = "Codex app-server returned data before initialization completed.".to_string();
+        let _ = if response_id == ACCOUNT_READ_REQUEST_ID {
+          sender.send(AppServerMessage::Account(Err(error)))
+        } else {
+          sender.send(AppServerMessage::RateLimits(Err(error)))
+        };
         return;
       }
 
       if let Some(error) = parsed.get("error") {
-        let _ = sender.send(AppServerMessage::RateLimits(Err(format!(
-          "Codex app-server rate-limit query failed: {}",
-          json_error_message(error)
-        ))));
+        let message = format!("Codex app-server query failed: {}", json_error_message(error));
+        let _ = if response_id == ACCOUNT_READ_REQUEST_ID {
+          sender.send(AppServerMessage::Account(Err(message)))
+        } else {
+          sender.send(AppServerMessage::RateLimits(Err(message)))
+        };
         return;
       }
 
       let Some(result) = parsed.get("result") else {
-        let _ = sender.send(AppServerMessage::RateLimits(Err(
-          "Codex app-server returned an empty rate-limit response.".to_string(),
-        )));
+        let message = "Codex app-server returned an empty response.".to_string();
+        let _ = if response_id == ACCOUNT_READ_REQUEST_ID {
+          sender.send(AppServerMessage::Account(Err(message)))
+        } else {
+          sender.send(AppServerMessage::RateLimits(Err(message)))
+        };
         return;
       };
 
-      let response = serde_json::from_value::<AppServerRateLimitReadResponse>(result.clone())
-        .map_err(|error| format!("Failed to decode Codex rate-limit response: {error}"));
-      let _ = sender.send(AppServerMessage::RateLimits(
-        response.map(|value| convert_live_rate_limits(value.rate_limits)),
-      ));
+      if response_id == ACCOUNT_READ_REQUEST_ID {
+        let _ = sender.send(AppServerMessage::Account(convert_account_status(result)));
+      } else {
+        let response = serde_json::from_value::<AppServerRateLimitReadResponse>(result.clone())
+          .map_err(|error| format!("Failed to decode Codex rate-limit response: {error}"));
+        let _ = sender.send(AppServerMessage::RateLimits(
+          response.map(|value| convert_live_rate_limits(value.rate_limits)),
+        ));
+      }
       return;
     }
 
@@ -174,7 +217,11 @@ pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
     }
     AppServerMessage::RateLimits(result) => {
       stop_app_server(&mut child);
-      return result;
+      return result.map(AppServerQueryResult::RateLimits);
+    }
+    AppServerMessage::Account(result) => {
+      stop_app_server(&mut child);
+      return result.map(AppServerQueryResult::Account);
     }
     AppServerMessage::Closed => {
       stop_app_server(&mut child);
@@ -182,15 +229,30 @@ pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
     }
   }
 
+  let (request_id, method, params, context) = match query {
+    AppServerQuery::RateLimits => (
+      READ_REQUEST_ID,
+      "account/rateLimits/read",
+      Value::Null,
+      "live rate limits",
+    ),
+    AppServerQuery::Account => (
+      ACCOUNT_READ_REQUEST_ID,
+      "account/read",
+      json!({ "refreshToken": false }),
+      "account status",
+    ),
+  };
+
   if let Err(error) = send_app_server_request(
     &mut child,
     json!({
-      "id": READ_REQUEST_ID,
-      "method": "account/rateLimits/read",
-      "params": Value::Null,
+      "id": request_id,
+      "method": method,
+      "params": params,
     }),
-    "Failed to request live rate limits after Codex app-server initialization",
-    "Failed to flush codex app-server rate-limit request",
+    &format!("Failed to request {context} after Codex app-server initialization"),
+    &format!("Failed to flush codex app-server {context} request"),
   ) {
     stop_app_server(&mut child);
     return Err(error);
@@ -201,17 +263,22 @@ pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
       Ok(message) => message,
       Err(_) => {
         stop_app_server(&mut child);
-        return Err("Timed out while querying live rate limits from Codex.".to_string());
+        return Err(format!("Timed out while querying {context} from Codex."));
       }
     };
 
     match message {
       AppServerMessage::Initialized(Ok(())) => continue,
       AppServerMessage::Initialized(Err(error)) => break Err(error),
-      AppServerMessage::RateLimits(result) => break result,
-      AppServerMessage::Closed => break Err(
-        "Codex app-server closed before returning live rate limits.".to_string(),
-      ),
+      AppServerMessage::RateLimits(result) => match query {
+        AppServerQuery::RateLimits => break result.map(AppServerQueryResult::RateLimits),
+        AppServerQuery::Account => continue,
+      },
+      AppServerMessage::Account(result) => match query {
+        AppServerQuery::Account => break result.map(AppServerQueryResult::Account),
+        AppServerQuery::RateLimits => continue,
+      },
+      AppServerMessage::Closed => break Err(format!("Codex app-server closed before returning {context}.")),
     }
   };
 
@@ -327,6 +394,37 @@ fn convert_live_rate_limits(snapshot: AppServerRateLimitSnapshot) -> LiveRateLim
     secondary: snapshot.secondary.map(convert_window),
     fetched_at: Local::now().to_rfc3339(),
   }
+}
+
+fn convert_account_status(result: &Value) -> Result<CodexAccountStatus, String> {
+  let requires_openai_auth = result
+    .get("requiresOpenaiAuth")
+    .and_then(Value::as_bool)
+    .unwrap_or(false);
+  let account = result.get("account").filter(|value| !value.is_null());
+  let account_type = account
+    .and_then(|value| value.get("type"))
+    .and_then(Value::as_str)
+    .map(str::to_string);
+  let email = account
+    .and_then(|value| value.get("email"))
+    .and_then(Value::as_str)
+    .map(str::to_string);
+  let plan_type = account
+    .and_then(|value| value.get("planType"))
+    .and_then(Value::as_str)
+    .map(str::to_string);
+
+  Ok(CodexAccountStatus {
+    available: true,
+    requires_openai_auth,
+    auth_mode: account_type.clone(),
+    account_type,
+    email,
+    plan_type,
+    error: None,
+    fetched_at: Local::now().to_rfc3339(),
+  })
 }
 
 fn convert_window(window: AppServerRateLimitWindow) -> RateLimitWindowSnapshot {
@@ -445,9 +543,12 @@ fn fallback_codex_binary() -> PathBuf {
 #[cfg(test)]
 mod tests {
   use super::convert_window;
+  #[cfg(windows)]
   use std::ffi::OsString;
+  #[cfg(windows)]
   use std::path::{Path, PathBuf};
 
+  #[cfg(windows)]
   fn existing_paths(paths: &[&str]) -> impl Fn(&Path) -> bool {
     let paths: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
     move |candidate| paths.iter().any(|path| path == candidate)
@@ -466,6 +567,27 @@ mod tests {
     assert_eq!(converted.window_duration_mins, Some(300));
     assert!(converted.resets_at.is_some());
     assert!(converted.window_start.is_some());
+  }
+
+  #[test]
+  fn convert_account_status_extracts_login_fields() {
+    let converted = super::convert_account_status(&serde_json::json!({
+      "requiresOpenaiAuth": false,
+      "account": {
+        "type": "chatgpt",
+        "email": "user@example.com",
+        "planType": "pro"
+      }
+    }))
+    .expect("convert account status");
+
+    assert!(converted.available);
+    assert!(!converted.requires_openai_auth);
+    assert_eq!(converted.account_type.as_deref(), Some("chatgpt"));
+    assert_eq!(converted.auth_mode.as_deref(), Some("chatgpt"));
+    assert_eq!(converted.email.as_deref(), Some("user@example.com"));
+    assert_eq!(converted.plan_type.as_deref(), Some("pro"));
+    assert!(converted.error.is_none());
   }
 
   #[test]

--- a/src-tauri/src/sources.rs
+++ b/src-tauri/src/sources.rs
@@ -1,0 +1,560 @@
+use std::collections::HashSet;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use tauri::{AppHandle, Emitter};
+
+use crate::database::{
+    get_codex_source, now_utc_string, open_connection, update_codex_source_download_state,
+};
+use crate::importer::perform_scan_for_source;
+use crate::models::{CodexSourceCandidate, CodexSourceDownloadProgress, CodexSourceDownloadResult};
+
+const DOWNLOAD_PROGRESS_EVENT: &str = "codex-pacer://source-download-progress";
+
+#[derive(Debug, Default, Clone)]
+struct HostBlock {
+    aliases: Vec<String>,
+    host_name: Option<String>,
+    user: Option<String>,
+    port: Option<i64>,
+}
+
+pub fn discover_ssh_codex_sources() -> Vec<CodexSourceCandidate> {
+    let Some(home_dir) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    let config_path = home_dir.join(".ssh").join("config");
+    let mut visited = HashSet::new();
+    let mut candidates = Vec::new();
+    parse_ssh_config_file(&config_path, &mut visited, &mut candidates);
+    dedupe_candidates(candidates)
+}
+
+pub fn source_cache_codex_home(app_data_dir: &Path, source_id: &str) -> PathBuf {
+    app_data_dir
+        .join("codex-sources")
+        .join(sanitize_component(source_id))
+        .join("codex-cache")
+}
+
+pub fn download_codex_source(
+    app: &AppHandle,
+    db_path: &Path,
+    app_data_dir: &Path,
+    source_id: &str,
+) -> Result<CodexSourceDownloadResult, String> {
+    let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+    let source = get_codex_source(&conn, source_id).map_err(|error| error.to_string())?;
+    if source.kind != "ssh" {
+        return Err("Only SSH sources can be downloaded.".to_string());
+    }
+    let ssh_alias = source
+        .ssh_alias
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "SSH source is missing an alias.".to_string())?;
+    let remote_home = source
+        .remote_codex_home
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("~/.codex");
+
+    let _ = update_codex_source_download_state(&conn, source_id, "downloading", None, None, None);
+    emit_progress(app, source_id, "connecting", None, "连接远程服务器");
+
+    let cache_dir = source_cache_codex_home(app_data_dir, source_id);
+    let parent = cache_dir
+        .parent()
+        .ok_or_else(|| "Failed to resolve source cache parent.".to_string())?;
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let temp_dir = parent.join(format!(
+        ".download-{}",
+        now_utc_string().replace([':', '.'], "-")
+    ));
+    if temp_dir.exists() {
+        fs::remove_dir_all(&temp_dir).map_err(|error| error.to_string())?;
+    }
+    fs::create_dir_all(&temp_dir).map_err(|error| error.to_string())?;
+
+    emit_progress(
+        app,
+        source_id,
+        "downloading",
+        None,
+        "下载远程 Codex usage 缓存",
+    );
+    let remote_command = remote_tar_command(remote_home);
+    let mut ssh = Command::new("ssh")
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg("-o")
+        .arg("ConnectTimeout=10")
+        .arg(ssh_alias)
+        .arg(remote_command)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("Failed to start ssh: {error}"))?;
+
+    let stdout = ssh
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture ssh stdout.".to_string())?;
+    let tar = Command::new("tar")
+        .arg("-xf")
+        .arg("-")
+        .arg("-C")
+        .arg(&temp_dir)
+        .stdin(Stdio::from(stdout))
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("Failed to start local tar: {error}"))?;
+
+    let tar_output = tar
+        .wait_with_output()
+        .map_err(|error| format!("Failed while extracting remote cache: {error}"))?;
+    let ssh_output = ssh
+        .wait_with_output()
+        .map_err(|error| format!("Failed while waiting for ssh: {error}"))?;
+
+    if !ssh_output.status.success() || !tar_output.status.success() {
+        let raw_message = [
+            String::from_utf8_lossy(&ssh_output.stderr)
+                .trim()
+                .to_string(),
+            String::from_utf8_lossy(&tar_output.stderr)
+                .trim()
+                .to_string(),
+        ]
+        .into_iter()
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join(" / ");
+        let error = remote_download_error_message(
+            &raw_message,
+            ssh_output.status.code(),
+            tar_output.status.code(),
+            remote_home,
+        );
+        let _ = update_codex_source_download_state(
+            &conn,
+            source_id,
+            "failed",
+            None,
+            None,
+            Some(&error),
+        );
+        let _ = fs::remove_dir_all(&temp_dir);
+        return Err(error);
+    }
+
+    emit_progress(app, source_id, "installing", Some(0.8), "写入本地缓存");
+    if cache_dir.exists() {
+        fs::remove_dir_all(&cache_dir).map_err(|error| error.to_string())?;
+    }
+    fs::rename(&temp_dir, &cache_dir).map_err(|error| error.to_string())?;
+
+    emit_progress(app, source_id, "scanning", Some(0.9), "导入缓存");
+    let scan_result = perform_scan_for_source(
+        db_path,
+        source_id,
+        Some(cache_dir.to_string_lossy().to_string()),
+    )?;
+    let now = now_utc_string();
+    let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+    let source = update_codex_source_download_state(
+        &conn,
+        source_id,
+        "ready",
+        Some(&now),
+        Some(&scan_result.last_completed_at),
+        None,
+    )
+    .map_err(|error| error.to_string())?;
+    emit_progress(app, source_id, "done", Some(1.0), "完成");
+
+    Ok(CodexSourceDownloadResult {
+        source,
+        scan_result,
+    })
+}
+
+fn emit_progress(
+    app: &AppHandle,
+    source_id: &str,
+    stage: &str,
+    progress: Option<f64>,
+    message: &str,
+) {
+    let _ = app.emit(
+        DOWNLOAD_PROGRESS_EVENT,
+        CodexSourceDownloadProgress {
+            source_id: source_id.to_string(),
+            stage: stage.to_string(),
+            progress,
+            message: message.to_string(),
+        },
+    );
+}
+
+fn remote_tar_command(remote_home: &str) -> String {
+    let home = remote_path_expr(remote_home);
+    format!(
+    "cd {home} || exit 2; set --; [ -f session_index.jsonl ] && set -- \"$@\" session_index.jsonl; [ -d sessions ] && set -- \"$@\" sessions; [ -d archived_sessions ] && set -- \"$@\" archived_sessions; [ \"$#\" -gt 0 ] || exit 3; tar -cf - \"$@\""
+  )
+}
+
+fn remote_path_expr(remote_home: &str) -> String {
+    let trimmed = remote_home.trim();
+    if trimmed == "~" {
+        return "\"$HOME\"".to_string();
+    }
+    if let Some(rest) = trimmed.strip_prefix("~/") {
+        if rest.is_empty() {
+            "\"$HOME\"".to_string()
+        } else {
+            format!("\"$HOME\"/{}", shell_quote(rest))
+        }
+    } else {
+        shell_quote(trimmed)
+    }
+}
+
+fn remote_download_error_message(
+    raw_message: &str,
+    ssh_status: Option<i32>,
+    tar_status: Option<i32>,
+    remote_home: &str,
+) -> String {
+    if ssh_status == Some(2) || raw_message.contains("cd:") {
+        return format!(
+            "远程 Codex 目录不存在：{}。请确认这台服务器已运行过 Codex，或重新添加服务器时改成实际目录。",
+            remote_home
+        );
+    }
+    if ssh_status == Some(3) {
+        return format!(
+            "远程目录 {} 存在，但没有找到 Codex 会话缓存（session_index.jsonl / sessions / archived_sessions）。",
+            remote_home
+        );
+    }
+    if raw_message.is_empty() {
+        if let Some(code) = tar_status {
+            return format!("下载远程 Codex 缓存失败，本地解压退出码 {code}。");
+        }
+        "下载远程 Codex 缓存失败。".to_string()
+    } else {
+        raw_message.to_string()
+    }
+}
+
+fn parse_ssh_config_file(
+    path: &Path,
+    visited: &mut HashSet<PathBuf>,
+    candidates: &mut Vec<CodexSourceCandidate>,
+) {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canonical.clone()) {
+        return;
+    }
+    let Ok(mut file) = fs::File::open(&canonical) else {
+        return;
+    };
+    let mut content = String::new();
+    if file.read_to_string(&mut content).is_err() {
+        return;
+    }
+
+    let base_dir = canonical.parent().unwrap_or_else(|| Path::new("/"));
+    let mut current = HostBlock::default();
+    for line in content.lines() {
+        let line = strip_comment(line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let Some(keyword) = parts.next() else {
+            continue;
+        };
+        let rest = parts.collect::<Vec<_>>();
+        match keyword.to_ascii_lowercase().as_str() {
+            "include" => {
+                flush_host_block(&current, candidates);
+                current = HostBlock::default();
+                for pattern in rest {
+                    for include_path in expand_include_pattern(base_dir, pattern) {
+                        parse_ssh_config_file(&include_path, visited, candidates);
+                    }
+                }
+            }
+            "host" => {
+                flush_host_block(&current, candidates);
+                current = HostBlock {
+                    aliases: rest.into_iter().map(ToString::to_string).collect(),
+                    ..HostBlock::default()
+                };
+            }
+            "hostname" => current.host_name = rest.first().map(|value| value.to_string()),
+            "user" => current.user = rest.first().map(|value| value.to_string()),
+            "port" => current.port = rest.first().and_then(|value| value.parse::<i64>().ok()),
+            _ => {}
+        }
+    }
+    flush_host_block(&current, candidates);
+}
+
+fn flush_host_block(block: &HostBlock, candidates: &mut Vec<CodexSourceCandidate>) {
+    for alias in &block.aliases {
+        let ignored_reason =
+            ignored_host_reason(alias, block.host_name.as_deref(), block.user.as_deref());
+        if ignored_reason.is_some() {
+            continue;
+        }
+        candidates.push(CodexSourceCandidate {
+            id: source_id_for_alias(alias),
+            label: alias.to_string(),
+            ssh_alias: alias.to_string(),
+            host_name: block.host_name.clone(),
+            user: block.user.clone(),
+            port: block.port,
+            remote_codex_home: "~/.codex".to_string(),
+            ignored_reason: None,
+        });
+    }
+}
+
+fn ignored_host_reason(alias: &str, host_name: Option<&str>, user: Option<&str>) -> Option<String> {
+    if alias.contains('*') || alias.contains('?') || alias.starts_with('!') {
+        return Some("pattern".to_string());
+    }
+    let lower_alias = alias.to_ascii_lowercase();
+    let lower_host = host_name.unwrap_or(alias).to_ascii_lowercase();
+    let lower_user = user.unwrap_or_default().to_ascii_lowercase();
+    if lower_user == "git" {
+        return Some("code-host".to_string());
+    }
+    let ignored = [
+        "github.com",
+        "gitlab.com",
+        "bitbucket.org",
+        "ssh.dev.azure.com",
+        "gist.github.com",
+        "gitee.com",
+        "codeberg.org",
+        "sr.ht",
+        "sourcehut",
+    ];
+    if ignored
+        .iter()
+        .any(|needle| lower_alias.contains(needle) || lower_host.contains(needle))
+    {
+        return Some("code-host".to_string());
+    }
+    if looks_like_git_host(&lower_alias) || looks_like_git_host(&lower_host) {
+        return Some("code-host".to_string());
+    }
+    None
+}
+
+fn looks_like_git_host(value: &str) -> bool {
+    let normalized = value.trim_matches('.');
+    normalized == "git"
+        || normalized.starts_with("git.")
+        || normalized.ends_with(".git")
+        || normalized.contains(".git.")
+        || normalized.starts_with("git-")
+        || normalized.contains("gitlab")
+        || normalized.contains("github")
+}
+
+fn dedupe_candidates(candidates: Vec<CodexSourceCandidate>) -> Vec<CodexSourceCandidate> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for candidate in candidates {
+        if seen.insert(candidate.id.clone()) {
+            result.push(candidate);
+        }
+    }
+    result.sort_by(|left, right| {
+        left.label
+            .to_ascii_lowercase()
+            .cmp(&right.label.to_ascii_lowercase())
+    });
+    result
+}
+
+fn expand_include_pattern(base_dir: &Path, pattern: &str) -> Vec<PathBuf> {
+    let expanded = expand_tilde(pattern);
+    let path = PathBuf::from(expanded);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        base_dir.join(path)
+    };
+    let pattern_string = path.to_string_lossy().to_string();
+    if !pattern_string.contains('*') {
+        return vec![path];
+    }
+    let parent = path.parent().unwrap_or(base_dir);
+    let file_pattern = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("*");
+    let Ok(entries) = fs::read_dir(parent) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|entry_path| {
+            entry_path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .map(|name| simple_star_match(file_pattern, name))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+fn expand_tilde(value: &str) -> String {
+    if value == "~" || value.starts_with("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return value.replacen('~', &home.to_string_lossy(), 1);
+        }
+    }
+    value.to_string()
+}
+
+fn simple_star_match(pattern: &str, value: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    let pieces = pattern.split('*').collect::<Vec<_>>();
+    if pieces.len() == 1 {
+        return pattern == value;
+    }
+    let mut rest = value;
+    if !pieces[0].is_empty() {
+        if !rest.starts_with(pieces[0]) {
+            return false;
+        }
+        rest = &rest[pieces[0].len()..];
+    }
+    for piece in pieces.iter().skip(1).take(pieces.len().saturating_sub(2)) {
+        if piece.is_empty() {
+            continue;
+        }
+        let Some(index) = rest.find(piece) else {
+            return false;
+        };
+        rest = &rest[index + piece.len()..];
+    }
+    if let Some(last) = pieces.last() {
+        last.is_empty() || rest.ends_with(last)
+    } else {
+        true
+    }
+}
+
+fn strip_comment(line: &str) -> &str {
+    line.split('#').next().unwrap_or(line)
+}
+
+fn source_id_for_alias(alias: &str) -> String {
+    let sanitized = sanitize_component(alias);
+    if sanitized.is_empty() {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        alias.hash(&mut hasher);
+        format!("ssh_{:x}", hasher.finish())
+    } else {
+        format!("ssh_{sanitized}")
+    }
+}
+
+fn sanitize_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ignored_host_reason_filters_common_code_hosts() {
+        assert_eq!(
+            ignored_host_reason("github.com", Some("github.com"), Some("git")).as_deref(),
+            Some("code-host")
+        );
+        assert_eq!(
+            ignored_host_reason("git.galbot.com", Some("git.galbot.com"), Some("git")).as_deref(),
+            Some("code-host")
+        );
+        assert_eq!(
+            ignored_host_reason("internal-gitlab", Some("gitlab.example.com"), None).as_deref(),
+            Some("code-host")
+        );
+        assert_eq!(
+            ignored_host_reason("4060_wtxy_dorm", Some("192.168.31.197"), Some("wtxy")),
+            None
+        );
+    }
+
+    #[test]
+    fn ignored_host_reason_filters_patterns() {
+        assert_eq!(
+            ignored_host_reason("*", None, None).as_deref(),
+            Some("pattern")
+        );
+        assert_eq!(
+            ignored_host_reason("!bastion", None, None).as_deref(),
+            Some("pattern")
+        );
+    }
+
+    #[test]
+    fn remote_tar_command_expands_tilde_on_remote_shell() {
+        let command = remote_tar_command("~/.codex");
+        assert!(command.starts_with("cd \"$HOME\"/'.codex' || exit 2;"));
+        assert!(!command.contains("cd '~/.codex'"));
+
+        let quoted = remote_tar_command("~/Codex Data");
+        assert!(quoted.starts_with("cd \"$HOME\"/'Codex Data' || exit 2;"));
+
+        let absolute = remote_tar_command("/opt/codex data");
+        assert!(absolute.starts_with("cd '/opt/codex data' || exit 2;"));
+    }
+
+    #[test]
+    fn remote_download_error_message_hides_raw_bash_cd_error() {
+        let error = remote_download_error_message(
+            "bash: line 1: cd: ~/.codex: No such file or directory",
+            Some(2),
+            Some(0),
+            "~/.codex",
+        );
+
+        assert!(error.contains("远程 Codex 目录不存在"));
+        assert!(!error.contains("bash: line 1"));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,14 +14,21 @@ import {
 
 import {
   createSubscriptionRecord,
+  deleteCodexSource,
   deleteSubscriptionRecord,
+  discoverSshCodexSources,
+  downloadCodexSource,
   getScanInProgress,
   getConversationDetail,
   getLiveRateLimits,
+  listCodexSources,
   listSubscriptionRecords,
   loadDashboard,
   refreshPricing,
+  scanCodexSources,
   scanCodexUsage,
+  setCodexSourceSelected,
+  upsertCodexSource,
   updateSubscriptionRecord,
   updateSubscriptionProfile,
   updateSyncSettings,
@@ -40,6 +47,9 @@ import type { TranslationSet } from './app/i18n'
 import { useI18n } from './app/useI18n'
 import type {
   AppView,
+  CodexSource,
+  CodexSourceCandidate,
+  CodexSourceInput,
   CompositionShare,
   ConversationDetail,
   ConversationListItem,
@@ -52,6 +62,7 @@ import type {
   ShareDimension,
   ShareMode,
   ShareSlice,
+  SourceShare,
   SubscriptionProfile,
   SubscriptionRecord,
   SubscriptionRecordInput,
@@ -61,6 +72,14 @@ import { ModelShareChart } from './components/ModelShareChart'
 import { QuotaTrendChart } from './components/QuotaTrendChart'
 import { SettingsPanel } from './components/SettingsPanel'
 import { TrendChart } from './components/TrendChart'
+import {
+  SidebarSourceManager,
+  SourceAddModal,
+  SourceDeleteDialog,
+  SourceManagerModal,
+  SourceSelectorPanel,
+  upsertSourceInList,
+} from './features/sources'
 
 const MENU_BAR_POPUP_WINDOW_LABEL = 'menu-bar-popup'
 const MENU_BAR_POPUP_REFRESH_EVENT = 'codex-counter://menu-bar-popup-refresh'
@@ -95,6 +114,17 @@ function App() {
   const [detail, setDetail] = useState<ConversationDetail | null>(null)
   const [syncSettings, setSyncSettings] = useState<SyncSettings | null>(null)
   const [subscriptionProfile, setSubscriptionProfile] = useState<SubscriptionProfile | null>(null)
+  const [codexSources, setCodexSources] = useState<CodexSource[]>([])
+  const [sourcePanelOpen, setSourcePanelOpen] = useState(false)
+  const [sourceManagerOpen, setSourceManagerOpen] = useState(false)
+  const [sourceModalOpen, setSourceModalOpen] = useState(false)
+  const [sourceCandidates, setSourceCandidates] = useState<CodexSourceCandidate[]>([])
+  const [sourceSelectionMessage, setSourceSelectionMessage] = useState('')
+  const [sourceManagerMessage, setSourceManagerMessage] = useState('')
+  const [sourceModalMessage, setSourceModalMessage] = useState('')
+  const [downloadingSourceIds, setDownloadingSourceIds] = useState<Set<string>>(() => new Set())
+  const [deletingSourceIds, setDeletingSourceIds] = useState<Set<string>>(() => new Set())
+  const [pendingDeleteSource, setPendingDeleteSource] = useState<CodexSource | null>(null)
   const [subscriptionRecords, setSubscriptionRecords] = useState<SubscriptionRecord[]>([])
   const [liveRateLimits, setLiveRateLimits] = useState<LiveRateLimitSnapshot | null>(null)
   const [loadedQueryKey, setLoadedQueryKey] = useState<string | null>(null)
@@ -111,6 +141,8 @@ function App() {
   const detailCacheRef = useRef(new Map<string, ConversationDetail>())
   const latestDetailRequestIdRef = useRef(0)
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
+  const selectedSourceIds = codexSources.filter((source) => source.selected).map((source) => source.id)
+  const sourceSelectionKey = selectedSourceIds.join(',')
 
   const waitForScanToSettle = useCallback(async () => {
     const startedAt = Date.now()
@@ -135,6 +167,9 @@ function App() {
     const requestCustomEnd = requestBucket === 'custom' ? customEnd : null
     const requestSearch = deferredSearch || null
     const requestLiveWindowOffset = requestBucket === 'five_hour' || requestBucket === 'seven_day' ? liveWindowOffset : 0
+    const requestSourceIds = codexSources.filter((source) => source.selected).map((source) => source.id)
+    const requestDashboardSourceIds = requestSourceIds.length > 0 ? requestSourceIds : null
+    const requestSourceSelectionKey = requestSourceIds.join(',')
     lastRequestedQueryKeyRef.current = buildQueryKey(
       requestBucket,
       requestAnchor,
@@ -142,6 +177,7 @@ function App() {
       requestCustomEnd,
       requestSearch,
       requestLiveWindowOffset,
+      requestSourceSelectionKey,
     )
     setIsBusy(true)
     if ((requestBucket === 'five_hour' || requestBucket === 'seven_day') && requestLiveWindowOffset === 0) {
@@ -150,8 +186,12 @@ function App() {
     try {
       if (requestScan) {
         try {
-          const scan = await scanCodexUsage(syncSettingsRef.current?.codexHome ?? null)
-          setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
+          const scans = codexSources.length > 0
+            ? await scanCodexSources(requestDashboardSourceIds)
+            : [await scanCodexUsage(syncSettingsRef.current?.codexHome ?? null)]
+          const scannedFiles = scans.reduce((sum, scan) => sum + scan.scannedFiles, 0)
+          const updatedSessions = scans.reduce((sum, scan) => sum + scan.updatedSessions, 0)
+          setStatusMessage(t.status.scannedFiles(scannedFiles, updatedSessions))
         } catch (error) {
           const message = String(error)
           if (!message.includes('already running')) {
@@ -167,6 +207,7 @@ function App() {
         requestAnchor,
         requestSearch,
         requestLiveWindowOffset,
+        requestDashboardSourceIds,
         requestCustomStart,
         requestCustomEnd,
       )
@@ -187,6 +228,7 @@ function App() {
         setConversations(snapshot.conversations)
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
+        setCodexSources(snapshot.codexSources)
         setSubscriptionRecords(snapshot.subscriptionRecords)
         setLiveRateLimits(snapshot.liveRateLimits)
         detailCacheRef.current = nextDetailCache
@@ -200,6 +242,7 @@ function App() {
             requestCustomEnd,
             requestSearch,
             snapshot.overview.liveWindowOffset,
+            requestSourceSelectionKey,
           ),
         )
         setSelectedRootSessionId((current) =>
@@ -221,7 +264,7 @@ function App() {
         setIsBusy(false)
       }
     }
-  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t, waitForScanToSettle])
+  }, [anchor, bucket, codexSources, customEnd, customStart, deferredSearch, liveWindowOffset, t, waitForScanToSettle])
 
   const currentQueryKey = buildQueryKey(
     bucket,
@@ -230,6 +273,7 @@ function App() {
     bucket === 'custom' ? customEnd : null,
     deferredSearch || null,
     bucket === 'five_hour' || bucket === 'seven_day' ? liveWindowOffset : 0,
+    sourceSelectionKey,
   )
 
   useEffect(() => {
@@ -387,6 +431,151 @@ function App() {
     }
   }
 
+  async function refreshCodexSources() {
+    try {
+      const nextSources = await listCodexSources()
+      setCodexSources(nextSources)
+    } catch (error) {
+      setSourceManagerMessage(String(error))
+    }
+  }
+
+  async function handleToggleSource(source: CodexSource, selected: boolean) {
+    if (!selected && codexSources.filter((item) => item.selected).length <= 1) {
+      setSourceSelectionMessage(t.sources.keepOneSelected)
+      return
+    }
+    try {
+      const updated = await setCodexSourceSelected(source.id, selected)
+      setCodexSources((current) => current.map((item) => (item.id === updated.id ? updated : item)))
+      setSourceSelectionMessage('')
+      detailCacheRef.current.clear()
+      await loadShell(false)
+    } catch (error) {
+      setSourceSelectionMessage(String(error))
+    }
+  }
+
+  async function handleOpenSourceModal() {
+    setSourceModalOpen(true)
+    setSourceModalMessage('')
+    try {
+      const [candidates, sources] = await Promise.all([discoverSshCodexSources(), listCodexSources()])
+      setSourceCandidates(candidates)
+      setCodexSources(sources)
+    } catch (error) {
+      setSourceModalMessage(String(error))
+    }
+  }
+
+  async function handleDiscoverSources() {
+    setSourceModalMessage('')
+    try {
+      setSourceCandidates(await discoverSshCodexSources())
+    } catch (error) {
+      setSourceModalMessage(String(error))
+    }
+  }
+
+  async function handleAddSource(candidate: CodexSourceCandidate) {
+    const payload: CodexSourceInput = {
+      label: candidate.label,
+      sshAlias: candidate.sshAlias,
+      hostName: candidate.hostName,
+      user: candidate.user,
+      port: candidate.port,
+      remoteCodexHome: candidate.remoteCodexHome || '~/.codex',
+      selected: true,
+    }
+    try {
+      const saved = await upsertCodexSource(payload)
+      setCodexSources((current) => upsertSourceInList(current, saved))
+      setSourceModalMessage(t.sources.addedSource(saved.label))
+    } catch (error) {
+      setSourceModalMessage(String(error))
+    }
+  }
+
+  async function handleDownloadSource(sourceId: string) {
+    setDownloadingSourceIds((current) => new Set(current).add(sourceId))
+    setSourceManagerMessage(t.sources.downloadingRemoteCache)
+    try {
+      const result = await downloadCodexSource(sourceId)
+      setCodexSources((current) => upsertSourceInList(current, result.source))
+      detailCacheRef.current.clear()
+      await loadShell(false)
+      setSourceManagerMessage(t.sources.downloadedAndImported(result.scanResult.scannedFiles))
+      if (isTauri()) {
+        await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
+      }
+    } catch (error) {
+      setSourceManagerMessage(String(error))
+      await refreshCodexSources()
+    } finally {
+      setDownloadingSourceIds((current) => {
+        const next = new Set(current)
+        next.delete(sourceId)
+        return next
+      })
+    }
+  }
+
+  async function handleDownloadAllSources() {
+    const remoteSources = codexSources.filter((source) => source.kind === 'ssh')
+    if (remoteSources.length === 0) {
+      setSourceManagerMessage(t.sources.noSshServersAdded)
+      await handleOpenSourceModal()
+      return
+    }
+
+    for (const source of remoteSources) {
+      // Sequential by design: avoids concurrent SSH/tar imports racing over the same database.
+      await handleDownloadSource(source.id)
+    }
+  }
+
+  async function handleDeleteSource(source: CodexSource) {
+    if (source.kind !== 'ssh') {
+      return
+    }
+    if (source.selected && codexSources.filter((item) => item.selected && item.id !== source.id).length === 0) {
+      setSourceSelectionMessage(t.sources.keepOneSelected)
+      setSourcePanelOpen(true)
+      return
+    }
+    setSourceManagerMessage('')
+    setPendingDeleteSource(source)
+  }
+
+  async function confirmDeleteSource() {
+    const source = pendingDeleteSource
+    if (!source || source.kind !== 'ssh') return
+
+    setDeletingSourceIds((current) => new Set(current).add(source.id))
+    setSourceManagerMessage(t.sources.deletingSource(source.label))
+    try {
+      const nextSources = await deleteCodexSource(source.id)
+      setCodexSources(nextSources)
+      detailCacheRef.current.clear()
+      setSourceSelectionMessage('')
+      setPendingDeleteSource(null)
+      await loadShell(false)
+      if (isTauri()) {
+        await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
+      }
+      setSourceManagerMessage(t.sources.deletedSource(source.label))
+    } catch (error) {
+      setSourceManagerMessage(String(error))
+      await refreshCodexSources()
+    } finally {
+      setDeletingSourceIds((current) => {
+        const next = new Set(current)
+        next.delete(source.id)
+        return next
+      })
+    }
+  }
+
   async function handleSaveSettings(payload: {
     syncSettings: SyncSettings
     subscriptionProfile: SubscriptionProfile
@@ -455,12 +644,14 @@ function App() {
     shareDimension,
     activeOverview?.modelShares ?? [],
     activeOverview?.compositionShares ?? [],
+    activeOverview?.sourceShares ?? [],
   )
   const activeDetail = snapshotIsCurrent ? detail : null
   const detailShareData = buildShareSlices(
     shareDimension,
     activeDetail?.modelBreakdown ?? [],
     activeDetail?.compositionBreakdown ?? [],
+    activeDetail?.sourceBreakdown ?? [],
   )
   const sessionSummariesById = new Map(
     (activeDetail?.sessions ?? []).map((session) => [session.sessionId, session] as const),
@@ -501,6 +692,7 @@ function App() {
             >
               <Sparkles size={18} /> {t.nav.conversations}
             </button>
+            <SidebarSourceManager onOpenManager={() => setSourceManagerOpen(true)} />
           </div>
 
           <div className="action-stack">
@@ -533,6 +725,13 @@ function App() {
           <section className="hero-panel hero-panel-filters hero-panel-filters--controls-only">
             <div className="hero-filter-region hero-filter-region--standalone">
               <div className="hero-filter-controls">
+                <SourceSelectorPanel
+                  isOpen={sourcePanelOpen}
+                  message={sourceSelectionMessage}
+                  onToggleOpen={() => setSourcePanelOpen((current) => !current)}
+                  onToggleSource={handleToggleSource}
+                  sources={codexSources}
+                />
                 <div className="pill-strip">
                   {BUCKETS.map((option) => (
                     <button
@@ -741,7 +940,13 @@ function App() {
                   onModeChange={setShareMode}
                   dimension={shareDimension}
                   onDimensionChange={setShareDimension}
-                  title={shareDimension === 'model' ? t.overview.modelShare : t.overview.costStructure}
+                  title={
+                    shareDimension === 'model'
+                      ? t.overview.modelShare
+                      : shareDimension === 'source'
+                        ? t.overview.sourceShare
+                        : t.overview.costStructure
+                  }
                   eyebrow={t.overview.distribution}
                 />
               </section>
@@ -857,6 +1062,8 @@ function App() {
                       title={
                         shareDimension === 'model'
                           ? t.detail.conversationModelBreakdown
+                          : shareDimension === 'source'
+                            ? t.detail.conversationSourceBreakdown
                           : t.detail.conversationCostBreakdown
                       }
                       eyebrow={t.detail.modelBreakdown}
@@ -933,6 +1140,36 @@ function App() {
         subscriptionRecords={subscriptionRecords}
         syncSettings={syncSettings}
       />
+
+      <SourceManagerModal
+        deletingSourceIds={deletingSourceIds}
+        downloadingSourceIds={downloadingSourceIds}
+        isOpen={sourceManagerOpen}
+        message={sourceManagerMessage}
+        onClose={() => setSourceManagerOpen(false)}
+        onDeleteSource={handleDeleteSource}
+        onDownloadAllSources={handleDownloadAllSources}
+        onDownloadSource={handleDownloadSource}
+        onOpenAddModal={handleOpenSourceModal}
+        sources={codexSources}
+      />
+
+      <SourceAddModal
+        candidates={sourceCandidates}
+        isOpen={sourceModalOpen}
+        message={sourceModalMessage}
+        onAddCandidate={handleAddSource}
+        onClose={() => setSourceModalOpen(false)}
+        onDiscover={handleDiscoverSources}
+        sources={codexSources}
+      />
+
+      <SourceDeleteDialog
+        isDeleting={pendingDeleteSource ? deletingSourceIds.has(pendingDeleteSource.id) : false}
+        onCancel={() => setPendingDeleteSource(null)}
+        onConfirm={confirmDeleteSource}
+        source={pendingDeleteSource}
+      />
     </div>
   )
 }
@@ -997,8 +1234,17 @@ function buildQueryKey(
   customEnd: string | null,
   search: string | null,
   liveWindowOffset: number,
+  sourceSelectionKey = '',
 ) {
-  return [bucket, anchor ?? '', customStart ?? '', customEnd ?? '', search ?? '', String(liveWindowOffset)].join('::')
+  return [
+    bucket,
+    anchor ?? '',
+    customStart ?? '',
+    customEnd ?? '',
+    search ?? '',
+    String(liveWindowOffset),
+    sourceSelectionKey,
+  ].join('::')
 }
 
 function formatCustomRangeLabel(windowStart: string | null, windowEnd: string | null, language: 'zh-CN' | 'en') {
@@ -1058,7 +1304,19 @@ function buildShareSlices(
   dimension: ShareDimension,
   modelShares: ModelShare[],
   compositionShares: CompositionShare[],
+  sourceShares: SourceShare[],
 ): ShareSlice[] {
+  if (dimension === 'source') {
+    return sourceShares.map((item) => ({
+      id: item.sourceId,
+      label: item.displayName,
+      secondaryLabel: item.sourceId,
+      apiValueUsd: item.apiValueUsd,
+      totalTokens: item.totalTokens,
+      color: item.color,
+    }))
+  }
+
   if (dimension === 'composition') {
     return compositionShares.map((item) => ({
       id: item.category,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import type { TranslationSet } from './app/i18n'
 import { useI18n } from './app/useI18n'
 import type {
   AppView,
+  CodexAccountStatus,
   CodexSource,
   CodexSourceCandidate,
   CodexSourceInput,
@@ -126,6 +127,7 @@ function App() {
   const [deletingSourceIds, setDeletingSourceIds] = useState<Set<string>>(() => new Set())
   const [pendingDeleteSource, setPendingDeleteSource] = useState<CodexSource | null>(null)
   const [subscriptionRecords, setSubscriptionRecords] = useState<SubscriptionRecord[]>([])
+  const [accountStatus, setAccountStatus] = useState<CodexAccountStatus | null>(null)
   const [liveRateLimits, setLiveRateLimits] = useState<LiveRateLimitSnapshot | null>(null)
   const [loadedQueryKey, setLoadedQueryKey] = useState<string | null>(null)
   const [dashboardRevision, setDashboardRevision] = useState(0)
@@ -230,6 +232,7 @@ function App() {
         setSubscriptionProfile(snapshot.subscriptionProfile)
         setCodexSources(snapshot.codexSources)
         setSubscriptionRecords(snapshot.subscriptionRecords)
+        setAccountStatus(snapshot.accountStatus)
         setLiveRateLimits(snapshot.liveRateLimits)
         detailCacheRef.current = nextDetailCache
         setDashboardRevision((current) => current + 1)
@@ -1136,6 +1139,7 @@ function App() {
         onLanguageChange={setLanguage}
         onSave={handleSaveSettings}
         onSaveSubscriptionRecord={handleSaveSubscriptionRecord}
+        accountStatus={accountStatus}
         subscriptionProfile={subscriptionProfile}
         subscriptionRecords={subscriptionRecords}
         syncSettings={syncSettings}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,12 +13,16 @@ import {
 } from 'lucide-react'
 
 import {
+  createSubscriptionRecord,
+  deleteSubscriptionRecord,
   getScanInProgress,
   getConversationDetail,
   getLiveRateLimits,
+  listSubscriptionRecords,
   loadDashboard,
   refreshPricing,
   scanCodexUsage,
+  updateSubscriptionRecord,
   updateSubscriptionProfile,
   updateSyncSettings,
 } from './app/api'
@@ -49,6 +53,8 @@ import type {
   ShareMode,
   ShareSlice,
   SubscriptionProfile,
+  SubscriptionRecord,
+  SubscriptionRecordInput,
   SyncSettings,
 } from './app/types'
 import { ModelShareChart } from './components/ModelShareChart'
@@ -89,6 +95,7 @@ function App() {
   const [detail, setDetail] = useState<ConversationDetail | null>(null)
   const [syncSettings, setSyncSettings] = useState<SyncSettings | null>(null)
   const [subscriptionProfile, setSubscriptionProfile] = useState<SubscriptionProfile | null>(null)
+  const [subscriptionRecords, setSubscriptionRecords] = useState<SubscriptionRecord[]>([])
   const [liveRateLimits, setLiveRateLimits] = useState<LiveRateLimitSnapshot | null>(null)
   const [loadedQueryKey, setLoadedQueryKey] = useState<string | null>(null)
   const [dashboardRevision, setDashboardRevision] = useState(0)
@@ -180,6 +187,7 @@ function App() {
         setConversations(snapshot.conversations)
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
+        setSubscriptionRecords(snapshot.subscriptionRecords)
         setLiveRateLimits(snapshot.liveRateLimits)
         detailCacheRef.current = nextDetailCache
         setDashboardRevision((current) => current + 1)
@@ -394,6 +402,26 @@ function App() {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
     }
     setStatusMessage(t.status.settingsSaved)
+  }
+
+  async function handleSaveSubscriptionRecord(payload: SubscriptionRecordInput, id?: number | null) {
+    if (id) {
+      await updateSubscriptionRecord(id, payload)
+    } else {
+      await createSubscriptionRecord(payload)
+    }
+    const nextRecords = await listSubscriptionRecords()
+    setSubscriptionRecords(nextRecords)
+    await loadShell(false)
+    setStatusMessage(t.status.subscriptionRecordSaved)
+  }
+
+  async function handleDeleteSubscriptionRecord(id: number) {
+    await deleteSubscriptionRecord(id)
+    const nextRecords = await listSubscriptionRecords()
+    setSubscriptionRecords(nextRecords)
+    await loadShell(false)
+    setStatusMessage(t.status.subscriptionRecordDeleted)
   }
 
   const snapshotIsCurrent = loadedQueryKey === currentQueryKey
@@ -670,12 +698,9 @@ function App() {
                       tone="secondary"
                       value={formatUsd(activeOverview?.stats.subscriptionCostUsd ?? 0, language)}
                       note={
-                        subscriptionProfile
-                          ? t.metrics.planPerMonth(
-                              subscriptionProfile.planType,
-                              formatUsd(subscriptionProfile.monthlyPrice, language),
-                            )
-                          : undefined
+                        subscriptionRecords.length > 0
+                          ? t.metrics.subscriptionLedgerNote(subscriptionRecords.length)
+                          : t.metrics.noSubscriptionRecords
                       }
                     />
                     <MetricCard
@@ -900,9 +925,12 @@ function App() {
         language={language}
         liveRateLimits={liveRateLimits}
         onClose={() => setSettingsOpen(false)}
+        onDeleteSubscriptionRecord={handleDeleteSubscriptionRecord}
         onLanguageChange={setLanguage}
         onSave={handleSaveSettings}
+        onSaveSubscriptionRecord={handleSaveSubscriptionRecord}
         subscriptionProfile={subscriptionProfile}
+        subscriptionRecords={subscriptionRecords}
         syncSettings={syncSettings}
       />
     </div>

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -9,6 +9,8 @@ import type {
   OverviewResponse,
   QuotaTrendPoint,
   SubscriptionProfile,
+  SubscriptionRecord,
+  SubscriptionRecordInput,
   SyncSettings,
 } from './types'
 
@@ -57,6 +59,10 @@ function createMockSubscriptionProfile(): SubscriptionProfile {
     billingAnchorDay: 1,
     updatedAt: nowIso(),
   }
+}
+
+function createMockSubscriptionRecords(): SubscriptionRecord[] {
+  return []
 }
 
 function createMockLiveRateLimits(): LiveRateLimitSnapshot {
@@ -260,6 +266,7 @@ export async function loadDashboard(
       conversations: [] as ConversationListItem[],
       syncSettings: createMockSyncSettings(),
       subscriptionProfile: createMockSubscriptionProfile(),
+      subscriptionRecords: createMockSubscriptionRecords(),
       liveRateLimits: createMockLiveRateLimits(),
     }),
   )
@@ -312,4 +319,30 @@ export async function updateSubscriptionProfile(payload: SubscriptionProfile) {
     ...payload,
     currency: 'USD',
   }))
+}
+
+export async function listSubscriptionRecords() {
+  return invokeOrMock('listSubscriptionRecords', {}, createMockSubscriptionRecords)
+}
+
+export async function createSubscriptionRecord(payload: SubscriptionRecordInput) {
+  return invokeOrMock('createSubscriptionRecord', { payload }, () => ({
+    id: Date.now(),
+    ...payload,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  }))
+}
+
+export async function updateSubscriptionRecord(id: number, payload: SubscriptionRecordInput) {
+  return invokeOrMock('updateSubscriptionRecord', { id, payload }, () => ({
+    id,
+    ...payload,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  }))
+}
+
+export async function deleteSubscriptionRecord(id: number) {
+  return invokeOrMock('deleteSubscriptionRecord', { id }, () => true)
 }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,6 +1,7 @@
 import { invoke, isTauri } from '@tauri-apps/api/core'
 
 import type {
+  CodexAccountStatus,
   CodexSource,
   CodexSourceCandidate,
   CodexSourceDownloadResult,
@@ -67,6 +68,19 @@ function createMockSubscriptionProfile(): SubscriptionProfile {
 
 function createMockSubscriptionRecords(): SubscriptionRecord[] {
   return []
+}
+
+function createMockCodexAccountStatus(): CodexAccountStatus {
+  return {
+    available: false,
+    requiresOpenaiAuth: false,
+    authMode: null,
+    accountType: null,
+    email: null,
+    planType: null,
+    error: null,
+    fetchedAt: nowIso(),
+  }
 }
 
 function createMockCodexSources(): CodexSource[] {
@@ -301,6 +315,7 @@ export async function loadDashboard(
       syncSettings: createMockSyncSettings(),
       subscriptionProfile: createMockSubscriptionProfile(),
       subscriptionRecords: createMockSubscriptionRecords(),
+      accountStatus: createMockCodexAccountStatus(),
       liveRateLimits: createMockLiveRateLimits(),
     }),
   )
@@ -387,6 +402,10 @@ export async function downloadCodexSource(sourceId: string): Promise<CodexSource
 
 export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {
   return invokeOrMock('getLiveRateLimits', {}, createMockLiveRateLimits)
+}
+
+export async function getCodexAccountStatus(): Promise<CodexAccountStatus> {
+  return invokeOrMock('getCodexAccountStatus', {}, createMockCodexAccountStatus)
 }
 
 export async function getConversationDetail(

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,6 +1,10 @@
 import { invoke, isTauri } from '@tauri-apps/api/core'
 
 import type {
+  CodexSource,
+  CodexSourceCandidate,
+  CodexSourceDownloadResult,
+  CodexSourceInput,
   ConversationFilters,
   ConversationListItem,
   LiveRateLimitSnapshot,
@@ -65,6 +69,30 @@ function createMockSubscriptionRecords(): SubscriptionRecord[] {
   return []
 }
 
+function createMockCodexSources(): CodexSource[] {
+  return [
+    {
+      id: 'local',
+      kind: 'local',
+      label: 'localhost',
+      sshAlias: null,
+      hostName: null,
+      user: null,
+      port: null,
+      remoteCodexHome: null,
+      localCodexHome: null,
+      selected: true,
+      status: 'ready',
+      lastDiscoveredAt: null,
+      lastDownloadedAt: null,
+      lastScannedAt: null,
+      lastError: null,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    },
+  ]
+}
+
 function createMockLiveRateLimits(): LiveRateLimitSnapshot {
   return {
     limitId: null,
@@ -123,6 +151,7 @@ function createMockOverview(
     quotaTrend: [],
     modelShares: [],
     compositionShares: [],
+    sourceShares: [],
     liveRateLimits: createMockLiveRateLimits(),
   }
 }
@@ -229,6 +258,7 @@ export async function getOverview(
   anchor?: string | null,
   customStart?: string | null,
   customEnd?: string | null,
+  sourceIds?: string[] | null,
 ): Promise<OverviewResponse> {
   return invokeOrMock(
     'getOverview',
@@ -238,6 +268,7 @@ export async function getOverview(
       customStart: bucket === 'custom' ? customStart ?? null : null,
       customEnd: bucket === 'custom' ? customEnd ?? null : null,
       liveWindowOffset: null,
+      sourceIds: sourceIds ?? null,
     },
     () => createMockOverview(bucket, anchor, customStart, customEnd),
   )
@@ -248,6 +279,7 @@ export async function loadDashboard(
   anchor?: string | null,
   search?: string | null,
   liveWindowOffset?: number | null,
+  sourceIds?: string[] | null,
   customStart?: string | null,
   customEnd?: string | null,
 ): Promise<import('./types').DashboardSnapshot> {
@@ -260,10 +292,12 @@ export async function loadDashboard(
       customEnd: bucket === 'custom' ? customEnd ?? null : null,
       search: search ?? null,
       liveWindowOffset: liveWindowOffset ?? null,
+      sourceIds: sourceIds ?? null,
     },
     () => ({
       overview: createMockOverview(bucket, anchor, customStart, customEnd),
       conversations: [] as ConversationListItem[],
+      codexSources: createMockCodexSources(),
       syncSettings: createMockSyncSettings(),
       subscriptionProfile: createMockSubscriptionProfile(),
       subscriptionRecords: createMockSubscriptionRecords(),
@@ -274,6 +308,81 @@ export async function loadDashboard(
 
 export async function listConversations(filters: ConversationFilters) {
   return invokeOrMock('listConversations', { filters }, () => [] satisfies ConversationListItem[])
+}
+
+export async function scanCodexSources(sourceIds?: string[] | null): Promise<import('./types').ScanResult[]> {
+  return invokeOrMock('scanCodexSources', { sourceIds: sourceIds ?? null }, () => [
+    {
+      codexHome: '~/.codex',
+      scannedFiles: 0,
+      importedSessions: 0,
+      updatedSessions: 0,
+      missingSessions: 0,
+      lastCompletedAt: nowIso(),
+    },
+  ])
+}
+
+export async function discoverSshCodexSources(): Promise<CodexSourceCandidate[]> {
+  return invokeOrMock('discoverSshCodexSources', {}, () => [])
+}
+
+export async function listCodexSources(): Promise<CodexSource[]> {
+  return invokeOrMock('listCodexSources', {}, createMockCodexSources)
+}
+
+export async function upsertCodexSource(payload: CodexSourceInput): Promise<CodexSource> {
+  return invokeOrMock('upsertCodexSource', { payload }, () => ({
+    id: `ssh_${payload.sshAlias.replace(/[^a-z0-9]+/gi, '_').toLowerCase()}`,
+    kind: 'ssh',
+    label: payload.label,
+    sshAlias: payload.sshAlias,
+    hostName: payload.hostName,
+    user: payload.user,
+    port: payload.port,
+    remoteCodexHome: payload.remoteCodexHome,
+    localCodexHome: null,
+    selected: payload.selected,
+    status: 'idle',
+    lastDiscoveredAt: nowIso(),
+    lastDownloadedAt: null,
+    lastScannedAt: null,
+    lastError: null,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  }))
+}
+
+export async function setCodexSourceSelected(sourceId: string, selected: boolean): Promise<CodexSource> {
+  return invokeOrMock('setCodexSourceSelected', { sourceId, selected }, () => ({
+    ...createMockCodexSources()[0],
+    id: sourceId,
+    selected,
+  }))
+}
+
+export async function deleteCodexSource(sourceId: string): Promise<CodexSource[]> {
+  return invokeOrMock('deleteCodexSource', { sourceId }, createMockCodexSources)
+}
+
+export async function downloadCodexSource(sourceId: string): Promise<CodexSourceDownloadResult> {
+  return invokeOrMock('downloadCodexSource', { sourceId }, () => ({
+    source: {
+      ...createMockCodexSources()[0],
+      id: sourceId,
+      kind: 'ssh',
+      status: 'ready',
+      lastDownloadedAt: nowIso(),
+    },
+    scanResult: {
+      codexHome: '~/.codex',
+      scannedFiles: 0,
+      importedSessions: 0,
+      updatedSessions: 0,
+      missingSessions: 0,
+      lastCompletedAt: nowIso(),
+    },
+  }))
 }
 
 export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -282,6 +282,11 @@ export type TranslationSet = {
         monthlyPrice: string
         billingAnchorDay: string
         billingAnchorDayNote: string
+        accountStatus: string
+        accountUnavailable: string
+        accountRequiresLogin: string
+        accountApiKey: string
+        accountUnknown: string
         planPlus: string
         planPro5: string
         planPro10: string
@@ -594,6 +599,11 @@ const translations: Record<AppLanguage, TranslationSet> = {
           monthlyPrice: '月订阅价格',
           billingAnchorDay: '订阅月起始日',
           billingAnchorDayNote: '订阅月会按这个日期切分。例如设置为 23，则统计范围是每月 23 号到次月 22 号。',
+          accountStatus: '当前 Codex 登录',
+          accountUnavailable: '不可用',
+          accountRequiresLogin: '需要登录 OpenAI',
+          accountApiKey: 'API key 模式',
+          accountUnknown: '未知账号',
           planPlus: 'ChatGPT Plus',
           planPro5: 'ChatGPT Pro 5x',
           planPro10: 'ChatGPT Pro 10x',
@@ -899,6 +909,11 @@ const translations: Record<AppLanguage, TranslationSet> = {
           monthlyPrice: 'Monthly subscription price',
           billingAnchorDay: 'Subscription month starts on',
           billingAnchorDayNote: 'The billing month is split by this day. For example, `23` means each window runs from the 23rd to the 22nd of the next month.',
+          accountStatus: 'Current Codex login',
+          accountUnavailable: 'Unavailable',
+          accountRequiresLogin: 'OpenAI login required',
+          accountApiKey: 'API key mode',
+          accountUnknown: 'Unknown account',
           planPlus: 'ChatGPT Plus',
           planPro5: 'ChatGPT Pro 5x',
           planPro10: 'ChatGPT Pro 10x',

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -189,6 +189,10 @@ export type TranslationSet = {
     speedTitle: string
     speedHint: string
     sevenDayUsageChart: string
+    chartLegendRemaining: string
+    chartLegendReference: string
+    chartLegendCurrent: string
+    chartValueBadge: string
     speedStatus: {
       fast: string
       healthy: string
@@ -506,6 +510,10 @@ const translations: Record<AppLanguage, TranslationSet> = {
       speedTitle: '7天节奏',
       speedHint: '100% = 额度消耗与时间同步；低于 100% 偏快，高于 100% 偏慢',
       sevenDayUsageChart: '7 天使用情况折线图',
+      chartLegendRemaining: '剩余额度',
+      chartLegendReference: '时间基准',
+      chartLegendCurrent: '当前',
+      chartValueBadge: 'API 价值',
       speedStatus: {
         fast: '放慢',
         healthy: '正常',
@@ -816,6 +824,10 @@ const translations: Record<AppLanguage, TranslationSet> = {
       speedTitle: '7D pace',
       speedHint: '100% = quota and time are aligned; below 100% is faster, above 100% is slower',
       sevenDayUsageChart: '7-day usage line chart',
+      chartLegendRemaining: 'Blue: quota left',
+      chartLegendReference: 'Dashed: time baseline',
+      chartLegendCurrent: 'Dot: current',
+      chartValueBadge: 'API value',
       speedStatus: {
         fast: 'Slow down',
         healthy: 'On pace',

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -92,6 +92,7 @@ export type TranslationSet = {
     distribution: string
     modelShare: string
     costStructure: string
+    sourceShare: string
   }
   conversationList: {
     eyebrow: string
@@ -104,6 +105,7 @@ export type TranslationSet = {
     modelBreakdown: string
     conversationModelBreakdown: string
     conversationCostBreakdown: string
+    conversationSourceBreakdown: string
     turnTimelineEyebrow: string
     turnUsage: string
     latestTurns: (count: number) => string
@@ -126,6 +128,7 @@ export type TranslationSet = {
     metricControlLabel: string
     byModel: string
     byStructure: string
+    bySource: string
     byValue: string
     byTokens: string
     liveQuotaEyebrow: string
@@ -137,6 +140,45 @@ export type TranslationSet = {
     remaining: string
     cumulativeValue: string
     windowValue: string
+  }
+  sources: {
+    label: string
+    remoteSources: string
+    chooseSources: string
+    noneSelected: string
+    listSeparator: string
+    local: string
+    localCodexHome: string
+    cached: string
+    added: string
+    failed: string
+    downloading: string
+    notDownloaded: string
+    addSsh: string
+    updateAll: string
+    noRemoteSources: string
+    update: string
+    updating: string
+    deleteSource: string
+    deleteSourceLabel: (label: string) => string
+    deleting: string
+    deleteServer: string
+    deleteServerTitle: (label: string) => string
+    deleteServerDescription: string
+    confirmDelete: string
+    addCodexServer: string
+    refreshSshList: string
+    filteredHostsNote: string
+    noSshServersDiscovered: string
+    add: string
+    keepOneSelected: string
+    addedSource: (label: string) => string
+    downloadingRemoteCache: string
+    downloadedAndImported: (files: number) => string
+    noSshServersAdded: string
+    deletingSource: (label: string) => string
+    deletedSource: (label: string) => string
+    maintenanceActions: string
   }
   popup: {
     title: string
@@ -362,6 +404,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       distribution: '分布',
       modelShare: '模型占比',
       costStructure: '成本结构',
+      sourceShare: '数据源占比',
     },
     conversationList: {
       eyebrow: '对话列表',
@@ -374,6 +417,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       modelBreakdown: '模型分布',
       conversationModelBreakdown: '对话模型分布',
       conversationCostBreakdown: '对话成本结构',
+      conversationSourceBreakdown: '对话数据源分布',
       turnTimelineEyebrow: 'Turn 时间线',
       turnUsage: 'Turn 用量',
       latestTurns: (count) => `最近 ${count} 个 turn`,
@@ -396,6 +440,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       metricControlLabel: '分布指标',
       byModel: '按模型',
       byStructure: '按结构',
+      bySource: '按数据源',
       byValue: '按价值',
       byTokens: '按 tokens',
       liveQuotaEyebrow: 'Live quota',
@@ -407,6 +452,45 @@ const translations: Record<AppLanguage, TranslationSet> = {
       remaining: '剩余',
       cumulativeValue: '累积价值',
       windowValue: '窗口价值',
+    },
+    sources: {
+      label: '数据源',
+      remoteSources: '远程数据源',
+      chooseSources: '选择要纳入统计的数据源',
+      noneSelected: '未选择',
+      listSeparator: '、',
+      local: '本机',
+      localCodexHome: '本机 ~/.codex',
+      cached: '已缓存',
+      added: '已添加',
+      failed: '失败',
+      downloading: '下载中',
+      notDownloaded: '未下载',
+      addSsh: '添加 SSH',
+      updateAll: '更新全部',
+      noRemoteSources: '还没有远程数据源。',
+      update: '更新',
+      updating: '更新中',
+      deleteSource: '删除数据源',
+      deleteSourceLabel: (label) => `删除 ${label}`,
+      deleting: '删除中…',
+      deleteServer: '删除服务器',
+      deleteServerTitle: (label) => `删除 ${label}？`,
+      deleteServerDescription: '这会移除这个 SSH 数据源、本地缓存和已导入的统计数据。不会影响远程服务器上的 ~/.codex。',
+      confirmDelete: '确认删除',
+      addCodexServer: '添加 Codex 服务器',
+      refreshSshList: '刷新 SSH 列表',
+      filteredHostsNote: '自动过滤 GitHub / GitLab 等代码托管 Host。',
+      noSshServersDiscovered: '没有发现可添加的 SSH 服务器。',
+      add: '添加',
+      keepOneSelected: '至少保留一个数据源。',
+      addedSource: (label) => `已添加 ${label}`,
+      downloadingRemoteCache: '正在下载远程缓存…',
+      downloadedAndImported: (files) => `已下载并导入 ${files} 个文件`,
+      noSshServersAdded: '还没有添加 SSH 服务器。',
+      deletingSource: (label) => `正在删除 ${label}…`,
+      deletedSource: (label) => `已删除 ${label}`,
+      maintenanceActions: '维护操作',
     },
     popup: {
       title: '托盘',
@@ -625,6 +709,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       distribution: 'Distribution',
       modelShare: 'Model share',
       costStructure: 'Cost structure',
+      sourceShare: 'Source share',
     },
     conversationList: {
       eyebrow: 'Conversation list',
@@ -637,6 +722,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       modelBreakdown: 'Model breakdown',
       conversationModelBreakdown: 'Conversation model breakdown',
       conversationCostBreakdown: 'Conversation cost structure',
+      conversationSourceBreakdown: 'Conversation source breakdown',
       turnTimelineEyebrow: 'Turn timeline',
       turnUsage: 'Turn usage',
       latestTurns: (count) => `Latest ${count} turns`,
@@ -659,6 +745,7 @@ const translations: Record<AppLanguage, TranslationSet> = {
       metricControlLabel: 'Distribution metric',
       byModel: 'By model',
       byStructure: 'By structure',
+      bySource: 'By source',
       byValue: 'By value',
       byTokens: 'By tokens',
       liveQuotaEyebrow: 'Live quota',
@@ -670,6 +757,45 @@ const translations: Record<AppLanguage, TranslationSet> = {
       remaining: 'Remaining',
       cumulativeValue: 'Cumulative value',
       windowValue: 'Window value',
+    },
+    sources: {
+      label: 'Sources',
+      remoteSources: 'Remote sources',
+      chooseSources: 'Choose sources for this view',
+      noneSelected: 'None selected',
+      listSeparator: ', ',
+      local: 'Local',
+      localCodexHome: 'Local ~/.codex',
+      cached: 'Cached',
+      added: 'Added',
+      failed: 'Failed',
+      downloading: 'Downloading',
+      notDownloaded: 'Not downloaded',
+      addSsh: 'Add SSH',
+      updateAll: 'Update all',
+      noRemoteSources: 'No remote sources yet.',
+      update: 'Update',
+      updating: 'Updating',
+      deleteSource: 'Delete source',
+      deleteSourceLabel: (label) => `Delete ${label}`,
+      deleting: 'Deleting…',
+      deleteServer: 'Delete server',
+      deleteServerTitle: (label) => `Delete ${label}?`,
+      deleteServerDescription: 'This removes the SSH source, its local cache, and imported stats. The remote ~/.codex is not changed.',
+      confirmDelete: 'Delete',
+      addCodexServer: 'Add Codex server',
+      refreshSshList: 'Refresh SSH list',
+      filteredHostsNote: 'GitHub/GitLab-style hosts are filtered automatically.',
+      noSshServersDiscovered: 'No SSH servers discovered.',
+      add: 'Add',
+      keepOneSelected: 'Keep at least one source selected.',
+      addedSource: (label) => `Added ${label}`,
+      downloadingRemoteCache: 'Downloading remote cache…',
+      downloadedAndImported: (files) => `Downloaded and imported ${files} files`,
+      noSshServersAdded: 'No SSH servers added yet.',
+      deletingSource: (label) => `Deleting ${label}…`,
+      deletedSource: (label) => `Deleted ${label}`,
+      maintenanceActions: 'Maintenance actions',
     },
     popup: {
       title: 'Tray',

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -59,6 +59,8 @@ export type TranslationSet = {
     failedToLoad: (bucketLabel: string, error: string) => string
     pricingRefreshed: string
     settingsSaved: string
+    subscriptionRecordSaved: string
+    subscriptionRecordDeleted: string
     waitingLiveQuota: string
   }
   buckets: Record<OverviewBucket, string>
@@ -82,6 +84,8 @@ export type TranslationSet = {
     subscriptionCost: string
     payoffRatio: string
     planPerMonth: (planType: string, price: string) => string
+    subscriptionLedgerNote: (count: number) => string
+    noSubscriptionRecords: string
     monthlyFeeShare: string
   }
   overview: {
@@ -236,6 +240,23 @@ export type TranslationSet = {
         monthlyPrice: string
         billingAnchorDay: string
         billingAnchorDayNote: string
+        planPlus: string
+        planPro5: string
+        planPro10: string
+        amountUsd: string
+        serviceStart: string
+        serviceEnd: string
+        addRecordTitle: string
+        editRecordTitle: string
+        addRecord: string
+        updateRecord: string
+        saveRecord: string
+        editRecord: string
+        removeRecord: string
+        cancelEditRecord: string
+        emptyRecords: string
+        accountEmail: string
+        accountEmailPlaceholder: string
       }
       liveQuota: {
         eyebrow: string
@@ -298,6 +319,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       failedToLoad: (bucketLabel, error) => `加载${bucketLabel}失败：${error}`,
       pricingRefreshed: '已按 OpenAI 标准短上下文定价刷新目录。',
       settingsSaved: '设置已保存。',
+      subscriptionRecordSaved: '订阅记录已保存。',
+      subscriptionRecordDeleted: '订阅记录已删除。',
       waitingLiveQuota: '等待 live quota',
     },
     buckets: {
@@ -331,7 +354,9 @@ const translations: Record<AppLanguage, TranslationSet> = {
       subscriptionCost: '订阅费',
       payoffRatio: '回本比例',
       planPerMonth: (planType, price) => `${planType} · ${price}/月`,
-      monthlyFeeShare: '占月费比例',
+      subscriptionLedgerNote: (count) => `${count} 条订阅记录`,
+      noSubscriptionRecords: '未添加订阅记录',
+      monthlyFeeShare: '订阅账本占比',
     },
     overview: {
       distribution: '分布',
@@ -485,6 +510,23 @@ const translations: Record<AppLanguage, TranslationSet> = {
           monthlyPrice: '月订阅价格',
           billingAnchorDay: '订阅月起始日',
           billingAnchorDayNote: '订阅月会按这个日期切分。例如设置为 23，则统计范围是每月 23 号到次月 22 号。',
+          planPlus: 'ChatGPT Plus',
+          planPro5: 'ChatGPT Pro 5x',
+          planPro10: 'ChatGPT Pro 10x',
+          amountUsd: '金额（USD）',
+          serviceStart: '服务开始',
+          serviceEnd: '服务结束',
+          addRecordTitle: '账本记录',
+          editRecordTitle: '编辑记录',
+          addRecord: '添加订阅记录',
+          updateRecord: '更新订阅记录',
+          saveRecord: '保存记录',
+          editRecord: '编辑',
+          removeRecord: '删除',
+          cancelEditRecord: '取消编辑',
+          emptyRecords: '还没有订阅账本记录。添加记录后，回本会按服务期重叠比例计算。',
+          accountEmail: '账号邮箱/备注',
+          accountEmailPlaceholder: '可选备注或邮箱',
         },
         liveQuota: {
           eyebrow: 'Live Quota',
@@ -540,6 +582,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       failedToLoad: (bucketLabel, error) => `Failed to load ${bucketLabel}: ${error}`,
       pricingRefreshed: 'Pricing catalog refreshed from OpenAI Standard short-context pricing.',
       settingsSaved: 'Settings saved.',
+      subscriptionRecordSaved: 'Subscription record saved.',
+      subscriptionRecordDeleted: 'Subscription record deleted.',
       waitingLiveQuota: 'Waiting for live quota',
     },
     buckets: {
@@ -573,7 +617,9 @@ const translations: Record<AppLanguage, TranslationSet> = {
       subscriptionCost: 'Subscription cost',
       payoffRatio: 'Payoff ratio',
       planPerMonth: (planType, price) => `${planType} · ${price}/mo`,
-      monthlyFeeShare: 'Share of monthly fee',
+      subscriptionLedgerNote: (count) => `${count} subscription records`,
+      noSubscriptionRecords: 'No subscription records',
+      monthlyFeeShare: 'Share of subscription ledger',
     },
     overview: {
       distribution: 'Distribution',
@@ -727,6 +773,23 @@ const translations: Record<AppLanguage, TranslationSet> = {
           monthlyPrice: 'Monthly subscription price',
           billingAnchorDay: 'Subscription month starts on',
           billingAnchorDayNote: 'The billing month is split by this day. For example, `23` means each window runs from the 23rd to the 22nd of the next month.',
+          planPlus: 'ChatGPT Plus',
+          planPro5: 'ChatGPT Pro 5x',
+          planPro10: 'ChatGPT Pro 10x',
+          amountUsd: 'Amount (USD)',
+          serviceStart: 'Service start',
+          serviceEnd: 'Service end',
+          addRecordTitle: 'Ledger record',
+          editRecordTitle: 'Edit record',
+          addRecord: 'Add subscription record',
+          updateRecord: 'Update subscription record',
+          saveRecord: 'Save record',
+          editRecord: 'Edit',
+          removeRecord: 'Delete',
+          cancelEditRecord: 'Cancel edit',
+          emptyRecords: 'No subscription ledger records yet. Add records to prorate payoff by service period overlap.',
+          accountEmail: 'Account email / note',
+          accountEmailPlaceholder: 'Optional note or email',
         },
         liveQuota: {
           eyebrow: 'Live Quota',

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -55,6 +55,27 @@ export interface SubscriptionProfile {
   updatedAt: string
 }
 
+export interface SubscriptionRecord {
+  id: number
+  paidAt: string
+  serviceStart: string
+  serviceEnd: string
+  amountUsd: number
+  planType: string
+  note: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SubscriptionRecordInput {
+  paidAt: string
+  serviceStart: string
+  serviceEnd: string
+  amountUsd: number
+  planType: string
+  note: string | null
+}
+
 export interface ScanResult {
   codexHome: string
   scannedFiles: number
@@ -191,6 +212,7 @@ export interface DashboardSnapshot {
   conversations: ConversationListItem[]
   syncSettings: SyncSettings
   subscriptionProfile: SubscriptionProfile
+  subscriptionRecords: SubscriptionRecord[]
   liveRateLimits: LiveRateLimitSnapshot | null
 }
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -10,7 +10,7 @@ export type OverviewBucket =
   | 'total'
 
 export type ShareMode = 'value' | 'tokens'
-export type ShareDimension = 'model' | 'composition'
+export type ShareDimension = 'model' | 'composition' | 'source'
 export type AppView = 'overview' | 'conversations'
 export type MenuBarPopupModuleId =
   | 'api_value'
@@ -53,6 +53,59 @@ export interface SubscriptionProfile {
   monthlyPrice: number
   billingAnchorDay: number
   updatedAt: string
+}
+
+export interface CodexSource {
+  id: string
+  kind: string
+  label: string
+  sshAlias: string | null
+  hostName: string | null
+  user: string | null
+  port: number | null
+  remoteCodexHome: string | null
+  localCodexHome: string | null
+  selected: boolean
+  status: string
+  lastDiscoveredAt: string | null
+  lastDownloadedAt: string | null
+  lastScannedAt: string | null
+  lastError: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CodexSourceCandidate {
+  id: string
+  label: string
+  sshAlias: string
+  hostName: string | null
+  user: string | null
+  port: number | null
+  remoteCodexHome: string
+  ignoredReason: string | null
+}
+
+export interface CodexSourceInput {
+  label: string
+  sshAlias: string
+  hostName: string | null
+  user: string | null
+  port: number | null
+  remoteCodexHome: string
+  selected: boolean
+}
+
+export interface CodexSourceDownloadProgress {
+  sourceId: string
+  stage: string
+  progress: number | null
+  message: string
+}
+
+export interface CodexSourceDownloadResult {
+  source: CodexSource
+  scanResult: ScanResult
 }
 
 export interface SubscriptionRecord {
@@ -183,6 +236,15 @@ export interface CompositionShare {
   color: string
 }
 
+export interface SourceShare {
+  sourceId: string
+  displayName: string
+  apiValueUsd: number
+  totalTokens: number
+  conversationCount: number
+  color: string
+}
+
 export interface ShareSlice {
   id: string
   label: string
@@ -204,12 +266,14 @@ export interface OverviewResponse {
   quotaTrend: QuotaTrendPoint[]
   modelShares: ModelShare[]
   compositionShares: CompositionShare[]
+  sourceShares: SourceShare[]
   liveRateLimits: LiveRateLimitSnapshot | null
 }
 
 export interface DashboardSnapshot {
   overview: OverviewResponse
   conversations: ConversationListItem[]
+  codexSources: CodexSource[]
   syncSettings: SyncSettings
   subscriptionProfile: SubscriptionProfile
   subscriptionRecords: SubscriptionRecord[]
@@ -223,6 +287,7 @@ export interface ConversationFilters {
   customEnd?: string | null
   search?: string | null
   liveWindowOffset?: number | null
+  sourceIds?: string[] | null
 }
 
 export interface ConversationListItem {
@@ -303,4 +368,5 @@ export interface ConversationDetail {
   turns: ConversationTurnPoint[]
   modelBreakdown: ModelShare[]
   compositionBreakdown: CompositionShare[]
+  sourceBreakdown: SourceShare[]
 }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -129,6 +129,17 @@ export interface SubscriptionRecordInput {
   note: string | null
 }
 
+export interface CodexAccountStatus {
+  available: boolean
+  requiresOpenaiAuth: boolean
+  authMode: string | null
+  accountType: string | null
+  email: string | null
+  planType: string | null
+  error: string | null
+  fetchedAt: string
+}
+
 export interface ScanResult {
   codexHome: string
   scannedFiles: number
@@ -277,6 +288,7 @@ export interface DashboardSnapshot {
   syncSettings: SyncSettings
   subscriptionProfile: SubscriptionProfile
   subscriptionRecords: SubscriptionRecord[]
+  accountStatus: CodexAccountStatus
   liveRateLimits: LiveRateLimitSnapshot | null
 }
 

--- a/src/components/ModelShareChart.tsx
+++ b/src/components/ModelShareChart.tsx
@@ -60,6 +60,14 @@ export function ModelShareChart({
                 >
                   {t.charts.byStructure}
                 </button>
+                <button
+                  aria-pressed={dimension === 'source'}
+                  className={dimension === 'source' ? 'active' : ''}
+                  onClick={() => onDimensionChange('source')}
+                  type="button"
+                >
+                  {t.charts.bySource}
+                </button>
               </div>
             </div>
           ) : null}

--- a/src/components/PopupSevenDayUsageChart.tsx
+++ b/src/components/PopupSevenDayUsageChart.tsx
@@ -28,7 +28,7 @@ const PADDING_BOTTOM = 14
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
 
 export function PopupSevenDayUsageChart({ ariaLabel, data, fetchedAt, quota, speed }: PopupSevenDayUsageChartProps) {
-  const { language } = useI18n()
+  const { language, t } = useI18n()
   const dataTimes = data
     .map((point) => toTimestamp(point.timestamp))
     .filter((value): value is number => value !== null)
@@ -42,6 +42,7 @@ export function PopupSevenDayUsageChart({ ariaLabel, data, fetchedAt, quota, spe
 
   const valuePoints = buildValuePoints(data, quota, currentTime, windowStart, safeWindowEnd)
   const plotPoints = valuePoints.map((point) => toPlotPoint(point, windowStart, safeWindowEnd))
+  const hasChartData = plotPoints.length > 0
   const actualPath = buildSmoothPath(plotPoints)
   const areaPath = buildAreaPath(plotPoints)
   const referenceStart = toPlotPoint({ time: windowStart, value: 100 }, windowStart, safeWindowEnd)
@@ -59,61 +60,84 @@ export function PopupSevenDayUsageChart({ ariaLabel, data, fetchedAt, quota, spe
 
   return (
     <section aria-label={ariaLabel} className="popup-seven-day-chart">
-      {speed ? (
-        <div className={`popup-seven-day-speed-badge popup-seven-day-speed-badge--${speed.status}`}>
-          {speed.emoji ? (
-            <span aria-hidden="true" className="popup-seven-day-speed-emoji">
-              {speed.emoji}
-            </span>
-          ) : null}
-          <strong>{speed.displayValue}</strong>
-        </div>
-      ) : null}
-      <div className="popup-seven-day-value-badge">
-        <span aria-hidden="true" className="popup-seven-day-badge-emoji">
-          💵
-        </span>
-        <strong>{formatUsd(apiValueUsd, language)}</strong>
-      </div>
-      <svg aria-hidden="true" className="popup-seven-day-svg" focusable="false" viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}>
-        <defs>
-          <linearGradient id="popupSevenDayUsageFill" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="#76c5ff" stopOpacity="0.24" />
-            <stop offset="100%" stopColor="#76c5ff" stopOpacity="0" />
-          </linearGradient>
-          <filter id="popupSevenDayCurrentGlow" x="-80%" y="-80%" width="260%" height="260%">
-            <feGaussianBlur stdDeviation="4" result="blur" />
-            <feColorMatrix
-              in="blur"
-              result="glow"
-              type="matrix"
-              values="0 0 0 0 0.462 0 0 0 0 0.773 0 0 0 0 1 0 0 0 0.7 0"
+      {hasChartData ? (
+        <>
+          <div className="popup-seven-day-badges">
+            <div className="popup-seven-day-value-badge">
+              <span aria-hidden="true" className="popup-seven-day-badge-emoji">
+                💵
+              </span>
+              <span className="popup-seven-day-badge-label">{t.popup.chartValueBadge}</span>
+              <strong>{formatUsd(apiValueUsd, language)}</strong>
+            </div>
+            {speed ? (
+              <div className={`popup-seven-day-speed-badge popup-seven-day-speed-badge--${speed.status}`}>
+                {speed.emoji ? (
+                  <span aria-hidden="true" className="popup-seven-day-speed-emoji">
+                    {speed.emoji}
+                  </span>
+                ) : null}
+                <strong>{speed.displayValue}</strong>
+              </div>
+            ) : null}
+          </div>
+          <svg aria-hidden="true" className="popup-seven-day-svg" focusable="false" viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}>
+            <defs>
+              <linearGradient id="popupSevenDayUsageFill" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="#76c5ff" stopOpacity="0.24" />
+                <stop offset="100%" stopColor="#76c5ff" stopOpacity="0" />
+              </linearGradient>
+              <filter id="popupSevenDayCurrentGlow" x="-80%" y="-80%" width="260%" height="260%">
+                <feGaussianBlur stdDeviation="4" result="blur" />
+                <feColorMatrix
+                  in="blur"
+                  result="glow"
+                  type="matrix"
+                  values="0 0 0 0 0.462 0 0 0 0 0.773 0 0 0 0 1 0 0 0 0.7 0"
+                />
+                <feMerge>
+                  <feMergeNode in="glow" />
+                  <feMergeNode in="SourceGraphic" />
+                </feMerge>
+              </filter>
+            </defs>
+            <rect className="popup-seven-day-plot" height={CHART_HEIGHT} rx="16" width={CHART_WIDTH} x="0" y="0" />
+            {dayLines}
+            {horizontalLines}
+            <line
+              className="popup-seven-day-reference"
+              x1={referenceStart.x}
+              x2={referenceEnd.x}
+              y1={referenceStart.y}
+              y2={referenceEnd.y}
             />
-            <feMerge>
-              <feMergeNode in="glow" />
-              <feMergeNode in="SourceGraphic" />
-            </feMerge>
-          </filter>
-        </defs>
-        <rect className="popup-seven-day-plot" height={CHART_HEIGHT} rx="16" width={CHART_WIDTH} x="0" y="0" />
-        {dayLines}
-        {horizontalLines}
-        <line
-          className="popup-seven-day-reference"
-          x1={referenceStart.x}
-          x2={referenceEnd.x}
-          y1={referenceStart.y}
-          y2={referenceEnd.y}
-        />
-        {areaPath ? <path className="popup-seven-day-area" d={areaPath} /> : null}
-        {actualPath ? <path className="popup-seven-day-line" d={actualPath} /> : null}
-        {currentPoint ? (
-          <g className="popup-seven-day-current" filter="url(#popupSevenDayCurrentGlow)">
-            <circle className="popup-seven-day-current-halo" cx={currentPoint.x} cy={currentPoint.y} r="9" />
-            <circle className="popup-seven-day-current-dot" cx={currentPoint.x} cy={currentPoint.y} r="4.5" />
-          </g>
-        ) : null}
-      </svg>
+            {areaPath ? <path className="popup-seven-day-area" d={areaPath} /> : null}
+            {actualPath ? <path className="popup-seven-day-line" d={actualPath} /> : null}
+            {currentPoint ? (
+              <g className="popup-seven-day-current" filter="url(#popupSevenDayCurrentGlow)">
+                <circle className="popup-seven-day-current-halo" cx={currentPoint.x} cy={currentPoint.y} r="9" />
+                <circle className="popup-seven-day-current-dot" cx={currentPoint.x} cy={currentPoint.y} r="4.5" />
+              </g>
+            ) : null}
+          </svg>
+          <div className="popup-seven-day-legend" aria-label={ariaLabel}>
+            <span className="popup-seven-day-legend-item">
+              <i className="popup-seven-day-legend-mark popup-seven-day-legend-mark--remaining" aria-hidden="true" />
+              {t.popup.chartLegendRemaining}
+            </span>
+            <span className="popup-seven-day-legend-item">
+              <i className="popup-seven-day-legend-mark popup-seven-day-legend-mark--reference" aria-hidden="true" />
+              {t.popup.chartLegendReference}
+            </span>
+            <span className="popup-seven-day-legend-item">
+              <i className="popup-seven-day-legend-mark popup-seven-day-legend-mark--current" aria-hidden="true" />
+              {t.popup.chartLegendCurrent}
+            </span>
+          </div>
+        </>
+      ) : (
+        <div className="popup-seven-day-empty">{t.common.noData}</div>
+      )}
     </section>
   )
 }

--- a/src/components/QuotaRingCard.tsx
+++ b/src/components/QuotaRingCard.tsx
@@ -4,6 +4,7 @@ interface QuotaRingCardProps {
   timePercent: number | null
   subtitle: string
   tone: 'warm' | 'cool'
+  available?: boolean
 }
 
 const RING_VIEWBOX_SIZE = 136
@@ -13,15 +14,15 @@ const INNER_RADIUS = 34
 const OUTER_CIRCUMFERENCE = 2 * Math.PI * OUTER_RADIUS
 const INNER_CIRCUMFERENCE = 2 * Math.PI * INNER_RADIUS
 
-export function QuotaRingCard({ label, percent, timePercent, subtitle, tone }: QuotaRingCardProps) {
-  const clampedPercent = Math.max(0, Math.min(100, percent))
-  const clampedTimePercent = timePercent === null ? null : Math.max(0, Math.min(100, timePercent))
+export function QuotaRingCard({ label, percent, timePercent, subtitle, tone, available = true }: QuotaRingCardProps) {
+  const clampedPercent = available ? clampPercent(percent) : 0
+  const clampedTimePercent = available && timePercent !== null ? clampPercent(timePercent) : null
   const outerStrokeOffset = OUTER_CIRCUMFERENCE * (1 - clampedPercent / 100)
   const innerStrokeOffset =
     clampedTimePercent === null ? INNER_CIRCUMFERENCE : INNER_CIRCUMFERENCE * (1 - clampedTimePercent / 100)
 
   return (
-    <section className={`quota-ring-card quota-ring-card--${tone}`}>
+    <section className={`quota-ring-card quota-ring-card--${tone} ${available ? '' : 'quota-ring-card--empty'}`}>
       <div className="quota-ring-visual">
         <svg aria-hidden="true" className="quota-ring-svg" viewBox={`0 0 ${RING_VIEWBOX_SIZE} ${RING_VIEWBOX_SIZE}`}>
           <circle className="quota-ring-track quota-ring-track--outer" cx={RING_CENTER} cy={RING_CENTER} r={OUTER_RADIUS} />
@@ -44,11 +45,16 @@ export function QuotaRingCard({ label, percent, timePercent, subtitle, tone }: Q
           />
         </svg>
         <div className="quota-ring-copy">
-          <strong>{clampedPercent}%</strong>
+          <strong>{available ? `${clampedPercent}%` : '—'}</strong>
         </div>
       </div>
       <p className="quota-ring-label">{label}</p>
       <p className="quota-ring-subtitle">{subtitle}</p>
     </section>
   )
+}
+
+function clampPercent(value: number) {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, Math.round(value)))
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -5,6 +5,7 @@ import { formatPercent, formatRemainingDuration, formatUsd, todayInputValue } fr
 import { SUPPORTED_LANGUAGES, type AppLanguage } from '../app/i18n'
 import { useI18n } from '../app/useI18n'
 import type {
+  CodexAccountStatus,
   LiveRateLimitSnapshot,
   MenuBarPopupModuleId,
   OverviewBucket,
@@ -21,6 +22,7 @@ interface SettingsPanelProps {
   syncSettings: SyncSettings | null
   subscriptionProfile: SubscriptionProfile | null
   subscriptionRecords: SubscriptionRecord[]
+  accountStatus: CodexAccountStatus | null
   onClose: () => void
   onLanguageChange: (language: AppLanguage) => void
   onSave: (payload: {
@@ -94,9 +96,12 @@ function defaultAmountForPlan(planType?: string | null) {
   return SUBSCRIPTION_PLAN_AMOUNTS[normalizePlanOption(planType)]
 }
 
-function createDefaultRecordForm(profile: SubscriptionProfile | null): SubscriptionRecordFormState {
+function createDefaultRecordForm(
+  profile: SubscriptionProfile | null,
+  accountStatus: CodexAccountStatus | null,
+): SubscriptionRecordFormState {
   const serviceStart = todayInputValue()
-  const planType = normalizePlanOption(profile?.planType)
+  const planType = normalizePlanOption(profile?.planType ?? accountStatus?.planType)
   return {
     serviceStart,
     serviceEnd: addOneMonth(serviceStart),
@@ -105,7 +110,7 @@ function createDefaultRecordForm(profile: SubscriptionProfile | null): Subscript
         ? profile.monthlyPrice
         : defaultAmountForPlan(planType),
     planType,
-    accountEmail: '',
+    accountEmail: accountStatus?.email ?? '',
   }
 }
 
@@ -134,6 +139,34 @@ function formatPlanLabel(
   return labels.planPlus
 }
 
+function maskEmail(email: string) {
+  const [name, domain] = email.split('@')
+  if (!name || !domain) return email
+  const visibleName = name.length <= 2 ? name : `${name.slice(0, 2)}…`
+  return `${visibleName}@${domain}`
+}
+
+function formatAccountStatus(
+  accountStatus: CodexAccountStatus | null,
+  labels: {
+    accountUnavailable: string
+    accountRequiresLogin: string
+    accountApiKey: string
+    accountUnknown: string
+  },
+) {
+  if (!accountStatus) return labels.accountUnavailable
+  if (!accountStatus.available) return accountStatus.error || labels.accountUnavailable
+  if (accountStatus.requiresOpenaiAuth && !accountStatus.accountType) return labels.accountRequiresLogin
+  if (accountStatus.accountType === 'apiKey') return labels.accountApiKey
+  const parts = [
+    accountStatus.accountType ?? labels.accountUnknown,
+    accountStatus.planType,
+    accountStatus.email ? maskEmail(accountStatus.email) : null,
+  ].filter(Boolean)
+  return parts.join(' / ') || labels.accountUnknown
+}
+
 function refreshSecondsToMinutes(seconds: number) {
   return Math.max(1, Math.round(seconds / 60))
 }
@@ -153,6 +186,7 @@ export function SettingsPanel({
   syncSettings,
   subscriptionProfile,
   subscriptionRecords,
+  accountStatus,
   onClose,
   onLanguageChange,
   onSave,
@@ -165,7 +199,7 @@ export function SettingsPanel({
     subscriptionProfile,
   )
   const [recordForm, setRecordForm] = useState<SubscriptionRecordFormState>(() =>
-    createDefaultRecordForm(subscriptionProfile),
+    createDefaultRecordForm(subscriptionProfile, accountStatus),
   )
   const [editingRecordId, setEditingRecordId] = useState<number | null>(null)
   const [saving, setSaving] = useState(false)
@@ -180,7 +214,7 @@ export function SettingsPanel({
     if (justOpened || (!draftSync && syncSettings) || (!draftSubscription && subscriptionProfile)) {
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
-      setRecordForm(createDefaultRecordForm(subscriptionProfile))
+      setRecordForm(createDefaultRecordForm(subscriptionProfile, accountStatus))
       setEditingRecordId(null)
       setSaving(false)
       setSavingRecord(false)
@@ -188,7 +222,7 @@ export function SettingsPanel({
     } else if (!isOpen && wasOpenRef.current) {
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
-      setRecordForm(createDefaultRecordForm(subscriptionProfile))
+      setRecordForm(createDefaultRecordForm(subscriptionProfile, accountStatus))
       setEditingRecordId(null)
       setSaving(false)
       setSavingRecord(false)
@@ -196,7 +230,7 @@ export function SettingsPanel({
     }
 
     wasOpenRef.current = isOpen
-  }, [draftSubscription, draftSync, isOpen, subscriptionProfile, syncSettings])
+  }, [accountStatus, draftSubscription, draftSync, isOpen, subscriptionProfile, syncSettings])
 
   if (!isOpen || !draftSync || !draftSubscription) return null
 
@@ -288,7 +322,7 @@ export function SettingsPanel({
   }
 
   function resetRecordForm() {
-    setRecordForm(createDefaultRecordForm(draftSubscription))
+    setRecordForm(createDefaultRecordForm(draftSubscription, accountStatus))
     setEditingRecordId(null)
   }
 
@@ -918,6 +952,11 @@ export function SettingsPanel({
                     }
                   />
                 </label>
+              </div>
+
+              <div className="subscription-account-card">
+                <span className="metric-label">{t.settings.sections.subscription.accountStatus}</span>
+                <strong>{formatAccountStatus(accountStatus, t.settings.sections.subscription)}</strong>
               </div>
 
               <div className="subscription-record-list">

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 
-import { formatPercent, formatRemainingDuration } from '../app/format'
+import { formatPercent, formatRemainingDuration, formatUsd, todayInputValue } from '../app/format'
 import { SUPPORTED_LANGUAGES, type AppLanguage } from '../app/i18n'
 import { useI18n } from '../app/useI18n'
 import type {
@@ -9,6 +9,8 @@ import type {
   MenuBarPopupModuleId,
   OverviewBucket,
   SubscriptionProfile,
+  SubscriptionRecord,
+  SubscriptionRecordInput,
   SyncSettings,
 } from '../app/types'
 
@@ -18,12 +20,15 @@ interface SettingsPanelProps {
   liveRateLimits: LiveRateLimitSnapshot | null
   syncSettings: SyncSettings | null
   subscriptionProfile: SubscriptionProfile | null
+  subscriptionRecords: SubscriptionRecord[]
   onClose: () => void
   onLanguageChange: (language: AppLanguage) => void
   onSave: (payload: {
     syncSettings: SyncSettings
     subscriptionProfile: SubscriptionProfile
   }) => Promise<void>
+  onSaveSubscriptionRecord: (payload: SubscriptionRecordInput, id?: number | null) => Promise<void>
+  onDeleteSubscriptionRecord: (id: number) => Promise<void>
 }
 
 interface SwitchFieldProps {
@@ -52,6 +57,83 @@ function SwitchField({ label, checked, disabled = false, onChange }: SwitchField
   )
 }
 
+function addOneMonth(value: string) {
+  const date = new Date(`${value}T00:00:00`)
+  if (Number.isNaN(date.getTime())) return value
+  date.setMonth(date.getMonth() + 1)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+type SubscriptionPlanOption = 'plus' | 'pro_x5' | 'pro_x10'
+
+interface SubscriptionRecordFormState {
+  serviceStart: string
+  serviceEnd: string
+  amountUsd: number
+  planType: SubscriptionPlanOption
+  accountEmail: string
+}
+
+const SUBSCRIPTION_PLAN_AMOUNTS: Record<SubscriptionPlanOption, number> = {
+  plus: 19.99,
+  pro_x5: 100,
+  pro_x10: 200,
+}
+
+function normalizePlanOption(planType?: string | null): SubscriptionPlanOption {
+  const normalized = planType?.toLowerCase().replace(/[×*]/g, 'x').replace(/[\s-]+/g, '_') ?? ''
+  if (normalized.includes('pro') && normalized.includes('5')) return 'pro_x5'
+  if (normalized.includes('pro')) return 'pro_x10'
+  return 'plus'
+}
+
+function defaultAmountForPlan(planType?: string | null) {
+  return SUBSCRIPTION_PLAN_AMOUNTS[normalizePlanOption(planType)]
+}
+
+function createDefaultRecordForm(profile: SubscriptionProfile | null): SubscriptionRecordFormState {
+  const serviceStart = todayInputValue()
+  const planType = normalizePlanOption(profile?.planType)
+  return {
+    serviceStart,
+    serviceEnd: addOneMonth(serviceStart),
+    amountUsd:
+      profile?.monthlyPrice && profile.monthlyPrice > 0
+        ? profile.monthlyPrice
+        : defaultAmountForPlan(planType),
+    planType,
+    accountEmail: '',
+  }
+}
+
+function recordToForm(record: SubscriptionRecord): SubscriptionRecordFormState {
+  const planType = normalizePlanOption(record.planType)
+  return {
+    serviceStart: record.serviceStart,
+    serviceEnd: record.serviceEnd,
+    amountUsd: record.amountUsd,
+    planType,
+    accountEmail: record.note ?? '',
+  }
+}
+
+function formatPlanLabel(
+  planType: string,
+  labels: {
+    planPlus: string
+    planPro5: string
+    planPro10: string
+  },
+) {
+  const normalized = normalizePlanOption(planType)
+  if (normalized === 'pro_x5') return labels.planPro5
+  if (normalized === 'pro_x10') return labels.planPro10
+  return labels.planPlus
+}
+
 function refreshSecondsToMinutes(seconds: number) {
   return Math.max(1, Math.round(seconds / 60))
 }
@@ -70,16 +152,25 @@ export function SettingsPanel({
   liveRateLimits,
   syncSettings,
   subscriptionProfile,
+  subscriptionRecords,
   onClose,
   onLanguageChange,
   onSave,
+  onSaveSubscriptionRecord,
+  onDeleteSubscriptionRecord,
 }: SettingsPanelProps) {
   const { t } = useI18n()
   const [draftSync, setDraftSync] = useState<SyncSettings | null>(syncSettings)
   const [draftSubscription, setDraftSubscription] = useState<SubscriptionProfile | null>(
     subscriptionProfile,
   )
+  const [recordForm, setRecordForm] = useState<SubscriptionRecordFormState>(() =>
+    createDefaultRecordForm(subscriptionProfile),
+  )
+  const [editingRecordId, setEditingRecordId] = useState<number | null>(null)
   const [saving, setSaving] = useState(false)
+  const [savingRecord, setSavingRecord] = useState(false)
+  const [deletingRecordId, setDeletingRecordId] = useState<number | null>(null)
   const wasOpenRef = useRef(false)
   const showDockSettings = isMacOs()
 
@@ -89,11 +180,19 @@ export function SettingsPanel({
     if (justOpened || (!draftSync && syncSettings) || (!draftSubscription && subscriptionProfile)) {
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
+      setRecordForm(createDefaultRecordForm(subscriptionProfile))
+      setEditingRecordId(null)
       setSaving(false)
+      setSavingRecord(false)
+      setDeletingRecordId(null)
     } else if (!isOpen && wasOpenRef.current) {
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
+      setRecordForm(createDefaultRecordForm(subscriptionProfile))
+      setEditingRecordId(null)
       setSaving(false)
+      setSavingRecord(false)
+      setDeletingRecordId(null)
     }
 
     wasOpenRef.current = isOpen
@@ -134,6 +233,24 @@ export function SettingsPanel({
     { value: 'conversation_count', label: t.popup.modules.conversationCount },
   ]
 
+  const planOptions: Array<{ value: SubscriptionPlanOption; label: string; amountUsd: number }> = [
+    {
+      value: 'plus',
+      label: t.settings.sections.subscription.planPlus,
+      amountUsd: SUBSCRIPTION_PLAN_AMOUNTS.plus,
+    },
+    {
+      value: 'pro_x5',
+      label: t.settings.sections.subscription.planPro5,
+      amountUsd: SUBSCRIPTION_PLAN_AMOUNTS.pro_x5,
+    },
+    {
+      value: 'pro_x10',
+      label: t.settings.sections.subscription.planPro10,
+      amountUsd: SUBSCRIPTION_PLAN_AMOUNTS.pro_x10,
+    },
+  ]
+
   function togglePopupModule(moduleId: MenuBarPopupModuleId, enabled: boolean) {
     setDraftSync((current) => {
       if (!current) return current
@@ -168,6 +285,69 @@ export function SettingsPanel({
         menuBarPopupModules: nextModules,
       }
     })
+  }
+
+  function resetRecordForm() {
+    setRecordForm(createDefaultRecordForm(draftSubscription))
+    setEditingRecordId(null)
+  }
+
+  function updateRecordForm(patch: Partial<SubscriptionRecordFormState>) {
+    setRecordForm((current) => ({ ...current, ...patch }))
+  }
+
+  function updateRecordPlan(planType: SubscriptionPlanOption) {
+    setRecordForm((current) => ({
+      ...current,
+      planType,
+      amountUsd: SUBSCRIPTION_PLAN_AMOUNTS[planType],
+    }))
+  }
+
+  function updateRecordServiceStart(serviceStart: string) {
+    setRecordForm((current) => ({
+      ...current,
+      serviceStart,
+      serviceEnd: current.serviceEnd <= serviceStart ? addOneMonth(serviceStart) : current.serviceEnd,
+    }))
+  }
+
+  function editSubscriptionRecord(record: SubscriptionRecord) {
+    setEditingRecordId(record.id)
+    setRecordForm(recordToForm(record))
+  }
+
+  async function saveSubscriptionRecordForm() {
+    setSavingRecord(true)
+    try {
+      const accountEmail = recordForm.accountEmail.trim()
+      await onSaveSubscriptionRecord(
+        {
+          paidAt: recordForm.serviceStart,
+          serviceStart: recordForm.serviceStart,
+          serviceEnd: recordForm.serviceEnd,
+          amountUsd: Math.max(0, Number(recordForm.amountUsd || 0)),
+          planType: recordForm.planType,
+          note: accountEmail || null,
+        },
+        editingRecordId,
+      )
+      resetRecordForm()
+    } finally {
+      setSavingRecord(false)
+    }
+  }
+
+  async function removeSubscriptionRecord(id: number) {
+    setDeletingRecordId(id)
+    try {
+      await onDeleteSubscriptionRecord(id)
+      if (editingRecordId === id) {
+        resetRecordForm()
+      }
+    } finally {
+      setDeletingRecordId(null)
+    }
   }
 
   async function handleSubmit() {
@@ -738,6 +918,159 @@ export function SettingsPanel({
                     }
                   />
                 </label>
+              </div>
+
+              <div className="subscription-record-list">
+                {subscriptionRecords.length === 0 ? (
+                  <div className="empty-state subscription-empty-state">
+                    {t.settings.sections.subscription.emptyRecords}
+                  </div>
+                ) : (
+                  subscriptionRecords.map((record) => (
+                    <div className="subscription-record-card subscription-record-summary-card" key={record.id}>
+                      <div className="subscription-record-summary-main">
+                        <span className="subscription-record-plan-badge">
+                          {formatPlanLabel(record.planType, t.settings.sections.subscription)}
+                        </span>
+                        <strong className="subscription-record-amount">
+                          {formatUsd(record.amountUsd, language)}
+                        </strong>
+                        <span className="field-note">
+                          {record.serviceStart} → {record.serviceEnd}
+                        </span>
+                      </div>
+                      <div className="subscription-record-summary-meta">
+                        {record.note ? (
+                          <span>{record.note}</span>
+                        ) : (
+                          <span>{t.settings.sections.subscription.accountEmailPlaceholder}</span>
+                        )}
+                      </div>
+                      <div className="subscription-record-actions">
+                        <button
+                          className="ghost-button"
+                          disabled={savingRecord || deletingRecordId === record.id}
+                          onClick={() => editSubscriptionRecord(record)}
+                          type="button"
+                        >
+                          {t.settings.sections.subscription.editRecord}
+                        </button>
+                        <button
+                          className="ghost-button"
+                          disabled={savingRecord || deletingRecordId === record.id}
+                          onClick={() => removeSubscriptionRecord(record.id)}
+                          type="button"
+                        >
+                          {deletingRecordId === record.id
+                            ? t.actions.saving
+                            : t.settings.sections.subscription.removeRecord}
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              <div className="subscription-record-editor">
+                <div className="settings-section-head">
+                  <p className="eyebrow">
+                    {editingRecordId
+                      ? t.settings.sections.subscription.editRecordTitle
+                      : t.settings.sections.subscription.addRecordTitle}
+                  </p>
+                  <h4>
+                    {editingRecordId
+                      ? t.settings.sections.subscription.updateRecord
+                      : t.settings.sections.subscription.addRecord}
+                  </h4>
+                </div>
+
+                <div className="subscription-record-grid">
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.planType}</span>
+                    <select
+                      value={recordForm.planType}
+                      onChange={(event) => updateRecordPlan(event.target.value as SubscriptionPlanOption)}
+                    >
+                      {planOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label} · {formatUsd(option.amountUsd, language)}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.amountUsd}</span>
+                    <input
+                      min={0}
+                      step={0.01}
+                      type="number"
+                      value={recordForm.amountUsd}
+                      onChange={(event) =>
+                        updateRecordForm({ amountUsd: Math.max(0, Number(event.target.value || 0)) })
+                      }
+                    />
+                  </label>
+
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.accountEmail}</span>
+                    <input
+                      placeholder={t.settings.sections.subscription.accountEmailPlaceholder}
+                      type="email"
+                      value={recordForm.accountEmail}
+                      onChange={(event) => updateRecordForm({ accountEmail: event.target.value })}
+                    />
+                  </label>
+
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.serviceStart}</span>
+                    <input
+                      type="date"
+                      value={recordForm.serviceStart}
+                      onChange={(event) => updateRecordServiceStart(event.target.value)}
+                    />
+                  </label>
+
+                  <label className="field">
+                    <span>{t.settings.sections.subscription.serviceEnd}</span>
+                    <input
+                      type="date"
+                      value={recordForm.serviceEnd}
+                      onChange={(event) => updateRecordForm({ serviceEnd: event.target.value })}
+                    />
+                  </label>
+
+                  <div className="subscription-record-form-actions">
+                    {editingRecordId ? (
+                      <button
+                        className="ghost-button"
+                        disabled={savingRecord}
+                        onClick={resetRecordForm}
+                        type="button"
+                      >
+                        {t.settings.sections.subscription.cancelEditRecord}
+                      </button>
+                    ) : null}
+                    <button
+                      className="accent-button"
+                      disabled={
+                        savingRecord ||
+                        !recordForm.serviceStart ||
+                        !recordForm.serviceEnd ||
+                        recordForm.serviceEnd <= recordForm.serviceStart
+                      }
+                      onClick={saveSubscriptionRecordForm}
+                      type="button"
+                    >
+                      {savingRecord
+                        ? t.actions.saving
+                        : editingRecordId
+                          ? t.settings.sections.subscription.updateRecord
+                          : t.settings.sections.subscription.saveRecord}
+                    </button>
+                  </div>
+                </div>
               </div>
             </section>
 

--- a/src/features/sources/SidebarSourceManager.tsx
+++ b/src/features/sources/SidebarSourceManager.tsx
@@ -1,0 +1,17 @@
+import { DatabaseZap } from 'lucide-react'
+
+import { useI18n } from '../../app/useI18n'
+
+interface SidebarSourceManagerProps {
+  onOpenManager: () => void
+}
+
+export function SidebarSourceManager({ onOpenManager }: SidebarSourceManagerProps) {
+  const { t } = useI18n()
+
+  return (
+    <button className="nav-button sidebar-source-nav-button" onClick={onOpenManager} type="button">
+      <DatabaseZap size={18} /> {t.sources.remoteSources}
+    </button>
+  )
+}

--- a/src/features/sources/SourceAddModal.tsx
+++ b/src/features/sources/SourceAddModal.tsx
@@ -1,0 +1,77 @@
+import { useI18n } from '../../app/useI18n'
+import type { CodexSource, CodexSourceCandidate } from '../../app/types'
+import { formatCandidateSubtitle } from './sourceUtils'
+
+interface SourceAddModalProps {
+  sources: CodexSource[]
+  candidates: CodexSourceCandidate[]
+  isOpen: boolean
+  message: string
+  onClose: () => void
+  onDiscover: () => void
+  onAddCandidate: (candidate: CodexSourceCandidate) => void
+}
+
+export function SourceAddModal({
+  sources,
+  candidates,
+  isOpen,
+  message,
+  onClose,
+  onDiscover,
+  onAddCandidate,
+}: SourceAddModalProps) {
+  const { t } = useI18n()
+  if (!isOpen) return null
+
+  const addedIds = new Set(sources.map((source) => source.id))
+  const visibleCandidates = candidates.filter((candidate) => !candidate.ignoredReason)
+
+  return (
+    <div className="modal-backdrop">
+      <section className="modal-panel source-modal-panel">
+        <div className="modal-header">
+          <div>
+            <p className="eyebrow">SSH</p>
+            <h3>{t.sources.addCodexServer}</h3>
+          </div>
+          <button className="ghost-button" onClick={onClose} type="button">
+            {t.actions.close}
+          </button>
+        </div>
+        <div className="source-modal-toolbar">
+          <button className="ghost-button" onClick={onDiscover} type="button">
+            {t.sources.refreshSshList}
+          </button>
+          <span>{t.sources.filteredHostsNote}</span>
+        </div>
+        <div className="source-candidate-list">
+          {visibleCandidates.length === 0 ? (
+            <div className="empty-state">{t.sources.noSshServersDiscovered}</div>
+          ) : (
+            visibleCandidates.map((candidate) => {
+              const alreadyAdded = addedIds.has(candidate.id)
+              return (
+                <article className="source-candidate-card" key={candidate.id}>
+                  <div>
+                    <strong>{candidate.label}</strong>
+                    <span>{formatCandidateSubtitle(candidate)}</span>
+                  </div>
+                  <button
+                    className="accent-button source-mini-button"
+                    disabled={alreadyAdded}
+                    onClick={() => onAddCandidate(candidate)}
+                    type="button"
+                  >
+                    {alreadyAdded ? t.sources.added : t.sources.add}
+                  </button>
+                </article>
+              )
+            })
+          )}
+        </div>
+        {message ? <p className="source-message source-message--modal">{message}</p> : null}
+      </section>
+    </div>
+  )
+}

--- a/src/features/sources/SourceDeleteDialog.tsx
+++ b/src/features/sources/SourceDeleteDialog.tsx
@@ -1,0 +1,43 @@
+import { useI18n } from '../../app/useI18n'
+import type { CodexSource } from '../../app/types'
+import { formatSourceSubtitle } from './sourceUtils'
+
+interface SourceDeleteDialogProps {
+  source: CodexSource | null
+  isDeleting: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+export function SourceDeleteDialog({
+  source,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: SourceDeleteDialogProps) {
+  const { t } = useI18n()
+  if (!source) return null
+
+  return (
+    <div className="modal-backdrop" onClick={isDeleting ? undefined : onCancel}>
+      <section className="modal-panel source-delete-panel" onClick={(event) => event.stopPropagation()}>
+        <div className="modal-header">
+          <div>
+            <p className="eyebrow">{t.sources.deleteServer}</p>
+            <h3>{t.sources.deleteServerTitle(source.label)}</h3>
+          </div>
+        </div>
+        <p className="source-delete-copy">{t.sources.deleteServerDescription}</p>
+        <p className="source-delete-address">{formatSourceSubtitle(source, t)}</p>
+        <div className="modal-actions">
+          <button className="ghost-button" disabled={isDeleting} onClick={onCancel} type="button">
+            {t.actions.cancel}
+          </button>
+          <button className="danger-button" disabled={isDeleting} onClick={onConfirm} type="button">
+            {isDeleting ? t.sources.deleting : t.sources.confirmDelete}
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/features/sources/SourceManagerModal.tsx
+++ b/src/features/sources/SourceManagerModal.tsx
@@ -1,0 +1,119 @@
+import { DatabaseZap, Trash2 } from 'lucide-react'
+
+import { useI18n } from '../../app/useI18n'
+import type { CodexSource } from '../../app/types'
+import { formatSourceStatus, formatSourceSubtitle } from './sourceUtils'
+
+interface SourceManagerModalProps {
+  sources: CodexSource[]
+  downloadingSourceIds: Set<string>
+  deletingSourceIds: Set<string>
+  isOpen: boolean
+  message: string
+  onClose: () => void
+  onOpenAddModal: () => void
+  onDownloadSource: (sourceId: string) => void
+  onDownloadAllSources: () => void
+  onDeleteSource: (source: CodexSource) => void
+}
+
+export function SourceManagerModal({
+  sources,
+  downloadingSourceIds,
+  deletingSourceIds,
+  isOpen,
+  message,
+  onClose,
+  onOpenAddModal,
+  onDownloadSource,
+  onDownloadAllSources,
+  onDeleteSource,
+}: SourceManagerModalProps) {
+  const { t } = useI18n()
+  if (!isOpen) return null
+
+  const remoteSources = sources.filter((source) => source.kind === 'ssh')
+  const hasRemoteSources = remoteSources.length > 0
+  const anyBusy = remoteSources.some(
+    (source) => downloadingSourceIds.has(source.id) || deletingSourceIds.has(source.id),
+  )
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <section className="modal-panel source-manager-modal" onClick={(event) => event.stopPropagation()}>
+        <div className="modal-header source-manager-modal-header">
+          <div className="source-manager-title">
+            <div className="sidebar-source-trigger-icon source-manager-title-icon" aria-hidden="true">
+              <DatabaseZap size={20} />
+            </div>
+            <div>
+              <p className="eyebrow">{t.sources.remoteSources}</p>
+              <h3>SSH Codex</h3>
+            </div>
+          </div>
+          <button className="ghost-button" onClick={onClose} type="button">
+            {t.actions.close}
+          </button>
+        </div>
+
+        <div className="source-manager-actions">
+          <button className="ghost-button sidebar-source-action" onClick={onOpenAddModal} type="button">
+            {t.sources.addSsh}
+          </button>
+          <button
+            className="ghost-button sidebar-source-action sidebar-source-action--update"
+            disabled={!hasRemoteSources || anyBusy}
+            onClick={onDownloadAllSources}
+            type="button"
+          >
+            {t.sources.updateAll}
+          </button>
+        </div>
+
+        <div className="source-manager-list">
+          {remoteSources.length === 0 ? (
+            <p className="sidebar-source-empty">{t.sources.noRemoteSources}</p>
+          ) : (
+            remoteSources.map((source) => {
+              const downloading = downloadingSourceIds.has(source.id)
+              const deleting = deletingSourceIds.has(source.id)
+              const busy = downloading || deleting
+              return (
+                <article className="source-manager-item" key={source.id}>
+                  <div className="sidebar-source-title-row">
+                    <strong title={source.label}>{source.label}</strong>
+                    <span className={`source-status source-status--${source.status}`}>{formatSourceStatus(source, t)}</span>
+                  </div>
+                  <small title={formatSourceSubtitle(source, t)}>{formatSourceSubtitle(source, t)}</small>
+                  <div className="sidebar-source-row-actions">
+                    <button
+                      className="ghost-button source-mini-button"
+                      disabled={busy}
+                      onClick={() => onDownloadSource(source.id)}
+                      type="button"
+                    >
+                      {downloading ? t.sources.updating : t.sources.update}
+                    </button>
+                    <button
+                      aria-label={t.sources.deleteSourceLabel(source.label)}
+                      className="ghost-button source-icon-button source-danger-button"
+                      disabled={busy}
+                      onClick={() => onDeleteSource(source)}
+                      title={deleting ? t.sources.deleting : t.sources.deleteSource}
+                      type="button"
+                    >
+                      <Trash2 aria-hidden="true" size={14} />
+                    </button>
+                  </div>
+                  {busy ? <div className="source-progress"><span /></div> : null}
+                  {source.lastError ? <p className="source-error">{source.lastError}</p> : null}
+                </article>
+              )
+            })
+          )}
+        </div>
+        {message ? <p className="source-message sidebar-source-message source-manager-message">{message}</p> : null}
+      </section>
+    </div>
+  )
+}

--- a/src/features/sources/SourceSelectorPanel.tsx
+++ b/src/features/sources/SourceSelectorPanel.tsx
@@ -1,0 +1,66 @@
+import { ChevronDown } from 'lucide-react'
+
+import { useI18n } from '../../app/useI18n'
+import type { CodexSource } from '../../app/types'
+import { formatSourceStatus, formatSourceSubtitle, sourceSelectionSummary } from './sourceUtils'
+
+interface SourceSelectorPanelProps {
+  sources: CodexSource[]
+  isOpen: boolean
+  message: string
+  onToggleOpen: () => void
+  onToggleSource: (source: CodexSource, selected: boolean) => void
+}
+
+export function SourceSelectorPanel({
+  sources,
+  isOpen,
+  message,
+  onToggleOpen,
+  onToggleSource,
+}: SourceSelectorPanelProps) {
+  const { t } = useI18n()
+  const selectedCount = sources.filter((source) => source.selected).length
+  const remoteCount = sources.filter((source) => source.kind === 'ssh').length
+  const selectedSummary = sourceSelectionSummary(sources, t)
+
+  return (
+    <section className="source-picker">
+      <span className="time-filter-label">{t.sources.label}</span>
+      <button className={`source-picker-trigger ${isOpen ? 'active' : ''}`} onClick={onToggleOpen} type="button">
+        <span>{selectedSummary}</span>
+        <small>
+          {selectedCount}/{sources.length || 1}
+          {remoteCount > 0 ? ` · SSH ${remoteCount}` : ''}
+        </small>
+        <ChevronDown aria-hidden="true" size={16} />
+      </button>
+      {isOpen ? (
+        <div className="source-popover">
+          <div className="source-popover-header">
+            <span>{t.sources.chooseSources}</span>
+          </div>
+          <div className="source-list">
+            {sources.map((source) => (
+              <article className="source-row source-row--select" key={source.id}>
+                <label className="source-row-main">
+                  <input
+                    checked={source.selected}
+                    onChange={(event) => onToggleSource(source, event.target.checked)}
+                    type="checkbox"
+                  />
+                  <span>
+                    <strong>{source.label}</strong>
+                    <small>{formatSourceSubtitle(source, t)}</small>
+                  </span>
+                </label>
+                <span className={`source-status source-status--${source.status}`}>{formatSourceStatus(source, t)}</span>
+              </article>
+            ))}
+          </div>
+          {message ? <p className="source-message source-message--picker">{message}</p> : null}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/features/sources/index.ts
+++ b/src/features/sources/index.ts
@@ -1,0 +1,6 @@
+export { SourceAddModal } from './SourceAddModal'
+export { SourceDeleteDialog } from './SourceDeleteDialog'
+export { SourceManagerModal } from './SourceManagerModal'
+export { SourceSelectorPanel } from './SourceSelectorPanel'
+export { SidebarSourceManager } from './SidebarSourceManager'
+export { upsertSourceInList } from './sourceUtils'

--- a/src/features/sources/sourceUtils.ts
+++ b/src/features/sources/sourceUtils.ts
@@ -1,0 +1,55 @@
+import type { TranslationSet } from '../../app/i18n'
+import type { CodexSource, CodexSourceCandidate } from '../../app/types'
+
+export function sourceSelectionSummary(sources: CodexSource[], t: TranslationSet) {
+  if (sources.length === 0) {
+    return 'localhost'
+  }
+  const selected = sources.filter((source) => source.selected)
+  if (selected.length === 0) {
+    return t.sources.noneSelected
+  }
+  if (selected.length === sources.length) {
+    const remoteCount = sources.filter((source) => source.kind === 'ssh').length
+    return remoteCount > 0 ? `localhost + ${remoteCount}` : 'localhost'
+  }
+  const labels = selected.slice(0, 2).map((source) => source.label).join(t.sources.listSeparator)
+  return selected.length > 2 ? `${labels} +${selected.length - 2}` : labels
+}
+
+export function upsertSourceInList(sources: CodexSource[], source: CodexSource) {
+  const exists = sources.some((item) => item.id === source.id)
+  const next = exists
+    ? sources.map((item) => (item.id === source.id ? source : item))
+    : [...sources, source]
+  return next.sort((left, right) => {
+    if (left.id === 'local') return -1
+    if (right.id === 'local') return 1
+    return left.label.localeCompare(right.label)
+  })
+}
+
+export function formatSourceSubtitle(source: CodexSource, t: TranslationSet) {
+  if (source.kind === 'local') {
+    return source.localCodexHome || t.sources.localCodexHome
+  }
+  const address = [source.user, source.hostName || source.sshAlias]
+    .filter(Boolean)
+    .join('@')
+  return `${address}${source.port ? `:${source.port}` : ''} · ${source.remoteCodexHome || '~/.codex'}`
+}
+
+export function formatCandidateSubtitle(candidate: CodexSourceCandidate) {
+  const address = [candidate.user, candidate.hostName || candidate.sshAlias].filter(Boolean).join('@')
+  return `${address}${candidate.port ? `:${candidate.port}` : ''} · ${candidate.remoteCodexHome}`
+}
+
+export function formatSourceStatus(source: CodexSource, t: TranslationSet) {
+  if (source.kind === 'local') return t.sources.local
+  if (source.status === 'ready') {
+    return source.lastDownloadedAt ? t.sources.cached : t.sources.added
+  }
+  if (source.status === 'failed') return t.sources.failed
+  if (source.status === 'downloading') return t.sources.downloading
+  return t.sources.notDownloaded
+}

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -243,6 +243,7 @@ export function MenuBarPopup() {
           <>
             <section className="popup-hero-grid">
               <QuotaRingCard
+                available={Boolean(snapshot.quota5h)}
                 label={t.buckets.five_hour}
                 percent={snapshot.quota5h?.remainingPercent ?? 0}
                 timePercent={computeRemainingTimePercent(snapshot.quota5h?.resetsAt ?? null, snapshot.quota5h?.windowStart ?? null)}
@@ -254,6 +255,7 @@ export function MenuBarPopup() {
                 tone="warm"
               />
               <QuotaRingCard
+                available={Boolean(snapshot.quota7d)}
                 label={t.buckets.seven_day}
                 percent={snapshot.quota7d?.remainingPercent ?? 0}
                 timePercent={computeRemainingTimePercent(snapshot.quota7d?.resetsAt ?? null, snapshot.quota7d?.windowStart ?? null)}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2142,3 +2142,517 @@ select:focus-visible {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Source management */
+.sidebar-source-nav-button {
+  width: 100%;
+}
+
+.time-filter-label {
+  padding-left: 8px;
+  color: var(--text-faint);
+  font-size: 10px;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.danger-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border: 1px solid rgba(248, 113, 113, 0.32);
+  border-radius: 16px;
+  padding: 12px 14px;
+  background: rgba(127, 29, 29, 0.28);
+  color: #fecaca;
+  font-weight: 800;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.danger-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(248, 113, 113, 0.48);
+  background: rgba(153, 27, 27, 0.34);
+  box-shadow: var(--shadow-soft);
+}
+
+.danger-button:disabled {
+  opacity: 0.58;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.source-picker {
+  position: relative;
+  display: grid;
+  gap: 5px;
+  min-width: 164px;
+  max-width: 230px;
+  z-index: 50;
+}
+
+.source-picker-trigger {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "title icon"
+    "meta icon";
+  align-items: center;
+  column-gap: 10px;
+  min-height: 46px;
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 17px;
+  border: 1px solid var(--line-subtle);
+  background: rgba(7, 13, 24, 0.62);
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.source-picker-trigger.active {
+  border-color: rgba(96, 165, 250, 0.42);
+  background: rgba(15, 38, 78, 0.56);
+}
+
+.source-picker-trigger span {
+  grid-area: title;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-strong);
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.source-picker-trigger small {
+  grid-area: meta;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.source-picker-trigger svg {
+  grid-area: icon;
+  color: var(--text-muted);
+}
+
+.source-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  z-index: 80;
+  width: min(420px, 88vw);
+  min-width: min(360px, 88vw);
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 18px;
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  background: rgba(9, 15, 27, 0.97);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32);
+}
+
+.source-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 2px 2px 6px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.source-list,
+.source-candidate-list {
+  display: grid;
+  gap: 7px;
+}
+
+.source-list {
+  max-height: min(48vh, 420px);
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.source-row,
+.source-candidate-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.11);
+}
+
+.source-row-main {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.source-row-main input {
+  flex: none;
+  accent-color: var(--accent-blue);
+}
+
+.source-row-main span,
+.source-candidate-card > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.source-row-main strong,
+.source-candidate-card strong {
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-row-main small,
+.source-candidate-card span,
+.source-modal-toolbar span,
+.source-message {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-modal-toolbar,
+.sidebar-source-title-row,
+.sidebar-source-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.sidebar-source-title-row {
+  justify-content: space-between;
+}
+
+.sidebar-source-row-actions,
+.source-modal-toolbar {
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+}
+
+.source-status {
+  flex: none;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.09);
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  white-space: nowrap;
+}
+
+.source-status--ready {
+  background: rgba(34, 197, 94, 0.12);
+  color: #a7f3d0;
+}
+
+.source-status--failed {
+  background: rgba(248, 113, 113, 0.12);
+  color: #fecaca;
+}
+
+.source-status--downloading {
+  background: rgba(96, 165, 250, 0.14);
+  color: #bfdbfe;
+}
+
+.source-mini-button {
+  min-height: 34px;
+  padding: 7px 10px;
+  border-radius: 12px;
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.source-icon-button {
+  min-width: 34px;
+  min-height: 34px;
+  justify-content: center;
+  padding: 7px;
+  border-radius: 12px;
+}
+
+.source-danger-button {
+  color: #fecaca;
+  border-color: rgba(248, 113, 113, 0.18);
+  background: rgba(127, 29, 29, 0.16);
+}
+
+.source-progress {
+  grid-column: 1 / -1;
+  height: 5px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.12);
+}
+
+.source-progress span {
+  display: block;
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent-blue), var(--accent-amber));
+  animation: source-progress-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes source-progress-slide {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(260%); }
+}
+
+.source-error {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: #fecaca;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.sidebar-source-trigger-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 13px;
+  color: #dbeafe;
+  background:
+    linear-gradient(135deg, rgba(96, 165, 250, 0.26), rgba(30, 64, 175, 0.18)),
+    rgba(15, 23, 42, 0.54);
+  border: 1px solid rgba(96, 165, 250, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.sidebar-source-action {
+  min-height: 34px;
+  justify-content: center;
+  padding: 7px 9px;
+  border-radius: 12px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.sidebar-source-action--update {
+  background: rgba(59, 130, 246, 0.14);
+  border-color: rgba(96, 165, 250, 0.22);
+}
+
+.sidebar-source-empty {
+  margin: 0;
+  padding: 10px;
+  border-radius: 14px;
+  color: var(--text-muted);
+  background: rgba(15, 23, 42, 0.42);
+  border: 1px dashed rgba(148, 163, 184, 0.14);
+  font-size: 0.82rem;
+}
+
+.sidebar-source-title-row strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-strong);
+  font-size: 0.86rem;
+}
+
+.sidebar-source-message {
+  margin: 0;
+  white-space: normal;
+  line-height: 1.35;
+}
+
+.source-manager-modal {
+  width: min(760px, 100%);
+}
+
+.source-manager-modal-header {
+  align-items: center;
+}
+
+.source-manager-title {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+.source-manager-title h3 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 1.35rem;
+  line-height: 1.1;
+}
+
+.source-manager-title-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+}
+
+.source-manager-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.source-manager-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  max-height: min(52vh, 520px);
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.source-manager-item {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding: 14px;
+  border-radius: 17px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.source-manager-item .sidebar-source-title-row strong {
+  max-width: none;
+  font-size: 0.94rem;
+}
+
+.source-manager-item > small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.source-manager-message {
+  margin-top: 12px;
+}
+
+.source-modal-panel {
+  width: min(780px, calc(100vw - 32px));
+  padding: 22px;
+  gap: 0;
+  border-radius: 22px;
+  background: rgba(11, 17, 28, 0.98);
+  box-shadow: 0 22px 54px rgba(2, 8, 23, 0.42);
+}
+
+.source-modal-toolbar {
+  justify-content: flex-start;
+  gap: 10px 12px;
+  flex-wrap: wrap;
+  margin: 14px 0 12px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.11);
+}
+
+.source-modal-toolbar span {
+  flex: 1 1 260px;
+  min-width: 0;
+  white-space: normal;
+  line-height: 1.45;
+}
+
+.source-delete-panel {
+  width: min(520px, 100%);
+}
+
+.source-delete-copy {
+  margin: 12px 0 0;
+  color: var(--text-primary);
+  line-height: 1.55;
+}
+
+.source-delete-address {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.54);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  color: var(--text-muted);
+  font-size: 0.84rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-candidate-list {
+  max-height: min(54vh, 520px);
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.source-modal-panel .source-candidate-list {
+  max-height: min(58vh, 500px);
+  padding: 1px 4px 1px 0;
+}
+
+.source-modal-panel .source-candidate-card {
+  min-height: 64px;
+  padding: 12px 14px;
+  border-radius: 15px;
+  background: rgba(15, 23, 42, 0.42);
+  border-color: rgba(148, 163, 184, 0.12);
+}
+
+.source-modal-panel .source-candidate-card strong {
+  font-family: 'Fira Sans', sans-serif;
+  font-size: 0.98rem;
+  letter-spacing: -0.015em;
+}
+
+.source-modal-panel .source-candidate-card span {
+  white-space: normal;
+  line-height: 1.35;
+}
+
+.source-modal-panel .source-mini-button {
+  min-width: 70px;
+  justify-content: center;
+  border-radius: 12px;
+  background: #f59e0b;
+  box-shadow: none;
+  font-weight: 700;
+}
+
+.source-modal-panel .source-mini-button:hover {
+  background: #fbbf24;
+  box-shadow: none;
+}
+
+.source-modal-panel .source-mini-button:disabled {
+  opacity: 1;
+  background: rgba(148, 163, 184, 0.13);
+  border-color: rgba(148, 163, 184, 0.14);
+  color: var(--text-muted);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1879,6 +1879,96 @@ select:focus-visible {
   font-family: 'Fira Code', monospace;
 }
 
+.subscription-record-card {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid var(--line-subtle);
+  background: rgba(7, 13, 24, 0.48);
+}
+
+.subscription-record-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.subscription-record-list {
+  display: grid;
+  gap: 12px;
+}
+
+.subscription-record-summary-card {
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 14px;
+}
+
+.subscription-record-summary-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.subscription-record-plan-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 78px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 179, 237, 0.28);
+  background: rgba(38, 94, 145, 0.18);
+  color: var(--text-strong);
+  font-weight: 700;
+}
+
+.subscription-record-amount {
+  color: var(--text-strong);
+  font-family: 'Fira Code', monospace;
+}
+
+.subscription-record-summary-meta {
+  min-width: 140px;
+  max-width: 260px;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.subscription-record-editor {
+  display: grid;
+  gap: 14px;
+  margin-top: 4px;
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 35%),
+    rgba(7, 13, 24, 0.54);
+}
+
+.subscription-record-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subscription-record-form-actions {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.subscription-empty-state {
+  padding: 24px 16px;
+}
+
 .modal-actions {
   justify-content: flex-end;
   margin-top: 16px;
@@ -1910,8 +2000,15 @@ select:focus-visible {
   .conversation-layout,
   .share-layout,
   .settings-grid,
+  .subscription-record-grid,
+  .subscription-record-summary-card,
   .detail-metrics {
     grid-template-columns: 1fr;
+  }
+
+  .subscription-record-form-actions,
+  .subscription-record-summary-meta {
+    justify-content: flex-start;
   }
 
   .field-span-2,

--- a/src/styles.css
+++ b/src/styles.css
@@ -842,6 +842,10 @@ select:focus-visible {
   color: #76c5ff;
 }
 
+.quota-ring-card--empty {
+  color: rgba(244, 234, 214, 0.52);
+}
+
 .quota-ring-visual {
   position: relative;
   width: 136px;
@@ -893,6 +897,16 @@ select:focus-visible {
 
 .quota-ring-card--cool .quota-ring-progress--inner {
   stroke: rgba(118, 197, 255, 0.62);
+}
+
+.quota-ring-card--empty .quota-ring-progress {
+  opacity: 0;
+}
+
+.quota-ring-card--empty .quota-ring-track {
+  stroke-dasharray: 3 8;
+  stroke-linecap: round;
+  stroke: rgba(255, 255, 255, 0.12);
 }
 
 .quota-ring-copy {
@@ -1032,17 +1046,39 @@ select:focus-visible {
 
 .popup-seven-day-chart {
   position: relative;
+  display: grid;
+  gap: 8px;
   padding: 2px 0 4px;
   overflow: visible;
 }
 
+.popup-seven-day-badges {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  padding: 0 2px;
+}
+
+.popup-seven-day-empty {
+  min-height: 148px;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.035);
+  color: rgba(244, 234, 214, 0.64);
+  text-align: center;
+}
+
 .popup-seven-day-speed-badge,
 .popup-seven-day-value-badge {
-  position: absolute;
-  z-index: 1;
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
   min-height: 28px;
   padding: 5px 9px;
   border-radius: 999px;
@@ -1053,13 +1089,11 @@ select:focus-visible {
 }
 
 .popup-seven-day-speed-badge {
-  top: 18px;
-  right: 18px;
+  flex: 0 0 auto;
 }
 
 .popup-seven-day-value-badge {
-  bottom: 18px;
-  left: 18px;
+  flex: 0 1 auto;
   background: rgba(68, 38, 9, 0.78);
   border-color: rgba(255, 179, 107, 0.42);
 }
@@ -1071,6 +1105,13 @@ select:focus-visible {
   font-size: 0.82rem;
   line-height: 1;
   font-variant-numeric: tabular-nums;
+}
+
+.popup-seven-day-badge-label {
+  color: rgba(244, 234, 214, 0.68);
+  font-size: 0.68rem;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .popup-seven-day-speed-badge--fast {
@@ -1095,6 +1136,7 @@ select:focus-visible {
   display: block;
   width: 100%;
   height: auto;
+  margin-top: -2px;
 }
 
 .popup-seven-day-plot {
@@ -1142,6 +1184,53 @@ select:focus-visible {
   fill: #fff7e8;
   stroke: #76c5ff;
   stroke-width: 2.2;
+}
+
+.popup-seven-day-legend {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px 12px;
+  flex-wrap: wrap;
+  padding: 2px 4px 0;
+  color: rgba(244, 234, 214, 0.68);
+  font-size: 0.68rem;
+  line-height: 1.2;
+}
+
+.popup-seven-day-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.popup-seven-day-legend-mark {
+  display: inline-block;
+  flex: 0 0 auto;
+}
+
+.popup-seven-day-legend-mark--remaining {
+  width: 20px;
+  height: 3px;
+  border-radius: 999px;
+  background: #76c5ff;
+  box-shadow: 0 0 10px rgba(118, 197, 255, 0.26);
+}
+
+.popup-seven-day-legend-mark--reference {
+  width: 20px;
+  height: 0;
+  border-top: 2px dashed rgba(255, 218, 160, 0.78);
+}
+
+.popup-seven-day-legend-mark--current {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #fff7e8;
+  border: 2px solid #76c5ff;
+  box-shadow: 0 0 10px rgba(118, 197, 255, 0.32);
 }
 
 .popup-reset-row,


### PR DESCRIPTION
## Summary
- Harden the menu bar quota rings so missing 5h/7d live quota windows render as unavailable (`—`) instead of looking like real 0% usage.
- Add a clearer 7-day popup chart presentation with a localized API value badge, an empty state, and a legend for remaining quota, the time baseline, and the current point.
- Add the Chinese and English popup copy plus CSS needed for the new chart/empty/legend states.

## Stacking note
This draft PR is stacked on #11, which is stacked on #10, #9, #8, and #7. It should be reviewed after the earlier PRs land; until then GitHub may show the earlier stacked commits in the combined diff.

## Validation
- `cargo test`
- `npm test`
- `npm run build`
- `git diff --check`
