### PR TITLE
Prepare v1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-05-19
+
+### Changed
+- database query access now uses versioned SQL query files and smaller persistence modules for cleaner release maintenance
+- public release documentation now points to the macOS DMG-only GitHub Release flow while Windows installer publishing remains paused
+
+### Fixed
+- token usage imports now treat cumulative snapshots as monotonic high-water marks so Codex state resets, replayed files, or process restarts do not rebill already-counted tokens
+- existing overcounted token usage rows are repaired once on the next scan, with failed source files tracked for targeted retry instead of forcing full repeated reimports
+
 ## [1.1.1] - 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ English | [简体中文](./README.zh-CN.md)
 
 **Codex Pacer** is a local-first desktop app for understanding Codex usage as pace, value, and session-level activity. It helps you see how quickly you are consuming quota, what that usage is worth in API-equivalent terms, and which conversations or subagents are driving it.
 
-> Current stable release: **v1.1.1**
-> Official downloads: signed and notarized **macOS Apple Silicon DMG** and unsigned **Windows NSIS setup EXE** via GitHub Releases
+> Current stable release: **v1.1.2**
+> Official download: signed **macOS Apple Silicon DMG** via GitHub Releases. Windows installer publishing is paused for this release.
 
 ## Highlights
 
@@ -39,13 +39,13 @@ Codex Pacer is local-first:
 
 ## Getting started
 
-The documentation set for installation, packaging, and release notes is maintained for the public `v1.1.1` release. Start with:
+The documentation set for installation, packaging, and release notes is maintained for the public `v1.1.2` release. Start with:
 
 - [Getting started](./docs/en/getting-started.md)
 - [Installing on macOS](./docs/en/installing-on-macos.md)
 - [Installing on Windows](./docs/en/installing-on-windows.md)
 - [Packaging and release](./docs/en/packaging-and-release.md)
-- [Release notes for v1.1.1](./docs/en/release-notes-v1.1.1.md)
+- [Release notes for v1.1.2](./docs/en/release-notes-v1.1.2.md)
 
 ## Development
 
@@ -80,12 +80,12 @@ npm run tauri build
 
 ## Project status
 
-`v1.1.1` is the current stable release line.
+`v1.1.2` is the current stable release line.
 
 Current release packaging focus:
 
-- officially released: signed and notarized macOS Apple Silicon DMG
-- officially released: unsigned Windows NSIS setup EXE
+- officially released: signed macOS Apple Silicon DMG
+- paused for this release: Windows NSIS setup EXE
 - source build support: additional Tauri-compatible desktop environments
 
 ## Open source

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,8 +8,8 @@
 
 **Codex Pacer** 是一个本地优先的桌面应用，用来把 Codex 使用情况转换成更容易行动的视角：额度节奏、API 等价价值，以及会话级别的使用分析。你可以更快看清自己消耗额度的速度、订阅回报，以及哪些对话或 subagent 正在驱动这些使用量。
 
-> 当前稳定版本：**v1.1.1**
-> 官方下载：通过 GitHub Releases 获取已签名并完成 notarization 的 **macOS Apple Silicon DMG**，以及未签名的 **Windows NSIS setup EXE**
+> 当前稳定版本：**v1.1.2**
+> 官方下载：通过 GitHub Releases 获取已签名的 **macOS Apple Silicon DMG**。本版本暂缓发布 Windows 安装包。
 
 ## 核心能力
 
@@ -39,13 +39,13 @@ Codex Pacer 是本地优先的：
 
 ## 开始使用
 
-安装、打包和发布说明已按公开 `v1.1.1` 版本维护。可以从这些文档入口开始：
+安装、打包和发布说明已按公开 `v1.1.2` 版本维护。可以从这些文档入口开始：
 
 - [快速开始](./docs/zh-CN/getting-started.md)
 - [在 macOS 上安装](./docs/zh-CN/installing-on-macos.md)
 - [在 Windows 上安装](./docs/zh-CN/installing-on-windows.md)
 - [打包与发布](./docs/zh-CN/packaging-and-release.md)
-- [v1.1.1 发布说明](./docs/zh-CN/release-notes-v1.1.1.md)
+- [v1.1.2 发布说明](./docs/zh-CN/release-notes-v1.1.2.md)
 
 ## 开发
 
@@ -80,12 +80,12 @@ npm run tauri build
 
 ## 项目状态
 
-`v1.1.1` 是当前稳定发布线。
+`v1.1.2` 是当前稳定发布线。
 
 当前发布重点：
 
-- 官方发布：已签名并完成 notarization 的 macOS Apple Silicon DMG
-- 官方发布：未签名的 Windows NSIS setup EXE
+- 官方发布：已签名的 macOS Apple Silicon DMG
+- 本版本暂缓：Windows NSIS setup EXE
 - 源码构建：其他兼容 Tauri 的桌面环境
 
 ## 开源协作

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -12,7 +12,7 @@ It is built to help you answer practical questions such as:
 
 ## Requirements
 
-- Apple Silicon macOS for the stable packaged app, or Windows for the test-stage installer
+- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.1.2`.
 - Local Codex data under `~/.codex` or a custom `CODEX_HOME`
 
 For development from source, you will also need:
@@ -26,7 +26,7 @@ For development from source, you will also need:
 Official public downloads are published through GitHub Releases:
 
 - signed **macOS Apple Silicon DMG**
-- unsigned **Windows NSIS setup EXE** as a test-stage asset
+- no Windows installer is attached to `v1.1.2`; use the Windows guide only for source validation
 
 Start here:
 
@@ -57,7 +57,7 @@ Use this for UI work only. Tauri-only features are limited or mocked in browser 
 
 ## First-time setup inside the app
 
-1. Launch **Codex Pacer** from `Applications` on macOS or the Start menu on Windows.
+1. Launch **Codex Pacer** from `Applications` on macOS, or from a local development build on Windows.
 2. Open **Settings**.
 3. Confirm the Codex home path (`~/.codex` by default) or point it to a custom `CODEX_HOME`.
 4. Run the first scan/import.

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -25,7 +25,7 @@ For development from source, you will also need:
 
 Official public downloads are published through GitHub Releases:
 
-- signed and notarized **macOS Apple Silicon DMG**
+- signed **macOS Apple Silicon DMG**
 - unsigned **Windows NSIS setup EXE** as a test-stage asset
 
 Start here:
@@ -106,4 +106,4 @@ npm run tauri build
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Packaging and release](./packaging-and-release.md)
-- [Release notes for v1.1.1](./release-notes-v1.1.1.md)
+- [Release notes for v1.1.2](./release-notes-v1.1.2.md)

--- a/docs/en/installing-on-macos.md
+++ b/docs/en/installing-on-macos.md
@@ -2,7 +2,7 @@
 
 ## macOS install path
 
-The macOS public installer for **Codex Pacer** is the signed and notarized **Apple Silicon DMG** published through GitHub Releases.
+The macOS public installer for **Codex Pacer** is the signed **Apple Silicon DMG** published through GitHub Releases.
 
 ## Happy path
 

--- a/docs/en/installing-on-windows.md
+++ b/docs/en/installing-on-windows.md
@@ -1,22 +1,22 @@
 # Installing on Windows
 
-## Windows test-stage install path
+## Windows test-stage status
 
-The Windows public installer for **Codex Pacer** is the NSIS setup `.exe` published through GitHub Releases.
+Windows installer publishing is paused for `v1.1.2`. No Windows setup `.exe` is attached to the current stable GitHub Release.
 
-Windows support is currently in a test stage. The Windows installer is unsigned unless Windows code signing is separately configured for a release, and Windows SmartScreen may warn that the publisher is unknown.
+Windows support is currently in a test stage. When a future release includes a Windows installer, it is unsigned unless Windows code signing is separately configured for that release, and Windows SmartScreen may warn that the publisher is unknown.
 
-## Standard install flow
+## Source validation flow
 
-1. Open the latest GitHub Releases page for `codex-pacer`.
-2. Download the latest Windows NSIS setup `.exe`.
-3. Run the downloaded setup file.
-4. If SmartScreen warns about an unknown publisher, confirm that the file came from the project GitHub Release before continuing.
-5. Launch **Codex Pacer** from the Start menu after installation.
+1. Check out the release tag from the GitHub repository.
+2. Install the Windows Tauri prerequisites.
+3. Run `npm ci`.
+4. Run `npm run lint`, `npm run build`, and `cargo test --manifest-path src-tauri/Cargo.toml --locked`.
+5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.1.2` on Windows.
 
 ## After installation
 
-On first run:
+When testing a local Windows build:
 
 1. Confirm the Codex home path (`~\.codex` by default) or choose a custom `CODEX_HOME`.
 2. Make sure local Codex CLI session and rate-limit data already exist at that path.
@@ -27,6 +27,7 @@ On first run:
 ## Notes
 
 - GitHub Releases is the official distribution channel.
-- The Windows setup `.exe` is a test-stage NSIS installer.
-- The installer does not install the Codex CLI and does not create Codex usage history.
+- `v1.1.2` only publishes the macOS Apple Silicon DMG asset.
+- Any locally built Windows setup `.exe` remains a test-stage NSIS installer.
+- A Windows installer does not install the Codex CLI and does not create Codex usage history.
 - Stable Windows support, Windows code signing, and auto-update delivery are not currently promised.

--- a/docs/en/packaging-and-release.md
+++ b/docs/en/packaging-and-release.md
@@ -6,11 +6,11 @@ The stable public release of **Codex Pacer** is distributed through **GitHub Rel
 
 The stable packaged asset is:
 
-- signed and notarized **macOS Apple Silicon DMG**
+- signed **macOS Apple Silicon DMG**
 
-Windows is currently published as a test-stage asset:
+Windows installer publishing is paused for `v1.1.2`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
 
-- unsigned **Windows NSIS setup EXE** for compatibility testing and early validation
+- unsigned **Windows NSIS setup EXE** for local compatibility testing and early validation only
 
 Items that are **not currently promised** as official release assets:
 
@@ -29,7 +29,7 @@ The intended public release flow is:
 
 1. Confirm public branding and documentation are ready for release.
 2. Build the signed macOS Apple Silicon DMG.
-3. Build the unsigned Windows NSIS setup EXE when the release includes a Windows test-stage asset.
+3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.1.2`.
 4. Publish the release assets through GitHub Releases.
 5. Attach or include release notes for the tagged version.
 
@@ -39,15 +39,15 @@ Public release preparation is driven by the release scripts below:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.1
-./scripts/release/publish-github-release.sh 1.1.1
+./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/publish-github-release.sh 1.1.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.1
+.\scripts\release\build-windows-release.ps1 1.1.2
 ```
 
-Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed and notarized DMG, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; upload the Windows EXE and checksum as test-stage release assets for releases that include Windows.
+Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.1.2`.
 
 ## Platform isolation rules
 
@@ -68,16 +68,16 @@ Windows-specific tray popup placement, hidden child-process windows, and unsigne
 - verify the generated DMG opens correctly on Apple Silicon macOS
 - verify the signed app launches from `Applications`
 - verify the macOS menu bar popup opens below the menu bar and macOS-only Dock settings remain macOS-only
-- verify the generated Windows setup EXE installs on Windows
-- verify the Windows tray popup opens above a bottom taskbar, grows upward as optional modules are shown, and live quota refresh does not show a console window
-- verify the Windows installer checksum and note that it is test-stage and unsigned unless signing was separately configured
+- when running local Windows validation, verify the generated Windows setup EXE installs on Windows
+- when running local Windows validation, verify the Windows tray popup opens above a bottom taskbar, grows upward as optional modules are shown, and live quota refresh does not show a console window
+- when running local Windows validation, verify the Windows installer checksum and note that it is test-stage and unsigned unless signing was separately configured
 
 ## Publishing guidance
 
 - Create the Git tag for the stable release version.
 - Create the GitHub Release from that tag.
-- Upload the signed and notarized Apple Silicon DMG.
-- Upload the unsigned Windows NSIS setup EXE as a test-stage asset when the Windows release script has been run.
+- Upload the signed Apple Silicon DMG.
+- Do not upload a Windows NSIS setup EXE for `v1.1.2`.
 - Add the matching release notes document for the version being published.
 - Verify the download and install flow after publication.
 
@@ -88,9 +88,9 @@ GitHub Releases is more than a file host in the current workflow. It is the publ
 For public docs and announcements, use this message consistently:
 
 - official distribution channel: GitHub Releases
-- stable release asset: signed and notarized macOS Apple Silicon DMG
-- Windows test-stage asset: unsigned Windows NSIS setup EXE
-- current stable line: `v1.1.1`
+- stable release asset: signed macOS Apple Silicon DMG
+- Windows installer: paused for `v1.1.2`
+- current stable line: `v1.1.2`
 
 ## Related docs
 
@@ -98,4 +98,4 @@ For public docs and announcements, use this message consistently:
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Release runbook](./release-runbook.md)
-- [Release notes for v1.1.1](./release-notes-v1.1.1.md)
+- [Release notes for v1.1.2](./release-notes-v1.1.2.md)

--- a/docs/en/release-notes-v1.1.1.md
+++ b/docs/en/release-notes-v1.1.1.md
@@ -30,6 +30,6 @@ GitHub Releases remains the public release boundary for Codex Pacer: each releas
 
 ## Notes
 
-- `v1.1.1` is the current stable release line.
+- `v1.1.1` was the previous stable release line. See the latest release notes for the current stable version.
 - Intel macOS, universal builds, Linux bundles, Windows code signing, stable Windows support, and auto-update delivery are not currently promised as official release assets.
 - Codex Pacer remains local-first and does not depend on a cloud sync service to work.

--- a/docs/en/release-notes-v1.1.2.md
+++ b/docs/en/release-notes-v1.1.2.md
@@ -1,0 +1,32 @@
+# Codex Pacer v1.1.2
+
+## Summary
+
+`v1.1.2` fixes token overcounting after Codex state resets, replayed session files, or process restarts.
+
+This release also includes the database query refactor now promoted from `develop` to `main`, keeping the same local-first storage model while making the release line easier to maintain.
+
+## Highlights
+
+- token imports now treat cumulative usage snapshots as monotonic high-water marks per session
+- replayed or rolled-back token totals no longer add the full current total again
+- component counters that roll back are clamped without losing legitimate total-token growth
+- existing overcounted token usage rows are repaired once during the next scan
+- source files that cannot be repaired are tracked for targeted retry instead of repeatedly forcing every session to reimport
+- database query SQL is split into versioned files, with smaller persistence modules for sync settings, subscription data, and rate-limit samples
+
+## Packaging
+
+Stable public release asset:
+
+- signed macOS Apple Silicon DMG via GitHub Releases
+
+Windows installer publishing is paused for this release. Windows compatibility should still be checked from source or on a Windows build host, but no Windows setup EXE is attached to `v1.1.2`.
+
+GitHub Releases remains the public release boundary for Codex Pacer: each release is tied to a Git tag, carries the user-facing release notes, and hosts the platform installer plus checksum users should install from.
+
+## Notes
+
+- `v1.1.2` is the current stable release line.
+- Intel macOS, universal builds, Linux bundles, macOS notarization, Windows code signing, stable Windows support, Windows installer publishing, and auto-update delivery are not currently promised as official release assets.
+- Codex Pacer remains local-first and does not depend on a cloud sync service to work.

--- a/docs/en/release-runbook.md
+++ b/docs/en/release-runbook.md
@@ -4,20 +4,20 @@
 
 This runbook is for maintainers producing public **Codex Pacer** release assets:
 
-- signed and notarized Apple Silicon DMG
-- unsigned Windows NSIS setup EXE as a test-stage asset
+- signed Apple Silicon DMG
+- Windows compatibility checks, with Windows installer publishing paused for `v1.1.2`
 - published through GitHub Releases
 
 The local release entry points are:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.1
-./scripts/release/publish-github-release.sh 1.1.1
+./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/publish-github-release.sh 1.1.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.1
+.\scripts\release\build-windows-release.ps1 1.1.2
 ```
 
 The macOS release scripts default `CARGO_TARGET_DIR` to `~/Library/Caches/CodexPacer/cargo-target` so signed macOS bundles are produced outside cloud-synced folders such as iCloud Drive. This avoids `codesign` failures caused by Finder and file-provider metadata on `.app` bundles.
@@ -98,10 +98,10 @@ Pick one notarization path and leave the other unset. The build script rejects a
 
 GitHub Releases is the handoff point between maintainer workflow and user installation. The tag records exactly what source was released, the release notes explain the user-facing change, and the attached platform installers plus checksums are the canonical install assets for that version.
 
-## Build the signed and notarized DMG
+## Build the signed DMG
 
 ```bash
-./scripts/release/build-macos-release.sh 1.1.1
+./scripts/release/build-macos-release.sh 1.1.2
 ```
 
 What the build script does:
@@ -127,7 +127,7 @@ What the build script does:
 Run this on Windows:
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.1
+.\scripts\release\build-windows-release.ps1 1.1.2
 ```
 
 What the Windows build script does:
@@ -150,7 +150,7 @@ If you need to override the Windows build output location, set `CARGO_TARGET_DIR
 
 ```powershell
 $env:CARGO_TARGET_DIR = "C:\Users\you\AppData\Local\CodexPacer\cargo-target"
-.\scripts\release\build-windows-release.ps1 1.1.1
+.\scripts\release\build-windows-release.ps1 1.1.2
 ```
 
 ### Optional target override
@@ -159,7 +159,7 @@ If you need to pass a specific Tauri target triple, set `TAURI_TARGET` before ru
 
 ```bash
 export TAURI_TARGET="aarch64-apple-darwin"
-./scripts/release/build-macos-release.sh 1.1.1
+./scripts/release/build-macos-release.sh 1.1.2
 ```
 
 `TAURI_TARGET` stays on the Tauri CLI side of the command, before the final `--` that introduces Cargo runner args such as `--locked`.
@@ -172,8 +172,8 @@ If you need to override the build output location, export `CARGO_TARGET_DIR` bef
 
 ```bash
 export CARGO_TARGET_DIR="$HOME/Library/Caches/CodexPacer/custom-target"
-./scripts/release/build-macos-release.sh 1.1.1
-./scripts/release/publish-github-release.sh 1.1.1
+./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/publish-github-release.sh 1.1.2
 ```
 
 Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other cloud/file-provider folders. Signed `.app` bundles created there can pick up `com.apple.FinderInfo` metadata and fail during `codesign`.
@@ -182,8 +182,8 @@ Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other clo
 
 ```bash
 git status --short
-git tag v1.1.1
-git push origin v1.1.1
+git tag v1.1.2
+git push origin v1.1.2
 ```
 
 The publish script expects:
@@ -196,18 +196,18 @@ The publish script expects:
 ## Publish the GitHub Release
 
 ```bash
-./scripts/release/publish-github-release.sh 1.1.1
+./scripts/release/publish-github-release.sh 1.1.2
 ```
 
 The publish script uses:
 
-- the built DMG for `v1.1.1`
+- the built DMG for `v1.1.2`
 - the sibling `.sha256` checksum file
-- `docs/en/release-notes-v1.1.1.md`
+- `docs/en/release-notes-v1.1.2.md`
 
 It publishes those assets with `gh release create`.
 
-For releases that include Windows, also attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release. Note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
+For `v1.1.2`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
 
 ## macOS manual smoke test
 
@@ -253,7 +253,7 @@ Run this before announcing Windows availability publicly:
 Useful spot check:
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.1.1_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.1.2_x64-setup.exe"
 ```
 
 ## Troubleshooting

--- a/docs/en/release-runbook.md
+++ b/docs/en/release-runbook.md
@@ -55,7 +55,7 @@ Use the exact certificate name for `APPLE_SIGNING_IDENTITY`.
 
 ## Required environment variables
 
-The build script expects a local signing identity plus exactly one notarization credential path.
+The build script expects a local signing identity. Notarization credentials are optional; when they are not provided, the macOS build is signed-only.
 
 ### Signing
 
@@ -65,7 +65,7 @@ export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
 
 `APPLE_SIGNING_IDENTITY` is the official Tauri-supported way to point a local macOS build at a keychain-installed certificate.
 
-### Notarization with Apple ID
+### Optional notarization with Apple ID
 
 ```bash
 export APPLE_ID="maintainer@example.com"
@@ -73,7 +73,7 @@ export APPLE_PASSWORD="app-specific-password"
 export APPLE_TEAM_ID="TEAMID1234"
 ```
 
-### Notarization with App Store Connect API
+### Optional notarization with App Store Connect API
 
 ```bash
 export APPLE_API_ISSUER="00000000-0000-0000-0000-000000000000"
@@ -81,14 +81,14 @@ export APPLE_API_KEY="ABC123DEFG"
 export APPLE_API_KEY_PATH="$HOME/keys/AuthKey_ABC123DEFG.p8"
 ```
 
-Pick one notarization path and leave the other unset. The build script rejects ambiguous or incomplete credential sets.
+Pick at most one notarization path and leave the other unset. The build script rejects ambiguous credential sets. If no notarization credential path is set, it skips notarytool, stapling, and Gatekeeper/stapler validation while still verifying the app and DMG signatures.
 
 ## Standard macOS release flow
 
 1. Confirm the target release notes file exists.
 2. Confirm `package.json` and `src-tauri/tauri.conf.json` both match the release version.
 3. Confirm `git status --short` is empty before starting release actions.
-4. Export `APPLE_SIGNING_IDENTITY` and one notarization credential set.
+4. Export `APPLE_SIGNING_IDENTITY`; optionally export one notarization credential set.
 5. Run the build script.
 6. Review the generated DMG and checksum.
 7. Create and push the Git tag.
@@ -116,10 +116,12 @@ What the build script does:
 - defaults `CARGO_TARGET_DIR` to `~/Library/Caches/CodexPacer/cargo-target`
 - rejects cloud-synced target roots that can inject Finder metadata into `.app` bundles
 - locates the most recent built `.app` and `.dmg` under the active Cargo target root
-- verifies the signed app with `codesign`, `spctl`, and `xcrun stapler validate`
-- submits the built DMG to Apple with `xcrun notarytool submit --wait`
-- staples the DMG ticket with `xcrun stapler staple`
-- verifies the signed DMG with `codesign`, `spctl --type open --context context:primary-signature`, and `xcrun stapler validate`
+- verifies the signed app with `codesign`
+- when notarization credentials are configured, verifies the app with `spctl` and `xcrun stapler validate`
+- when notarization credentials are configured, submits the built DMG to Apple with `xcrun notarytool submit --wait`
+- when notarization credentials are configured, staples the DMG ticket with `xcrun stapler staple`
+- verifies the signed DMG with `codesign` and `hdiutil verify`
+- when notarization credentials are configured, verifies the DMG with `spctl --type open --context context:primary-signature` and `xcrun stapler validate`
 - writes a sibling checksum file at `<artifact>.dmg.sha256`
 
 ## Build the Windows NSIS installer

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -12,7 +12,7 @@
 
 ## 环境要求
 
-- 稳定打包版本面向 Apple Silicon macOS；Windows 安装包目前作为测试阶段资产提供
+- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.1.2` 暂缓发布 Windows 安装包
 - 本地 Codex 数据位于 `~/.codex` 或自定义 `CODEX_HOME`
 
 如果你要从源码开发，还需要：
@@ -26,7 +26,7 @@
 官方公开下载方式均通过 GitHub Releases 提供：
 
 - 已签名的 **macOS Apple Silicon DMG**
-- 未签名的 **Windows NSIS setup EXE**，作为测试阶段资产
+- `v1.1.2` 不附加 Windows 安装包；Windows 文档仅用于源码验证
 
 请先阅读：
 
@@ -57,7 +57,7 @@ npm run dev
 
 ## App 内首次设置
 
-1. 在 macOS 从 `Applications` 启动 **Codex Pacer**，在 Windows 从 Start menu 启动。
+1. 在 macOS 从 `Applications` 启动 **Codex Pacer**；在 Windows 使用本地开发构建启动。
 2. 打开 **Settings**。
 3. 确认 Codex home 路径（默认 `~/.codex`），或改成自定义 `CODEX_HOME`。
 4. 运行首次扫描 / 导入。

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -25,7 +25,7 @@
 
 官方公开下载方式均通过 GitHub Releases 提供：
 
-- 已签名并完成 notarization 的 **macOS Apple Silicon DMG**
+- 已签名的 **macOS Apple Silicon DMG**
 - 未签名的 **Windows NSIS setup EXE**，作为测试阶段资产
 
 请先阅读：
@@ -106,4 +106,4 @@ npm run tauri build
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [打包与发布](./packaging-and-release.md)
-- [v1.1.1 发布说明](./release-notes-v1.1.1.md)
+- [v1.1.2 发布说明](./release-notes-v1.1.2.md)

--- a/docs/zh-CN/installing-on-macos.md
+++ b/docs/zh-CN/installing-on-macos.md
@@ -2,7 +2,7 @@
 
 ## macOS 安装路径
 
-**Codex Pacer** 的 macOS 公开安装包，是通过 GitHub Releases 发布的、已签名并完成 notarization 的 **Apple Silicon DMG**。
+**Codex Pacer** 的 macOS 公开安装包，是通过 GitHub Releases 发布的、已签名的 **Apple Silicon DMG**。
 
 ## 标准安装流程
 

--- a/docs/zh-CN/installing-on-windows.md
+++ b/docs/zh-CN/installing-on-windows.md
@@ -1,22 +1,22 @@
 # 在 Windows 上安装
 
-## Windows 测试阶段安装路径
+## Windows 测试阶段状态
 
-**Codex Pacer** 的 Windows 公开安装包，是通过 GitHub Releases 发布的 NSIS setup `.exe`。
+`v1.1.2` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
 
-Windows 支持目前仍处于测试阶段。Windows 安装包当前默认未签名，除非某次发布单独配置了 Windows code signing。Windows SmartScreen 可能会提示发布者未知。
+Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windows 安装包，除非该版本单独配置了 Windows code signing，否则安装包默认未签名，Windows SmartScreen 可能会提示发布者未知。
 
-## 标准安装流程
+## 源码验证流程
 
-1. 打开 `codex-pacer` 的最新 GitHub Releases 页面。
-2. 下载最新的 Windows NSIS setup `.exe`。
-3. 运行下载得到的 setup 文件。
-4. 如果 SmartScreen 提示发布者未知，请先确认文件来自项目 GitHub Release，再继续安装。
-5. 安装后从 Start menu 启动 **Codex Pacer**。
+1. 从 GitHub 仓库检出对应 release tag。
+2. 安装 Windows Tauri 前置依赖。
+3. 运行 `npm ci`。
+4. 运行 `npm run lint`、`npm run build` 和 `cargo test --manifest-path src-tauri/Cargo.toml --locked`。
+5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.1.2`。
 
 ## 安装后
 
-首次运行建议完成这些步骤：
+测试本地 Windows 构建时，首次运行建议完成这些步骤：
 
 1. 确认 Codex home 路径（Windows 默认 `~\.codex`），或选择自定义 `CODEX_HOME`。
 2. 确认该路径下已经有本地 Codex CLI 会话与 rate-limit 数据。
@@ -27,6 +27,7 @@ Windows 支持目前仍处于测试阶段。Windows 安装包当前默认未签�
 ## 说明
 
 - GitHub Releases 是官方分发渠道。
-- Windows setup `.exe` 是测试阶段的 NSIS 安装包。
-- 安装包不会安装 Codex CLI，也不会创建 Codex 使用历史。
+- `v1.1.2` 只发布 macOS Apple Silicon DMG 资产。
+- 任何本地构建的 Windows setup `.exe` 仍是测试阶段的 NSIS 安装包。
+- Windows 安装包不会安装 Codex CLI，也不会创建 Codex 使用历史。
 - Windows 稳定支持、Windows code signing 和自动更新交付目前都不承诺。

--- a/docs/zh-CN/packaging-and-release.md
+++ b/docs/zh-CN/packaging-and-release.md
@@ -6,11 +6,11 @@
 
 当前稳定公开打包资产为：
 
-- 已签名并完成 notarization 的 **macOS Apple Silicon DMG**
+- 已签名的 **macOS Apple Silicon DMG**
 
-Windows 目前作为测试阶段资产发布：
+`v1.1.2` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
 
-- 未签名的 **Windows NSIS setup EXE**，用于兼容性测试和早期验证
+- 未签名的 **Windows NSIS setup EXE**，仅用于本地兼容性测试和早期验证
 
 以下内容**目前不承诺**作为官方发布资产提供：
 
@@ -28,8 +28,8 @@ Windows 目前作为测试阶段资产发布：
 当前面向公开发布的目标流程是：
 
 1. 确认公开品牌文案和文档已经准备完成。
-2. 构建已签名并完成 notarization 的 macOS Apple Silicon DMG。
-3. 如果该版本包含 Windows 测试阶段资产，构建未签名的 Windows NSIS setup EXE。
+2. 构建已签名的 macOS Apple Silicon DMG。
+3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.1.2` 不发布 Windows 安装包。
 4. 通过 GitHub Releases 发布这些安装资产。
 5. 附上对应版本的发布说明。
 
@@ -39,15 +39,15 @@ Windows 目前作为测试阶段资产发布：
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.1
-./scripts/release/publish-github-release.sh 1.1.1
+./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/publish-github-release.sh 1.1.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.1
+.\scripts\release\build-windows-release.ps1 1.1.2
 ```
 
-这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名并完成 notarization 的 DMG，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；如果该版本包含 Windows 安装包，请同时以测试阶段资产上传 Windows EXE 与 checksum。
+这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.1.2` 不上传 Windows EXE 资产。
 
 ## 平台隔离规则
 
@@ -68,16 +68,16 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 - 确认生成的 DMG 能在 Apple Silicon macOS 上正常打开
 - 确认已签名的应用可以从 `Applications` 正常启动
 - 确认 macOS menu bar 弹窗仍在 menu bar 下方打开，且 macOS 专属 Dock 设置不会出现在非 macOS
-- 确认生成的 Windows setup EXE 可以在 Windows 上安装
-- 确认 Windows 托盘弹窗在底部任务栏上方向上展开，显示可选模块后仍向上扩展，并且刷新 live quota 时不会弹出命令行窗口
-- 确认 Windows 安装包 checksum，并注明除非另行配置签名，否则该安装包仍处于测试阶段且未签名
+- 如果执行本地 Windows 验证，确认生成的 Windows setup EXE 可以在 Windows 上安装
+- 如果执行本地 Windows 验证，确认 Windows 托盘弹窗在底部任务栏上方向上展开，显示可选模块后仍向上扩展，并且刷新 live quota 时不会弹出命令行窗口
+- 如果执行本地 Windows 验证，确认 Windows 安装包 checksum，并注明除非另行配置签名，否则该安装包仍处于测试阶段且未签名
 
 ## 发布建议
 
 - 为稳定版本创建 Git tag
 - 基于该 tag 创建 GitHub Release
-- 上传已签名并完成 notarization 的 Apple Silicon DMG
-- 如果已运行 Windows 发布脚本，以测试阶段资产上传未签名的 Windows NSIS setup EXE
+- 上传已签名的 Apple Silicon DMG
+- `v1.1.2` 不上传 Windows NSIS setup EXE
 - 附上该版本对应的发布说明
 - 发布后再次验证下载与安装流程
 
@@ -88,9 +88,9 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 面向外部文档和公告时，请保持以下表述一致：
 
 - 官方分发渠道：GitHub Releases
-- 稳定发布资产：已签名并完成 notarization 的 macOS Apple Silicon DMG
-- Windows 测试阶段资产：未签名的 Windows NSIS setup EXE
-- 当前稳定版本线：`v1.1.1`
+- 稳定发布资产：已签名的 macOS Apple Silicon DMG
+- Windows 安装包：`v1.1.2` 暂缓发布
+- 当前稳定版本线：`v1.1.2`
 
 ## 相关文档
 
@@ -98,4 +98,4 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [发布 Runbook](./release-runbook.md)
-- [v1.1.1 发布说明](./release-notes-v1.1.1.md)
+- [v1.1.2 发布说明](./release-notes-v1.1.2.md)

--- a/docs/zh-CN/release-notes-v1.1.1.md
+++ b/docs/zh-CN/release-notes-v1.1.1.md
@@ -30,6 +30,6 @@ GitHub Releases 仍是 Codex Pacer 的公开发布边界：每个 release 对应
 
 ## 说明
 
-- `v1.1.1` 是当前稳定发布线。
+- `v1.1.1` 是上一条稳定发布线。请查看最新发布说明了解当前稳定版本。
 - Intel macOS、universal 构建、Linux 打包产物、Windows code signing、Windows 稳定支持，以及自动更新交付目前都不承诺作为官方发布资产。
 - Codex Pacer 保持本地优先，不依赖云端同步服务即可运行。

--- a/docs/zh-CN/release-notes-v1.1.2.md
+++ b/docs/zh-CN/release-notes-v1.1.2.md
@@ -1,0 +1,32 @@
+# Codex Pacer v1.1.2
+
+## 概要
+
+`v1.1.2` 修复 Codex 状态重置、会话文件重放或进程重启后可能出现的 token 重复计数问题。
+
+这个版本也包含已经从 `develop` 推进到 `main` 的数据库查询重构，在保持本地优先存储模型不变的前提下，让发布线更容易维护。
+
+## 版本亮点
+
+- token 导入现在把每个 session 的累计用量快照视为单调高水位
+- 重放或回退的 token 总量不会再把当前累计总量重复计入
+- 组成项计数器回退时会被安全截断，同时保留合法的 total token 增长
+- 已经出现异常的历史 token 使用行会在下一次扫描时执行一次修复
+- 无法修复的源文件会被记录为待重试文件，避免反复强制重导全部 session
+- 数据库查询 SQL 拆分为版本化文件，同步设置、订阅数据和 rate-limit 样本持久化也拆成更小的模块
+
+## 打包形态
+
+当前稳定公开发布资产：
+
+- 通过 GitHub Releases 分发的、已签名的 macOS Apple Silicon DMG
+
+本版本暂缓发布 Windows 安装包。Windows 兼容性仍应通过源码或 Windows 构建机检查，但 `v1.1.2` 不附加 Windows setup EXE。
+
+GitHub Releases 仍是 Codex Pacer 的公开发布边界：每个 release 对应一个 Git tag，承载面向用户的发布说明，并托管用户应下载和安装的平台安装包及 checksum。
+
+## 说明
+
+- `v1.1.2` 是当前稳定发布线。
+- Intel macOS、universal 构建、Linux 打包产物、macOS notarization、Windows code signing、Windows 稳定支持、Windows 安装包发布，以及自动更新交付目前都不承诺作为官方发布资产。
+- Codex Pacer 保持本地优先，不依赖云端同步服务即可运行。

--- a/docs/zh-CN/release-runbook.md
+++ b/docs/zh-CN/release-runbook.md
@@ -31,7 +31,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 - `package.json` 与 `src-tauri/tauri.conf.json` 版本一致
 - 发布前工作区保持 clean
 
-构建前需要设置 `APPLE_SIGNING_IDENTITY`，并在 Apple ID notarization 或 App Store Connect API notarization 两条路径中选择一条。不要同时设置两组 notarization 凭据。
+构建前必须设置 `APPLE_SIGNING_IDENTITY`。notarization 凭据是可选项；如果不设置 Apple ID notarization 或 App Store Connect API notarization 凭据，macOS 构建会走 signed-only 路径。不要同时设置两组 notarization 凭据。
 
 ## Windows 发布要求
 
@@ -47,7 +47,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 ./scripts/release/build-macos-release.sh 1.1.2
 ```
 
-脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，构建 app/dmg，执行 codesign、notarization 与 stapling，并写入 `<artifact>.dmg.sha256`。
+脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，构建 app/dmg，执行 codesign，并写入 `<artifact>.dmg.sha256`。如果配置了 notarization 凭据，脚本还会执行 notarytool、stapling、Gatekeeper 与 stapler 校验；如果未配置，则跳过这些 notarization 专属步骤。
 
 ## Windows 构建
 

--- a/docs/zh-CN/release-runbook.md
+++ b/docs/zh-CN/release-runbook.md
@@ -4,22 +4,22 @@
 
 本文面向维护者，说明如何生成 **Codex Pacer** 的公开发布资产：
 
-- 已签名并完成 notarization 的 Apple Silicon DMG
-- 作为测试阶段资产的未签名 Windows NSIS setup EXE
+- 已签名的 Apple Silicon DMG
+- Windows 兼容性检查，且 `v1.1.2` 暂缓发布 Windows 安装包
 - 通过 GitHub Releases 分发
 
 本地发布入口：
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.1
+./scripts/release/build-macos-release.sh 1.1.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.1
+.\scripts\release\build-windows-release.ps1 1.1.2
 ```
 
-macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.1` 上传 DMG 与 checksum。包含 Windows 的 release 还需要把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
+macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.2` 上传 DMG 与 checksum。`v1.1.2` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
 
 ## macOS 发布要求
 
@@ -44,7 +44,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 ## macOS 构建
 
 ```bash
-./scripts/release/build-macos-release.sh 1.1.1
+./scripts/release/build-macos-release.sh 1.1.2
 ```
 
 脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，构建 app/dmg，执行 codesign、notarization 与 stapling，并写入 `<artifact>.dmg.sha256`。
@@ -52,7 +52,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 ## Windows 构建
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.1
+.\scripts\release\build-windows-release.ps1 1.1.2
 ```
 
 脚本会校验版本，运行 `npm ci`、lint、前端构建和 Rust 测试，执行 `npm run tauri build -- --ci --bundles nsis -- --locked`，定位生成的 NSIS setup `.exe`，并写入 `<installer>.exe.sha256`。
@@ -68,7 +68,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 5. 如该版本包含 Windows，构建 Windows setup EXE 与 checksum。
 6. 创建并 push `vVERSION` tag。
 7. 发布 GitHub Release。
-8. 上传已签名并完成 notarization 的 macOS DMG 与 checksum。
+8. 上传已签名的 macOS DMG 与 checksum。
 9. 如该版本包含 Windows，上传测试阶段的未签名 Windows NSIS setup EXE 与 checksum。
 10. 在 release body 中说明 Windows installer 仍处于测试阶段且默认未签名，用户可能看到 SmartScreen unknown publisher 警告。
 
@@ -98,7 +98,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 10. 刷新 live quota 数据，确认不会弹出黑色命令行窗口。
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.1.1_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.1.2_x64-setup.exe"
 ```
 
 ## 相关文档

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-pacer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-pacer",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-pacer",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/release/build-macos-release.sh
+++ b/scripts/release/build-macos-release.sh
@@ -173,6 +173,28 @@ main() {
 
   local has_apple_id_path=0
   local has_api_path=0
+  local apple_id_field_count=0
+  local api_field_count=0
+
+  [[ -n "${APPLE_ID:-}" ]] && (( apple_id_field_count += 1 ))
+  [[ -n "${APPLE_PASSWORD:-}" ]] && (( apple_id_field_count += 1 ))
+  [[ -n "${APPLE_TEAM_ID:-}" ]] && (( apple_id_field_count += 1 ))
+
+  [[ -n "${APPLE_API_ISSUER:-}" ]] && (( api_field_count += 1 ))
+  [[ -n "${APPLE_API_KEY:-}" ]] && (( api_field_count += 1 ))
+  [[ -n "${APPLE_API_KEY_PATH:-}" ]] && (( api_field_count += 1 ))
+
+  if (( apple_id_field_count > 0 && apple_id_field_count < 3 )); then
+    echo "ERROR: Incomplete Apple ID notarization credentials." >&2
+    echo "  Provide APPLE_ID + APPLE_PASSWORD + APPLE_TEAM_ID, or unset all three for a signed-only build." >&2
+    exit 1
+  fi
+
+  if (( api_field_count > 0 && api_field_count < 3 )); then
+    echo "ERROR: Incomplete App Store Connect API notarization credentials." >&2
+    echo "  Provide APPLE_API_ISSUER + APPLE_API_KEY + APPLE_API_KEY_PATH, or unset all three for a signed-only build." >&2
+    exit 1
+  fi
 
   if [[ -n "${APPLE_ID:-}" && -n "${APPLE_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
     has_apple_id_path=1

--- a/scripts/release/build-macos-release.sh
+++ b/scripts/release/build-macos-release.sh
@@ -9,7 +9,7 @@ Usage: ./scripts/release/build-macos-release.sh VERSION
 Required environment variables:
   APPLE_SIGNING_IDENTITY
 
-Notarization environment variables (choose exactly one path):
+Notarization environment variables (optional; choose at most one path):
   APPLE_ID + APPLE_PASSWORD + APPLE_TEAM_ID
   or
   APPLE_API_ISSUER + APPLE_API_KEY + APPLE_API_KEY_PATH
@@ -129,6 +129,7 @@ main() {
   require_command codesign
   require_command spctl
   require_command xcrun
+  require_command hdiutil
   require_command shasum
   require_command git
 
@@ -181,8 +182,8 @@ main() {
     has_api_path=1
   fi
 
-  if (( has_apple_id_path + has_api_path != 1 )); then
-    echo "ERROR: Provide exactly one notarization credential path." >&2
+  if (( has_apple_id_path + has_api_path > 1 )); then
+    echo "ERROR: Provide at most one notarization credential path." >&2
     echo "  Apple ID: APPLE_ID + APPLE_PASSWORD + APPLE_TEAM_ID" >&2
     echo "  API key : APPLE_API_ISSUER + APPLE_API_KEY + APPLE_API_KEY_PATH" >&2
     exit 1
@@ -193,16 +194,21 @@ main() {
     exit 1
   fi
 
-  local notarization_mode="Apple ID"
-  if (( has_api_path == 1 )); then
+  local notarization_mode="not configured; signed-only DMG"
+  local should_notarize=0
+  if (( has_apple_id_path == 1 )); then
+    notarization_mode="Apple ID"
+    should_notarize=1
+  elif (( has_api_path == 1 )); then
     notarization_mode="App Store Connect API"
+    should_notarize=1
   fi
 
   local -a notarytool_auth_args tauri_build_args cargo_runner_args
   notarytool_auth_args=()
   if (( has_apple_id_path == 1 )); then
     notarytool_auth_args+=(--apple-id "${APPLE_ID}" --password "${APPLE_PASSWORD}" --team-id "${APPLE_TEAM_ID}")
-  else
+  elif (( has_api_path == 1 )); then
     notarytool_auth_args+=(--key "${APPLE_API_KEY_PATH}" --key-id "${APPLE_API_KEY}")
     if [[ -n "${APPLE_API_ISSUER:-}" ]]; then
       notarytool_auth_args+=(--issuer "${APPLE_API_ISSUER}")
@@ -274,20 +280,34 @@ main() {
   echo
   echo "Verifying signed app..."
   codesign --verify --deep --strict --verbose=2 "${app_path}"
-  spctl -a -vv --type exec "${app_path}"
-  xcrun stapler validate "${app_path}"
+  if (( should_notarize == 1 )); then
+    spctl -a -vv --type exec "${app_path}"
+    xcrun stapler validate "${app_path}"
+  else
+    echo "Skipping Gatekeeper and stapler app checks because notarization credentials were not provided."
+  fi
 
-  echo
-  echo "Notarizing DMG..."
-  xcrun notarytool submit "${dmg_path}" "${notarytool_auth_args[@]}" --wait
-  echo "Stapling DMG..."
-  xcrun stapler staple "${dmg_path}"
+  if (( should_notarize == 1 )); then
+    echo
+    echo "Notarizing DMG..."
+    xcrun notarytool submit "${dmg_path}" "${notarytool_auth_args[@]}" --wait
+    echo "Stapling DMG..."
+    xcrun stapler staple "${dmg_path}"
+  else
+    echo
+    echo "Skipping DMG notarization; build is signed-only."
+  fi
 
   echo
   echo "Verifying signed DMG..."
   codesign --verify --verbose=2 "${dmg_path}"
-  spctl -a -vv --type open --context context:primary-signature "${dmg_path}"
-  xcrun stapler validate "${dmg_path}"
+  hdiutil verify "${dmg_path}"
+  if (( should_notarize == 1 )); then
+    spctl -a -vv --type open --context context:primary-signature "${dmg_path}"
+    xcrun stapler validate "${dmg_path}"
+  else
+    echo "Skipping Gatekeeper and stapler DMG checks because notarization credentials were not provided."
+  fi
 
   echo
   echo "Writing DMG checksum..."

--- a/scripts/release/test-build-macos-release.sh
+++ b/scripts/release/test-build-macos-release.sh
@@ -219,4 +219,29 @@ if ! grep -F -- "verify ${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_${REL
   exit 1
 fi
 
+: > "${TEST_RELEASE_LOG}"
+export APPLE_ID="maintainer@example.com"
+export APPLE_PASSWORD="app-specific-password"
+unset APPLE_TEAM_ID
+
+set +e
+partial_output="$("${REPO_ROOT}/scripts/release/build-macos-release.sh" "${RELEASE_VERSION}" 2>&1)"
+partial_status=$?
+set -e
+
+if [[ "${partial_status}" -eq 0 ]]; then
+  echo "expected incomplete notarization credentials to fail" >&2
+  exit 1
+fi
+
+if [[ "${partial_output}" != *"Incomplete Apple ID notarization credentials"* ]]; then
+  echo "expected incomplete Apple ID credential failure to be explicit" >&2
+  exit 1
+fi
+
+if [[ -s "${TEST_RELEASE_LOG}" ]]; then
+  echo "expected incomplete notarization credentials to stop before npm commands run" >&2
+  exit 1
+fi
+
 echo "build-macos-release regression test passed"

--- a/scripts/release/test-build-macos-release.sh
+++ b/scripts/release/test-build-macos-release.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TEST_ROOT="$(mktemp -d)"
 STUB_BIN="${TEST_ROOT}/bin"
 LOG_DIR="${TEST_ROOT}/logs"
+RELEASE_VERSION="$(node -p "require('${REPO_ROOT}/package.json').version")"
 
 cleanup() {
   rm -rf "${TEST_ROOT}"
@@ -66,6 +67,13 @@ printf '%s\n' "$*" >> "${TEST_XCRUN_LOG:?}"
 exit 0
 EOF
 
+cat > "${STUB_BIN}/hdiutil" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${TEST_HDIUTIL_LOG:?}"
+exit 0
+EOF
+
 cat > "${STUB_BIN}/shasum" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -106,7 +114,7 @@ if [[ "${1:-}" == "run" && "${2:-}" == "tauri" && "${3:-}" == "build" ]]; then
   dmg_dir="${CARGO_TARGET_DIR}/release/bundle/dmg"
   macos_dir="${CARGO_TARGET_DIR}/release/bundle/macos"
   mkdir -p "${dmg_dir}" "${macos_dir}"
-  touch "${dmg_dir}/Codex Pacer_1.1.0_aarch64.dmg"
+  touch "${dmg_dir}/Codex Pacer_${TEST_RELEASE_VERSION}_aarch64.dmg"
 
   case "${bundles}" in
     app,dmg|dmg,app)
@@ -134,6 +142,7 @@ chmod +x \
   "${STUB_BIN}/codesign" \
   "${STUB_BIN}/spctl" \
   "${STUB_BIN}/xcrun" \
+  "${STUB_BIN}/hdiutil" \
   "${STUB_BIN}/shasum" \
   "${STUB_BIN}/npm"
 
@@ -141,13 +150,15 @@ export PATH="${STUB_BIN}:${PATH}"
 export TEST_RELEASE_LOG="${LOG_DIR}/npm.log"
 export TEST_SPCTL_LOG="${LOG_DIR}/spctl.log"
 export TEST_XCRUN_LOG="${LOG_DIR}/xcrun.log"
+export TEST_HDIUTIL_LOG="${LOG_DIR}/hdiutil.log"
+export TEST_RELEASE_VERSION="${RELEASE_VERSION}"
 export APPLE_SIGNING_IDENTITY="Developer ID Application: Test Maintainer (TEAMID1234)"
 export APPLE_ID="maintainer@example.com"
 export APPLE_PASSWORD="app-specific-password"
 export APPLE_TEAM_ID="TEAMID1234"
 export CARGO_TARGET_DIR="${TEST_ROOT}/target"
 
-"${REPO_ROOT}/scripts/release/build-macos-release.sh" "1.1.0"
+"${REPO_ROOT}/scripts/release/build-macos-release.sh" "${RELEASE_VERSION}"
 
 if ! grep -F -- "--bundles app,dmg" "${TEST_RELEASE_LOG}" >/dev/null; then
   echo "expected build script to request both app and dmg bundles" >&2
@@ -159,23 +170,52 @@ if [[ ! -d "${CARGO_TARGET_DIR}/release/bundle/macos/Codex Pacer.app" ]]; then
   exit 1
 fi
 
-if [[ ! -f "${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_1.1.0_aarch64.dmg.sha256" ]]; then
+if [[ ! -f "${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_${RELEASE_VERSION}_aarch64.dmg.sha256" ]]; then
   echo "expected checksum to be written beside the mocked DMG" >&2
   exit 1
 fi
 
-if ! grep -F -- "notarytool submit ${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_1.1.0_aarch64.dmg --apple-id maintainer@example.com --password app-specific-password --team-id TEAMID1234 --wait" "${TEST_XCRUN_LOG}" >/dev/null; then
+if ! grep -F -- "notarytool submit ${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_${RELEASE_VERSION}_aarch64.dmg --apple-id maintainer@example.com --password app-specific-password --team-id TEAMID1234 --wait" "${TEST_XCRUN_LOG}" >/dev/null; then
   echo "expected build script to notarize the built DMG with notarytool" >&2
   exit 1
 fi
 
-if ! grep -F -- "stapler staple ${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_1.1.0_aarch64.dmg" "${TEST_XCRUN_LOG}" >/dev/null; then
+if ! grep -F -- "stapler staple ${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_${RELEASE_VERSION}_aarch64.dmg" "${TEST_XCRUN_LOG}" >/dev/null; then
   echo "expected build script to staple the built DMG" >&2
   exit 1
 fi
 
-if ! grep -F -- "--type open --context context:primary-signature ${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_1.1.0_aarch64.dmg" "${TEST_SPCTL_LOG}" >/dev/null; then
+if ! grep -F -- "--type open --context context:primary-signature ${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_${RELEASE_VERSION}_aarch64.dmg" "${TEST_SPCTL_LOG}" >/dev/null; then
   echo "expected build script to assess the DMG with the primary-signature context" >&2
+  exit 1
+fi
+
+rm -rf "${CARGO_TARGET_DIR}"
+: > "${TEST_RELEASE_LOG}"
+: > "${TEST_SPCTL_LOG}"
+: > "${TEST_XCRUN_LOG}"
+: > "${TEST_HDIUTIL_LOG}"
+unset APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
+
+"${REPO_ROOT}/scripts/release/build-macos-release.sh" "${RELEASE_VERSION}"
+
+if grep -F -- "notarytool submit" "${TEST_XCRUN_LOG}" >/dev/null; then
+  echo "expected signed-only build to skip notarytool" >&2
+  exit 1
+fi
+
+if grep -F -- "stapler" "${TEST_XCRUN_LOG}" >/dev/null; then
+  echo "expected signed-only build to skip stapler" >&2
+  exit 1
+fi
+
+if [[ -s "${TEST_SPCTL_LOG}" ]]; then
+  echo "expected signed-only build to skip Gatekeeper assessment" >&2
+  exit 1
+fi
+
+if ! grep -F -- "verify ${CARGO_TARGET_DIR}/release/bundle/dmg/Codex Pacer_${RELEASE_VERSION}_aarch64.dmg" "${TEST_HDIUTIL_LOG}" >/dev/null; then
+  echo "expected signed-only build to verify the DMG image" >&2
   exit 1
 fi
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-pacer"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-pacer"
-version = "1.1.1"
+version = "1.1.2"
 description = "Codex Pacer desktop analytics"
 authors = ["Codex"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Codex Pacer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.codex.counter",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bump Codex Pacer to v1.1.2 across npm, Cargo, Tauri, and lockfiles.
- Add bilingual v1.1.2 release notes and update README, changelog, install, packaging, and release runbook docs.
- Document the v1.1.2 release scope as signed macOS Apple Silicon DMG only; Windows installer publishing is paused while compatibility remains test-stage.

## Verification
- git diff --check
- ./scripts/release/audit-public-branding.sh
- version alignment check for package.json, package-lock.json, Cargo.toml, and tauri.conf.json
- npm run lint
- npm test
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml --locked

## Windows compatibility note
- x86_64-pc-windows-msvc Rust target is installed, but cargo check for that target cannot complete on this macOS host because third-party C dependencies require MSVC/Windows C headers.
- PowerShell is not installed on this host, so the Windows release script and installer smoke test were not executed.
- Windows release assets are intentionally not included in v1.1.2.