### PR TITLE
[codex] Optimize background scan maintenance

### DIFF
--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -96,6 +96,7 @@ CREATE TABLE IF NOT EXISTS sync_settings (
   menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
   last_scan_started_at TEXT,
   last_scan_completed_at TEXT,
+  last_full_scan_completed_at TEXT,
   updated_at TEXT NOT NULL
 );
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -13,7 +13,8 @@ pub use subscriptions::{
     canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
 };
 pub use sync_settings::{
-    get_sync_settings, save_sync_settings, set_last_scan_completed, set_last_scan_started,
+    get_last_full_scan_completed, get_sync_settings, save_sync_settings,
+    set_last_full_scan_completed, set_last_scan_completed, set_last_scan_started,
 };
 
 pub fn now_utc_string() -> String {
@@ -79,9 +80,9 @@ fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {
       menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
       menu_bar_popup_enabled, menu_bar_popup_modules,
       menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
-      last_scan_started_at, last_scan_completed_at, updated_at
+      last_scan_started_at, last_scan_completed_at, last_full_scan_completed_at, updated_at
     )
-    VALUES (1, 2, NULL, 1, 5, 300, 0, 0, 1, 1, 0, 'remaining_percent', 'five_hour', 'day', 1, 85, 115, '🟢', '🔥', '🐢', 1, ?2, 1, 1, NULL, NULL, ?1)
+    VALUES (1, 2, NULL, 1, 5, 300, 0, 0, 1, 1, 0, 'remaining_percent', 'five_hour', 'day', 1, 85, 115, '🟢', '🔥', '🐢', 1, ?2, 1, 1, NULL, NULL, NULL, ?1)
     ON CONFLICT(singleton_id) DO NOTHING
     ",
         params![now, sync_settings::default_menu_bar_popup_modules_json()],
@@ -143,7 +144,23 @@ mod tests {
         );
         assert!(settings.menu_bar_popup_show_reset_timeline);
         assert!(settings.menu_bar_popup_show_actions);
+        assert!(get_last_full_scan_completed(&conn).expect("load last full scan").is_none());
         assert!(!settings.hide_dock_icon_when_menu_bar_visible);
+    }
+
+    #[test]
+    fn sync_settings_tracks_last_full_scan_completion() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        assert!(get_last_full_scan_completed(&conn).expect("load initial value").is_none());
+
+        set_last_full_scan_completed(&conn, "2026-03-27T00:00:00Z").expect("set full scan timestamp");
+
+        assert_eq!(
+            get_last_full_scan_completed(&conn).expect("load saved value"),
+            Some("2026-03-27T00:00:00Z".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -217,6 +217,26 @@ mod tests {
     }
 
     #[test]
+    fn save_sync_settings_honors_long_background_refresh_intervals() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                auto_scan_interval_minutes: 180,
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save settings");
+
+        let settings = get_sync_settings(&conn).expect("load settings");
+
+        assert_eq!(settings.auto_scan_interval_minutes, 180);
+        assert_eq!(settings.live_quota_refresh_interval_seconds, 10800);
+    }
+
+    #[test]
     fn init_db_migrates_old_default_refresh_and_disables_legacy_fast_mode_once() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -241,7 +241,8 @@ mod tests {
         save_sync_settings(
             &conn,
             &SyncSettings {
-                live_quota_refresh_interval_seconds: 600,
+                auto_scan_interval_minutes: 10,
+                live_quota_refresh_interval_seconds: 60,
                 ..SyncSettings::default()
             },
         )
@@ -250,6 +251,7 @@ mod tests {
         init_db(&conn).expect("run init again");
         let settings = get_sync_settings(&conn).expect("reload settings");
 
+        assert_eq!(settings.auto_scan_interval_minutes, 10);
         assert_eq!(settings.live_quota_refresh_interval_seconds, 600);
     }
 

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -466,7 +466,7 @@ pub fn save_sync_settings(
 }
 
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
-    auto_scan_interval_minutes.max(1).saturating_mul(60).clamp(60, 3600)
+    auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
 
 pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -341,14 +341,15 @@ pub fn get_sync_settings(conn: &Connection) -> rusqlite::Result<SyncSettings> {
            last_scan_started_at, last_scan_completed_at, updated_at
     FROM sync_settings
     WHERE singleton_id = 1
-    ",
+        ",
         [],
         |row| {
+            let auto_scan_interval_minutes = row.get::<_, i64>(2)?.max(1);
             Ok(SyncSettings {
                 codex_home: row.get(0)?,
                 auto_scan_enabled: i64_to_bool(row.get::<_, i64>(1)?),
-                auto_scan_interval_minutes: row.get(2)?,
-                live_quota_refresh_interval_seconds: row.get(3)?,
+                auto_scan_interval_minutes,
+                live_quota_refresh_interval_seconds: unified_refresh_interval_seconds(auto_scan_interval_minutes),
                 hide_dock_icon_when_menu_bar_visible: i64_to_bool(row.get::<_, i64>(4)?),
                 show_menu_bar_logo: i64_to_bool(row.get::<_, i64>(5)?),
                 show_menu_bar_daily_api_value: i64_to_bool(row.get::<_, i64>(6)?),
@@ -379,6 +380,7 @@ pub fn save_sync_settings(
     settings: &SyncSettings,
 ) -> rusqlite::Result<SyncSettings> {
     let updated_at = now_utc_string();
+    let auto_scan_interval_minutes = settings.auto_scan_interval_minutes.max(1);
     conn.execute(
     "
     INSERT INTO sync_settings (
@@ -426,8 +428,8 @@ pub fn save_sync_settings(
     params![
       settings.codex_home,
       bool_to_i64(settings.auto_scan_enabled),
-      settings.auto_scan_interval_minutes.max(1),
-      settings.live_quota_refresh_interval_seconds.clamp(60, 3600),
+      auto_scan_interval_minutes,
+      unified_refresh_interval_seconds(auto_scan_interval_minutes),
       bool_to_i64(settings.hide_dock_icon_when_menu_bar_visible),
       bool_to_i64(settings.show_menu_bar_logo),
       bool_to_i64(settings.show_menu_bar_daily_api_value),
@@ -451,6 +453,10 @@ pub fn save_sync_settings(
     ],
     )?;
     get_sync_settings(conn)
+}
+
+fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
+    auto_scan_interval_minutes.max(1).saturating_mul(60).clamp(60, 3600)
 }
 
 pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -284,6 +284,16 @@ pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result
     )?;
     }
 
+    if !column_names
+        .iter()
+        .any(|name| name == "last_full_scan_completed_at")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN last_full_scan_completed_at TEXT",
+      [],
+    )?;
+    }
+
     migrate_sync_settings_defaults_to_minutes(conn)?;
 
     Ok(())
@@ -476,6 +486,30 @@ pub fn set_last_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::
         "
     UPDATE sync_settings
     SET last_scan_completed_at = ?1, updated_at = ?1
+    WHERE singleton_id = 1
+    ",
+        params![timestamp],
+    )?;
+    Ok(())
+}
+
+pub fn get_last_full_scan_completed(conn: &Connection) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "
+    SELECT last_full_scan_completed_at
+    FROM sync_settings
+    WHERE singleton_id = 1
+    ",
+        [],
+        |row| row.get(0),
+    )
+}
+
+pub fn set_last_full_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET last_full_scan_completed_at = ?1, updated_at = ?1
     WHERE singleton_id = 1
     ",
         params![timestamp],

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 
 use crate::database::{
   bool_to_i64, get_sync_settings, init_db, now_utc_string, open_connection,
-  replace_session_rate_limit_samples, set_last_scan_completed, set_last_scan_started,
+  replace_session_rate_limit_samples, set_last_full_scan_completed, set_last_scan_completed, set_last_scan_started,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
@@ -63,7 +63,6 @@ enum SessionParseError {
 
 const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
 const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
-const INCREMENTAL_DISCOVERY_DAYS: i64 = 14;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ScanScope {
@@ -110,7 +109,7 @@ fn perform_scan_with_scope(
 
   let session_files = match effective_scope {
     ScanScope::Full => collect_session_files(&codex_home),
-    ScanScope::Incremental => collect_incremental_session_files(&codex_home, &import_state, &pending_token_repair_paths),
+    ScanScope::Incremental => collect_active_session_files(&codex_home),
   };
   let present_paths: HashSet<String> = session_files
     .iter()
@@ -198,6 +197,8 @@ fn perform_scan_with_scope(
   if effective_scope == ScanScope::Full {
     mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
     prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
+  } else {
+    mark_missing_active_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
   }
   if topology_dirty {
     recompute_conversation_links(&conn).map_err(|error| error.to_string())?;
@@ -221,6 +222,9 @@ fn perform_scan_with_scope(
   if needs_token_usage_repair_sweep {
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
+  }
+  if effective_scope == ScanScope::Full {
+    set_last_full_scan_completed(&conn, &completed_at).map_err(|error| error.to_string())?;
   }
   set_last_scan_completed(&conn, &completed_at).map_err(|error| error.to_string())?;
 
@@ -395,84 +399,20 @@ fn collect_session_files(codex_home: &Path) -> Vec<SessionFile> {
   files
 }
 
-fn collect_incremental_session_files(
-  codex_home: &Path,
-  import_state: &HashMap<String, ImportState>,
-  pending_token_repair_paths: &HashSet<String>,
-) -> Vec<SessionFile> {
-  let mut files = Vec::new();
-  let mut seen_paths = HashSet::new();
-
-  for state in import_state.values() {
-    let is_pending_repair = pending_token_repair_paths.contains(&state.source_path);
-    if state.source_bucket != "active" && !is_pending_repair {
-      continue;
-    }
-
-    let path = PathBuf::from(&state.source_path);
-    if !seen_paths.insert(path.clone()) {
-      continue;
-    }
-    if let Some(session_file) = session_file_from_path(path, &state.source_bucket) {
-      files.push(session_file);
-    }
-  }
-
-  for source_path in pending_token_repair_paths {
-    let path = PathBuf::from(source_path);
-    if !seen_paths.insert(path.clone()) {
-      continue;
-    }
-    let bucket = infer_source_bucket(codex_home, &path);
-    if let Some(session_file) = session_file_from_path(path, bucket) {
-      files.push(session_file);
-    }
-  }
-
-  for session_file in collect_recent_active_session_files(codex_home) {
-    if seen_paths.insert(session_file.path.clone()) {
-      files.push(session_file);
-    }
-  }
-
-  files.sort_by(|left, right| left.path.cmp(&right.path));
-  files
-}
-
-fn collect_recent_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
+fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
   let sessions_root = codex_home.join("sessions");
   if !sessions_root.exists() {
     return Vec::new();
   }
 
-  let today = Local::now().date_naive();
   let mut files = Vec::new();
-  for days_ago in 0..=INCREMENTAL_DISCOVERY_DAYS {
-    let day = today - chrono::Duration::days(days_ago);
-    let day_dir = sessions_root
-      .join(day.format("%Y").to_string())
-      .join(day.format("%m").to_string())
-      .join(day.format("%d").to_string());
-    if !day_dir.exists() {
-      continue;
-    }
-
-    for entry in WalkDir::new(day_dir).into_iter().filter_map(Result::ok) {
-      if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), "active") {
-        files.push(session_file);
-      }
+  for entry in WalkDir::new(sessions_root).into_iter().filter_map(Result::ok) {
+    if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), "active") {
+      files.push(session_file);
     }
   }
-
+  files.sort_by(|left, right| left.path.cmp(&right.path));
   files
-}
-
-fn infer_source_bucket(codex_home: &Path, path: &Path) -> &'static str {
-  if path.starts_with(codex_home.join("archived_sessions")) {
-    "archived"
-  } else {
-    "active"
-  }
 }
 
 fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
@@ -1022,7 +962,7 @@ fn normalize_local_timestamp(timestamp: chrono::DateTime<Local>) -> chrono::Date
 fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, ImportState>> {
   let mut stmt = conn.prepare(
     "
-    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms
+    SELECT source_path, session_id, file_size, file_mtime_ms
     FROM import_state
     ",
   )?;
@@ -1031,9 +971,8 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
     Ok(ImportState {
       source_path: row.get(0)?,
       session_id: row.get(1)?,
-      source_bucket: row.get(2)?,
-      file_size: row.get(3)?,
-      file_mtime_ms: row.get(4)?,
+      file_size: row.get(2)?,
+      file_mtime_ms: row.get(3)?,
     })
   })?;
 
@@ -1177,6 +1116,37 @@ fn mark_missing_sources(conn: &Connection, present_paths: &HashSet<String>) -> r
   Ok(())
 }
 
+fn mark_missing_active_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, source_path
+    FROM sessions
+    WHERE source_state = 'active' AND source_bucket = 'active' AND source_path IS NOT NULL
+    ",
+  )?;
+  let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
+
+  for row in rows {
+    let (session_id, source_path) = row?;
+    if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
+      let now = now_utc_string();
+      conn.execute(
+        "
+        UPDATE sessions
+        SET source_state = 'missing', imported_at = ?1
+        WHERE session_id = ?2
+        ",
+        params![now, session_id],
+      )?;
+      conn.execute(
+        "DELETE FROM import_state WHERE source_path = ?1",
+        params![source_path],
+      )?;
+    }
+  }
+  Ok(())
+}
+
 fn prune_import_state(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
   let mut stmt = conn.prepare("SELECT source_path FROM import_state")?;
   let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
@@ -1290,7 +1260,6 @@ fn read_percent(value: &Value, key: &str) -> Option<i64> {
 struct ImportState {
   source_path: String,
   session_id: Option<String>,
-  source_bucket: String,
   file_size: i64,
   file_mtime_ms: i64,
 }
@@ -1894,6 +1863,69 @@ mod tests {
     assert_eq!(result.updated_sessions, 1);
     assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
     assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+  }
+
+  #[test]
+  fn incremental_scan_discovers_new_old_dated_active_session() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let existing_session_id = "10101010-2020-3030-4040-505050505050";
+    write_session_file(
+      &sessions_dir.join("existing.jsonl"),
+      existing_session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+
+    let old_dir = sessions_dir.join("2025").join("11").join("05");
+    std::fs::create_dir_all(&old_dir).expect("old sessions dir");
+    let new_session_id = "60606060-7070-8080-9090-a0a0a0a0a0a0";
+    write_session_file(
+      &old_dir.join("old-new.jsonl"),
+      new_session_id,
+      &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
+    );
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+  }
+
+  #[test]
+  fn incremental_scan_marks_missing_active_source() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "b0b0b0b0-c0c0-d0d0-e0e0-f0f0f0f0f0f0";
+    let session_path = sessions_dir.join("sample.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+    std::fs::remove_file(&session_path).expect("remove active session");
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 0);
+    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_source_state(&conn, session_id), Some("missing".to_string()));
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -62,8 +62,28 @@ enum SessionParseError {
 }
 
 const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
+const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
+const INCREMENTAL_DISCOVERY_DAYS: i64 = 14;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScanScope {
+  Full,
+  Incremental,
+}
 
 pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
+  perform_scan_with_scope(db_path, codex_home_override, ScanScope::Full)
+}
+
+pub fn perform_incremental_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
+  perform_scan_with_scope(db_path, codex_home_override, ScanScope::Incremental)
+}
+
+fn perform_scan_with_scope(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_scope: ScanScope,
+) -> Result<ScanResult, String> {
   let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
@@ -72,18 +92,30 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
   let scan_started_at = now_utc_string();
   set_last_scan_started(&conn, &scan_started_at).map_err(|error| error.to_string())?;
 
-  let session_files = collect_session_files(&codex_home);
-  let present_paths: HashSet<String> = session_files
-    .iter()
-    .map(|item| item.path.to_string_lossy().to_string())
-    .collect();
-
   let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
   let needs_token_usage_repair_sweep =
     data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
   let pending_token_repair_paths =
     load_pending_data_repair_paths(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let effective_scope = if requested_scope == ScanScope::Full
+    || import_state.is_empty()
+    || needs_rate_limit_backfill
+    || needs_token_usage_repair_sweep
+  {
+    ScanScope::Full
+  } else {
+    ScanScope::Incremental
+  };
+
+  let session_files = match effective_scope {
+    ScanScope::Full => collect_session_files(&codex_home),
+    ScanScope::Incremental => collect_incremental_session_files(&codex_home, &import_state, &pending_token_repair_paths),
+  };
+  let present_paths: HashSet<String> = session_files
+    .iter()
+    .map(|item| item.path.to_string_lossy().to_string())
+    .collect();
 
   let mut changed_sessions = 0usize;
   let mut imported_session_ids = HashSet::new();
@@ -163,8 +195,10 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
     }
   }
 
-  mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
-  prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
+  if effective_scope == ScanScope::Full {
+    mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
+    prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
+  }
   if topology_dirty {
     recompute_conversation_links(&conn).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
@@ -180,6 +214,10 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
     .map_err(|error| error.to_string())? as usize;
 
   let completed_at = now_utc_string();
+  if needs_rate_limit_backfill {
+    mark_data_repair_complete(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &completed_at)
+      .map_err(|error| error.to_string())?;
+  }
   if needs_token_usage_repair_sweep {
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
@@ -348,33 +386,119 @@ fn collect_session_files(codex_home: &Path) -> Vec<SessionFile> {
       continue;
     }
     for entry in WalkDir::new(base).into_iter().filter_map(Result::ok) {
-      if !entry.file_type().is_file() {
-        continue;
+      if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), bucket) {
+        files.push(session_file);
       }
-      if entry.path().extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
-        continue;
-      }
-      let Ok(metadata) = entry.metadata() else {
-        continue;
-      };
-      let file_size = metadata.len() as i64;
-      let file_mtime_ms = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|duration| duration.as_millis() as i64)
-        .unwrap_or_default();
-
-      files.push(SessionFile {
-        path: entry.path().to_path_buf(),
-        bucket: bucket.to_string(),
-        file_size,
-        file_mtime_ms,
-      });
     }
   }
   files.sort_by(|left, right| left.path.cmp(&right.path));
   files
+}
+
+fn collect_incremental_session_files(
+  codex_home: &Path,
+  import_state: &HashMap<String, ImportState>,
+  pending_token_repair_paths: &HashSet<String>,
+) -> Vec<SessionFile> {
+  let mut files = Vec::new();
+  let mut seen_paths = HashSet::new();
+
+  for state in import_state.values() {
+    let is_pending_repair = pending_token_repair_paths.contains(&state.source_path);
+    if state.source_bucket != "active" && !is_pending_repair {
+      continue;
+    }
+
+    let path = PathBuf::from(&state.source_path);
+    if !seen_paths.insert(path.clone()) {
+      continue;
+    }
+    if let Some(session_file) = session_file_from_path(path, &state.source_bucket) {
+      files.push(session_file);
+    }
+  }
+
+  for source_path in pending_token_repair_paths {
+    let path = PathBuf::from(source_path);
+    if !seen_paths.insert(path.clone()) {
+      continue;
+    }
+    let bucket = infer_source_bucket(codex_home, &path);
+    if let Some(session_file) = session_file_from_path(path, bucket) {
+      files.push(session_file);
+    }
+  }
+
+  for session_file in collect_recent_active_session_files(codex_home) {
+    if seen_paths.insert(session_file.path.clone()) {
+      files.push(session_file);
+    }
+  }
+
+  files.sort_by(|left, right| left.path.cmp(&right.path));
+  files
+}
+
+fn collect_recent_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
+  let sessions_root = codex_home.join("sessions");
+  if !sessions_root.exists() {
+    return Vec::new();
+  }
+
+  let today = Local::now().date_naive();
+  let mut files = Vec::new();
+  for days_ago in 0..=INCREMENTAL_DISCOVERY_DAYS {
+    let day = today - chrono::Duration::days(days_ago);
+    let day_dir = sessions_root
+      .join(day.format("%Y").to_string())
+      .join(day.format("%m").to_string())
+      .join(day.format("%d").to_string());
+    if !day_dir.exists() {
+      continue;
+    }
+
+    for entry in WalkDir::new(day_dir).into_iter().filter_map(Result::ok) {
+      if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), "active") {
+        files.push(session_file);
+      }
+    }
+  }
+
+  files
+}
+
+fn infer_source_bucket(codex_home: &Path, path: &Path) -> &'static str {
+  if path.starts_with(codex_home.join("archived_sessions")) {
+    "archived"
+  } else {
+    "active"
+  }
+}
+
+fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
+  if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+    return None;
+  }
+
+  let metadata = std::fs::metadata(&path).ok()?;
+  if !metadata.is_file() {
+    return None;
+  }
+
+  let file_size = metadata.len() as i64;
+  let file_mtime_ms = metadata
+    .modified()
+    .ok()
+    .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+    .map(|duration| duration.as_millis() as i64)
+    .unwrap_or_default();
+
+  Some(SessionFile {
+    path,
+    bucket: bucket.to_string(),
+    file_size,
+    file_mtime_ms,
+  })
 }
 
 fn parse_session_file(
@@ -898,7 +1022,7 @@ fn normalize_local_timestamp(timestamp: chrono::DateTime<Local>) -> chrono::Date
 fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, ImportState>> {
   let mut stmt = conn.prepare(
     "
-    SELECT source_path, session_id, file_size, file_mtime_ms
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms
     FROM import_state
     ",
   )?;
@@ -907,8 +1031,9 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
     Ok(ImportState {
       source_path: row.get(0)?,
       session_id: row.get(1)?,
-      file_size: row.get(2)?,
-      file_mtime_ms: row.get(3)?,
+      source_bucket: row.get(2)?,
+      file_size: row.get(3)?,
+      file_mtime_ms: row.get(4)?,
     })
   })?;
 
@@ -921,16 +1046,7 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
 }
 
 fn needs_rate_limit_sample_backfill(conn: &Connection) -> rusqlite::Result<bool> {
-  let count = conn.query_row(
-    "
-    SELECT COUNT(*)
-    FROM rate_limit_samples
-    WHERE source_kind = 'session'
-    ",
-    [],
-    |row| row.get::<_, i64>(0),
-  )?;
-  Ok(count == 0)
+  data_repair_is_pending(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY)
 }
 
 fn data_repair_is_pending(conn: &Connection, repair_key: &str) -> rusqlite::Result<bool> {
@@ -1174,6 +1290,7 @@ fn read_percent(value: &Value, key: &str) -> Option<i64> {
 struct ImportState {
   source_path: String,
   session_id: Option<String>,
+  source_bucket: String,
   file_size: i64,
   file_mtime_ms: i64,
 }
@@ -1695,6 +1812,131 @@ mod tests {
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
     assert_eq!(session_source_state(&conn, session_id), Some("archived".to_string()));
+  }
+
+  #[test]
+  fn incremental_scan_skips_archived_session_changes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archived_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_dir).expect("archived dir");
+
+    let active_session_id = "12121212-3434-5656-7878-909090909090";
+    let archived_session_id = "abababab-cdcd-efef-1212-343434343434";
+    write_session_file(
+      &sessions_dir.join("active.jsonl"),
+      active_session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let archived_path = archived_dir.join("archived.jsonl");
+    write_session_file(
+      &archived_path,
+      archived_session_id,
+      &[("2026-03-24T00:00:01Z", 150, 30, 40, 190)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+    write_session_file(
+      &archived_path,
+      archived_session_id,
+      &[
+        ("2026-03-24T00:00:01Z", 150, 30, 40, 190),
+        ("2026-03-24T00:10:01Z", 300, 60, 80, 380),
+      ],
+    );
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 0);
+    assert_eq!(session_usage_totals(&conn, active_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_usage_totals(&conn, archived_session_id), (150, 30, 40, 190, 1));
+  }
+
+  #[test]
+  fn incremental_scan_discovers_new_recent_active_session() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let existing_session_id = "99999999-8888-7777-6666-555555555555";
+    write_session_file(
+      &sessions_dir.join("existing.jsonl"),
+      existing_session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+
+    let today = Local::now();
+    let recent_dir = sessions_dir
+      .join(today.format("%Y").to_string())
+      .join(today.format("%m").to_string())
+      .join(today.format("%d").to_string());
+    std::fs::create_dir_all(&recent_dir).expect("recent sessions dir");
+    let new_session_id = "44444444-3333-2222-1111-000000000000";
+    write_session_file(
+      &recent_dir.join("new.jsonl"),
+      new_session_id,
+      &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
+    );
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+  }
+
+  #[test]
+  fn incremental_scan_retries_pending_repair_path_without_import_state() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let existing_session_id = "77777777-8888-9999-aaaa-bbbbbbbbbbbb";
+    write_session_file(
+      &sessions_dir.join("existing.jsonl"),
+      existing_session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let pending_path = sessions_dir.join("unparseable.jsonl");
+    std::fs::write(&pending_path, "not json\n").expect("write bad session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+
+    let recovered_session_id = "88888888-9999-aaaa-bbbb-cccccccccccc";
+    write_session_file(
+      &pending_path,
+      recovered_session_id,
+      &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
+    );
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_usage_totals(&conn, recovered_session_id), (180, 40, 45, 225, 1));
+    let pending_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![TOKEN_USAGE_MONOTONIC_REPAIR_KEY],
+        |row| row.get(0),
+      )
+      .expect("query pending repairs");
+    assert_eq!(pending_count, 0);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use database::{
   canonical_subscription_currency, get_subscription_profile, get_sync_settings, init_db,
   insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
 };
-use importer::{perform_scan, recalculate_all_session_values};
+use importer::{perform_incremental_scan, perform_scan, recalculate_all_session_values};
 use models::{
   ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
@@ -338,6 +338,21 @@ fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanR
   }
 
   let result = perform_scan(&state.db_path, codex_home);
+  state.scan_in_progress.store(false, Ordering::SeqCst);
+  refresh_daily_value_menu_bar(&state);
+  result
+}
+
+fn run_incremental_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
+  if state
+    .scan_in_progress
+    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+    .is_err()
+  {
+    return Err("A scan is already running.".to_string());
+  }
+
+  let result = perform_incremental_scan(&state.db_path, codex_home);
   state.scan_in_progress.store(false, Ordering::SeqCst);
   refresh_daily_value_menu_bar(&state);
   result
@@ -935,7 +950,7 @@ fn refresh_rate_limit_history_if_idle(state: &AppState) {
     return;
   }
 
-  let result = perform_scan(&state.db_path, None);
+  let result = perform_incremental_scan(&state.db_path, None);
   state.scan_in_progress.store(false, Ordering::SeqCst);
   if let Err(error) = result {
     log::warn!("Failed to refresh Codex history rate-limit samples: {error}");
@@ -1525,7 +1540,7 @@ fn show_main_window(app: &AppHandle) {
 
 fn spawn_initial_scan(state: AppState) {
   tauri::async_runtime::spawn(async move {
-    let _ = run_scan_if_idle(state, None);
+    let _ = run_incremental_scan_if_idle(state, None);
   });
 }
 
@@ -1565,7 +1580,7 @@ fn spawn_scheduler(state: AppState) {
       };
 
       if should_scan {
-        let _ = run_scan_if_idle(state.clone(), settings.codex_home.clone());
+        let _ = run_incremental_scan_if_idle(state.clone(), settings.codex_home.clone());
       }
     }
   });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1165,7 +1165,7 @@ fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
 }
 
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
-  auto_scan_interval_minutes.max(1).saturating_mul(60).clamp(60, 3600)
+  auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
 
 fn build_menu_bar_popup_window(app: &AppHandle) -> Result<WebviewWindow, String> {
@@ -1842,6 +1842,25 @@ mod tests {
     );
     assert_eq!(
       scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:07:00Z")),
+      Duration::ZERO
+    );
+  }
+
+  #[test]
+  fn scheduler_honors_auto_scan_intervals_above_one_hour() {
+    let settings = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 180,
+      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T01:00:00Z")),
+      Duration::from_secs(7200)
+    );
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T03:00:00Z")),
       Duration::ZERO
     );
   }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -363,8 +363,44 @@ fn run_incremental_scan_if_idle(state: AppState, codex_home: Option<String>) -> 
 fn prepare_app_database(db_path: &Path) -> Result<(), String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
+  let pricing_signature_before = load_pricing_value_signature(&conn).map_err(|error| error.to_string())?;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
+  let pricing_signature_after = load_pricing_value_signature(&conn).map_err(|error| error.to_string())?;
+  if pricing_signature_before != pricing_signature_after {
+    recalculate_all_session_values(&conn).map_err(|error| error.to_string())?;
+  }
   Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+struct PricingValueSignatureEntry {
+  model_id: String,
+  input_price_per_million: f64,
+  cached_input_price_per_million: f64,
+  output_price_per_million: f64,
+  effective_model_id: String,
+}
+
+fn load_pricing_value_signature(conn: &rusqlite::Connection) -> rusqlite::Result<Vec<PricingValueSignatureEntry>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT model_id, input_price_per_million, cached_input_price_per_million,
+           output_price_per_million, effective_model_id
+    FROM pricing_catalog
+    ORDER BY model_id
+    ",
+  )?;
+  let rows = stmt.query_map([], |row| {
+    Ok(PricingValueSignatureEntry {
+      model_id: row.get(0)?,
+      input_price_per_million: row.get(1)?,
+      cached_input_price_per_million: row.get(2)?,
+      output_price_per_million: row.get(3)?,
+      effective_model_id: row.get(4)?,
+    })
+  })?;
+
+  rows.collect()
 }
 
 fn refresh_daily_value_menu_bar(state: &AppState) {
@@ -1877,6 +1913,68 @@ mod tests {
       .expect("load usage value");
 
     assert_eq!(value_usd, 123.45);
+  }
+
+  #[test]
+  fn startup_database_prepare_recalculates_usage_values_when_seed_pricing_changes() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    conn
+      .execute(
+        "
+        UPDATE pricing_catalog
+        SET input_price_per_million = 1.00
+        WHERE model_id = 'gpt-5.4'
+        ",
+        [],
+      )
+      .expect("seed stale pricing");
+    let created_at = database::now_utc_string();
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, parent_session_id, title, source_state, source_path,
+          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+        )
+        VALUES ('startup-session', 'startup-session', NULL, NULL, 'active', NULL, 'active',
+          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.4', 0, ?1, ?1)
+        ",
+        params![created_at],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('startup-session', '2026-03-26T04:30:00Z', 'gpt-5.4',
+          1000000, 0, 0, 0, 1000000, 123.45, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage event");
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let value_usd: f64 = conn
+      .query_row(
+        "SELECT value_usd FROM usage_events WHERE session_id = 'startup-session'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load usage value");
+
+    assert_eq!(value_usd, 2.50);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ mod queries;
 mod rate_limits;
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{
   atomic::{AtomicBool, Ordering},
   Arc, Mutex,
@@ -27,7 +27,9 @@ use models::{
   ScanResult, SubscriptionProfile, SyncSettings,
 };
 use pricing::{load_catalog, refresh_pricing_catalog_from_openai, seed_pricing_catalog};
-use queries::{get_conversation_detail, get_overview, get_quota_trend, list_conversations, load_dashboard_data};
+use queries::{
+  get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
+};
 use rate_limits::query_live_rate_limits;
 use tauri::{
   Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
@@ -341,6 +343,13 @@ fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanR
   result
 }
 
+fn prepare_app_database(db_path: &Path) -> Result<(), String> {
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  init_db(&conn).map_err(|error| error.to_string())?;
+  seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
+  Ok(())
+}
+
 fn refresh_daily_value_menu_bar(state: &AppState) {
   if let Err(error) = update_daily_value_menu_bar(state) {
     log::warn!("Failed to update menu bar display: {error}");
@@ -429,16 +438,16 @@ fn current_menu_bar_title_parts(
     None
   };
   let api_value_title = if settings.show_menu_bar_daily_api_value {
-    let overview = get_overview(
+    let api_value_usd = get_window_api_value(
       &state.db_path,
-      Some(bucket.clone()),
+      bucket.clone(),
       if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
       None,
       None,
       live_rate_limits.clone(),
       None,
     )?;
-    Some(format!("${:.1}", overview.stats.api_value_usd))
+    Some(format!("${:.1}", api_value_usd))
   } else {
     None
   };
@@ -1620,10 +1629,8 @@ pub fn run() {
         .map_err(|error| format!("Failed to create app data dir {}: {error}", app_data_dir.display()))?;
       let db_path = app_data_dir.join("codex-counter.sqlite");
 
+      prepare_app_database(&db_path)?;
       let conn = open_connection(&db_path).map_err(|error| error.to_string())?;
-      init_db(&conn).map_err(|error| error.to_string())?;
-      seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
-      recalculate_all_session_values(&conn).map_err(|error| error.to_string())?;
 
       let app_handle = app.app_handle();
       let daily_value_tray = match build_daily_value_menu_bar(&app_handle, &db_path) {
@@ -1677,6 +1684,7 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use tempfile::tempdir;
 
   fn speed_test_settings() -> SyncSettings {
     SyncSettings {
@@ -1695,6 +1703,58 @@ mod tests {
     DateTime::parse_from_rfc3339(value)
       .expect("parse test timestamp")
       .with_timezone(&Local)
+  }
+
+  #[test]
+  fn startup_database_prepare_does_not_recalculate_usage_values() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    let created_at = database::now_utc_string();
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, parent_session_id, title, source_state, source_path,
+          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+        )
+        VALUES ('startup-session', 'startup-session', NULL, NULL, 'active', NULL, 'active',
+          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.4', 0, ?1, ?1)
+        ",
+        params![created_at],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('startup-session', '2026-03-26T04:30:00Z', 'gpt-5.4',
+          100, 0, 10, 0, 110, 123.45, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage event");
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let value_usd: f64 = conn
+      .query_row(
+        "SELECT value_usd FROM usage_events WHERE session_id = 'startup-session'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load usage value");
+
+    assert_eq!(value_usd, 123.45);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,10 +13,10 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
-use chrono::{DateTime, Duration as ChronoDuration, Local};
+use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
 use rusqlite::params;
 use database::{
-  canonical_subscription_currency, get_subscription_profile, get_sync_settings, init_db,
+  canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
   insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
 };
 use importer::{perform_incremental_scan, perform_scan, recalculate_all_session_values};
@@ -53,6 +53,7 @@ const MENU_BAR_POPUP_MAX_HEIGHT: f64 = 760.0;
 const MENU_BAR_POPUP_OFFSET_Y: i32 = 8;
 const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
+const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 #[derive(Clone)]
 struct CachedRateLimitSnapshot {
   fetched_at: Instant,
@@ -1562,17 +1563,24 @@ fn spawn_scheduler(state: AppState) {
         tokio::time::sleep(Duration::from_secs(60)).await;
         continue;
       };
-      let delay = scheduler_delay_until_next_refresh(&settings, chrono::Utc::now());
+      let now = Utc::now();
+      let delay = scheduler_delay_until_next_refresh(&settings, now);
       if !delay.is_zero() {
         tokio::time::sleep(delay).await;
         continue;
       }
+      let should_run_full = get_last_full_scan_completed(&conn)
+        .map(|last_completed_at| full_maintenance_due(last_completed_at.as_deref(), now))
+        .unwrap_or(true);
+      drop(conn);
 
       if state.scan_in_progress.load(Ordering::SeqCst) {
         tokio::time::sleep(Duration::from_secs(
           unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
         ))
         .await;
+      } else if should_run_full {
+        let _ = run_scan_if_idle(state.clone(), settings.codex_home.clone());
       } else {
         let _ = run_incremental_scan_if_idle(state.clone(), settings.codex_home.clone());
       }
@@ -1598,6 +1606,19 @@ fn scheduler_delay_until_next_refresh(settings: &SyncSettings, now: chrono::Date
     .max(0);
   let remaining_seconds = interval_seconds.saturating_sub(elapsed_seconds);
   Duration::from_secs(remaining_seconds as u64)
+}
+
+fn full_maintenance_due(last_completed_at: Option<&str>, now: chrono::DateTime<chrono::Utc>) -> bool {
+  let Some(last_completed_at) = last_completed_at else {
+    return true;
+  };
+  let Some(last_completed_at) = chrono::DateTime::parse_from_rfc3339(last_completed_at).ok() else {
+    return true;
+  };
+  now
+    .signed_duration_since(last_completed_at.with_timezone(&chrono::Utc))
+    .num_seconds()
+    >= FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -1787,6 +1808,23 @@ mod tests {
       scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:07:00Z")),
       Duration::ZERO
     );
+  }
+
+  #[test]
+  fn full_maintenance_is_due_without_previous_full_scan() {
+    assert!(full_maintenance_due(None, utc_time("2026-03-27T00:00:00Z")));
+  }
+
+  #[test]
+  fn full_maintenance_waits_until_daily_interval() {
+    assert!(!full_maintenance_due(
+      Some("2026-03-27T00:00:00Z"),
+      utc_time("2026-03-27T23:59:59Z")
+    ));
+    assert!(full_maintenance_due(
+      Some("2026-03-27T00:00:00Z"),
+      utc_time("2026-03-28T00:00:00Z")
+    ));
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -272,11 +272,12 @@ fn updateSyncSettings(
 ) -> Result<SyncSettings, String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let current = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+  let auto_scan_interval_minutes = payload.auto_scan_interval_minutes.max(1);
   let updated = SyncSettings {
     codex_home: payload.codex_home,
     auto_scan_enabled: payload.auto_scan_enabled,
-    auto_scan_interval_minutes: payload.auto_scan_interval_minutes.max(1),
-    live_quota_refresh_interval_seconds: payload.live_quota_refresh_interval_seconds.clamp(60, 3600),
+    auto_scan_interval_minutes,
+    live_quota_refresh_interval_seconds: unified_refresh_interval_seconds(auto_scan_interval_minutes),
     hide_dock_icon_when_menu_bar_visible: payload.hide_dock_icon_when_menu_bar_visible,
     show_menu_bar_logo: payload.show_menu_bar_logo,
     show_menu_bar_daily_api_value: payload.show_menu_bar_daily_api_value,
@@ -1025,7 +1026,7 @@ fn build_menu_bar_popup_snapshot(
 
   Ok(MenuBarPopupSnapshot {
     fetched_at: Local::now().to_rfc3339(),
-    refresh_interval_seconds: settings.live_quota_refresh_interval_seconds,
+    refresh_interval_seconds: unified_refresh_interval_seconds(settings.auto_scan_interval_minutes),
     selected_bucket,
     quota_5h: live_rate_limits
       .as_ref()
@@ -1120,8 +1121,14 @@ fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
   open_connection(&state.db_path)
     .ok()
     .and_then(|conn| get_sync_settings(&conn).ok())
-    .map(|settings| Duration::from_secs(settings.live_quota_refresh_interval_seconds.clamp(60, 3600) as u64))
+    .map(|settings| {
+      Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64)
+    })
     .unwrap_or(Duration::from_secs(300))
+}
+
+fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
+  auto_scan_interval_minutes.max(1).saturating_mul(60).clamp(60, 3600)
 }
 
 fn build_menu_bar_popup_window(app: &AppHandle) -> Result<WebviewWindow, String> {
@@ -1547,43 +1554,50 @@ fn spawn_initial_scan(state: AppState) {
 fn spawn_scheduler(state: AppState) {
   tauri::async_runtime::spawn(async move {
     loop {
-      tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-
-      if state.scan_in_progress.load(Ordering::SeqCst) {
-        continue;
-      }
-
       let Ok(conn) = open_connection(&state.db_path) else {
+        tokio::time::sleep(Duration::from_secs(60)).await;
         continue;
       };
       let Ok(settings) = get_sync_settings(&conn) else {
+        tokio::time::sleep(Duration::from_secs(60)).await;
         continue;
       };
-      if menu_bar_has_visible_content(&settings) {
-        refresh_daily_value_menu_bar(&state);
-      }
-      if !settings.auto_scan_enabled {
+      let delay = scheduler_delay_until_next_refresh(&settings, chrono::Utc::now());
+      if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
         continue;
       }
 
-      let should_scan = match settings.last_scan_completed_at.as_deref() {
-        Some(last_completed_at) => {
-          chrono::DateTime::parse_from_rfc3339(last_completed_at)
-            .ok()
-            .map(|last| {
-              let elapsed = chrono::Utc::now().signed_duration_since(last.with_timezone(&chrono::Utc));
-              elapsed.num_minutes() >= settings.auto_scan_interval_minutes.max(1)
-            })
-            .unwrap_or(true)
-        }
-        None => true,
-      };
-
-      if should_scan {
+      if state.scan_in_progress.load(Ordering::SeqCst) {
+        tokio::time::sleep(Duration::from_secs(
+          unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
+        ))
+        .await;
+      } else {
         let _ = run_incremental_scan_if_idle(state.clone(), settings.codex_home.clone());
       }
     }
   });
+}
+
+fn scheduler_delay_until_next_refresh(settings: &SyncSettings, now: chrono::DateTime<chrono::Utc>) -> Duration {
+  let interval_seconds = unified_refresh_interval_seconds(settings.auto_scan_interval_minutes);
+  if !settings.auto_scan_enabled {
+    return Duration::from_secs(interval_seconds as u64);
+  }
+
+  let Some(last_completed_at) = settings.last_scan_completed_at.as_deref() else {
+    return Duration::ZERO;
+  };
+  let Some(last_completed_at) = chrono::DateTime::parse_from_rfc3339(last_completed_at).ok() else {
+    return Duration::ZERO;
+  };
+  let elapsed_seconds = now
+    .signed_duration_since(last_completed_at.with_timezone(&chrono::Utc))
+    .num_seconds()
+    .max(0);
+  let remaining_seconds = interval_seconds.saturating_sub(elapsed_seconds);
+  Duration::from_secs(remaining_seconds as u64)
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -1718,6 +1732,61 @@ mod tests {
     DateTime::parse_from_rfc3339(value)
       .expect("parse test timestamp")
       .with_timezone(&Local)
+  }
+
+  fn utc_time(value: &str) -> chrono::DateTime<chrono::Utc> {
+    DateTime::parse_from_rfc3339(value)
+      .expect("parse test timestamp")
+      .with_timezone(&chrono::Utc)
+  }
+
+  #[test]
+  fn scheduler_uses_auto_scan_interval_when_disabled() {
+    let settings = SyncSettings {
+      auto_scan_enabled: false,
+      auto_scan_interval_minutes: 7,
+      last_scan_completed_at: None,
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
+      Duration::from_secs(420)
+    );
+  }
+
+  #[test]
+  fn scheduler_runs_immediately_without_previous_scan() {
+    let settings = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 7,
+      last_scan_completed_at: None,
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
+      Duration::ZERO
+    );
+  }
+
+  #[test]
+  fn scheduler_waits_remaining_auto_scan_interval() {
+    let settings = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 7,
+      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:03:00Z")),
+      Duration::from_secs(240)
+    );
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:07:00Z")),
+      Duration::ZERO
+    );
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use chrono::{
   DateTime, Datelike, Days, Local, LocalResult, Months, NaiveDate, NaiveDateTime, TimeZone,
-  Timelike,
+  SecondsFormat, Timelike,
 };
 use rusqlite::Connection;
 use serde_json::Value;
@@ -160,6 +160,35 @@ pub fn get_quota_trend(
     &filtered_events,
     live_rate_limits.as_ref(),
   ))
+}
+
+pub fn get_window_api_value(
+  db_path: &Path,
+  bucket: String,
+  anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
+  live_rate_limits: Option<LiveRateLimitSnapshot>,
+  live_window_offset: Option<i64>,
+) -> Result<f64, String> {
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  if bucket == "total" {
+    return sum_all_api_value(&conn).map_err(|error| error.to_string());
+  }
+
+  let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let resolved_window = resolve_window(
+    &conn,
+    Some(bucket),
+    anchor,
+    custom_start,
+    custom_end,
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    live_window_offset,
+  )?;
+  sum_window_api_value(&conn, &resolved_window.window).map_err(|error| error.to_string())
 }
 
 pub fn list_conversations(
@@ -1160,6 +1189,30 @@ fn load_events_for_root_session(conn: &Connection, root_session_id: &str) -> rus
   })?;
 
   rows.collect()
+}
+
+fn sum_all_api_value(conn: &Connection) -> rusqlite::Result<f64> {
+  conn.query_row("SELECT COALESCE(SUM(value_usd), 0.0) FROM usage_events", [], |row| {
+    row.get(0)
+  })
+}
+
+fn sum_window_api_value(conn: &Connection, window: &Window) -> rusqlite::Result<f64> {
+  conn.query_row(
+    "
+    SELECT COALESCE(SUM(value_usd), 0.0)
+    FROM usage_events
+    WHERE timestamp >= ?1 AND timestamp < ?2
+    ",
+    rusqlite::params![utc_timestamp_key(window.start), utc_timestamp_key(window.end)],
+    |row| row.get(0),
+  )
+}
+
+fn utc_timestamp_key(timestamp: DateTime<Local>) -> String {
+  timestamp
+    .with_timezone(&chrono::Utc)
+    .to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
 fn resolve_window(
@@ -2266,6 +2319,58 @@ mod tests {
     assert_eq!(window.window.anchor, "2026-03-26");
     assert_eq!(window.window.start.to_rfc3339(), "2026-03-26T11:27:00+08:00");
     assert_eq!(window.window.end.to_rfc3339(), "2026-03-26T16:27:00+08:00");
+  }
+
+  #[test]
+  fn menu_bar_api_value_uses_selected_live_window() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES
+          ('inside', '2026-03-26T04:30:00Z', 'gpt-5.4', 0, 0, 0, 0, 0, 2.50, 0, 0),
+          ('outside', '2026-03-26T09:30:00Z', 'gpt-5.4', 0, 0, 0, 0, 0, 7.25, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage events");
+    let live_rate_limits = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: Some(crate::models::RateLimitWindowSnapshot {
+        used_percent: 8,
+        remaining_percent: 92,
+        window_duration_mins: Some(300),
+        resets_at: Some("2026-03-26T16:27:36+08:00".to_string()),
+        window_start: Some("2026-03-26T11:27:36+08:00".to_string()),
+      }),
+      secondary: None,
+      fetched_at: "2026-03-26T14:33:00+08:00".to_string(),
+    };
+    insert_live_rate_limit_snapshot(&conn, &live_rate_limits).expect("insert live rate limit snapshot");
+    drop(conn);
+
+    let api_value = get_window_api_value(
+      &db_path,
+      "five_hour".to_string(),
+      None,
+      None,
+      None,
+      Some(live_rate_limits),
+      None,
+    )
+    .expect("load menu bar api value");
+
+    assert_eq!(api_value, 2.50);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use chrono::{
   DateTime, Datelike, Days, Local, LocalResult, Months, NaiveDate, NaiveDateTime, TimeZone,
-  SecondsFormat, Timelike,
+  Timelike,
 };
 use rusqlite::Connection;
 use serde_json::Value;
@@ -176,6 +176,7 @@ pub fn get_window_api_value(
     return sum_all_api_value(&conn).map_err(|error| error.to_string());
   }
 
+  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let resolved_window = resolve_window(
     &conn,
@@ -183,12 +184,12 @@ pub fn get_window_api_value(
     anchor,
     custom_start,
     custom_end,
-    &[],
+    &events,
     profile.billing_anchor_day,
     live_rate_limits.as_ref(),
     live_window_offset,
   )?;
-  sum_window_api_value(&conn, &resolved_window.window).map_err(|error| error.to_string())
+  Ok(sum_window_api_value(&events, &resolved_window.window))
 }
 
 pub fn list_conversations(
@@ -1197,22 +1198,12 @@ fn sum_all_api_value(conn: &Connection) -> rusqlite::Result<f64> {
   })
 }
 
-fn sum_window_api_value(conn: &Connection, window: &Window) -> rusqlite::Result<f64> {
-  conn.query_row(
-    "
-    SELECT COALESCE(SUM(value_usd), 0.0)
-    FROM usage_events
-    WHERE timestamp >= ?1 AND timestamp < ?2
-    ",
-    rusqlite::params![utc_timestamp_key(window.start), utc_timestamp_key(window.end)],
-    |row| row.get(0),
-  )
-}
-
-fn utc_timestamp_key(timestamp: DateTime<Local>) -> String {
-  timestamp
-    .with_timezone(&chrono::Utc)
-    .to_rfc3339_opts(SecondsFormat::Millis, true)
+fn sum_window_api_value(events: &[EventRow], window: &Window) -> f64 {
+  events
+    .iter()
+    .filter(|event| event_in_window(event, window))
+    .map(|event| event.value_usd)
+    .sum()
 }
 
 fn resolve_window(
@@ -2337,6 +2328,7 @@ mod tests {
         )
         VALUES
           ('inside', '2026-03-26T04:30:00Z', 'gpt-5.4', 0, 0, 0, 0, 0, 2.50, 0, 0),
+          ('inside-offset', '2026-03-26T11:45:00+08:00', 'gpt-5.4', 0, 0, 0, 0, 0, 1.25, 0, 0),
           ('outside', '2026-03-26T09:30:00Z', 'gpt-5.4', 0, 0, 0, 0, 0, 7.25, 0, 0)
         ",
         [],
@@ -2370,7 +2362,7 @@ mod tests {
     )
     .expect("load menu bar api value");
 
-    assert_eq!(api_value, 2.50);
+    assert_eq!(api_value, 3.75);
   }
 
   #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -308,7 +308,7 @@ function App() {
     let cancelled = false
 
     const bootstrap = async () => {
-      await loadShellRef.current(true)
+      await loadShellRef.current(false)
       if (!cancelled) {
         setHasBootstrapped(true)
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,10 @@ const BUCKETS: OverviewBucket[] = [
   'total',
 ]
 
+function unifiedRefreshIntervalMs(autoScanIntervalMinutes: number | null | undefined) {
+  return Math.max(60000, (autoScanIntervalMinutes ?? 5) * 60 * 1000)
+}
+
 function App() {
   const { language, setLanguage, t } = useI18n()
   const [view, setView] = useState<AppView>('overview')
@@ -330,15 +334,11 @@ function App() {
 
   useEffect(() => {
     if (!hasBootstrapped) return
-    const refreshMs =
-      bucket === 'five_hour' || bucket === 'seven_day'
-        ? (syncSettings?.liveQuotaRefreshIntervalSeconds ?? 300) * 1000
-        : 60000
     const interval = window.setInterval(() => {
       void loadShell(false)
-    }, Math.max(5000, refreshMs))
+    }, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
     return () => window.clearInterval(interval)
-  }, [bucket, hasBootstrapped, loadShell, syncSettings?.liveQuotaRefreshIntervalSeconds])
+  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanIntervalMinutes])
 
   useEffect(() => {
     if (!settingsOpen) return
@@ -352,15 +352,12 @@ function App() {
         })
         .catch(() => {})
     refresh()
-    const interval = window.setInterval(
-      refresh,
-      Math.max(60000, (syncSettings?.liveQuotaRefreshIntervalSeconds ?? 300) * 1000),
-    )
+    const interval = window.setInterval(refresh, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
     return () => {
       cancelled = true
       window.clearInterval(interval)
     }
-  }, [settingsOpen, syncSettings?.liveQuotaRefreshIntervalSeconds])
+  }, [settingsOpen, syncSettings?.autoScanIntervalMinutes])
 
   async function handleRescan() {
     await loadShell(true)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,9 +109,9 @@ function App() {
   const latestDetailRequestIdRef = useRef(0)
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
-  const waitForScanToSettle = useCallback(async () => {
+  const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
     const startedAt = Date.now()
-    while (Date.now() - startedAt < 15000) {
+    while (Date.now() - startedAt < timeoutMs) {
       if (!(await getScanInProgress())) {
         return
       }
@@ -308,6 +308,7 @@ function App() {
     let cancelled = false
 
     const bootstrap = async () => {
+      await waitForScanToSettle(60000)
       await loadShellRef.current(false)
       if (!cancelled) {
         setHasBootstrapped(true)
@@ -319,7 +320,7 @@ function App() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [waitForScanToSettle])
 
   useEffect(() => {
     if (!hasBootstrapped) return

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -184,8 +184,6 @@ export type TranslationSet = {
         autoScanEnabled: string
         autoScanEnabledNote: string
         autoScanIntervalMinutes: string
-        liveQuotaRefreshIntervalSeconds: string
-        liveQuotaRefreshNote: string
       }
       menuBar: {
         eyebrow: string
@@ -427,14 +425,12 @@ const translations: Record<AppLanguage, TranslationSet> = {
         sync: {
           eyebrow: '同步',
           title: '扫描与数据源',
-          description: '控制 Codex 数据目录、自动扫描频率，以及 live quota 的刷新周期。',
+          description: '控制 Codex 数据目录，以及所有后台自动刷新的统一频率。',
           codexHome: 'Codex home',
           codexHomePlaceholder: '默认使用 CODEX_HOME 或 ~/.codex',
           autoScanEnabled: '启用自动扫描',
           autoScanEnabledNote: '关闭后仅保留手动扫描，不再按周期自动刷新数据。',
-          autoScanIntervalMinutes: '自动扫描间隔（分钟）',
-          liveQuotaRefreshIntervalSeconds: 'Live quota 刷新间隔（分钟）',
-          liveQuotaRefreshNote: '独立控制 `5小时 / 7天` live quota 的主动刷新与历史持久化频率。',
+          autoScanIntervalMinutes: '后台自动刷新间隔（分钟）',
         },
         menuBar: {
           eyebrow: '托盘',
@@ -669,14 +665,12 @@ const translations: Record<AppLanguage, TranslationSet> = {
         sync: {
           eyebrow: 'Sync',
           title: 'Scan and data sources',
-          description: 'Control the Codex data directory, automatic scan cadence, and live quota refresh interval.',
+          description: 'Control the Codex data directory and the unified cadence for all background refreshes.',
           codexHome: 'Codex home',
           codexHomePlaceholder: 'Defaults to CODEX_HOME or ~/.codex',
           autoScanEnabled: 'Auto scan enabled',
           autoScanEnabledNote: 'When disabled, only manual scans are kept and periodic refresh stops.',
-          autoScanIntervalMinutes: 'Auto scan interval (minutes)',
-          liveQuotaRefreshIntervalSeconds: 'Live quota refresh interval (minutes)',
-          liveQuotaRefreshNote: 'Separately controls active refresh and history persistence for `5h / 7d` live quota snapshots.',
+          autoScanIntervalMinutes: 'Background refresh interval (minutes)',
         },
         menuBar: {
           eyebrow: 'Tray',

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -52,14 +52,6 @@ function SwitchField({ label, checked, disabled = false, onChange }: SwitchField
   )
 }
 
-function refreshSecondsToMinutes(seconds: number) {
-  return Math.max(1, Math.round(seconds / 60))
-}
-
-function refreshMinutesToSeconds(minutes: number) {
-  return Math.min(60, Math.max(1, minutes)) * 60
-}
-
 function isMacOs() {
   return typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac')
 }
@@ -272,37 +264,16 @@ export function SettingsPanel({
                     type="number"
                     value={draftSync.autoScanIntervalMinutes}
                     onChange={(event) =>
-                      setDraftSync((current) =>
-                        current
+                      setDraftSync((current) => {
+                        const intervalMinutes = Math.max(1, Number(event.target.value || 5))
+                        return current
                           ? {
                               ...current,
-                              autoScanIntervalMinutes: Math.max(1, Number(event.target.value || 5)),
+                              autoScanIntervalMinutes: intervalMinutes,
+                              liveQuotaRefreshIntervalSeconds: intervalMinutes * 60,
                             }
-                          : current,
-                      )
-                    }
-                  />
-                </label>
-
-                <label className="field">
-                  <span>{t.settings.sections.sync.liveQuotaRefreshIntervalSeconds}</span>
-                  <input
-                    min={1}
-                    max={60}
-                    step={1}
-                    type="number"
-                    value={refreshSecondsToMinutes(draftSync.liveQuotaRefreshIntervalSeconds)}
-                    onChange={(event) =>
-                      setDraftSync((current) =>
-                        current
-                          ? {
-                              ...current,
-                              liveQuotaRefreshIntervalSeconds: refreshMinutesToSeconds(
-                                Number(event.target.value || 5),
-                              ),
-                            }
-                          : current,
-                      )
+                          : current
+                      })
                     }
                   />
                 </label>


### PR DESCRIPTION
## Summary

- Make regular background refresh scan only active session files under `sessions/**/*.jsonl`, while full scans still handle active and archived state, missing cleanup, repair, and backfill.
- Add an internal `last_full_scan_completed_at` timestamp so the unified background refresh runs full maintenance only once every 24 hours.
- Mark disappeared active session files as `missing` during incremental scans and remove stale import state for those paths.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml`
- Profiled the release test binary against the current `~/.codex`: active incremental scanned 771 files at 5.99 ms per run, no-change full scanned 2041 files at 11.49 ms per run, and the first warm full import took 43.86 s.