### PR TITLE
Support GPT-5.6 and repair fork token accounting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,10 @@ If this public repository has just been initialized and `develop` is not availab
 
 ## Verification
 
+- [ ] `npm test`
 - [ ] `npm run lint`
 - [ ] `npm run build`
-- [ ] `cargo test`
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --locked`
 
 ## Checklist
 

--- a/.superpowers/sdd/task-2b2-report.md
+++ b/.superpowers/sdd/task-2b2-report.md
@@ -1,0 +1,101 @@
+# Task 2B2 production integration report
+
+Date: 2026-07-10
+
+Base commit: `eee8405ae960ceecb9134579294f770d92a13352`
+
+## Result
+
+The importer now removes direct-parent token replay from explicit fork sessions. It resolves a parent source without walking the archive, reads only replay metadata and token counters, computes the reviewed cutoff, and applies that cutoff inside the existing session transaction. When a parent cannot be used, the first explicit-fork snapshot falls back to `last_token_usage`; roots and thread-spawn-only sessions keep their previous cumulative accounting.
+
+## RED to GREEN evidence
+
+Each named test was run separately before and after the production change.
+
+| Test | RED value | GREEN value |
+| --- | ---: | ---: |
+| `fork_replay_counts_only_child_usage` | child `310`, expected `50` | child `50`; parent `260`; family `310` |
+| `incremental_fork_scan_loads_unchanged_archived_parent` | child `310`, expected `50` | child `50`; unchanged archived parent `260`; family `310` |
+| `nested_fork_replay_uses_direct_parent` | child `310`, expected `50` | root `260`; child `50`; grandchild `20`; family `330` |
+| `parent_path_validation_rejects_child_file_with_replayed_parent_meta` | child `150`, expected `90` | child `90`; parent remains `25` |
+| `fork_first_snapshot_uses_last_usage_as_baseline` | child `1000`, expected `40` | child `40` |
+| `thread_spawn_without_fork_keeps_full_usage` | `1000` before the change | `1000` after the change |
+
+The thread-spawn test was a guard rather than a RED case. It passed on both runs.
+
+## Implementation
+
+Changed production file: `src-tauri/src/importer.rs`.
+
+- Added `inherited_token_snapshot_cutoff` to `ParsedSession`, initialized to zero by the parser.
+- Built the session source map before changed files are processed. Priority is `sessions`, then `import_state`, then UUID-bearing files in the current scan.
+- Added an on-demand direct-parent cache keyed by requested parent ID. The cache stores both loaded snapshots and unavailable results.
+- Validated UUID-bearing filenames against the requested parent ID. Paths without a filename UUID must have a matching first usable `session_meta.payload.id`.
+- Added a parent replay reader that prefilters unrelated JSONL lines before JSON parsing. It retains only timestamp, cumulative token usage, and optional last token usage. It does not retain model names, rate limits, titles, or message text, and warnings contain only IDs and source paths.
+- Connected direct-parent snapshots to `replayed_child_snapshot_cutoff()` for changed explicit forks with a valid fork timestamp.
+- Started persistence from the final skipped cumulative snapshot and iterated from the cutoff. Explicit forks with cutoff zero use `last_token_usage` for the first counted snapshot when available. Later snapshots retain the existing cumulative high-water behavior.
+- Kept usage deletion, value calculation, usage insertion, import-state updates, and commit inside the existing session transaction.
+
+No schema, repair key, pricing rule, topology rule, public command response, UI, or test expectation changed.
+
+## Commands and results
+
+Named tests, each run with its own exact filter:
+
+```bash
+tests=(
+  fork_replay_counts_only_child_usage
+  incremental_fork_scan_loads_unchanged_archived_parent
+  nested_fork_replay_uses_direct_parent
+  parent_path_validation_rejects_child_file_with_replayed_parent_meta
+  fork_first_snapshot_uses_last_usage_as_baseline
+  thread_spawn_without_fork_keeps_full_usage
+)
+for test_name in $tests; do
+  cargo test --manifest-path src-tauri/Cargo.toml "importer::tests::$test_name" --locked -- --exact --nocapture
+done
+```
+
+All six named filters passed after implementation.
+
+Full importer suite:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests --locked
+```
+
+Result: `64 passed; 0 failed; 83 filtered out` in the library target. The binary target ran zero tests and passed.
+
+Compiler check:
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml --locked
+```
+
+Result: exit code 0 with no warnings.
+
+Whitespace check:
+
+```bash
+git diff --check
+```
+
+Result: exit code 0.
+
+## Self-review
+
+- Source resolution follows the required priority and uses persisted paths for parents omitted from an incremental scan.
+- Parent lookup does not add an archive-directory walk.
+- The reader rejects a stale child UUID path even when that child replays the requested parent's metadata.
+- Nested forks read their direct parent file, not the root file or already persisted token totals.
+- The cache key is the requested direct-parent ID, and unavailable reads are cached.
+- The replay reader parses only prefiltered `session_meta` and `event_msg/token_count` records. It never logs file contents or parser errors.
+- A nonzero cutoff seeds `previous_usage` from the last skipped raw snapshot. At-or-below high-water snapshots remain non-billable, and later growth still uses `diff_usage()`.
+- The cutoff and fallback only change explicit forks. Thread-spawn-only children and roots still bill the full first cumulative snapshot.
+- The production diff is limited to `src-tauri/src/importer.rs`; this report is the only additional file.
+
+## Concerns
+
+No known blocking concern remains. The conservative path is intentional: if a parent source is missing, unreadable, invalid, or points at another UUID, the importer uses cutoff zero and the explicit-fork first-snapshot fallback instead of guessing replay length.
+
+The required verification scope covers the importer suite and a locked compiler check, not the entire workspace test suite. A separate default `cargo fmt --check` was informational only and reported existing repository-wide formatting differences in untouched files; it did not modify the working tree.

--- a/.superpowers/sdd/task-2b2-report.md
+++ b/.superpowers/sdd/task-2b2-report.md
@@ -99,3 +99,69 @@ Result: exit code 0.
 No known blocking concern remains. The conservative path is intentional: if a parent source is missing, unreadable, invalid, or points at another UUID, the importer uses cutoff zero and the explicit-fork first-snapshot fallback instead of guessing replay length.
 
 The required verification scope covers the importer suite and a locked compiler check, not the entire workspace test suite. A separate default `cargo fmt --check` was informational only and reported existing repository-wide formatting differences in untouched files; it did not modify the working tree.
+
+## Review follow-up: conservative parent metadata parsing
+
+The first Task 2B2 review found two reader boundary problems. The parent reader could deserialize an unrelated line into a full `serde_json::Value`, and damaged token candidates were skipped instead of making the parent unavailable. The follow-up is limited to `src-tauri/src/importer.rs` and keeps the existing source locator, cache, warnings, matcher, and persistence behavior.
+
+### Follow-up RED to GREEN evidence
+
+| Test | RED | GREEN |
+| --- | --- | --- |
+| `parent_replay_reader_rejects_malformed_token_candidate_between_snapshots` | `.is_err()` failed because two valid snapshots were stitched across malformed JSON | reader returns `Err(())` at the malformed candidate |
+| `parent_replay_reader_rejects_token_count_without_timestamp` | `.is_err()` failed because the incomplete candidate was skipped | reader returns `Err(())` when a structural token event has no timestamp |
+| `parent_replay_reader_rejects_token_count_without_total_usage` | `.is_err()` failed because the incomplete candidate was skipped | reader returns `Err(())` when token info has no cumulative total |
+| `parent_replay_reader_rejects_non_numeric_token_usage` | `.is_err()` failed because the string input count became zero | reader returns `Err(())` for an invalid numeric representation |
+| `parent_replay_reader_ignores_nested_token_types_in_unrelated_root_record` | guard passed with one snapshot totaling `100` | guard still passes with one snapshot totaling `100` |
+
+The first four tests failed at their intended assertions before production changed. The nested-type test is a structural guard, so it passed before and after the implementation.
+
+### Follow-up implementation
+
+- Replaced full-`Value` parsing in `read_parent_replay_snapshots()` with small serde structs.
+- The first envelope borrows only the root timestamp, root type, payload ID, and payload type from the JSONL line.
+- A second numeric envelope runs only after the first envelope identifies a root `event_msg` whose payload type is `token_count`.
+- Serde skips unknown fields. The reader does not retain or materialize message bodies, rate limits, model labels, titles, or other payload content.
+- Prefiltered candidate JSON that cannot be parsed now returns `Err(())`.
+- Structural token events require a timestamp, `info`, and `total_token_usage`. Invalid token numbers also return `Err(())`.
+- Non-token `event_msg` records and unrelated root records remain ignored, even when nested objects contain `event_msg` and `token_count` type fields.
+- Reader errors remain opaque. No file contents or parser details reach the existing warning path.
+
+### Follow-up commands and results
+
+Focused reader tests were run separately with exact filters:
+
+```bash
+tests=(
+  parent_replay_reader_rejects_malformed_token_candidate_between_snapshots
+  parent_replay_reader_rejects_token_count_without_timestamp
+  parent_replay_reader_rejects_token_count_without_total_usage
+  parent_replay_reader_rejects_non_numeric_token_usage
+  parent_replay_reader_ignores_nested_token_types_in_unrelated_root_record
+)
+for test_name in $tests; do
+  cargo test --manifest-path src-tauri/Cargo.toml "importer::tests::$test_name" --locked -- --exact --nocapture
+done
+```
+
+Result: all five focused filters passed after implementation.
+
+The six original Task 2B2 fork and thread-spawn filters were also rerun separately. All six passed with their previously recorded accounting values.
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests --locked
+cargo check --manifest-path src-tauri/Cargo.toml --locked
+git diff --check
+```
+
+Final result: `69 passed; 0 failed; 83 filtered out` for the importer library tests. The binary target ran zero tests and passed. `cargo check` and `git diff --check` returned exit code 0, and the compiler emitted no warnings.
+
+### Follow-up self-review and concerns
+
+- Root and payload type checks, not raw substring matches, decide whether a line is a token snapshot.
+- The substring prefilter only avoids parsing clearly unrelated lines. A line admitted by the prefilter must pass the borrowed structural envelope.
+- Token details use integer fields with serde defaults for absent components, preserving the existing zero defaults and derived `total_tokens` behavior. Present values with the wrong JSON type are rejected.
+- A damaged candidate makes the cached parent unavailable, so the existing conservative explicit-fork fallback applies. Cache keys and warning content did not change.
+- No schema, repair key, query, pricing rule, UI, public response, or test expectation changed.
+
+No blocking concern remains. Allocation telemetry was not added; the privacy boundary is enforced by the small serde field set and verified by code inspection plus the nested-structure guard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- GPT-5.6 Sol, Terra, and Luna model recognition with bundled Standard API pricing; the `gpt-5.6` alias uses Sol pricing
+- automatic discovery of the Codex CLI bundled with the ChatGPT desktop app on macOS, while retaining standalone CLI and `CODEX_BIN` support
+
+### Changed
+- changing a custom Codex home now starts a full refresh without reusing scan times from the previous directory
+- dashboard refreshes now wait for an active scan to finish and reload conversation details when their source values have changed
+
+### Fixed
+- GPT-5.6 API-equivalent values now recalculate at startup, including rows that were zero or used a cache-write price as the output price
+- incremental imports now capture final snapshots moved into `archived_sessions`, refresh titles from `session_index.jsonl`, avoid saving partial results from unreadable files, and repair missing conversation links
+- persisted quota fallback now chooses the latest timestamp by its actual instant and never combines windows from different samples
+
 ## [1.1.2] - 2026-05-19
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,10 @@ Keep contributions:
 Recommended verification before opening a pull request:
 
 ```bash
+npm test
 npm run lint
 npm run build
-cargo test
+cargo test --manifest-path src-tauri/Cargo.toml --locked
 ```
 
 If your change affects documentation or user-facing behavior, update the relevant docs in the same pull request when they are in scope. If you touch shared copy, keep English and Chinese surfaces aligned.
@@ -51,6 +52,7 @@ If your change affects documentation or user-facing behavior, update the relevan
 - Frontend: React + TypeScript + Vite
 - Desktop shell: Tauri 2
 - Backend and data layer: Rust + SQLite
+- On macOS, live quota testing can use the Codex CLI bundled with `ChatGPT.app`; a standalone CLI and `CODEX_BIN` remain supported
 
 ## Pull request checklist
 
@@ -58,9 +60,10 @@ If your change affects documentation or user-facing behavior, update the relevan
 - [ ] My pull request targets `develop` unless it is release-only work
 - [ ] If `develop` does not exist yet in a newly initialized public repository, I coordinated with the maintainer before opening the first pull request
 - [ ] The change is scoped and explained clearly
+- [ ] I ran `npm test`
 - [ ] I ran `npm run lint`
 - [ ] I ran `npm run build`
-- [ ] I ran `cargo test`
+- [ ] I ran `cargo test --manifest-path src-tauri/Cargo.toml --locked`
 - [ ] I updated in-scope docs if behavior or setup changed
 - [ ] I avoided unrelated changes
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ English | [简体中文](./README.zh-CN.md)
 - Imports local Codex usage data from `~/.codex` or a custom `CODEX_HOME`
 - Builds a local SQLite index for fast analysis and drill-down views
 - Estimates API-equivalent value and subscription payoff from token usage
+- Recognizes GPT-5.6 Sol, Terra, and Luna with bundled Standard API pricing
 - Tracks rolling quota windows, including `5-hour` and `7-day` pacing when available
 - Breaks usage down by conversation, root session, subagent, model, and token composition
 - Provides a macOS menu bar experience for quick quota checks
@@ -47,6 +48,8 @@ The documentation set for installation, packaging, and release notes is maintain
 - [Packaging and release](./docs/en/packaging-and-release.md)
 - [Release notes for v1.1.2](./docs/en/release-notes-v1.1.2.md)
 
+On macOS, Codex Pacer can use the Codex CLI bundled with the ChatGPT desktop app for live quota reads. It discovers `/Applications/ChatGPT.app/Contents/Resources/codex` automatically. A standalone Codex CLI and the `CODEX_BIN` override remain supported.
+
 ## Development
 
 Requirements:
@@ -74,7 +77,7 @@ Production build:
 ```bash
 npm install
 npm run build
-cargo test
+cargo test --manifest-path src-tauri/Cargo.toml --locked
 npm run tauri build
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ On macOS, Codex Pacer can use the Codex CLI bundled with the ChatGPT desktop app
 
 Requirements:
 
-- Node.js 20+
+- Node.js 22.18+
 - Rust toolchain
 - Tauri build prerequisites for your platform
 - Local Codex data under `~/.codex` or a custom `CODEX_HOME`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,7 +54,7 @@ Codex Pacer 是本地优先的：
 
 环境要求：
 
-- Node.js 20+
+- Node.js 22.18+
 - Rust toolchain
 - 当前平台所需的 Tauri 构建依赖
 - `~/.codex` 或自定义 `CODEX_HOME` 中的本地 Codex 数据

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,7 @@
 - 从 `~/.codex` 或自定义 `CODEX_HOME` 导入本地 Codex 使用数据
 - 建立本地 SQLite 索引，便于快速分析和下钻
 - 基于 token 使用量估算 API 等价价值与订阅回本情况
+- 支持 GPT-5.6 Sol、Terra 和 Luna，并内置 Standard API 定价
 - 在可用时跟踪 `5小时`、`7天` 等滚动额度窗口的使用节奏
 - 按对话、root session、subagent、模型、token 构成拆解使用情况
 - 提供 macOS 菜单栏入口，方便快速查看额度状态
@@ -47,6 +48,8 @@ Codex Pacer 是本地优先的：
 - [打包与发布](./docs/zh-CN/packaging-and-release.md)
 - [v1.1.2 发布说明](./docs/zh-CN/release-notes-v1.1.2.md)
 
+在 macOS 上，Codex Pacer 可以使用 ChatGPT 桌面应用内置的 Codex CLI 读取实时额度。应用会自动发现 `/Applications/ChatGPT.app/Contents/Resources/codex`。独立安装的 Codex CLI 和 `CODEX_BIN` 覆盖配置仍然可用。
+
 ## 开发
 
 环境要求：
@@ -74,7 +77,7 @@ npm run dev
 ```bash
 npm install
 npm run build
-cargo test
+cargo test --manifest-path src-tauri/Cargo.toml --locked
 npm run tauri build
 ```
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -17,7 +17,7 @@ It is built to help you answer practical questions such as:
 
 For development from source, you will also need:
 
-- Node.js 20+
+- Node.js 22.18+
 - Rust toolchain
 - Tauri build prerequisites for your platform
 

--- a/docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
+++ b/docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
@@ -1,0 +1,581 @@
+# Codex 5.6 and ChatGPT app compatibility implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Codex Pacer accurate with the GPT-5.6 model family and the merged ChatGPT desktop app, while repairing confirmed stale and partial data-update paths.
+
+**Architecture:** Preserve the current JSONL-to-SQLite pipeline. Extend the executable resolver and pricing catalog at their existing boundaries, then make importer, persisted quota, and frontend cache updates fail safely. Startup pricing-signature comparison remains the migration trigger for historical value recalculation.
+
+**Tech stack:** Rust 2021, rusqlite, serde_json, Tauri 2, React 19, TypeScript 5.9, Node 22, Vite 8.
+
+## Global constraints
+
+- Keep `CODEX_BIN` and explicit `CODEX_HOME` settings authoritative.
+- Keep Codex Pacer branding, bundle identifiers, database names, and internal event names unchanged.
+- Treat `gpt-5.6` as an alias for `gpt-5.6-sol`.
+- Use OpenAI Standard API prices, not Codex credit rates.
+- Preserve unknown model IDs and assign no guessed API-equivalent value.
+- Do not expose implementation notes or migration mechanics in the user interface.
+- Every production behavior change begins with a test that fails for the expected reason.
+
+---
+
+### Task 1: GPT-5.6 pricing and historical value repair
+
+**Files:**
+
+- Modify: `src-tauri/src/pricing.rs`
+- Modify: `src-tauri/src/importer.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+
+- Consumes: `pricing_seed()`, `parse_official_pricing_catalog()`, `resolve_pricing()`, and the existing startup pricing-signature check.
+- Produces: catalog entries for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; row parsing that uses the last price as output; automatic repair and recalculation of stored values.
+
+- [ ] **Step 1: Add failing pricing tests**
+
+Add tests that require exact prices, dated-prefix fallback, alias behavior, distinct display names, and the new four-price official row:
+
+```rust
+#[test]
+fn resolve_pricing_includes_gpt_56_family_and_alias() {
+    let catalog = pricing_seed()
+        .into_iter()
+        .map(|entry| (entry.model_id.clone(), entry))
+        .collect::<HashMap<_, _>>();
+
+    for (model, input, cached, output) in [
+        ("gpt-5.6", 5.0, 0.5, 30.0),
+        ("gpt-5.6-sol-2026-07-09", 5.0, 0.5, 30.0),
+        ("gpt-5.6-terra-2026-07-09", 2.5, 0.25, 15.0),
+        ("gpt-5.6-luna-2026-07-09", 1.0, 0.1, 6.0),
+    ] {
+        let pricing = resolve_pricing(&catalog, model).expect(model);
+        assert_eq!(pricing.input_price_per_million, input);
+        assert_eq!(pricing.cached_input_price_per_million, cached);
+        assert_eq!(pricing.output_price_per_million, output);
+    }
+}
+
+#[test]
+fn parses_gpt_56_cache_write_price_without_treating_it_as_output() {
+    let html = complete_standard_fixture_with_gpt56_rows();
+    let catalog = parse_official_pricing_catalog(&html)
+        .expect("parse pricing")
+        .into_iter()
+        .map(|entry| (entry.model_id.clone(), entry))
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(catalog["gpt-5.6-sol"].output_price_per_million, 30.0);
+    assert_eq!(catalog["gpt-5.6-terra"].output_price_per_million, 15.0);
+    assert_eq!(catalog["gpt-5.6-luna"].output_price_per_million, 6.0);
+}
+
+fn complete_standard_fixture_with_gpt56_rows() -> String {
+    concat!(
+        "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.6-sol&quot;],[0,5],[0,0.5],[0,6.25],[0,30]]],[1,[[0,&quot;gpt-5.6-terra&quot;],[0,2.5],[0,0.25],[0,3.125],[0,15]]],[1,[[0,&quot;gpt-5.6-luna&quot;],[0,1],[0,0.1],[0,1.25],[0,6]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
+        "<astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,1.75],[0,0.175],[0,14]]]]]}]]]}\"></astro-island>"
+    ).to_string()
+}
+```
+
+- [ ] **Step 2: Run the pricing tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml pricing::tests::resolve_pricing_includes_gpt_56_family_and_alias -- --exact
+cargo test --manifest-path src-tauri/Cargo.toml pricing::tests::parses_gpt_56_cache_write_price_without_treating_it_as_output -- --exact
+```
+
+Expected: the first test fails because 5.6 has no catalog entry; the second fails because `6.25` is read as Sol output.
+
+- [ ] **Step 3: Implement the model catalog and row-boundary parser**
+
+Add the official Standard prices to the seed. Store the alias with `effective_model_id` set to `gpt-5.6-sol`. Refactor row parsing to collect values only until the next model-name marker:
+
+```rust
+let next_row = block[name_end..]
+    .find(marker)
+    .map(|offset| name_end + offset)
+    .unwrap_or(block.len());
+let row_source = &block[name_end..next_row];
+let mut value_cursor = 0usize;
+let mut values = Vec::new();
+while let Some(value) = parse_next_pricing_value(row_source, &mut value_cursor) {
+    values.push(value);
+}
+
+let input = values.first().copied().flatten();
+let cached_input = values.get(1).copied().flatten();
+let output = values.last().copied().flatten();
+```
+
+Require the three explicit GPT-5.6 rows in `required_models`. Add prefix resolution in this order: Sol, Terra, Luna, then the family alias. Add display names and existing-theme chart colors for all four IDs.
+
+- [ ] **Step 4: Add failing corruption and startup-recalculation tests**
+
+Insert an official Sol row with input `5.0`, cached input `0.5`, and output `6.25`, then call `seed_pricing_catalog`. Assert output becomes `30.0`. Add a startup database test with a zero-valued `gpt-5.6-sol` usage event and assert `prepare_app_database` recalculates it.
+
+- [ ] **Step 5: Verify the repair tests fail for the intended reasons**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml pricing::tests::seed_repairs_misparsed_gpt_56_output_prices -- --exact
+cargo test --manifest-path src-tauri/Cargo.toml tests::startup_database_prepare_recalculates_new_gpt_56_values -- --exact
+```
+
+Expected: the malformed official row remains `6.25`, and the event remains zero.
+
+- [ ] **Step 6: Repair only the known malformed pattern**
+
+Allow `PreserveOfficial` seeding to replace a GPT-5.6 row only when its current output equals `input * 1.25`, within floating-point tolerance. Correct official rows remain untouched. The existing before-and-after pricing signature then triggers `recalculate_all_session_values`.
+
+- [ ] **Step 7: Add and pass a GPT-5.6 importer fixture**
+
+Create a JSONL fixture in the importer test with `turn_context.payload.model = "gpt-5.6-sol"` and a token snapshot. Assert token totals and the Standard API-equivalent value. Run the full pricing and importer test modules.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add src-tauri/src/pricing.rs src-tauri/src/importer.rs src-tauri/src/lib.rs
+git commit -m "fix: support GPT-5.6 pricing and value repair"
+```
+
+### Task 2: ChatGPT desktop executable discovery
+
+**Files:**
+
+- Modify: `src-tauri/src/rate_limits.rs`
+
+**Interfaces:**
+
+- Consumes: `resolve_codex_binary_from_env()` and `app_server_command_spec()`.
+- Produces: macOS candidate paths for the merged ChatGPT app and legacy Codex app without changing Windows or Linux behavior.
+
+- [ ] **Step 1: Add failing macOS resolver tests**
+
+```rust
+#[test]
+#[cfg(target_os = "macos")]
+fn resolve_codex_binary_prefers_chatgpt_app_bundle() {
+    let resolved = super::resolve_codex_binary_from_env(
+        None,
+        None,
+        Some(Path::new("/Users/CodexUser")),
+        existing_paths(&[
+            "/Applications/ChatGPT.app/Contents/Resources/codex",
+            "/opt/homebrew/bin/codex",
+        ]),
+    );
+    assert_eq!(resolved, PathBuf::from("/Applications/ChatGPT.app/Contents/Resources/codex"));
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn resolve_codex_binary_uses_legacy_app_when_chatgpt_is_missing() {
+    let resolved = super::resolve_codex_binary_from_env(
+        None,
+        None,
+        Some(Path::new("/Users/CodexUser")),
+        existing_paths(&["/Applications/Codex.app/Contents/Resources/codex"]),
+    );
+    assert_eq!(resolved, PathBuf::from("/Applications/Codex.app/Contents/Resources/codex"));
+}
+```
+
+- [ ] **Step 2: Run both tests and verify RED**
+
+Expected: both resolve to the fallback command name because app bundle paths are absent from the candidate list.
+
+- [ ] **Step 3: Add ordered macOS bundle candidates**
+
+Inside the non-Windows candidate builder, prepend system and user `ChatGPT.app` paths, followed by system and user `Codex.app` paths under `#[cfg(target_os = "macos")]`. Keep `CODEX_BIN` resolution outside this list so it stays first.
+
+- [ ] **Step 4: Verify GREEN and remove platform-only warnings**
+
+Conditionally import Windows-only test types. Run `cargo test --manifest-path src-tauri/Cargo.toml rate_limits::tests` and require clean compiler output.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add src-tauri/src/rate_limits.rs
+git commit -m "fix: discover Codex inside the ChatGPT app"
+```
+
+### Task 3: Importer update integrity
+
+**Files:**
+
+- Modify: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+
+- Consumes: `perform_scan()`, `perform_incremental_scan()`, `ImportState`, session JSONL, and `session_index.jsonl`.
+- Produces: validated custom homes, immediate moved-archive imports, title-only refresh, read-error retry, and topology self-repair.
+
+- [ ] **Step 1: Add failing tests for each confirmed importer edge**
+
+Add five tests. Reuse the existing `write_session_file`, `write_session_file_with_parent`, `session_usage_totals`, and `conversation_link` test helpers:
+
+```rust
+#[test]
+fn invalid_custom_home_does_not_advance_completed_scan_time() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let missing = directory.path().join("missing-codex-home");
+
+    let error = perform_scan(&db_path, Some(missing.to_string_lossy().to_string()))
+        .expect_err("missing home must fail");
+    assert!(error.contains("existing directory"));
+
+    let conn = open_connection(&db_path).expect("open db");
+    let completed: Option<String> = conn
+        .query_row(
+            "SELECT last_scan_completed_at FROM sync_settings WHERE singleton_id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("load completion");
+    assert!(completed.is_none());
+}
+
+#[test]
+fn incremental_scan_imports_final_snapshot_after_active_file_is_archived() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    let archived = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&archived).expect("archive");
+    let session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let archived_path = archived.join(active_path.file_name().expect("filename"));
+    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+
+    write_session_file(
+        &active_path,
+        session_id,
+        &[
+            ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+            ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+        ],
+    );
+    std::fs::rename(&active_path, &archived_path).expect("archive session");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, session_id).4, 200);
+    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+}
+
+#[test]
+fn full_scan_refreshes_title_when_only_session_index_changes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    write_session_file(
+        &sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl")),
+        session_id,
+        &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let index_path = codex_home.join("session_index.jsonl");
+    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"A\"}}\n"))
+        .expect("title A");
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"B\"}}\n"))
+        .expect("title B");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let title: String = conn
+        .query_row("SELECT title FROM sessions WHERE session_id = ?1", params![session_id], |row| row.get(0))
+        .expect("title");
+    assert_eq!(title, "B");
+}
+
+#[test]
+fn invalid_utf8_does_not_commit_partial_session_or_import_state() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    let path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let mut file = File::create(&path).expect("session file");
+    writeln!(file, "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session_id}\"}}}}")
+        .expect("meta");
+    file.write_all(&[0xff, b'\n']).expect("invalid utf8");
+    writeln!(file, "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}")
+        .expect("tail");
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan skips bad file");
+    let conn = open_connection(&db_path).expect("open db");
+    let sessions_count: i64 = conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0)).expect("sessions");
+    let states_count: i64 = conn.query_row("SELECT COUNT(*) FROM import_state", [], |row| row.get(0)).expect("states");
+    assert_eq!((sessions_count, states_count), (0, 0));
+}
+
+#[test]
+fn incremental_scan_repairs_missing_conversation_link_without_source_change() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let parent = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let child = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    write_session_file_with_parent(
+        &sessions.join(format!("rollout-2026-07-10T00-00-00-{parent}.jsonl")),
+        parent,
+        None,
+        &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    write_session_file_with_parent(
+        &sessions.join(format!("rollout-2026-07-10T00-01-00-{child}.jsonl")),
+        child,
+        Some(parent),
+        &[("2026-07-10T00:01:00Z", 50, 10, 5, 55)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open db");
+    conn.execute("DELETE FROM conversation_links WHERE session_id = ?1", params![child])
+        .expect("remove link");
+    drop(conn);
+
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("repair scan");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(conversation_link(&conn, child).expect("child link").0, parent);
+}
+```
+
+Use concrete assertions: final token total equals the appended snapshot, source state is `archived`, title equals `B`, partial session count is zero, and the child root equals its parent.
+
+- [ ] **Step 2: Run each test and verify RED**
+
+Run each exact test name with `cargo test --manifest-path src-tauri/Cargo.toml importer::tests::<name> -- --exact`. Confirm each failure matches the audited behavior.
+
+- [ ] **Step 3: Validate and expand Codex home paths**
+
+Add a helper that expands exactly `~` and `~/...` against the resolved home directory, then rejects a path that does not exist or is not a directory:
+
+```rust
+fn validate_codex_home(path: PathBuf, home_dir: Option<&Path>) -> Result<PathBuf, String> {
+    let expanded = expand_home_prefix(path, home_dir)?;
+    if !expanded.is_dir() {
+        return Err(format!("Codex home is not an existing directory: {}", expanded.display()));
+    }
+    Ok(expanded)
+}
+```
+
+Call this before `set_last_scan_started`.
+
+- [ ] **Step 4: Detect active files moved to the archive**
+
+Load `source_bucket` into `ImportState`. During an incremental scan, build the active path set. For each missing active import state, test `codex_home/archived_sessions/<original filename>`. Add an existing match as an archived `SessionFile` so normal parsing and duplicate-state cleanup handle it.
+
+- [ ] **Step 5: Refresh titles and topology independently of changed JSONL**
+
+On a full scan, load `session_index.jsonl` once and update matching non-empty titles even if no session file changed. Add `conversation_links_need_repair()` that detects a session without a link or with a direct-parent mismatch. Recompute links when this check or the existing topology flag is true.
+
+- [ ] **Step 6: Propagate line read errors**
+
+Replace `map_while(Result::ok)` in `parse_session_file_once` with an explicit loop:
+
+```rust
+for line_result in BufReader::new(file).lines() {
+    let line = line_result.map_err(|error| {
+        SessionParseError::Fatal(format!("Failed to read {}: {error}", session_file.path.display()))
+    })?;
+    // Existing JSON parsing follows.
+}
+```
+
+Keep malformed JSON lines retryable, including an incomplete trailing record.
+
+- [ ] **Step 7: Run all importer tests and verify GREEN**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml importer::tests`. Require all old incomplete-line and replay tests to remain green.
+
+- [ ] **Step 8: Commit Task 3**
+
+```bash
+git add src-tauri/src/importer.rs
+git commit -m "fix: make session imports update safely"
+```
+
+### Task 4: Persisted live-quota freshness
+
+**Files:**
+
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+
+- Consumes: `rate_limit_samples.sample_timestamp` and `load_persisted_live_rate_limits_for_source()`.
+- Produces: absolute-time ordering and a snapshot containing only windows from the same sample instant.
+
+- [ ] **Step 1: Add failing mixed-offset and mixed-sample tests**
+
+Insert `2026-07-10T09:00:00+08:00` followed by `2026-07-10T02:00:00Z`; assert the latter wins. Insert an older primary and secondary pair plus a newer primary-only sample; assert the result contains the newer primary and no secondary.
+
+- [ ] **Step 2: Run both tests and verify RED**
+
+Expected: text sorting chooses `09:00+08:00`, and the loader combines windows from different samples.
+
+- [ ] **Step 3: Order by SQLite time and select one coherent sample**
+
+Use `ORDER BY julianday(sample_timestamp) DESC, id DESC`. Parse each selected timestamp with `DateTime::parse_from_rfc3339`, find the newest instant, and discard a window whose timestamp differs from that instant. Set `fetched_at` to the retained timestamp.
+
+- [ ] **Step 4: Run live-rate fallback tests and verify GREEN**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml tests::background_live_rate_limit` and the two new exact tests.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src-tauri/src/lib.rs
+git commit -m "fix: select coherent persisted quota samples"
+```
+
+### Task 5: Settings, detail cache, and overlapping refreshes
+
+**Files:**
+
+- Create: `src/app/dataFreshness.ts`
+- Create: `scripts/test-data-freshness.mjs`
+- Modify: `src/App.tsx`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/database/sync_settings.rs`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Consumes: `ConversationDetail`, `ConversationListItem`, `SubscriptionProfile`, scan state, and saved sync settings.
+- Produces: cache-retention and scan-settle helpers plus freshness reset when Codex home changes.
+
+- [ ] **Step 1: Add failing Node behavior tests**
+
+Export these pure helpers from `src/app/dataFreshness.ts`:
+
+```ts
+export function shouldKeepConversationDetail(
+  cached: ConversationDetail,
+  summary: ConversationListItem,
+  monthlyPrice: number,
+): boolean
+
+export async function waitForOverlappingScan(
+  getScanInProgress: () => Promise<boolean>,
+  waitForScanToSettle: () => Promise<void>,
+): Promise<void>
+```
+
+The Node test imports the TypeScript file directly. It asserts cache rejection when API value or expected subscription share changes, cache retention when all derived values match, and one settle wait when scan state is true.
+
+- [ ] **Step 2: Run the Node test and verify RED**
+
+Run `node scripts/test-data-freshness.mjs`. Expected: module or export not found.
+
+- [ ] **Step 3: Implement the helpers and use them in App.tsx**
+
+Use a small epsilon for floating-point comparisons. In `loadShell`, retain cached detail only through `shouldKeepConversationDetail`. After `refreshBackgroundData`, call `waitForOverlappingScan(getScanInProgress, waitForScanToSettle)` before `loadShell(false)`.
+
+- [ ] **Step 4: Add a failing Rust test for source switching**
+
+Save settings with scan timestamps, change only `codex_home`, call the backend normalization helper, and assert both exposed scan timestamps and `last_full_scan_completed_at` are cleared.
+
+- [ ] **Step 5: Reset freshness and trigger the new full scan**
+
+Add `clear_scan_timestamps()` in `database/sync_settings.rs`. Call it after saving when normalized `codex_home` changed. In `handleSaveSettings`, update `syncSettingsRef.current` immediately and call `loadShell(true)` when the home changed; otherwise call `loadShell(false)`.
+
+- [ ] **Step 6: Add the Node test to npm test and verify GREEN**
+
+Add `test:data-freshness` to `package.json` and include it in `npm test`. Run `npm test`, `npm run lint`, and `npm run build`.
+
+- [ ] **Step 7: Commit Task 5**
+
+```bash
+git add src/app/dataFreshness.ts scripts/test-data-freshness.mjs src/App.tsx src-tauri/src/lib.rs src-tauri/src/database/sync_settings.rs package.json
+git commit -m "fix: invalidate stale dashboard data"
+```
+
+### Task 6: Documentation and full verification
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+
+- Consumes: final verified behavior and exact commands.
+- Produces: current setup guidance and a concise change record.
+
+- [ ] **Step 1: Update setup and test commands**
+
+State that Codex Pacer can use the CLI bundled with the ChatGPT desktop app on macOS. Replace root-level `cargo test` examples with:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+```
+
+- [ ] **Step 2: Humanize and audit the documentation**
+
+Keep the prose factual. Scan for placeholders, em dashes, en dashes, stale Codex app-only wording, and accidental implementation notes.
+
+- [ ] **Step 3: Run static and unit verification**
+
+```bash
+npm test
+npm run lint
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+./scripts/release/audit-public-branding.sh
+./scripts/release/test-build-macos-release.sh
+```
+
+- [ ] **Step 4: Run real local-data verification without mutating the live Pacer database**
+
+Copy the current `~/.codex` session and index files to a temporary Codex home. Run the backend scan against a temporary SQLite database. Compare session count, latest session model, latest token total, and GPT-5.6 API-equivalent value with direct JSONL inspection.
+
+- [ ] **Step 5: Verify the ChatGPT-bundled app-server and packaged app**
+
+Run initialize plus `account/rateLimits/read` through `/Applications/ChatGPT.app/Contents/Resources/codex`. Build the Tauri app, launch it with the temporary database and copied Codex home, then confirm dashboard, conversation detail, model legend, refresh, and live quota behavior.
+
+- [ ] **Step 6: Review the complete diff**
+
+Run `git diff develop...HEAD`, `git diff --check`, and `git status --short`. Confirm no personal paths, copied session content, credentials, build products, or unrelated dependency changes are tracked.
+
+- [ ] **Step 7: Commit documentation and any verification-only fixtures**
+
+```bash
+git add README.md README.zh-CN.md CONTRIBUTING.md CHANGELOG.md docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
+git commit -m "docs: document ChatGPT and GPT-5.6 support"
+```
+
+- [ ] **Step 8: Push the development branch**
+
+```bash
+git push -u origin codex/adapt-chatgpt-codex-5-6
+```
+
+Report the branch, commit list, exact verification results, remaining warnings or environmental limits, and the user tests needed before starting the pull-request process.

--- a/docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
+++ b/docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
@@ -4,9 +4,9 @@
 
 **Goal:** Keep Codex Pacer accurate with the GPT-5.6 model family and the merged ChatGPT desktop app, while repairing confirmed stale and partial data-update paths.
 
-**Architecture:** Preserve the current JSONL-to-SQLite pipeline. Extend the executable resolver and pricing catalog at their existing boundaries, then make importer, persisted quota, and frontend cache updates fail safely. Startup pricing-signature comparison remains the migration trigger for historical value recalculation.
+**Architecture:** Preserve the current JSONL-to-SQLite pipeline. Extend the executable resolver and pricing catalog at their existing boundaries, then make importer, persisted quota, and frontend cache updates fail safely. Historical value recalculation is triggered by either a changed price-bearing catalog signature or a pending durable pricing-resolution repair.
 
-**Tech stack:** Rust 2021, rusqlite, serde_json, Tauri 2, React 19, TypeScript 5.9, Node 22, Vite 8.
+**Tech stack:** Rust 2021, rusqlite, serde_json, Tauri 2, React 19, TypeScript 5.9, Node 22.18 or newer, Vite 8.
 
 ## Global constraints
 
@@ -30,7 +30,7 @@
 
 **Interfaces:**
 
-- Consumes: `pricing_seed()`, `parse_official_pricing_catalog()`, `resolve_pricing()`, and the existing startup pricing-signature check.
+- Consumes: `pricing_seed()`, `parse_official_pricing_catalog()`, `resolve_pricing()`, the startup pricing-signature check, and the durable pricing-resolution repair marker.
 - Produces: catalog entries for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; row parsing that uses the last price as output; automatic repair and recalculation of stored values.
 
 - [ ] **Step 1: Add failing pricing tests**
@@ -131,7 +131,7 @@ Expected: the malformed official row remains `6.25`, and the event remains zero.
 
 - [ ] **Step 6: Repair only the known malformed pattern**
 
-Allow `PreserveOfficial` seeding to replace a GPT-5.6 row only when its current output equals `input * 1.25`, within floating-point tolerance. Correct official rows remain untouched. The existing before-and-after pricing signature then triggers `recalculate_all_session_values`.
+Allow `PreserveOfficial` seeding to replace a GPT-5.6 row only when its current output equals `input * 1.25`, within floating-point tolerance. Correct official rows remain untouched. A changed before-and-after pricing signature triggers `recalculate_all_session_values`; the durable repair marker also guarantees a one-time recalculation for resolver-only changes.
 
 - [ ] **Step 7: Add and pass a GPT-5.6 importer fixture**
 

--- a/docs/superpowers/plans/2026-07-10-fork-token-accounting.md
+++ b/docs/superpowers/plans/2026-07-10-fork-token-accounting.md
@@ -1,0 +1,315 @@
+# Fork token accounting implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove parent token history copied into Codex fork files, repair existing usage rows, and install a verified macOS build.
+
+**Architecture:** Keep cumulative usage as the monotonic high-water mark. Parse `last_token_usage`, identify exact direct-parent replay prefixes for explicit forks, and use the final copied cumulative value as the child baseline. A new durable repair key forces unchanged session files through the corrected importer.
+
+**Tech stack:** Rust 2021, rusqlite, serde_json, Tauri 2, React 19, TypeScript 5.9, Node 22.18 or newer, macOS release shell scripts.
+
+## Global constraints
+
+- Apply cross-session replay removal only to `session_meta.payload.forked_from_id`.
+- Require at least two consecutive exact `(total_token_usage, last_token_usage)` pairs.
+- Keep timestamps and model labels out of replay matching.
+- Keep the `usage_events` schema and public response types unchanged.
+- Preserve cumulative high-water handling for repeated and non-monotonic totals.
+- Fall back to legacy cumulative accounting when `last_token_usage` is absent.
+- Do not read or log user and model message bodies during replay matching.
+- Every production behavior change begins with a test that fails for the expected reason.
+
+---
+
+### Task 1: Reproduce fork replay and inherited baselines
+
+**Files:**
+
+- Modify: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+
+- Consumes: `perform_scan()`, `session_usage_totals()`, and JSONL test fixtures.
+- Produces: regression tests for copied parent history, inherited first snapshots, and non-fork subagents.
+
+- [ ] **Step 1: Add a fixture that writes cumulative and last usage**
+
+Add a test helper that writes both source counters without depending on production parsing helpers:
+
+```rust
+#[derive(Clone, Copy)]
+struct TokenFixture {
+  timestamp: &'static str,
+  total: (i64, i64, i64, i64),
+  last: (i64, i64, i64, i64),
+}
+
+fn token_count_line(fixture: TokenFixture) -> String {
+  let (input, cached, output, total) = fixture.total;
+  let (last_input, last_cached, last_output, last_total) = fixture.last;
+  format!(
+    concat!(
+      "{{\"timestamp\":\"{}\",\"type\":\"event_msg\",\"payload\":{{",
+      "\"type\":\"token_count\",\"info\":{{",
+      "\"total_token_usage\":{{\"input_tokens\":{},\"cached_input_tokens\":{},",
+      "\"output_tokens\":{},\"reasoning_output_tokens\":0,\"total_tokens\":{}}},",
+      "\"last_token_usage\":{{\"input_tokens\":{},\"cached_input_tokens\":{},",
+      "\"output_tokens\":{},\"reasoning_output_tokens\":0,\"total_tokens\":{}}}",
+      "}}}}}}\n"
+    ),
+    fixture.timestamp, input, cached, output, total,
+    last_input, last_cached, last_output, last_total,
+  )
+}
+```
+
+- [ ] **Step 2: Add the copied-prefix regression test**
+
+Create a parent with cumulative totals `100`, `180`, and `260`. Create an explicit child fork whose first three numeric pairs are identical but whose timestamps use the child creation time. Append one new child snapshot with total `310` and last usage `50`. Assert parent total `260`, child total `50`, and root-family total `310`.
+
+- [ ] **Step 3: Add first-snapshot and non-fork tests**
+
+For an explicit fork with cumulative total `1000` and last total `40`, assert child total `40`. For a session that has only `thread_spawn.parent_thread_id`, use the same counters and assert total `1000`, proving that normal child sessions keep their existing semantics.
+
+- [ ] **Step 4: Run the three focused tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::fork_replay_counts_only_child_usage -- --exact
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::fork_first_snapshot_uses_last_usage_as_baseline -- --exact
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::thread_spawn_without_fork_keeps_full_usage -- --exact
+```
+
+Expected: the fork tests report the full inherited cumulative totals. The thread-spawn test passes and remains a guard during implementation.
+
+### Task 2: Parse source counters and remove exact replay prefixes
+
+**Files:**
+
+- Modify: `src-tauri/src/models.rs`
+- Modify: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+
+- Consumes: `total_token_usage`, optional `last_token_usage`, the direct parent's source path, and `persist_session()`.
+- Produces: `UsageSnapshot.last_usage`, an explicit fork parent ID, linear replay matching, and corrected deltas.
+
+- [ ] **Step 1: Retain last-turn usage and explicit fork identity**
+
+Extend the internal snapshot data and parser:
+
+```rust
+pub struct UsageSnapshot {
+  pub timestamp: String,
+  pub model_id: String,
+  pub usage: TokenUsage,
+  pub last_usage: Option<TokenUsage>,
+  pub plan_type: Option<String>,
+  pub limit_id: Option<String>,
+  pub limit_name: Option<String>,
+  pub explicit_fast_mode: Option<bool>,
+}
+```
+
+Add `forked_from_session_id: Option<String>` to `SessionMetaCandidate` and `ParsedSession`. Populate it only from `payload.forked_from_id`; keep the existing broader `parent_session_id` behavior.
+
+- [ ] **Step 2: Add unit tests for replay matching**
+
+Test a complete match, a match starting inside the parent sequence, a one-record match that returns zero, and a sequence interrupted by a missing last-usage value.
+
+```rust
+assert_eq!(longest_inherited_prefix(&child, &parent), 3);
+assert_eq!(longest_inherited_prefix(&one_record_child, &parent), 0);
+assert_eq!(longest_inherited_prefix(&legacy_child, &parent), 0);
+```
+
+- [ ] **Step 3: Run matching tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::replay_prefix_ -- --nocapture
+```
+
+Expected: compilation fails because the replay-key and prefix functions do not exist.
+
+- [ ] **Step 4: Implement linear prefix matching**
+
+Define an equality-only replay key and KMP prefix scan:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UsageReplayKey {
+  total_usage: TokenUsage,
+  last_usage: TokenUsage,
+}
+
+fn usage_replay_key(snapshot: &UsageSnapshot) -> Option<UsageReplayKey> {
+  Some(UsageReplayKey {
+    total_usage: snapshot.usage.clone(),
+    last_usage: snapshot.last_usage.clone()?,
+  })
+}
+```
+
+Build the child pattern only through its first missing key. Scan parent segments with a KMP prefix table. Return zero for matches shorter than two records.
+
+- [ ] **Step 5: Resolve and cache direct-parent sequences**
+
+Build a session source-path map from current scan files and `sessions.source_path`. For each changed explicit fork, read only `turn_context` and `event_msg/token_count` metadata from the direct parent. Cache `Vec<Option<UsageReplayKey>>` by parent session ID for the rest of the scan.
+
+- [ ] **Step 6: Apply the corrected baseline in persistence**
+
+Store the inherited prefix length on `ParsedSession`. Start `previous_usage` from the last skipped snapshot. If no prefix was found for an explicit fork, use `last_usage` for its first delta when present. Continue using `diff_usage()` for later snapshots.
+
+```rust
+let mut previous_usage = parsed
+  .inherited_token_snapshot_count
+  .checked_sub(1)
+  .and_then(|index| parsed.snapshots.get(index))
+  .map(|snapshot| snapshot.usage.clone());
+
+for snapshot in parsed.snapshots.iter().skip(parsed.inherited_token_snapshot_count) {
+  let delta = match previous_usage.as_ref() {
+    Some(previous) => diff_usage(previous, &snapshot.usage),
+    None if parsed.forked_from_session_id.is_some() => {
+      snapshot.last_usage.clone().unwrap_or_else(|| snapshot.usage.clone())
+    }
+    None => snapshot.usage.clone(),
+  };
+  previous_usage = Some(snapshot.usage.clone());
+  // Persist non-zero monotonic deltas through the existing path.
+}
+```
+
+- [ ] **Step 7: Verify GREEN and preserve monotonic tests**
+
+Run all `importer::tests` and require the new fork tests plus existing replay, archive, source-switch, and pending-repair tests to pass.
+
+### Task 3: Force a durable historical rebuild
+
+**Files:**
+
+- Modify: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+
+- Consumes: `data_repairs`, `data_repair_pending_files`, and unchanged import-state metadata.
+- Produces: the `token_usage_fork_replay_v3` repair marker and a retryable one-time sweep.
+
+- [ ] **Step 1: Add a failing v2-to-v3 repair test**
+
+Create an unchanged fork file and preseed overcounted `usage_events`, matching `import_state`, `rate_limit_sample_backfill_v1`, and `token_usage_monotonic_v2`. Run `perform_incremental_scan()` and assert that the corrected rows replace the stale rows and `token_usage_fork_replay_v3` is recorded.
+
+- [ ] **Step 2: Run the repair test and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::v3_repair_rebuilds_unchanged_fork_usage -- --exact
+```
+
+Expected: no file is reimported because the installed v2 marker is already complete.
+
+- [ ] **Step 3: Replace the repair key and keep pending-file behavior**
+
+Set the active token repair key to `token_usage_fork_replay_v3`. Do not delete the v2 marker. Reuse the existing full-scan promotion, per-file pending records, and completion marker.
+
+- [ ] **Step 4: Verify repair retry tests**
+
+Run the v3 test and all existing tests that contain `repair` in their name. Confirm that an unreadable file remains pending and a later successful read clears it.
+
+### Task 4: Validate with real data and the full test matrix
+
+**Files:**
+
+- No production file changes.
+
+**Interfaces:**
+
+- Consumes: a temporary copy of `~/.codex`, a temporary SQLite database, and the independent audit script.
+- Produces: corrected totals, database integrity evidence, and complete automated-test output.
+
+- [ ] **Step 1: Run formatting and focused Rust tests**
+
+```bash
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests --locked
+```
+
+- [ ] **Step 2: Run the complete project checks**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+npm test
+npm run lint
+npm run build
+./scripts/release/test-build-macos-release.sh
+```
+
+- [ ] **Step 3: Scan a copied source into a temporary database**
+
+Copy `~/.codex` into a temporary directory, run the importer against a temporary SQLite database, and compare all-time plus selected-root totals with `/tmp/codex_pacer_token_replay_audit.py`. Require `PRAGMA quick_check = ok`, zero exact duplicate usage rows, and a repaired total within the audit's documented conservative bounds.
+
+- [ ] **Step 4: Verify the installed database repair on a backup**
+
+Copy `~/Library/Application Support/com.codex.counter/codex-counter.sqlite` to a temporary path. Run the new importer against the copy. Confirm the v3 marker exists, pending v3 files are reported, settings are unchanged, and the current root no longer contains the copied parent prefix.
+
+### Task 5: Build, install, and launch the macOS app
+
+**Files:**
+
+- Build artifacts under an external `CARGO_TARGET_DIR`.
+- Install: `/Applications/Codex Pacer.app`.
+
+**Interfaces:**
+
+- Consumes: the release script, local Developer ID identity, and the completed source tree.
+- Produces: a signed app, DMG, checksum, installed app, running process, and repaired live database.
+
+- [ ] **Step 1: Commit and verify a clean release tree**
+
+```bash
+git add docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md \
+  docs/superpowers/plans/2026-07-10-fork-token-accounting.md \
+  src-tauri/src/models.rs src-tauri/src/importer.rs
+git commit -m "fix: remove fork token replay from usage totals"
+git status --short
+```
+
+- [ ] **Step 2: Build the signed app and DMG**
+
+Use an external target directory because the repository is stored in iCloud:
+
+```bash
+export CARGO_TARGET_DIR="$HOME/.cache/codex-pacer-target"
+export APPLE_SIGNING_IDENTITY="$(security find-identity -v -p codesigning | sed -n 's/.*\"\(Developer ID Application:[^\"]*\)\".*/\1/p' | head -n 1)"
+./scripts/release/build-macos-release.sh 1.1.2
+```
+
+Require the app bundle, DMG, and SHA-256 file to exist. Run `codesign --verify --deep --strict` and `hdiutil verify` on the generated artifacts.
+
+- [ ] **Step 3: Replace the installed app safely**
+
+Quit Codex Pacer, copy the existing app to a timestamped temporary backup, install the newly built bundle into `/Applications`, and remove the backup only after launch verification.
+
+```bash
+osascript -e 'tell application "Codex Pacer" to quit' || true
+ditto "/Applications/Codex Pacer.app" "/tmp/Codex Pacer.previous.app"
+rm -rf "/Applications/Codex Pacer.app"
+ditto "$CARGO_TARGET_DIR/release/bundle/macos/Codex Pacer.app" "/Applications/Codex Pacer.app"
+open -a "/Applications/Codex Pacer.app"
+```
+
+- [ ] **Step 4: Verify the running installation**
+
+Confirm the process executable resolves inside `/Applications/Codex Pacer.app`, the bundle version is `1.1.2`, the code signature passes, the v3 repair marker appears after scan completion, SQLite quick check returns `ok`, and the dashboard database totals match the corrected importer output.
+
+- [ ] **Step 5: Push the development branch**
+
+```bash
+git push origin codex/adapt-chatgpt-codex-5-6
+```
+
+Report the installed app path, DMG path, checksum, test commands, corrected before-and-after totals, and any source files that remain pending. Ask the user to test before starting the PR flow.

--- a/docs/superpowers/plans/2026-07-10-fork-token-accounting.md
+++ b/docs/superpowers/plans/2026-07-10-fork-token-accounting.md
@@ -12,7 +12,7 @@
 
 - Apply cross-session replay removal only to `session_meta.payload.forked_from_id`.
 - Require at least two consecutive exact `(total_token_usage, last_token_usage)` pairs.
-- Keep timestamps and model labels out of replay matching.
+- Do not compare child and parent timestamps; exclude parent records created after the explicit fork timestamp.
 - Keep the `usage_events` schema and public response types unchanged.
 - Preserve cumulative high-water handling for repeated and non-monotonic totals.
 - Fall back to legacy cumulative accounting when `last_token_usage` is absent.
@@ -116,7 +116,7 @@ Add `forked_from_session_id: Option<String>` to `SessionMetaCandidate` and `Pars
 
 - [ ] **Step 2: Add unit tests for replay matching**
 
-Test a complete match, a match starting inside the parent sequence, a one-record match that returns zero, and a sequence interrupted by a missing last-usage value.
+Test a complete match, a match starting inside the parent sequence, a one-record match that returns zero, and a sequence interrupted by a missing last-usage value. Add a same-total record whose last usage changes and assert that cumulative canonicalization removes it. Add a parent record after the fork whose numbers equal the child's first new usage and assert that the match stops before it.
 
 ```rust
 assert_eq!(longest_inherited_prefix(&child, &parent), 3);
@@ -153,11 +153,11 @@ fn usage_replay_key(snapshot: &UsageSnapshot) -> Option<UsageReplayKey> {
 }
 ```
 
-Build the child pattern only through its first missing key. Scan parent segments with a KMP prefix table. Return zero for matches shorter than two records.
+Reduce parent and child snapshots to strictly increasing cumulative high-water records. Keep each canonical child's original snapshot index so the matched prefix can map back to the raw sequence. Build the child pattern only through its first missing key. Exclude parent records later than the explicit fork timestamp, scan the remaining parent segments with a KMP prefix table, and return zero for matches shorter than two records.
 
 - [ ] **Step 5: Resolve and cache direct-parent sequences**
 
-Build a session source-path map from current scan files and `sessions.source_path`. For each changed explicit fork, read only `turn_context` and `event_msg/token_count` metadata from the direct parent. Cache `Vec<Option<UsageReplayKey>>` by parent session ID for the rest of the scan.
+Build a session source-path map from current scan files and `sessions.source_path`. For each changed explicit fork, read only timestamps and `event_msg/token_count` metadata from the direct parent. Cache the raw replay records by parent session ID for the rest of the scan, then apply each child's fork-time cutoff before canonicalization and matching.
 
 - [ ] **Step 6: Apply the corrected baseline in persistence**
 
@@ -212,9 +212,9 @@ cargo test --manifest-path src-tauri/Cargo.toml importer::tests::v3_repair_rebui
 
 Expected: no file is reimported because the installed v2 marker is already complete.
 
-- [ ] **Step 3: Replace the repair key and keep pending-file behavior**
+- [ ] **Step 3: Add the repair key and keep pending-file behavior**
 
-Set the active token repair key to `token_usage_fork_replay_v3`. Do not delete the v2 marker. Reuse the existing full-scan promotion, per-file pending records, and completion marker.
+Add `token_usage_fork_replay_v3` without deleting the v2 constant or marker. Promote an incremental request to a full scan when either repair is pending, merge both sets of pending paths into the changed-file set, and keep retrying v2 pending files. Record completion for each sweep independently. Reuse the existing per-file pending records and completion helpers.
 
 - [ ] **Step 4: Verify repair retry tests**
 

--- a/docs/superpowers/specs/2026-07-10-codex-5-6-chatgpt-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-10-codex-5-6-chatgpt-compatibility-design.md
@@ -31,7 +31,7 @@ On macOS, automatic discovery uses this order:
 5. Homebrew, `/usr/local/bin`, and `~/.cargo/bin` locations.
 6. The command name `codex`, which lets the operating system search `PATH`.
 
-Windows behavior stays unchanged. Linux keeps its existing standalone CLI lookup. The app-server transport and JSON-RPC methods also stay unchanged because the current bundled executable passed a real initialize and live quota read.
+Windows behavior stays unchanged. Linux keeps its existing standalone CLI lookup. The app-server transport and quota method stay the same. After `initialize` succeeds, Pacer now sends the standard `initialized` notification before reading live quota data.
 
 ## Pricing and data repair
 
@@ -43,7 +43,7 @@ The bundled Standard prices per million tokens are:
 | GPT-5.6 Terra | $2.50 | $0.25 | $15.00 |
 | GPT-5.6 Luna | $1.00 | $0.10 | $6.00 |
 
-The seed catalog adds these rows at startup. The existing pricing-signature check then detects the new rows and recalculates stored usage values, including GPT-5.6 events that were previously worth zero.
+The seed catalog adds these rows at startup. Historical values are recalculated when price-bearing catalog fields change or when the durable `pricing_value_resolution_v2` repair has not completed. The catalog update, recalculation, and repair marker share one transaction, so a failed upgrade can be retried without leaving mixed values behind.
 
 There is one repair case for users who clicked "Refresh pricing" after OpenAI added the new cache-write column but before this fix. Those databases can contain official GPT-5.6 rows whose output price is 1.25 times the input price: 6.25 for Sol, 3.125 for Terra, or 1.25 for Luna. Seeding may replace only that known malformed pattern. Correct official rows remain untouched. A later successful online refresh marks the corrected rows official again.
 
@@ -55,15 +55,19 @@ The audit found several update paths where valid local data can remain stale or 
 
 - A custom Codex home expands a leading `~` and must exist as a directory before a scan starts. An invalid path returns an error and does not advance the completed-scan timestamp.
 - Changing the Codex home clears the old freshness timestamps and triggers a full scan after settings are saved. Existing history stays in Pacer, while the new source becomes the active refresh target.
+- The resolved Codex home is stored with scan freshness. A default source change from A to B is detected even when the saved selector remains empty, and an incomplete first scan stays due for a full retry.
+- An authoritative source scan marks sessions from the previous home missing and removes their import state even when the old files still exist elsewhere on disk.
 - Incremental scans check whether a previously active file moved to the flat `archived_sessions` directory. This imports the final token snapshot immediately instead of waiting for daily maintenance.
 - A full scan refreshes titles from `session_index.jsonl` even when the session JSONL files did not change.
 - A UTF-8 read failure aborts that file before its metadata is committed. Ordinary incomplete JSON at the end of a file remains retryable on the next size or mtime change.
 - A missing or inconsistent conversation link triggers topology repair even when the source file itself did not change.
 - Persisted quota rows are ordered by their parsed RFC3339 instant, not by text. Primary and secondary windows are combined only when they came from the same sample time.
-- Conversation-detail cache entries are retained only while their source time, API-equivalent value, and subscription share still match the refreshed dashboard.
+- Conversation-detail cache entries are retained only while the refreshed title, timestamps, model set, token totals, session composition, API-equivalent value, and source states still match.
 - If a periodic refresh finds another scan in progress, the frontend waits for that scan to settle before loading the dashboard.
+- Pricing refreshes and scans share one mutation lock, so a scan cannot write values from an older catalog after a refresh commits.
+- A failed Codex-home change restores the previous settings and subscription profile, then rescans the restored source before reporting the error.
 
-These fixes keep the existing database schema. They use current metadata and comparisons, so users do not need to delete or rebuild their Pacer database.
+The database migration adds one nullable internal field, `last_scan_codex_home`, to bind freshness to the resolved source. Existing databases are upgraded automatically; users do not need to delete or rebuild them.
 
 ## User-visible behavior
 

--- a/docs/superpowers/specs/2026-07-10-codex-5-6-chatgpt-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-10-codex-5-6-chatgpt-compatibility-design.md
@@ -1,0 +1,102 @@
+# Codex 5.6 and ChatGPT app compatibility design
+
+## Problem
+
+Codex Pacer still imports the current session format, but two parts of the integration have fallen behind the July 2026 Codex release.
+
+First, the macOS build only looks for a standalone `codex` executable in Homebrew, `/usr/local/bin`, or `~/.cargo/bin`. The current ChatGPT desktop app ships its own executable at `/Applications/ChatGPT.app/Contents/Resources/codex`. A machine with the ChatGPT app but no standalone CLI cannot load live quota data.
+
+Second, the pricing catalog stops at GPT-5.5. A real GPT-5.6 Sol session imported 1,963,678 tokens into the local database with an API-equivalent value of zero. The official pricing page also added a cache-write price between cached input and output for GPT-5.6 rows. The existing parser reads the third number as output, so a pricing refresh can store the cache-write price as the output price.
+
+The current GPT-5.6 session files still live under `~/.codex/sessions` and retain the `session_meta`, `turn_context`, and `event_msg/token_count` records used by the importer. The live `account/rateLimits/read` request also succeeds against the executable bundled with ChatGPT 26.707.30751. No session-path or JSONL schema migration is needed for this release.
+
+## Chosen approach
+
+The compatibility work has three focused parts:
+
+1. Discover the Codex executable inside the ChatGPT app before trying legacy app and standalone CLI locations on macOS. `CODEX_BIN` remains the first choice so explicit configuration still wins.
+2. Add exact catalog, display, color, and prefix-resolution support for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` using the official Standard API prices. Treat the official `gpt-5.6` alias as Sol.
+3. Parse each official pricing row within its own boundary. The first value is input, the second is cached input, and the last value is output. Any optional middle value, including cache-write pricing, does not affect Pacer because local usage records do not contain cache-write token counts.
+
+This approach avoids guessing a price for unknown future models. Unknown model IDs remain visible but keep a zero API-equivalent value until OpenAI publishes a matching price.
+
+## Executable discovery
+
+On macOS, automatic discovery uses this order:
+
+1. An existing path from `CODEX_BIN`.
+2. `/Applications/ChatGPT.app/Contents/Resources/codex`.
+3. `~/Applications/ChatGPT.app/Contents/Resources/codex`.
+4. The equivalent system and user paths for the legacy `Codex.app` name.
+5. Homebrew, `/usr/local/bin`, and `~/.cargo/bin` locations.
+6. The command name `codex`, which lets the operating system search `PATH`.
+
+Windows behavior stays unchanged. Linux keeps its existing standalone CLI lookup. The app-server transport and JSON-RPC methods also stay unchanged because the current bundled executable passed a real initialize and live quota read.
+
+## Pricing and data repair
+
+The bundled Standard prices per million tokens are:
+
+| Model | Input | Cached input | Output |
+| --- | ---: | ---: | ---: |
+| GPT-5.6 / GPT-5.6 Sol | $5.00 | $0.50 | $30.00 |
+| GPT-5.6 Terra | $2.50 | $0.25 | $15.00 |
+| GPT-5.6 Luna | $1.00 | $0.10 | $6.00 |
+
+The seed catalog adds these rows at startup. The existing pricing-signature check then detects the new rows and recalculates stored usage values, including GPT-5.6 events that were previously worth zero.
+
+There is one repair case for users who clicked "Refresh pricing" after OpenAI added the new cache-write column but before this fix. Those databases can contain official GPT-5.6 rows whose output price is 1.25 times the input price: 6.25 for Sol, 3.125 for Terra, or 1.25 for Luna. Seeding may replace only that known malformed pattern. Correct official rows remain untouched. A later successful online refresh marks the corrected rows official again.
+
+Official-page parsing accepts both the older three-price rows and the new four-price rows. The parser still requires the supported flagship rows to be present before it replaces the catalog, which prevents a partial or structurally changed page from silently wiping valid prices.
+
+## Session refresh safety
+
+The audit found several update paths where valid local data can remain stale or be recorded only in part. This release fixes the cases that can silently lose or mislabel data:
+
+- A custom Codex home expands a leading `~` and must exist as a directory before a scan starts. An invalid path returns an error and does not advance the completed-scan timestamp.
+- Changing the Codex home clears the old freshness timestamps and triggers a full scan after settings are saved. Existing history stays in Pacer, while the new source becomes the active refresh target.
+- Incremental scans check whether a previously active file moved to the flat `archived_sessions` directory. This imports the final token snapshot immediately instead of waiting for daily maintenance.
+- A full scan refreshes titles from `session_index.jsonl` even when the session JSONL files did not change.
+- A UTF-8 read failure aborts that file before its metadata is committed. Ordinary incomplete JSON at the end of a file remains retryable on the next size or mtime change.
+- A missing or inconsistent conversation link triggers topology repair even when the source file itself did not change.
+- Persisted quota rows are ordered by their parsed RFC3339 instant, not by text. Primary and secondary windows are combined only when they came from the same sample time.
+- Conversation-detail cache entries are retained only while their source time, API-equivalent value, and subscription share still match the refreshed dashboard.
+- If a periodic refresh finds another scan in progress, the frontend waits for that scan to settle before loading the dashboard.
+
+These fixes keep the existing database schema. They use current metadata and comparisons, so users do not need to delete or rebuild their Pacer database.
+
+## User-visible behavior
+
+Model charts and conversation details show the names GPT-5.6 Sol, GPT-5.6 Terra, and GPT-5.6 Luna. Each model gets a distinct chart color, while the text label remains the primary identifier. No workflow depends on color alone.
+
+Codex Pacer keeps its current product name and continues to describe the imported data as Codex usage. The ChatGPT app change affects executable discovery, not the meaning of the analytics.
+
+## Failure handling
+
+If no executable exists, live quota reads return the existing launch error and persisted session-derived quota samples remain available as the fallback. An invalid `CODEX_BIN` does not block automatic discovery.
+
+If the official pricing page cannot be fetched or parsed, Pacer keeps the bundled catalog. If a model has no supported catalog entry, its token totals remain correct and only its API-equivalent value stays zero.
+
+## Verification
+
+Tests cover these behaviors before production code changes:
+
+- ChatGPT app discovery wins over legacy and standalone locations on macOS.
+- Explicit `CODEX_BIN` still wins.
+- The GPT-5.6 alias and all three variants resolve exact and dated model IDs.
+- Official three-price and four-price rows use the last value as output.
+- Seeding repairs the known cache-write-column corruption without overwriting correct official prices.
+- Startup recalculation changes a stored GPT-5.6 event from zero to the expected value.
+- A GPT-5.6 JSONL fixture imports token totals and API-equivalent value correctly.
+- Invalid custom homes, moved archives, title-only changes, UTF-8 failures, and missing topology links follow the refresh rules above.
+- Mixed-offset quota timestamps select the true latest sample and do not combine different sample times.
+- Derived-value changes invalidate a cached conversation detail, and a busy background refresh waits before reloading.
+
+Final verification includes the Rust test suite, frontend tests, lint, production web build, Tauri build checks, a real scan of a copied `~/.codex` data set, and a live quota request through the executable bundled with `/Applications/ChatGPT.app`.
+
+## Sources
+
+- [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
+- [Codex pricing and GPT-5.6 model guidance](https://developers.openai.com/codex/pricing)
+- [Codex app documentation](https://developers.openai.com/codex/app)
+- [ChatGPT desktop app July 2026 update](https://learn.chatgpt.com/docs/whats-new#july-6-10-2026)

--- a/docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md
+++ b/docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md
@@ -12,7 +12,9 @@ A second case occurs when the first child snapshot already contains an inherited
 
 The importer will keep the cumulative counter as its monotonic high-water mark. It will also parse `last_token_usage` for replay identification and first-snapshot recovery.
 
-For a session with an explicit `forked_from_id`, the importer will load the direct parent's numeric token sequence. It will compare each child snapshot by the exact pair `(total_token_usage, last_token_usage)`. A copied prefix is removed only when at least two consecutive child pairs match one contiguous slice of the direct parent's sequence. Timestamps and model labels do not participate because Codex can rewrite them during a fork.
+For a session with an explicit `forked_from_id`, the importer will load the direct parent's numeric token sequence. Parent and child sequences are first reduced to the same cumulative high-water records used for billing. This removes repeated snapshots, including records where total usage is unchanged but last usage differs. The importer then compares each child record by the exact pair `(total_token_usage, last_token_usage)`. A copied prefix is removed only when at least two consecutive child pairs match one contiguous slice of the direct parent's sequence.
+
+Child and parent timestamps do not need to be equal because Codex rewrites copied timestamps. The explicit fork timestamp still supplies a causal boundary: parent records created after the fork cannot have been inherited and are excluded before matching. Model labels do not participate in matching.
 
 The matching algorithm finds the longest child prefix contained in the parent sequence in linear time. Missing `last_token_usage` breaks a candidate match. This keeps older JSONL formats on the existing cumulative-counter path.
 
@@ -24,13 +26,13 @@ Sessions linked only through `source.subagent.thread_spawn.parent_thread_id` do 
 
 `UsageSnapshot` will retain both cumulative and last-turn token usage. `ParsedSession` will separately retain the explicit fork parent ID so the importer can distinguish a true fork from a normal spawned subagent.
 
-At scan time, the importer builds a session-to-source-path map from the files in the current scan and existing session records. When a changed explicit fork is parsed, the importer reads the direct parent's numeric token records on demand and caches the result for sibling forks. It does not load message text into memory.
+At scan time, the importer builds a session-to-source-path map from the files in the current scan and existing session records. When a changed explicit fork is parsed, the importer reads the direct parent's token numbers and timestamps on demand, drops records later than the fork, and caches the result for sibling forks. It does not load message text into memory.
 
 The persisted `usage_events` table remains unchanged. It continues to store deltas, not source cumulative counters. API-equivalent value is calculated from the corrected deltas in the same transaction that replaces the session's usage rows.
 
 ## Historical repair
 
-The existing `token_usage_monotonic_v2` repair marker has already completed on installed databases. The new algorithm therefore uses `token_usage_fork_replay_v3`. Its absence forces a full scan and rebuilds unchanged usage files under the selected Codex home.
+The existing `token_usage_monotonic_v2` repair marker has already completed on installed databases. The new algorithm therefore adds `token_usage_fork_replay_v3`. Its absence forces a full scan and rebuilds unchanged usage files under the selected Codex home. The importer continues to load and retry any older v2 pending files instead of abandoning them when v3 is introduced.
 
 If a source file is unreadable, the existing pending-file mechanism records it and retries it on a later scan. A direct parent that is no longer available cannot support exact prefix matching. In that case the child still receives the first-snapshot baseline correction, and the importer logs that full replay matching was unavailable.
 
@@ -38,13 +40,16 @@ Historical sessions from a different Codex home can only be rebuilt while their 
 
 ## Performance
 
-Normal root sessions do no extra file work. An explicit fork loads only its direct parent's numeric token records. Multiple children of one parent share the cached sequence for the duration of the scan. Prefix matching uses a KMP-style prefix table, so its cost is proportional to the parent and child sequence lengths.
+Normal root sessions do no extra file work. An explicit fork loads only its direct parent's numeric token records. Multiple children of one parent share the raw sequence for the duration of the scan, then apply their own fork-time cutoff. Prefix matching uses a KMP-style prefix table, so its cost is proportional to the parent and child sequence lengths.
 
 ## Verification
 
 Automated tests cover:
 
 - a child that copies three parent snapshots and then adds new usage;
+- a copied sequence that starts in the middle of the parent history;
+- unchanged cumulative totals with different last-usage values producing no extra match or charge;
+- parent usage after the fork being ineligible for replay matching;
 - a fork whose first snapshot contains a large inherited baseline;
 - a normal spawned subagent that must not use fork replay removal;
 - a nested fork that compares against its direct parent;

--- a/docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md
+++ b/docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md
@@ -1,0 +1,57 @@
+# Fork token accounting design
+
+## Problem
+
+Codex fork files can begin with a copy of the direct parent's `token_count` history. The copied records keep the parent's numeric `total_token_usage` and `last_token_usage` values, but Codex rewrites their timestamps to the fork creation time. Codex Pacer currently treats every file as an independent counter. It starts the child at zero and imports the copied cumulative history again.
+
+The local audit found no duplicate SQLite rows and no duplicate import-state records. The error is in the JSONL import semantics. Across the current data set, the copied history accounts for about 43 percent of the displayed all-time total. In the active root conversation, it accounts for about 86 percent.
+
+A second case occurs when the first child snapshot already contains an inherited cumulative baseline. For example, a child may report `total_token_usage.total_tokens = 153235349` while `last_token_usage.total_tokens = 289826`. Counting the cumulative value assigns the parent's history to the child. The child's first real increment is the `last_token_usage` value.
+
+## Selected approach
+
+The importer will keep the cumulative counter as its monotonic high-water mark. It will also parse `last_token_usage` for replay identification and first-snapshot recovery.
+
+For a session with an explicit `forked_from_id`, the importer will load the direct parent's numeric token sequence. It will compare each child snapshot by the exact pair `(total_token_usage, last_token_usage)`. A copied prefix is removed only when at least two consecutive child pairs match one contiguous slice of the direct parent's sequence. Timestamps and model labels do not participate because Codex can rewrite them during a fork.
+
+The matching algorithm finds the longest child prefix contained in the parent sequence in linear time. Missing `last_token_usage` breaks a candidate match. This keeps older JSONL formats on the existing cumulative-counter path.
+
+After a match, the last copied cumulative value becomes the child's baseline. The first new child snapshot is calculated against that baseline. If no reliable parent prefix is available, the first explicit-fork snapshot uses `last_token_usage` when present. Later snapshots continue to use cumulative high-water differences, which preserves the existing protection against repeated and non-monotonic totals.
+
+Sessions linked only through `source.subagent.thread_spawn.parent_thread_id` do not use cross-session replay removal. The audit did not find copied token prefixes in those files. Their current accounting remains unchanged.
+
+## Data flow
+
+`UsageSnapshot` will retain both cumulative and last-turn token usage. `ParsedSession` will separately retain the explicit fork parent ID so the importer can distinguish a true fork from a normal spawned subagent.
+
+At scan time, the importer builds a session-to-source-path map from the files in the current scan and existing session records. When a changed explicit fork is parsed, the importer reads the direct parent's numeric token records on demand and caches the result for sibling forks. It does not load message text into memory.
+
+The persisted `usage_events` table remains unchanged. It continues to store deltas, not source cumulative counters. API-equivalent value is calculated from the corrected deltas in the same transaction that replaces the session's usage rows.
+
+## Historical repair
+
+The existing `token_usage_monotonic_v2` repair marker has already completed on installed databases. The new algorithm therefore uses `token_usage_fork_replay_v3`. Its absence forces a full scan and rebuilds unchanged usage files under the selected Codex home.
+
+If a source file is unreadable, the existing pending-file mechanism records it and retries it on a later scan. A direct parent that is no longer available cannot support exact prefix matching. In that case the child still receives the first-snapshot baseline correction, and the importer logs that full replay matching was unavailable.
+
+Historical sessions from a different Codex home can only be rebuilt while their source files are available. Selecting that source again causes an authoritative full scan. Missing source files remain visible as missing and are not silently treated as repaired data.
+
+## Performance
+
+Normal root sessions do no extra file work. An explicit fork loads only its direct parent's numeric token records. Multiple children of one parent share the cached sequence for the duration of the scan. Prefix matching uses a KMP-style prefix table, so its cost is proportional to the parent and child sequence lengths.
+
+## Verification
+
+Automated tests cover:
+
+- a child that copies three parent snapshots and then adds new usage;
+- a fork whose first snapshot contains a large inherited baseline;
+- a normal spawned subagent that must not use fork replay removal;
+- a nested fork that compares against its direct parent;
+- a missing `last_token_usage` field that keeps legacy cumulative behavior;
+- the new repair marker rebuilding unchanged, previously overcounted rows;
+- repeated and non-monotonic snapshots retaining their current high-water behavior.
+
+Integration verification runs the importer against a copied `~/.codex` tree and a temporary SQLite database. The test compares corrected totals with the independent read-only audit, checks database integrity, and confirms that the installed database can be repaired without deleting settings.
+
+The release check then runs Rust tests, frontend tests, lint, the production build, the macOS release script, code-signature verification, DMG verification, installation into `/Applications`, application launch, and a post-launch database query.

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -17,7 +17,7 @@
 
 如果你要从源码开发，还需要：
 
-- Node.js 20+
+- Node.js 22.18+
 - Rust toolchain
 - 当前平台所需的 Tauri 构建依赖
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-pacer",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-pacer",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "npm run test:issue-1 && npm run test:issue-3",
+    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness",
     "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
     "test:issue-3": "node scripts/test-issue-3-custom-range.mjs",
+    "test:data-freshness": "node scripts/test-data-freshness.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-pacer",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.2.0",
   "type": "module",
   "engines": {
     "node": ">=22.18.0"

--- a/package.json
+++ b/package.json
@@ -3,14 +3,18 @@
   "private": true,
   "version": "1.1.2",
   "type": "module",
+  "engines": {
+    "node": ">=22.18.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness",
+    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness && npm run test:settings-save",
     "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
     "test:issue-3": "node scripts/test-issue-3-custom-range.mjs",
-    "test:data-freshness": "node scripts/test-data-freshness.mjs",
+    "test:data-freshness": "node --experimental-strip-types scripts/test-data-freshness.mjs",
+    "test:settings-save": "node --experimental-strip-types scripts/test-settings-save.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/scripts/test-data-freshness.mjs
+++ b/scripts/test-data-freshness.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+
+import {
+  shouldKeepConversationDetail,
+  waitForOverlappingScan,
+} from '../src/app/dataFreshness.ts'
+
+const summary = {
+  rootSessionId: 'root-session',
+  updatedAt: '2026-07-10T08:00:00Z',
+  apiValueUsd: 12.5,
+  subscriptionShare: 0.125,
+}
+
+const cachedDetail = {
+  rootSessionId: 'root-session',
+  updatedAt: summary.updatedAt,
+  apiValueUsd: summary.apiValueUsd,
+  subscriptionShare: summary.apiValueUsd / 100,
+}
+
+assert.equal(
+  shouldKeepConversationDetail(
+    { ...cachedDetail, updatedAt: '2026-07-10T07:59:59Z' },
+    summary,
+    100,
+  ),
+  false,
+  'detail cache should reject an older conversation timestamp',
+)
+
+assert.equal(
+  shouldKeepConversationDetail(
+    { ...cachedDetail, apiValueUsd: summary.apiValueUsd - 0.5 },
+    summary,
+    100,
+  ),
+  false,
+  'detail cache should reject a stale API value',
+)
+
+assert.equal(
+  shouldKeepConversationDetail(cachedDetail, summary, 200),
+  false,
+  'detail cache should reject subscription share derived from an older monthly price',
+)
+
+assert.equal(
+  shouldKeepConversationDetail(
+    {
+      ...cachedDetail,
+      apiValueUsd: summary.apiValueUsd + 1e-10,
+      subscriptionShare: summary.apiValueUsd / 100 + 1e-10,
+    },
+    summary,
+    100,
+  ),
+  true,
+  'detail cache should retain matching derived values within floating-point tolerance',
+)
+
+let scanChecks = 0
+let settleWaits = 0
+await waitForOverlappingScan(
+  async () => {
+    scanChecks += 1
+    return true
+  },
+  async () => {
+    settleWaits += 1
+  },
+)
+
+assert.equal(scanChecks, 1, 'overlapping refresh should check scan state once')
+assert.equal(settleWaits, 1, 'overlapping refresh should wait once for an active scan')
+
+settleWaits = 0
+await waitForOverlappingScan(
+  async () => false,
+  async () => {
+    settleWaits += 1
+  },
+)
+
+assert.equal(settleWaits, 0, 'refresh should not wait when no scan is active')

--- a/scripts/test-data-freshness.mjs
+++ b/scripts/test-data-freshness.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
+  loadConversationDetailForGeneration,
   refreshDashboardAfterBackgroundScan,
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
@@ -8,18 +12,107 @@ import {
   waitForScanToSettleUntilCancelled,
 } from '../src/app/dataFreshness.ts'
 
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
+
 const summary = {
   rootSessionId: 'root-session',
+  title: 'Current title',
+  startedAt: '2026-07-10T07:00:00Z',
   updatedAt: '2026-07-10T08:00:00Z',
+  modelIds: ['gpt-5.6-sol', 'gpt-5.6-terra'],
+  inputTokens: 100,
+  cachedInputTokens: 20,
+  outputTokens: 25,
+  reasoningOutputTokens: 5,
+  totalTokens: 125,
+  sessionCount: 2,
+  subagentCount: 1,
+  hasFastMode: true,
   apiValueUsd: 12.5,
   subscriptionShare: 0.125,
+  sourceStates: ['active', 'archived'],
 }
 
 const cachedDetail = {
   rootSessionId: 'root-session',
+  title: summary.title,
+  startedAt: summary.startedAt,
   updatedAt: summary.updatedAt,
+  inputTokens: summary.inputTokens,
+  cachedInputTokens: summary.cachedInputTokens,
+  outputTokens: summary.outputTokens,
+  reasoningOutputTokens: summary.reasoningOutputTokens,
+  totalTokens: summary.totalTokens,
   apiValueUsd: summary.apiValueUsd,
   subscriptionShare: summary.apiValueUsd / 100,
+  multipleAgent: true,
+  sourceStates: ['archived', 'active'],
+  sessions: [
+    { isSubagent: false, fastModeEffective: false },
+    { isSubagent: true, fastModeEffective: true },
+  ],
+  modelBreakdown: [
+    { modelId: 'gpt-5.6-terra' },
+    { modelId: 'gpt-5.6-sol' },
+  ],
+}
+
+assert.equal(
+  shouldKeepConversationDetail(cachedDetail, summary, 100),
+  true,
+  'detail cache should retain a detail whose user-visible summary fields still match',
+)
+
+let detailGeneration = 1
+let releaseStaleDetail
+const staleDetailRequest = loadConversationDetailForGeneration(
+  () =>
+    new Promise((resolve) => {
+      releaseStaleDetail = resolve
+    }),
+  detailGeneration,
+  () => detailGeneration,
+)
+detailGeneration += 1
+releaseStaleDetail({ title: 'Stale title' })
+assert.equal(
+  await staleDetailRequest,
+  null,
+  'a detail response from before dashboard cache reconciliation should be discarded',
+)
+assert.match(
+  appSource,
+  /latestDetailRequestIdRef\.current \+= 1[\s\S]*detailCacheRef\.current = nextDetailCache/,
+  'dashboard reconciliation should invalidate in-flight detail requests before replacing the cache',
+)
+assert.match(
+  appSource,
+  /setDetail\(\(current\)[\s\S]*nextDetailCache\.get\(current\.rootSessionId\)[\s\S]*\? current : null/,
+  'dashboard reconciliation should stop showing a detail that was evicted from the cache',
+)
+
+for (const [label, changedSummary] of [
+  ['root session', { ...summary, rootSessionId: 'different-root' }],
+  ['title', { ...summary, title: 'Updated title' }],
+  ['start timestamp', { ...summary, startedAt: '2026-07-10T07:00:01Z' }],
+  ['model list', { ...summary, modelIds: ['gpt-5.6-sol'] }],
+  ['input tokens', { ...summary, inputTokens: summary.inputTokens + 1 }],
+  ['cached input tokens', { ...summary, cachedInputTokens: summary.cachedInputTokens + 1 }],
+  ['output tokens', { ...summary, outputTokens: summary.outputTokens + 1 }],
+  ['reasoning tokens', { ...summary, reasoningOutputTokens: summary.reasoningOutputTokens + 1 }],
+  ['total tokens', { ...summary, totalTokens: summary.totalTokens + 1 }],
+  ['session count', { ...summary, sessionCount: summary.sessionCount + 1 }],
+  ['subagent count', { ...summary, subagentCount: 0 }],
+  ['fast-mode state', { ...summary, hasFastMode: false }],
+  ['subscription share', { ...summary, subscriptionShare: summary.subscriptionShare + 0.01 }],
+  ['source state', { ...summary, sourceStates: ['archived'] }],
+]) {
+  assert.equal(
+    shouldKeepConversationDetail(cachedDetail, changedSummary, 100),
+    false,
+    `detail cache should reject a stale ${label}`,
+  )
 }
 
 assert.equal(

--- a/scripts/test-data-freshness.mjs
+++ b/scripts/test-data-freshness.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict'
 
 import {
+  refreshDashboardAfterBackgroundScan,
+  runScanWithOverlapRetry,
   shouldKeepConversationDetail,
   waitForOverlappingScan,
+  waitForScanToSettleUntilCancelled,
 } from '../src/app/dataFreshness.ts'
 
 const summary = {
@@ -61,25 +64,168 @@ assert.equal(
 
 let scanChecks = 0
 let settleWaits = 0
-await waitForOverlappingScan(
+const settledAfterOverlap = await waitForOverlappingScan(
   async () => {
     scanChecks += 1
     return true
   },
   async () => {
     settleWaits += 1
+    return true
   },
 )
 
 assert.equal(scanChecks, 1, 'overlapping refresh should check scan state once')
 assert.equal(settleWaits, 1, 'overlapping refresh should wait once for an active scan')
+assert.equal(settledAfterOverlap, true, 'overlapping refresh should report a settled scan')
+
+const timedOutAfterOverlap = await waitForOverlappingScan(
+  async () => true,
+  async () => false,
+)
+
+assert.equal(timedOutAfterOverlap, false, 'overlapping refresh should report a settle timeout')
 
 settleWaits = 0
-await waitForOverlappingScan(
+const settledWithoutOverlap = await waitForOverlappingScan(
   async () => false,
   async () => {
     settleWaits += 1
+    return true
   },
 )
 
 assert.equal(settleWaits, 0, 'refresh should not wait when no scan is active')
+assert.equal(settledWithoutOverlap, true, 'refresh should be ready when no scan is active')
+
+let scanAttempts = 0
+let overlapNotices = 0
+const retriedScan = await runScanWithOverlapRetry(
+  async () => {
+    scanAttempts += 1
+    if (scanAttempts === 1) {
+      throw new Error('A scan is already running.')
+    }
+    return { codexHome: '/tmp/new-home' }
+  },
+  (error) => String(error).includes('already running'),
+  async () => true,
+  () => {
+    overlapNotices += 1
+  },
+)
+
+assert.deepEqual(retriedScan, { codexHome: '/tmp/new-home' })
+assert.equal(scanAttempts, 2, 'source switch should retry a full scan after the old scan settles')
+assert.equal(overlapNotices, 1, 'source switch should report one overlapping scan')
+
+scanAttempts = 0
+await assert.rejects(
+  runScanWithOverlapRetry(
+    async () => {
+      scanAttempts += 1
+      throw new Error('A scan is already running.')
+    },
+    (error) => String(error).includes('already running'),
+    async () => false,
+  ),
+  /did not finish before the timeout/,
+  'source switch should fail instead of reading the dashboard after a settle timeout',
+)
+assert.equal(scanAttempts, 1, 'source switch should not retry while the old scan is still active')
+
+let dashboardLoads = 0
+await refreshDashboardAfterBackgroundScan(
+  async () => {
+    throw new Error('background refresh failed')
+  },
+  async () => false,
+  async () => true,
+  async () => {
+    dashboardLoads += 1
+  },
+)
+assert.equal(dashboardLoads, 1, 'background refresh errors should still allow a current dashboard load')
+
+dashboardLoads = 0
+await refreshDashboardAfterBackgroundScan(
+  async () => null,
+  async () => true,
+  async () => false,
+  async () => {
+    dashboardLoads += 1
+  },
+)
+assert.equal(dashboardLoads, 0, 'a settle timeout should skip the current background dashboard load')
+
+let cancelled = false
+let releaseWait
+let markWaitStarted
+const waitStarted = new Promise((resolve) => {
+  markWaitStarted = resolve
+})
+const pendingRefresh = refreshDashboardAfterBackgroundScan(
+  async () => null,
+  async () => true,
+  async () => {
+    markWaitStarted()
+    return new Promise((resolve) => {
+      releaseWait = resolve
+    })
+  },
+  async () => {
+    dashboardLoads += 1
+  },
+  () => cancelled,
+)
+
+await waitStarted
+cancelled = true
+releaseWait(true)
+await pendingRefresh
+assert.equal(dashboardLoads, 0, 'effect cleanup should cancel a refresh that was waiting on a scan')
+
+await refreshDashboardAfterBackgroundScan(
+  async () => null,
+  async () => {
+    throw new Error('scan state unavailable')
+  },
+  async () => true,
+  async () => {
+    dashboardLoads += 1
+  },
+)
+assert.equal(dashboardLoads, 0, 'scan-state errors should not load or reject the interval task')
+
+await refreshDashboardAfterBackgroundScan(
+  async () => null,
+  async () => true,
+  async () => {
+    throw new Error('settle state unavailable')
+  },
+  async () => {
+    dashboardLoads += 1
+  },
+)
+assert.equal(dashboardLoads, 0, 'settle errors should not load or reject the interval task')
+
+let bootstrapWaits = 0
+const bootstrapSettled = await waitForScanToSettleUntilCancelled(
+  async () => {
+    bootstrapWaits += 1
+    return bootstrapWaits > 1
+  },
+  () => false,
+)
+assert.equal(bootstrapSettled, true, 'bootstrap should keep waiting after one settle timeout')
+assert.equal(bootstrapWaits, 2, 'bootstrap should retry its settle wait after a timeout')
+
+let bootstrapCancelled = false
+const cancelledBootstrapSettled = await waitForScanToSettleUntilCancelled(
+  async () => {
+    bootstrapCancelled = true
+    return false
+  },
+  () => bootstrapCancelled,
+)
+assert.equal(cancelledBootstrapSettled, false, 'bootstrap should stop retrying after cleanup')

--- a/scripts/test-settings-save.mjs
+++ b/scripts/test-settings-save.mjs
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  closeSettingsPanelIfIdle,
+  saveSettingsWithCodexHomeRollback,
+} from '../src/app/settingsSave.ts'
+
+const previousSyncSettings = { codexHome: '/tmp/codex-home-a', interval: 5 }
+const nextSyncSettings = { codexHome: '/tmp/missing-codex-home', interval: 10 }
+const previousSubscriptionProfile = { planType: 'plus', monthlyPrice: 20 }
+const nextSubscriptionProfile = { planType: 'pro', monthlyPrice: 200 }
+
+let storedSyncSettings = previousSyncSettings
+let storedSubscriptionProfile = previousSubscriptionProfile
+const calls = []
+
+await assert.rejects(
+  saveSettingsWithCodexHomeRollback({
+    previousSyncSettings,
+    nextSyncSettings,
+    previousSubscriptionProfile,
+    nextSubscriptionProfile,
+    updateSyncSettings: async (settings) => {
+      calls.push(`sync:${settings.codexHome}`)
+      storedSyncSettings = settings
+      return settings
+    },
+    updateSubscriptionProfile: async (profile) => {
+      calls.push(`profile:${profile.planType}`)
+      storedSubscriptionProfile = profile
+      return profile
+    },
+    scanCodexHome: async (codexHome) => {
+      calls.push(`scan:${codexHome}`)
+      if (codexHome === nextSyncSettings.codexHome) {
+        throw new Error(`Codex home is not an existing directory: ${codexHome}`)
+      }
+    },
+  }),
+  /not an existing directory/,
+  'an invalid Codex home should reject the settings save',
+)
+
+assert.deepEqual(
+  storedSyncSettings,
+  previousSyncSettings,
+  'an invalid Codex home should restore the previously persisted sync settings',
+)
+assert.deepEqual(
+  storedSubscriptionProfile,
+  previousSubscriptionProfile,
+  'a failed settings save should restore the previous subscription profile',
+)
+assert.deepEqual(
+  calls,
+  [
+    'sync:/tmp/missing-codex-home',
+    'profile:pro',
+    'scan:/tmp/missing-codex-home',
+    'sync:/tmp/codex-home-a',
+    'profile:plus',
+    'scan:/tmp/codex-home-a',
+  ],
+  'an invalid source should restore both settings and rescan the restored source for freshness',
+)
+
+calls.length = 0
+const validResult = await saveSettingsWithCodexHomeRollback({
+  previousSyncSettings,
+  nextSyncSettings: { ...nextSyncSettings, codexHome: '/tmp/codex-home-b' },
+  previousSubscriptionProfile,
+  nextSubscriptionProfile,
+  updateSyncSettings: async (settings) => {
+    calls.push(`sync:${settings.codexHome}`)
+    return settings
+  },
+  updateSubscriptionProfile: async (profile) => {
+    calls.push(`profile:${profile.planType}`)
+    return profile
+  },
+  scanCodexHome: async (codexHome) => {
+    calls.push(`scan:${codexHome}`)
+  },
+})
+
+assert.equal(validResult.codexHomeChanged, true)
+assert.equal(validResult.syncSettings.codexHome, '/tmp/codex-home-b')
+assert.deepEqual(
+  calls,
+  ['sync:/tmp/codex-home-b', 'profile:pro', 'scan:/tmp/codex-home-b'],
+  'a valid source change should be scanned after persistence so it is authoritative',
+)
+
+calls.length = 0
+const unchangedResult = await saveSettingsWithCodexHomeRollback({
+  previousSyncSettings,
+  nextSyncSettings: { ...previousSyncSettings, interval: 15 },
+  previousSubscriptionProfile,
+  nextSubscriptionProfile,
+  updateSyncSettings: async (settings) => {
+    calls.push(`sync:${settings.codexHome}`)
+    return settings
+  },
+  updateSubscriptionProfile: async (profile) => {
+    calls.push(`profile:${profile.planType}`)
+    return profile
+  },
+  scanCodexHome: async () => {
+    calls.push('unexpected-scan')
+  },
+})
+
+assert.equal(unchangedResult.codexHomeChanged, false)
+assert.deepEqual(
+  calls,
+  ['sync:/tmp/codex-home-a', 'profile:pro'],
+  'saving unrelated settings should not trigger a Codex home scan',
+)
+
+calls.length = 0
+storedSubscriptionProfile = previousSubscriptionProfile
+storedSyncSettings = previousSyncSettings
+await assert.rejects(
+  saveSettingsWithCodexHomeRollback({
+    previousSyncSettings,
+    nextSyncSettings: { ...previousSyncSettings, interval: 30 },
+    previousSubscriptionProfile,
+    nextSubscriptionProfile,
+    updateSyncSettings: async (settings) => {
+      calls.push(`sync:${settings.interval}`)
+      storedSyncSettings = settings
+      return settings
+    },
+    updateSubscriptionProfile: async () => {
+      calls.push('profile:failed')
+      throw new Error('profile save failed')
+    },
+    scanCodexHome: async () => {
+      calls.push('unexpected-scan')
+    },
+  }),
+  /profile save failed/,
+)
+assert.deepEqual(storedSyncSettings, previousSyncSettings)
+assert.deepEqual(storedSubscriptionProfile, previousSubscriptionProfile)
+assert.deepEqual(
+  calls,
+  ['sync:30', 'profile:failed', 'sync:5'],
+  'a later persistence failure should restore sync settings saved earlier in the operation',
+)
+
+let closeCount = 0
+assert.equal(closeSettingsPanelIfIdle(true, () => (closeCount += 1)), false)
+assert.equal(closeCount, 0, 'the settings modal should stay open while validation is pending')
+assert.equal(closeSettingsPanelIfIdle(false, () => (closeCount += 1)), true)
+assert.equal(closeCount, 1, 'the settings modal should close normally while idle')
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
+const panelSource = readFileSync(join(repoRoot, 'src/components/SettingsPanel.tsx'), 'utf8')
+const i18nSource = readFileSync(join(repoRoot, 'src/app/i18n.ts'), 'utf8')
+const packageMetadata = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'))
+const readmeSource = readFileSync(join(repoRoot, 'README.md'), 'utf8')
+const chineseReadmeSource = readFileSync(join(repoRoot, 'README.zh-CN.md'), 'utf8')
+const englishGettingStarted = readFileSync(join(repoRoot, 'docs/en/getting-started.md'), 'utf8')
+const chineseGettingStarted = readFileSync(join(repoRoot, 'docs/zh-CN/getting-started.md'), 'utf8')
+
+assert.match(
+  appSource,
+  /saveSettingsWithCodexHomeRollback\([\s\S]*scanCodexHome:[\s\S]*runScanWithOverlapRetry/,
+  'settings save should validate the persisted Codex home through a tracked scan that can reject',
+)
+assert.doesNotMatch(
+  appSource,
+  /await loadShell\(codexHomeChanged\)/,
+  'settings save should not rely on loadShell, which handles dashboard errors internally, to validate a source',
+)
+assert.match(
+  panelSource,
+  /catch \(error\)[\s\S]*setSaveError\(t\.status\.settingsSaveFailed\(String\(error\)\)\)/,
+  'the settings panel should keep the modal open and show save failures',
+)
+assert.match(
+  panelSource,
+  /const handleClose = \(\) => closeSettingsPanelIfIdle\(saving, onClose\)/,
+  'all settings close paths should share the saving guard',
+)
+assert.match(
+  panelSource,
+  /modal-backdrop" onClick=\{handleClose\}[\s\S]*disabled=\{saving\}[\s\S]*onClick=\{handleClose\}[\s\S]*disabled=\{saving\}[\s\S]*onClick=\{handleClose\}/,
+  'backdrop, Close, and Cancel should keep the modal open while a save is pending',
+)
+assert.match(
+  panelSource,
+  /className="settings-save-error" role="alert"/,
+  'settings save failures should be exposed as an accessible inline alert',
+)
+assert.match(i18nSource, /settingsSaveFailed: \(error: string\) => string/)
+assert.match(i18nSource, /settingsSaveFailed: \(error\) => `设置未保存：\$\{error\}`/)
+assert.match(i18nSource, /settingsSaveFailed: \(error\) => `Settings were not saved: \$\{error\}`/)
+assert.equal(
+  packageMetadata.engines?.node,
+  '>=22.18.0',
+  'package metadata should enforce the Node runtime required for direct TypeScript test imports',
+)
+assert.match(packageMetadata.scripts['test:data-freshness'], /node --experimental-strip-types /)
+assert.match(packageMetadata.scripts['test:settings-save'], /node --experimental-strip-types /)
+for (const [label, source] of [
+  ['README', readmeSource],
+  ['Chinese README', chineseReadmeSource],
+  ['English getting started guide', englishGettingStarted],
+  ['Chinese getting started guide', chineseGettingStarted],
+]) {
+  assert.match(source, /Node\.js 22\.18\+/, `${label} should document the Node 22.18 minimum`)
+  assert.doesNotMatch(source, /Node\.js 20\+/, `${label} should not advertise an incompatible Node 20 runtime`)
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-pacer"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-pacer"
-version = "1.1.2"
+version = "1.2.0"
 description = "Codex Pacer desktop analytics"
 authors = ["Codex"]
 license = ""

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -97,6 +97,7 @@ CREATE TABLE IF NOT EXISTS sync_settings (
   last_scan_started_at TEXT,
   last_scan_completed_at TEXT,
   last_full_scan_completed_at TEXT,
+  last_scan_codex_home TEXT,
   updated_at TEXT NOT NULL
 );
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -151,6 +151,61 @@ mod tests {
     }
 
     #[test]
+    fn init_db_adds_resolved_scan_source_to_existing_sync_settings() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+
+        conn.execute_batch(
+            "
+        CREATE TABLE sync_settings (
+          singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+          codex_home TEXT,
+          auto_scan_enabled INTEGER NOT NULL,
+          auto_scan_interval_minutes INTEGER NOT NULL,
+          last_scan_started_at TEXT,
+          last_scan_completed_at TEXT,
+          updated_at TEXT NOT NULL
+        );
+
+        INSERT INTO sync_settings (
+          singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
+          last_scan_started_at, last_scan_completed_at, updated_at
+        )
+        VALUES (
+          1, NULL, 1, 5,
+          '2026-07-09T23:00:00Z', '2026-07-09T23:01:00Z',
+          '2026-07-10T00:00:00Z'
+        );
+        ",
+        )
+        .expect("seed legacy schema");
+
+        init_db(&conn).expect("migrate schema");
+
+        let (resolved_source, started, completed, full_completed): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "
+                SELECT last_scan_codex_home, last_scan_started_at,
+                       last_scan_completed_at, last_full_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("load resolved scan source");
+
+        assert_eq!(resolved_source, None);
+        assert_eq!(started, None);
+        assert_eq!(completed, None);
+        assert_eq!(full_completed, None);
+    }
+
+    #[test]
     fn sync_settings_tracks_last_full_scan_completion() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
         init_db(&conn).expect("init database");
@@ -163,6 +218,104 @@ mod tests {
             get_last_full_scan_completed(&conn).expect("load saved value"),
             Some("2026-03-27T00:00:00Z".to_string())
         );
+    }
+
+    #[test]
+    fn scan_freshness_tracks_resolved_source_when_default_selector_moves() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let first = set_last_scan_started_for_source(
+            &conn,
+            "2026-07-10T00:00:00Z",
+            None,
+            "/tmp/codex-home-a",
+        )
+        .expect("start first scan");
+        assert!(first.recorded);
+        assert!(first.source_changed);
+
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-10T00:01:00Z",
+            None,
+            "/tmp/codex-home-a",
+            true,
+        )
+        .expect("complete first scan"));
+
+        let second = set_last_scan_started_for_source(
+            &conn,
+            "2026-07-10T01:00:00Z",
+            None,
+            "/tmp/codex-home-b",
+        )
+        .expect("start second scan");
+        assert!(second.recorded);
+        assert!(second.source_changed);
+        assert!(second.full_scan_required);
+
+        let (resolved_source, started, completed, full_completed): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "
+                SELECT last_scan_codex_home, last_scan_started_at,
+                       last_scan_completed_at, last_full_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("load moved scan source");
+
+        assert_eq!(resolved_source.as_deref(), Some("/tmp/codex-home-b"));
+        assert_eq!(started.as_deref(), Some("2026-07-10T01:00:00Z"));
+        assert_eq!(completed, None);
+        assert_eq!(full_completed, None);
+
+        let retry = set_last_scan_started_for_source(
+            &conn,
+            "2026-07-10T01:00:30Z",
+            None,
+            "/tmp/codex-home-b",
+        )
+        .expect("retry second scan");
+        assert!(retry.recorded);
+        assert!(!retry.source_changed);
+        assert!(retry.full_scan_required);
+
+        assert!(!set_scan_completed_for_source(
+            &conn,
+            "2026-07-10T01:01:00Z",
+            None,
+            "/tmp/codex-home-a",
+            true,
+        )
+        .expect("reject completion from first source"));
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-10T01:02:00Z",
+            None,
+            "/tmp/codex-home-b",
+            true,
+        )
+        .expect("complete second scan"));
+
+        let next = set_last_scan_started_for_source(
+            &conn,
+            "2026-07-10T02:00:00Z",
+            None,
+            "/tmp/codex-home-b",
+        )
+        .expect("start next incremental scan");
+        assert!(next.recorded);
+        assert!(!next.source_changed);
+        assert!(!next.full_scan_required);
     }
 
     #[test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -241,6 +241,7 @@ mod tests {
             None,
             "/tmp/codex-home-a",
             true,
+            false,
         )
         .expect("complete first scan"));
 
@@ -295,6 +296,7 @@ mod tests {
             None,
             "/tmp/codex-home-a",
             true,
+            false,
         )
         .expect("reject completion from first source"));
         assert!(set_scan_completed_for_source(
@@ -303,6 +305,7 @@ mod tests {
             None,
             "/tmp/codex-home-b",
             true,
+            false,
         )
         .expect("complete second scan"));
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -14,8 +14,10 @@ pub use subscriptions::{
 };
 pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
-    set_last_full_scan_completed, set_last_scan_completed, set_last_scan_started,
+    set_last_scan_started_for_source, set_scan_completed_for_source,
 };
+#[cfg(test)]
+pub use sync_settings::set_last_full_scan_completed;
 
 pub fn now_utc_string() -> String {
     Utc::now().to_rfc3339()

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -506,28 +506,50 @@ fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
     auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
 
-pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
-    conn.execute(
+pub fn set_last_scan_started_for_source(
+    conn: &Connection,
+    timestamp: &str,
+    codex_home_selector: Option<&str>,
+) -> rusqlite::Result<bool> {
+    let updated = conn.execute(
         "
     UPDATE sync_settings
     SET last_scan_started_at = ?1, updated_at = ?1
     WHERE singleton_id = 1
+      AND (
+        (codex_home IS NULL AND ?2 IS NULL)
+        OR codex_home = ?2
+      )
     ",
-        params![timestamp],
+        params![timestamp, codex_home_selector],
     )?;
-    Ok(())
+    Ok(updated == 1)
 }
 
-pub fn set_last_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
-    conn.execute(
+pub fn set_scan_completed_for_source(
+    conn: &Connection,
+    timestamp: &str,
+    codex_home_selector: Option<&str>,
+    full_scan: bool,
+) -> rusqlite::Result<bool> {
+    let updated = conn.execute(
         "
     UPDATE sync_settings
-    SET last_scan_completed_at = ?1, updated_at = ?1
+    SET last_scan_completed_at = ?1,
+        last_full_scan_completed_at = CASE
+          WHEN ?3 != 0 THEN ?1
+          ELSE last_full_scan_completed_at
+        END,
+        updated_at = ?1
     WHERE singleton_id = 1
+      AND (
+        (codex_home IS NULL AND ?2 IS NULL)
+        OR codex_home = ?2
+      )
     ",
-        params![timestamp],
+        params![timestamp, codex_home_selector, bool_to_i64(full_scan)],
     )?;
-    Ok(())
+    Ok(updated == 1)
 }
 
 pub fn get_last_full_scan_completed(conn: &Connection) -> rusqlite::Result<Option<String>> {
@@ -542,6 +564,7 @@ pub fn get_last_full_scan_completed(conn: &Connection) -> rusqlite::Result<Optio
     )
 }
 
+#[cfg(test)]
 pub fn set_last_full_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
     conn.execute(
         "

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -389,9 +389,27 @@ pub fn save_sync_settings(
     conn: &Connection,
     settings: &SyncSettings,
 ) -> rusqlite::Result<SyncSettings> {
+    let transaction = conn.unchecked_transaction()?;
+    let current_codex_home = transaction
+        .query_row(
+            "SELECT codex_home FROM sync_settings WHERE singleton_id = 1",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+    let codex_home_changed = current_codex_home.as_deref() != settings.codex_home.as_deref();
     let updated_at = now_utc_string();
     let auto_scan_interval_minutes = settings.auto_scan_interval_minutes.max(1);
-    conn.execute(
+    let (last_scan_started_at, last_scan_completed_at) = if codex_home_changed {
+        (None, None)
+    } else {
+        (
+            settings.last_scan_started_at.as_deref(),
+            settings.last_scan_completed_at.as_deref(),
+        )
+    };
+    transaction.execute(
     "
     INSERT INTO sync_settings (
       singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
@@ -457,12 +475,31 @@ pub fn save_sync_settings(
       serialize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
       bool_to_i64(settings.menu_bar_popup_show_reset_timeline),
       bool_to_i64(settings.menu_bar_popup_show_actions),
-      settings.last_scan_started_at,
-      settings.last_scan_completed_at,
+      last_scan_started_at,
+      last_scan_completed_at,
       updated_at,
     ],
     )?;
-    get_sync_settings(conn)
+    if codex_home_changed {
+        clear_scan_timestamps(&transaction)?;
+    }
+    let saved = get_sync_settings(&transaction)?;
+    transaction.commit()?;
+    Ok(saved)
+}
+
+fn clear_scan_timestamps(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET last_scan_started_at = NULL,
+        last_scan_completed_at = NULL,
+        last_full_scan_completed_at = NULL
+    WHERE singleton_id = 1
+    ",
+        [],
+    )?;
+    Ok(())
 }
 
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -595,14 +595,17 @@ pub fn set_scan_completed_for_source(
     timestamp: &str,
     codex_home_selector: Option<&str>,
     resolved_codex_home: &str,
-    full_scan: bool,
+    full_scan_completed: bool,
+    full_scan_incomplete: bool,
 ) -> rusqlite::Result<bool> {
+    debug_assert!(!(full_scan_completed && full_scan_incomplete));
     let updated = conn.execute(
         "
         UPDATE sync_settings
         SET last_scan_completed_at = ?1,
             last_full_scan_completed_at = CASE
               WHEN ?4 != 0 THEN ?1
+              WHEN ?5 != 0 THEN NULL
               ELSE last_full_scan_completed_at
             END,
             updated_at = ?1
@@ -617,7 +620,8 @@ pub fn set_scan_completed_for_source(
             timestamp,
             codex_home_selector,
             resolved_codex_home,
-            bool_to_i64(full_scan)
+            bool_to_i64(full_scan_completed),
+            bool_to_i64(full_scan_incomplete)
         ],
     )?;
     Ok(updated == 1)

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 
 use crate::models::SyncSettings;
 
@@ -294,6 +294,25 @@ pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result
     )?;
     }
 
+    if !column_names.iter().any(|name| name == "last_scan_codex_home") {
+        let transaction = conn.unchecked_transaction()?;
+        transaction.execute(
+            "ALTER TABLE sync_settings ADD COLUMN last_scan_codex_home TEXT",
+            [],
+        )?;
+        transaction.execute(
+            "
+            UPDATE sync_settings
+            SET last_scan_started_at = NULL,
+                last_scan_completed_at = NULL,
+                last_full_scan_completed_at = NULL
+            WHERE singleton_id = 1
+            ",
+            [],
+        )?;
+        transaction.commit()?;
+    }
+
     migrate_sync_settings_defaults_to_minutes(conn)?;
 
     Ok(())
@@ -494,7 +513,8 @@ fn clear_scan_timestamps(conn: &Connection) -> rusqlite::Result<()> {
     UPDATE sync_settings
     SET last_scan_started_at = NULL,
         last_scan_completed_at = NULL,
-        last_full_scan_completed_at = NULL
+        last_full_scan_completed_at = NULL,
+        last_scan_codex_home = NULL
     WHERE singleton_id = 1
     ",
         [],
@@ -502,54 +522,109 @@ fn clear_scan_timestamps(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
-fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
-    auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScanFreshnessStart {
+    pub recorded: bool,
+    pub source_changed: bool,
+    pub full_scan_required: bool,
 }
 
 pub fn set_last_scan_started_for_source(
     conn: &Connection,
     timestamp: &str,
     codex_home_selector: Option<&str>,
-) -> rusqlite::Result<bool> {
-    let updated = conn.execute(
+    resolved_codex_home: &str,
+) -> rusqlite::Result<ScanFreshnessStart> {
+    let transaction =
+        Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let previous_freshness = transaction
+        .query_row(
+            "
+            SELECT last_scan_codex_home, last_full_scan_completed_at
+            FROM sync_settings
+            WHERE singleton_id = 1
+              AND (
+                (codex_home IS NULL AND ?1 IS NULL)
+                OR codex_home = ?1
+              )
+            ",
+            params![codex_home_selector],
+            |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
+        )
+        .optional()?;
+    let Some((previous_source, last_full_scan_completed_at)) = previous_freshness else {
+        transaction.commit()?;
+        return Ok(ScanFreshnessStart::default());
+    };
+    let source_changed = previous_source.as_deref() != Some(resolved_codex_home);
+    let full_scan_required = source_changed || last_full_scan_completed_at.is_none();
+
+    let updated = transaction.execute(
         "
-    UPDATE sync_settings
-    SET last_scan_started_at = ?1, updated_at = ?1
-    WHERE singleton_id = 1
-      AND (
-        (codex_home IS NULL AND ?2 IS NULL)
-        OR codex_home = ?2
-      )
-    ",
-        params![timestamp, codex_home_selector],
+        UPDATE sync_settings
+        SET last_scan_started_at = ?1,
+            last_scan_completed_at = CASE
+              WHEN last_scan_codex_home = ?3 THEN last_scan_completed_at
+              ELSE NULL
+            END,
+            last_full_scan_completed_at = CASE
+              WHEN last_scan_codex_home = ?3 THEN last_full_scan_completed_at
+              ELSE NULL
+            END,
+            last_scan_codex_home = ?3,
+            updated_at = ?1
+        WHERE singleton_id = 1
+          AND (
+            (codex_home IS NULL AND ?2 IS NULL)
+            OR codex_home = ?2
+          )
+        ",
+        params![timestamp, codex_home_selector, resolved_codex_home],
     )?;
-    Ok(updated == 1)
+    transaction.commit()?;
+
+    Ok(ScanFreshnessStart {
+        recorded: updated == 1,
+        source_changed: updated == 1 && source_changed,
+        full_scan_required: updated == 1 && full_scan_required,
+    })
 }
 
 pub fn set_scan_completed_for_source(
     conn: &Connection,
     timestamp: &str,
     codex_home_selector: Option<&str>,
+    resolved_codex_home: &str,
     full_scan: bool,
 ) -> rusqlite::Result<bool> {
     let updated = conn.execute(
         "
-    UPDATE sync_settings
-    SET last_scan_completed_at = ?1,
-        last_full_scan_completed_at = CASE
-          WHEN ?3 != 0 THEN ?1
-          ELSE last_full_scan_completed_at
-        END,
-        updated_at = ?1
-    WHERE singleton_id = 1
-      AND (
-        (codex_home IS NULL AND ?2 IS NULL)
-        OR codex_home = ?2
-      )
-    ",
-        params![timestamp, codex_home_selector, bool_to_i64(full_scan)],
+        UPDATE sync_settings
+        SET last_scan_completed_at = ?1,
+            last_full_scan_completed_at = CASE
+              WHEN ?4 != 0 THEN ?1
+              ELSE last_full_scan_completed_at
+            END,
+            updated_at = ?1
+        WHERE singleton_id = 1
+          AND (
+            (codex_home IS NULL AND ?2 IS NULL)
+            OR codex_home = ?2
+          )
+          AND last_scan_codex_home = ?3
+        ",
+        params![
+            timestamp,
+            codex_home_selector,
+            resolved_codex_home,
+            bool_to_i64(full_scan)
+        ],
     )?;
     Ok(updated == 1)
+}
+
+fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
+    auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
 
 pub fn get_last_full_scan_completed(conn: &Connection) -> rusqlite::Result<Option<String>> {

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Timelike};
 use rusqlite::{params, Connection, OptionalExtension};
+use serde::Deserialize;
 use serde_json::Value;
 use walkdir::WalkDir;
 
@@ -1047,23 +1048,14 @@ fn read_parent_replay_snapshots(
 
   for line_result in BufReader::new(file).lines() {
     let line = line_result.map_err(|_| ())?;
-    let may_be_session_meta = json_line_has_string_field(&line, "type", "session_meta");
-    let may_be_token_count = json_line_has_string_field(&line, "type", "event_msg")
-      && json_line_has_string_field(&line, "type", "token_count");
-    if !may_be_session_meta && !may_be_token_count {
+    if !line.contains("\"session_meta\"") && !line.contains("\"token_count\"") {
       continue;
     }
 
-    let Ok(value) = serde_json::from_str::<Value>(&line) else {
-      continue;
-    };
-    match value.get("type").and_then(Value::as_str) {
+    let envelope = serde_json::from_str::<ReplayParentLineEnvelope<'_>>(&line).map_err(|_| ())?;
+    match envelope.record_type {
       Some("session_meta") if first_session_meta_id.is_none() => {
-        let Some(session_id) = value
-          .get("payload")
-          .and_then(|payload| payload.get("id"))
-          .and_then(Value::as_str)
-        else {
+        let Some(session_id) = envelope.payload.as_ref().and_then(|payload| payload.id) else {
           continue;
         };
         if filename_session_id.is_none() && session_id != requested_parent_id {
@@ -1071,28 +1063,25 @@ fn read_parent_replay_snapshots(
         }
         first_session_meta_id = Some(session_id.to_string());
       }
-      Some("event_msg") => {
-        let payload = value.get("payload").unwrap_or(&Value::Null);
-        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
-          continue;
-        }
-        let info = payload.get("info").unwrap_or(&Value::Null);
-        let total_usage = info.get("total_token_usage").unwrap_or(&Value::Null);
-        let Some(timestamp) = value.get("timestamp").and_then(Value::as_str) else {
-          continue;
-        };
-        if total_usage.is_null() {
-          continue;
-        }
+      Some("event_msg")
+        if envelope
+          .payload
+          .as_ref()
+          .and_then(|payload| payload.record_type)
+          == Some("token_count") =>
+      {
+        let timestamp = envelope.timestamp.ok_or(())?;
+        let details = serde_json::from_str::<ReplayParentTokenDetails>(&line).map_err(|_| ())?;
 
         snapshots.push(UsageSnapshot {
           timestamp: timestamp.to_string(),
           model_id: String::new(),
-          usage: token_usage_from_json(total_usage),
-          last_token_usage: info
-            .get("last_token_usage")
-            .filter(|last_usage| !last_usage.is_null())
-            .map(token_usage_from_json),
+          usage: details.payload.info.total_token_usage.into_token_usage(),
+          last_token_usage: details
+            .payload
+            .info
+            .last_token_usage
+            .map(ReplayParentTokenUsage::into_token_usage),
           plan_type: None,
           limit_id: None,
           limit_name: None,
@@ -1113,25 +1102,66 @@ fn read_parent_replay_snapshots(
   Ok(snapshots)
 }
 
-fn json_line_has_string_field(line: &str, field: &str, expected_value: &str) -> bool {
-  let field = format!("\"{field}\"");
-  let expected_value = format!("\"{expected_value}\"");
-
-  line.match_indices(&field).any(|(index, _)| {
-    line[index + field.len()..]
-      .trim_start()
-      .strip_prefix(':')
-      .is_some_and(|rest| rest.trim_start().starts_with(&expected_value))
-  })
+#[derive(Deserialize)]
+struct ReplayParentLineEnvelope<'a> {
+  #[serde(default)]
+  timestamp: Option<&'a str>,
+  #[serde(rename = "type", default)]
+  record_type: Option<&'a str>,
+  #[serde(default, borrow)]
+  payload: Option<ReplayParentPayloadEnvelope<'a>>,
 }
 
-fn token_usage_from_json(value: &Value) -> TokenUsage {
-  TokenUsage {
-    input_tokens: read_i64(value, "input_tokens"),
-    cached_input_tokens: read_i64(value, "cached_input_tokens"),
-    output_tokens: read_i64(value, "output_tokens"),
-    reasoning_output_tokens: read_i64(value, "reasoning_output_tokens"),
-    total_tokens: read_total_tokens(value),
+#[derive(Deserialize)]
+struct ReplayParentPayloadEnvelope<'a> {
+  #[serde(default)]
+  id: Option<&'a str>,
+  #[serde(rename = "type", default)]
+  record_type: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct ReplayParentTokenDetails {
+  payload: ReplayParentTokenPayload,
+}
+
+#[derive(Deserialize)]
+struct ReplayParentTokenPayload {
+  info: ReplayParentTokenInfo,
+}
+
+#[derive(Deserialize)]
+struct ReplayParentTokenInfo {
+  total_token_usage: ReplayParentTokenUsage,
+  #[serde(default)]
+  last_token_usage: Option<ReplayParentTokenUsage>,
+}
+
+#[derive(Deserialize)]
+struct ReplayParentTokenUsage {
+  #[serde(default)]
+  input_tokens: i64,
+  #[serde(default)]
+  cached_input_tokens: i64,
+  #[serde(default)]
+  output_tokens: i64,
+  #[serde(default)]
+  reasoning_output_tokens: i64,
+  #[serde(default)]
+  total_tokens: Option<i64>,
+}
+
+impl ReplayParentTokenUsage {
+  fn into_token_usage(self) -> TokenUsage {
+    TokenUsage {
+      input_tokens: self.input_tokens,
+      cached_input_tokens: self.cached_input_tokens,
+      output_tokens: self.output_tokens,
+      reasoning_output_tokens: self.reasoning_output_tokens,
+      total_tokens: self
+        .total_tokens
+        .unwrap_or_else(|| self.input_tokens + self.output_tokens),
+    }
   }
 }
 
@@ -1905,6 +1935,130 @@ mod tests {
 
   fn fork_instant(timestamp: &str) -> chrono::DateTime<chrono::FixedOffset> {
     chrono::DateTime::parse_from_rfc3339(timestamp).expect("valid fork instant")
+  }
+
+  #[test]
+  fn parent_replay_reader_rejects_malformed_token_candidate_between_snapshots() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "10101010-1010-4010-8010-101010101010";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = format!(
+      "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{parent_session_id}\"}}}}\n"
+    );
+    body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    }));
+    body.push_str(
+      "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":\n",
+    );
+    body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:03Z",
+      total: (180, 0, 0, 180),
+      last: (80, 0, 0, 80),
+    }));
+    std::fs::write(&parent_path, body).expect("write malformed replay parent");
+
+    assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
+  }
+
+  #[test]
+  fn parent_replay_reader_rejects_token_count_without_timestamp() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "20202020-2020-4020-8020-202020202020";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    });
+    body.push_str(
+      concat!(
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{",
+        "\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":0,",
+        "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":180}}}}\n"
+      ),
+    );
+    std::fs::write(&parent_path, body).expect("write replay parent without timestamp");
+
+    assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
+  }
+
+  #[test]
+  fn parent_replay_reader_rejects_token_count_without_total_usage() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "30303030-3030-4030-8030-303030303030";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    });
+    body.push_str(
+      concat!(
+        "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",",
+        "\"payload\":{\"type\":\"token_count\",\"info\":{",
+        "\"last_token_usage\":{\"input_tokens\":80,\"cached_input_tokens\":0,",
+        "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":80}}}}\n"
+      ),
+    );
+    std::fs::write(&parent_path, body).expect("write replay parent without total usage");
+
+    assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
+  }
+
+  #[test]
+  fn parent_replay_reader_rejects_non_numeric_token_usage() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "40404040-4040-4040-8040-404040404040";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let body = concat!(
+      "{\"timestamp\":\"2026-03-24T00:00:01Z\",\"type\":\"event_msg\",",
+      "\"payload\":{\"type\":\"token_count\",\"info\":{",
+      "\"total_token_usage\":{\"input_tokens\":\"not-a-number\",\"cached_input_tokens\":0,",
+      "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":100}}}}\n"
+    );
+    std::fs::write(&parent_path, body).expect("write replay parent with invalid usage");
+
+    assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
+  }
+
+  #[test]
+  fn parent_replay_reader_ignores_nested_token_types_in_unrelated_root_record() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "50505050-5050-4050-8050-505050505050";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    });
+    body.push_str(
+      concat!(
+        "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"response_item\",",
+        "\"payload\":{\"message\":{\"type\":\"event_msg\",\"payload\":{",
+        "\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
+        "\"input_tokens\":900,\"cached_input_tokens\":0,\"output_tokens\":0,",
+        "\"reasoning_output_tokens\":0,\"total_tokens\":900}}}}}}\n"
+      ),
+    );
+    std::fs::write(&parent_path, body).expect("write replay parent with nested token types");
+
+    let snapshots = read_parent_replay_snapshots(&parent_path, parent_session_id)
+      .expect("ignore unrelated nested token fields");
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].usage.total_tokens, 100);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3463,6 +3463,320 @@ mod tests {
   }
 
   #[test]
+  fn incremental_fork_scan_loads_unchanged_archived_parent() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archived_sessions_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_sessions_dir).expect("archived sessions dir");
+
+    let parent_session_id = "11111111-1111-4111-8111-111111111111";
+    let child_session_id = "22222222-2222-4222-8222-222222222222";
+    let parent_path = archived_sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    let parent_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:00:01Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:10:01Z",
+        total: (180, 0, 0, 180),
+        last: (80, 0, 0, 80),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:20:01Z",
+        total: (260, 0, 0, 260),
+        last: (80, 0, 0, 80),
+      },
+    ];
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    for fixture in parent_fixtures.iter().copied() {
+      parent_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&parent_path, parent_body).expect("write archived parent session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("full parent scan");
+
+    let child_created_at = "2026-03-24T00:30:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    for (index, fixture) in parent_fixtures.iter().copied().enumerate() {
+      let timestamp = match index {
+        0 => "2026-03-24T00:30:01Z",
+        1 => "2026-03-24T00:30:02Z",
+        _ => "2026-03-24T00:30:03Z",
+      };
+      child_body.push_str(&token_count_line(TokenFixture {
+        timestamp,
+        ..fixture
+      }));
+    }
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (310, 0, 0, 310),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write active fork child");
+
+    let incremental =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("incremental child scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let parent_total = session_usage_totals(&conn, parent_session_id).3;
+    let child_total = session_usage_totals(&conn, child_session_id).3;
+    assert_eq!(incremental.updated_sessions, 1);
+    assert_eq!(parent_total, 260);
+    assert_eq!(child_total, 50);
+    assert_eq!(parent_total + child_total, 310);
+  }
+
+  #[test]
+  fn nested_fork_replay_uses_direct_parent() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let root_session_id = "33333333-3333-4333-8333-333333333333";
+    let child_session_id = "44444444-4444-4444-8444-444444444444";
+    let grandchild_session_id = "55555555-5555-4555-8555-555555555555";
+    let root_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{root_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    let grandchild_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T01-00-00-{grandchild_session_id}.jsonl"
+    ));
+    let root_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:00:01Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:10:01Z",
+        total: (180, 0, 0, 180),
+        last: (80, 0, 0, 80),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:20:01Z",
+        total: (260, 0, 0, 260),
+        last: (80, 0, 0, 80),
+      },
+    ];
+    let child_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:30:01Z",
+        ..root_fixtures[0]
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:30:02Z",
+        ..root_fixtures[1]
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:30:03Z",
+        ..root_fixtures[2]
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:31:00Z",
+        total: (310, 0, 0, 310),
+        last: (50, 0, 0, 50),
+      },
+    ];
+
+    let mut root_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      root_session_id,
+    );
+    for fixture in root_fixtures.iter().copied() {
+      root_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&root_path, root_body).expect("write root session");
+
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_session_id,
+      root_session_id,
+    );
+    for fixture in child_fixtures.iter().copied() {
+      child_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&child_path, child_body).expect("write child session");
+
+    let mut grandchild_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      grandchild_session_id,
+      child_session_id,
+    );
+    for (index, fixture) in child_fixtures.iter().copied().enumerate() {
+      let timestamp = match index {
+        0 => "2026-03-24T01:00:01Z",
+        1 => "2026-03-24T01:00:02Z",
+        2 => "2026-03-24T01:00:03Z",
+        _ => "2026-03-24T01:00:04Z",
+      };
+      grandchild_body.push_str(&token_count_line(TokenFixture {
+        timestamp,
+        ..fixture
+      }));
+    }
+    grandchild_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T01:01:00Z",
+      total: (330, 0, 0, 330),
+      last: (20, 0, 0, 20),
+    }));
+    std::fs::write(&grandchild_path, grandchild_body).expect("write grandchild session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full family scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let root_total = session_usage_totals(&conn, root_session_id).3;
+    let child_total = session_usage_totals(&conn, child_session_id).3;
+    let grandchild_total = session_usage_totals(&conn, grandchild_session_id).3;
+    assert_eq!(root_total, 260);
+    assert_eq!(child_total, 50);
+    assert_eq!(grandchild_total, 20);
+    assert_eq!(root_total + child_total + grandchild_total, 330);
+  }
+
+  #[test]
+  fn parent_path_validation_rejects_child_file_with_replayed_parent_meta() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "66666666-6666-4666-8666-666666666666";
+    let child_session_id = "77777777-7777-4777-8777-777777777777";
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T01-00-00-{child_session_id}.jsonl"
+    ));
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    parent_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (25, 0, 0, 25),
+      last: (25, 0, 0, 25),
+    }));
+    std::fs::write(&parent_path, parent_body).expect("write parent session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("full parent scan");
+
+    let conn = open_connection(&db_path).expect("open db to corrupt parent source path");
+    assert_eq!(
+      conn
+        .execute(
+          "UPDATE sessions SET source_path = ?1 WHERE session_id = ?2",
+          params![child_path.to_string_lossy().to_string(), parent_session_id],
+        )
+        .expect("corrupt parent source path"),
+      1
+    );
+    drop(conn);
+
+    let child_created_at = "2026-03-24T01:00:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    for fixture in [
+      TokenFixture {
+        timestamp: child_created_at,
+        total: (100, 0, 0, 100),
+        last: (40, 0, 0, 40),
+      },
+      TokenFixture {
+        timestamp: child_created_at,
+        total: (150, 0, 0, 150),
+        last: (50, 0, 0, 50),
+      },
+    ] {
+      child_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&child_path, child_body).expect("write child with replayed parent meta");
+
+    let incremental =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("incremental child scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(incremental.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, parent_session_id).3, 25);
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 90);
+  }
+
+  #[test]
   fn fork_first_snapshot_uses_last_usage_as_baseline() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -120,6 +120,8 @@ fn perform_scan_with_scope(
 
   let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
+  let pending_rate_limit_repair_paths =
+    load_pending_data_repair_paths(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY).map_err(|error| error.to_string())?;
   let needs_token_usage_repair_sweep =
     data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
   let pending_token_repair_paths =
@@ -148,7 +150,10 @@ fn perform_scan_with_scope(
   let mut changed_files = Vec::new();
   for session_file in &session_files {
     let source_path = session_file.path.to_string_lossy().to_string();
-    if needs_rate_limit_backfill || needs_token_usage_repair_sweep || pending_token_repair_paths.contains(&source_path)
+    if needs_rate_limit_backfill
+      || pending_rate_limit_repair_paths.contains(&source_path)
+      || needs_token_usage_repair_sweep
+      || pending_token_repair_paths.contains(&source_path)
     {
       changed_files.push(session_file);
       continue;
@@ -184,6 +189,8 @@ fn perform_scan_with_scope(
 
     for session_file in changed_files {
       let source_path = session_file.path.to_string_lossy().to_string();
+      let file_needs_rate_limit_repair =
+        needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
       let file_needs_token_repair =
         needs_token_usage_repair_sweep || pending_token_repair_paths.contains(&source_path);
       let parsed = match parse_session_file(session_file, &titles) {
@@ -197,6 +204,10 @@ fn perform_scan_with_scope(
           );
           if file_needs_token_repair {
             mark_data_repair_file_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path, &error)
+              .map_err(|error| error.to_string())?;
+          }
+          if file_needs_rate_limit_repair {
+            mark_data_repair_file_pending(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path, &error)
               .map_err(|error| error.to_string())?;
           }
           continue;
@@ -219,6 +230,10 @@ fn perform_scan_with_scope(
       }
 
       persist_session(&mut conn, session_file, &parsed, &catalog).map_err(|error| error.to_string())?;
+      if file_needs_rate_limit_repair {
+        clear_pending_data_repair_file(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)
+          .map_err(|error| error.to_string())?;
+      }
       if file_needs_token_repair {
         clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)
           .map_err(|error| error.to_string())?;
@@ -232,8 +247,21 @@ fn perform_scan_with_scope(
   }
 
   if effective_scope == ScanScope::Full {
-    mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
-    prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
+    // A full scan that is required for freshness is authoritative even on retry:
+    // paths outside the resolved source must not remain active just because they still exist.
+    let reconcile_existing_absent_sources = scan_freshness_start.full_scan_required;
+    mark_missing_sources(
+      &conn,
+      &present_paths,
+      reconcile_existing_absent_sources,
+    )
+    .map_err(|error| error.to_string())?;
+    prune_import_state(
+      &conn,
+      &present_paths,
+      reconcile_existing_absent_sources,
+    )
+    .map_err(|error| error.to_string())?;
   } else {
     mark_missing_active_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
   }
@@ -268,6 +296,7 @@ fn perform_scan_with_scope(
       scan_source_selector.as_deref(),
       &resolved_codex_home,
       effective_scope == ScanScope::Full && !skipped_session_files,
+      effective_scope == ScanScope::Full && skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
@@ -1273,13 +1302,19 @@ fn conversation_links_need_repair(conn: &Connection) -> rusqlite::Result<bool> {
   )
 }
 
-fn mark_missing_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
+fn mark_missing_sources(
+  conn: &Connection,
+  present_paths: &HashSet<String>,
+  reconcile_existing_absent_sources: bool,
+) -> rusqlite::Result<()> {
   let mut stmt = conn.prepare("SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL")?;
   let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
 
   for row in rows {
     let (session_id, source_path) = row?;
-    if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
+    if !present_paths.contains(&source_path)
+      && (reconcile_existing_absent_sources || !Path::new(&source_path).exists())
+    {
       conn.execute(
         "
         UPDATE sessions
@@ -1324,12 +1359,18 @@ fn mark_missing_active_sources(conn: &Connection, present_paths: &HashSet<String
   Ok(())
 }
 
-fn prune_import_state(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
+fn prune_import_state(
+  conn: &Connection,
+  present_paths: &HashSet<String>,
+  reconcile_existing_absent_sources: bool,
+) -> rusqlite::Result<()> {
   let mut stmt = conn.prepare("SELECT source_path FROM import_state")?;
   let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
   for row in rows {
     let source_path = row?;
-    if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
+    if !present_paths.contains(&source_path)
+      && (reconcile_existing_absent_sources || !Path::new(&source_path).exists())
+    {
       conn.execute(
         "DELETE FROM import_state WHERE source_path = ?1",
         params![source_path],
@@ -2966,7 +3007,7 @@ mod tests {
   }
 
   #[test]
-  fn incremental_scan_finds_untracked_archives_after_default_source_moves() {
+  fn moved_default_source_reconciles_sessions_from_the_previous_existing_home() {
     let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
     let directory = tempdir().expect("tempdir");
     let first_codex_home = directory.path().join("codex-home-a");
@@ -3014,6 +3055,152 @@ mod tests {
     assert_eq!(result.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
     assert_eq!(session_usage_totals(&conn, first_session_id).3, 110);
+    assert_eq!(session_source_state(&conn, first_session_id), Some("missing".to_string()));
+    assert_eq!(import_state_session_id(&conn, &first_sessions.join("first.jsonl")), None);
+    assert!(first_sessions.join("first.jsonl").is_file());
+  }
+
+  #[test]
+  fn full_scan_retry_reconciles_previous_source_after_the_first_attempt_fails() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let first_codex_home = directory.path().join("codex-home-a");
+    let second_codex_home = directory.path().join("codex-home-b");
+    let first_sessions = first_codex_home.join("sessions");
+    let second_sessions = second_codex_home.join("sessions");
+    std::fs::create_dir_all(&first_sessions).expect("first sessions");
+    std::fs::create_dir_all(&second_sessions).expect("second sessions");
+
+    let first_session_id = "19191919-1919-1919-1919-191919191919";
+    let first_session_path = first_sessions.join("first.jsonl");
+    write_session_file(
+      &first_session_path,
+      first_session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let second_session_id = "29292929-2929-2929-2929-292929292929";
+    write_session_file(
+      &second_sessions.join("second.jsonl"),
+      second_session_id,
+      &[("2026-07-10T01:00:00Z", 200, 40, 20, 220)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    let _environment = CodexHomeEnvGuard::set(&first_codex_home);
+    perform_scan(&db_path, None).expect("scan first default source");
+
+    let conn = open_connection(&db_path).expect("open database");
+    conn
+      .execute_batch(&format!(
+        "
+        CREATE TRIGGER fail_previous_source_reconciliation
+        BEFORE UPDATE OF source_state ON sessions
+        WHEN OLD.session_id = '{first_session_id}'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced source reconciliation failure');
+        END;
+        "
+      ))
+      .expect("create reconciliation trigger");
+    drop(conn);
+
+    std::env::set_var("CODEX_HOME", &second_codex_home);
+    let error = perform_incremental_scan(&db_path, None).expect_err("first moved-source scan should fail");
+    assert!(error.contains("forced source reconciliation failure"));
+
+    let conn = open_connection(&db_path).expect("reopen failed database");
+    assert_eq!(get_last_full_scan_completed(&conn).expect("load full freshness"), None);
+    conn
+      .execute_batch("DROP TRIGGER fail_previous_source_reconciliation;")
+      .expect("drop reconciliation trigger");
+    drop(conn);
+
+    let retry = perform_incremental_scan(&db_path, None).expect("retry moved default source");
+
+    let conn = open_connection(&db_path).expect("open retried database");
+    assert_eq!(retry.scanned_files, 1);
+    assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
+    assert_eq!(session_source_state(&conn, first_session_id), Some("missing".to_string()));
+    assert_eq!(import_state_session_id(&conn, &first_session_path), None);
+    assert!(first_session_path.is_file());
+  }
+
+  #[test]
+  fn partial_full_scan_invalidates_freshness_and_tracks_skipped_rate_limit_backfill() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let archived_sessions = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&archived_sessions).expect("archived sessions");
+
+    let session_id = "39393939-3939-3939-3939-393939393939";
+    let session_path = archived_sessions.join("archive.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    let _environment = CodexHomeEnvGuard::set(&codex_home);
+    perform_scan(&db_path, None).expect("initial full scan");
+
+    let conn = open_connection(&db_path).expect("open initial database");
+    assert!(get_last_full_scan_completed(&conn).expect("load initial freshness").is_some());
+    conn
+      .execute(
+        "DELETE FROM data_repairs WHERE repair_key = ?1",
+        params![RATE_LIMIT_SAMPLE_BACKFILL_KEY],
+      )
+      .expect("make rate-limit backfill pending");
+    drop(conn);
+
+    std::fs::write(&session_path, [0xff, 0xfe, 0xfd]).expect("corrupt archived session");
+    perform_scan(&db_path, None).expect("partial full scan");
+
+    let conn = open_connection(&db_path).expect("open partial database");
+    let (completed, full_completed): (Option<String>, Option<String>) = conn
+      .query_row(
+        "SELECT last_scan_completed_at, last_full_scan_completed_at FROM sync_settings WHERE singleton_id = 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+      )
+      .expect("load partial scan freshness");
+    assert!(completed.is_some());
+    assert_eq!(full_completed, None);
+    let pending_rate_limit_path: Option<String> = conn
+      .query_row(
+        "SELECT source_path FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![RATE_LIMIT_SAMPLE_BACKFILL_KEY],
+        |row| row.get(0),
+      )
+      .optional()
+      .expect("load pending rate-limit repair");
+    assert_eq!(pending_rate_limit_path.as_deref(), Some(session_path.to_string_lossy().as_ref()));
+    drop(conn);
+
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 200, 40, 20, 220),
+      ],
+    );
+    let retry = perform_incremental_scan(&db_path, None).expect("retry repaired archive");
+
+    let conn = open_connection(&db_path).expect("open repaired database");
+    assert_eq!(retry.scanned_files, 1);
+    assert_eq!(session_usage_totals(&conn, session_id).3, 220);
+    assert!(get_last_full_scan_completed(&conn).expect("load repaired freshness").is_some());
+    let pending_rate_limit_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![RATE_LIMIT_SAMPLE_BACKFILL_KEY],
+        |row| row.get(0),
+      )
+      .expect("count pending rate-limit repairs");
+    assert_eq!(pending_rate_limit_count, 0);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -258,7 +258,7 @@ fn perform_scan_with_scope(
           continue;
         }
       };
-      assign_inherited_token_snapshot_cutoff(
+      let replay_parent_unavailable = assign_inherited_token_snapshot_cutoff(
         &mut parsed,
         &session_source_paths,
         &mut parent_snapshot_cache,
@@ -274,7 +274,8 @@ fn perform_scan_with_scope(
         &parsed.raw_session.session_id,
       );
       file_needs_token_v2_repair |= !related_pending_token_v2_paths.is_empty();
-      file_needs_fork_replay_v3_repair |= !related_pending_fork_replay_v3_paths.is_empty();
+      file_needs_fork_replay_v3_repair |=
+        replay_parent_unavailable || !related_pending_fork_replay_v3_paths.is_empty();
       imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
       match classify_topology_maintenance(
@@ -305,11 +306,21 @@ fn perform_scan_with_scope(
         }
       }
       if file_needs_fork_replay_v3_repair {
-        clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
-          .map_err(|error| error.to_string())?;
-        for related_source_path in related_pending_fork_replay_v3_paths {
-          clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &related_source_path)
+        if replay_parent_unavailable {
+          mark_data_repair_file_pending(
+            &conn,
+            TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+            &source_path,
+            "fork replay parent unavailable",
+          )
             .map_err(|error| error.to_string())?;
+        } else {
+          clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
+            .map_err(|error| error.to_string())?;
+          for related_source_path in related_pending_fork_replay_v3_paths {
+            clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &related_source_path)
+              .map_err(|error| error.to_string())?;
+          }
         }
       }
       changed_sessions += 1;
@@ -1050,16 +1061,16 @@ fn assign_inherited_token_snapshot_cutoff(
   parsed: &mut ParsedSession,
   session_source_paths: &HashMap<String, PathBuf>,
   parent_snapshot_cache: &mut HashMap<String, Option<Vec<UsageSnapshot>>>,
-) {
+) -> bool {
   let Some(parent_session_id) = parsed
     .explicit_forked_from_id
     .as_deref()
     .filter(|session_id| !session_id.trim().is_empty())
   else {
-    return;
+    return false;
   };
   let Some(fork_timestamp) = parsed.explicit_fork_timestamp else {
-    return;
+    return false;
   };
 
   if !parent_snapshot_cache.contains_key(parent_session_id) {
@@ -1092,7 +1103,7 @@ fn assign_inherited_token_snapshot_cutoff(
     .get(parent_session_id)
     .and_then(Option::as_deref)
   else {
-    return;
+    return true;
   };
 
   parsed.inherited_token_snapshot_cutoff = replayed_child_snapshot_cutoff(
@@ -1100,6 +1111,7 @@ fn assign_inherited_token_snapshot_cutoff(
     &parsed.snapshots,
     Some(fork_timestamp),
   );
+  false
 }
 
 fn read_parent_replay_snapshots(
@@ -3682,6 +3694,98 @@ mod tests {
         |row| row.get(0),
       )
       .expect("count pending v3 repair files");
+    assert_eq!(pending_v3_count, 0);
+  }
+
+  #[test]
+  fn fork_repair_retries_child_after_parent_source_recovers() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "63636363-6363-4363-8363-636363636363";
+    let child_session_id = "64646464-6464-4464-8464-646464646464";
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    std::fs::write(&parent_path, "not json\n").expect("write unavailable parent");
+    let inherited = TokenFixture {
+      timestamp: "2026-03-24T00:30:00Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    };
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_session_id,
+      parent_session_id,
+    );
+    child_body.push_str(&token_count_line(inherited));
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (150, 0, 0, 150),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write fork child");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+
+    let conn = open_connection(&db_path).expect("open initial db");
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 150);
+    let pending_child_count: i64 = conn
+      .query_row(
+        "
+        SELECT COUNT(*)
+        FROM data_repair_pending_files
+        WHERE repair_key = ?1 AND source_path = ?2
+        ",
+        params![
+          TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+          child_path.to_string_lossy().to_string()
+        ],
+        |row| row.get(0),
+      )
+      .expect("count pending child repair");
+    assert_eq!(pending_child_count, 1);
+    drop(conn);
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    parent_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:00Z",
+      ..inherited
+    }));
+    std::fs::write(&parent_path, parent_body).expect("restore parent source");
+    let retry = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("retry recovered parent and child");
+
+    let conn = open_connection(&db_path).expect("open repaired db");
+    assert_eq!(retry.updated_sessions, 2);
+    assert_eq!(session_usage_totals(&conn, parent_session_id).3, 100);
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 50);
+    let pending_v3_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY],
+        |row| row.get(0),
+      )
+      .expect("count pending v3 repairs");
     assert_eq!(pending_v3_count, 0);
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1380,6 +1380,60 @@ mod tests {
   }
 
   #[test]
+  fn scan_prices_gpt_56_sol_at_standard_api_equivalent_value() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "56565656-5656-5656-5656-565656565656";
+    let session_path = sessions_dir.join("gpt56-sol.jsonl");
+    std::fs::write(
+      &session_path,
+      concat!(
+        "{\"timestamp\":\"2026-07-09T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"56565656-5656-5656-5656-565656565656\"}}\n",
+        "{\"timestamp\":\"2026-07-09T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.6-sol\"}}\n",
+        "{\"timestamp\":\"2026-07-09T00:00:02Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":25,\"output_tokens\":40,\"reasoning_output_tokens\":0,\"total_tokens\":140}},\"rate_limits\":{\"plan_type\":\"pro\"}}}\n"
+      ),
+    )
+    .expect("write GPT-5.6 Sol session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let (input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd):
+      (i64, i64, i64, i64, f64) = conn
+      .query_row(
+        "
+        SELECT input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd
+        FROM usage_events
+        WHERE session_id = ?1
+        ",
+        params![session_id],
+        |row| {
+          Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+          ))
+        },
+      )
+      .expect("query usage");
+
+    assert_eq!(input_tokens, 100);
+    assert_eq!(cached_input_tokens, 25);
+    assert_eq!(output_tokens, 40);
+    assert_eq!(total_tokens, 140);
+    let standard = (75.0 / 1_000_000.0) * 5.0
+      + (25.0 / 1_000_000.0) * 0.5
+      + (40.0 / 1_000_000.0) * 30.0;
+    assert!((value_usd - standard).abs() < 1e-9);
+  }
+
+  #[test]
   fn import_state_mismatch_reimports_even_when_file_metadata_is_unchanged() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -141,10 +141,10 @@ fn perform_scan_with_scope(
     pending_repair_session_ids(&import_state, &pending_token_v2_repair_paths);
   let pending_fork_replay_v3_repair_session_ids =
     pending_repair_session_ids(&import_state, &pending_fork_replay_v3_repair_paths);
-  let pending_token_repair_session_ids = pending_token_v2_repair_session_ids
-    .union(&pending_fork_replay_v3_repair_session_ids)
-    .cloned()
-    .collect::<HashSet<_>>();
+  let mut pending_repair_session_ids =
+    pending_repair_session_ids(&import_state, &pending_rate_limit_repair_paths);
+  pending_repair_session_ids.extend(pending_token_v2_repair_session_ids.iter().cloned());
+  pending_repair_session_ids.extend(pending_fork_replay_v3_repair_session_ids.iter().cloned());
   let needs_token_usage_repair_sweep =
     needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
   let effective_scope = effective_scan_scope(
@@ -158,7 +158,7 @@ fn perform_scan_with_scope(
   let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
     ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
     ScanScope::Incremental => {
-      collect_incremental_session_files(&codex_home, &import_state, &pending_token_repair_session_ids)
+      collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
     }
   };
   let session_source_paths =
@@ -4965,6 +4965,57 @@ mod tests {
     assert_eq!(retry.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, session_id).3, 220);
     assert!(get_last_full_scan_completed(&conn).expect("load repaired freshness").is_some());
+    let pending_rate_limit_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![RATE_LIMIT_SAMPLE_BACKFILL_KEY],
+        |row| row.get(0),
+      )
+      .expect("count pending rate-limit repairs");
+    assert_eq!(pending_rate_limit_count, 0);
+  }
+
+  #[test]
+  fn incremental_scan_retries_unchanged_pending_rate_limit_archive() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let archived_sessions = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&archived_sessions).expect("archived sessions");
+
+    let session_id = "69696969-6969-4969-8969-696969696969";
+    let session_path = archived_sessions.join(format!(
+      "rollout-2026-07-10T00-00-00-{session_id}.jsonl"
+    ));
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:01Z", 80, 0, 20, 100)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    conn
+      .execute(
+        "
+        INSERT INTO data_repair_pending_files (repair_key, source_path, last_error, updated_at)
+        VALUES (?1, ?2, 'temporary read failure', ?3)
+        ",
+        params![
+          RATE_LIMIT_SAMPLE_BACKFILL_KEY,
+          session_path.to_string_lossy().to_string(),
+          now_utc_string(),
+        ],
+      )
+      .expect("insert pending rate-limit archive");
+    drop(conn);
+
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("retry unchanged rate-limit archive");
+
+    let conn = open_connection(&db_path).expect("open retried db");
+    assert_eq!(result.updated_sessions, 1);
     let pending_rate_limit_count: i64 = conn
       .query_row(
         "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-use chrono::{Local, LocalResult, TimeZone, Timelike};
+use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Timelike};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde_json::Value;
 use walkdir::WalkDir;
@@ -30,6 +30,10 @@ struct ParsedSession {
   raw_session: RawSession,
   snapshots: Vec<UsageSnapshot>,
   rate_limit_samples: Vec<RateLimitSampleRecord>,
+  #[allow(dead_code)]
+  explicit_forked_from_id: Option<String>,
+  #[allow(dead_code)]
+  explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
   explicit_fast_mode: Option<bool>,
   latest_plan_type: Option<String>,
   last_model_id: Option<String>,
@@ -39,6 +43,8 @@ struct ParsedSession {
 struct SessionMetaCandidate {
   session_id: String,
   parent_session_id: Option<String>,
+  explicit_forked_from_id: Option<String>,
+  explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
   agent_nickname: Option<String>,
   agent_role: Option<String>,
 }
@@ -651,6 +657,8 @@ fn parse_session_file_once(
   let mut current_model: Option<String> = None;
   let mut agent_nickname: Option<String> = None;
   let mut agent_role: Option<String> = None;
+  let mut explicit_forked_from_id: Option<String> = None;
+  let mut explicit_fork_timestamp: Option<DateTime<FixedOffset>> = None;
   let mut explicit_fast_mode: Option<bool> = None;
   let mut latest_plan_type: Option<String> = None;
   let mut snapshots = Vec::new();
@@ -695,10 +703,12 @@ fn parse_session_file_once(
     match value.get("type").and_then(Value::as_str).unwrap_or_default() {
       "session_meta" => {
         let payload = value.get("payload").unwrap_or(&Value::Null);
-        let parent = payload
+        let candidate_explicit_forked_from_id = payload
           .get("forked_from_id")
           .and_then(Value::as_str)
-          .map(ToString::to_string)
+          .map(ToString::to_string);
+        let parent = candidate_explicit_forked_from_id
+          .clone()
           .or_else(|| {
             payload
               .get("source")
@@ -708,6 +718,10 @@ fn parse_session_file_once(
               .and_then(Value::as_str)
               .map(ToString::to_string)
           });
+        let candidate_explicit_fork_timestamp = candidate_explicit_forked_from_id
+          .as_ref()
+          .and_then(|_| timestamp.as_deref())
+          .and_then(|timestamp| DateTime::parse_from_rfc3339(timestamp).ok());
 
         let nickname = payload
           .get("agent_nickname")
@@ -741,6 +755,8 @@ fn parse_session_file_once(
           let candidate = SessionMetaCandidate {
             session_id: id.to_string(),
             parent_session_id: parent,
+            explicit_forked_from_id: candidate_explicit_forked_from_id,
+            explicit_fork_timestamp: candidate_explicit_fork_timestamp,
             agent_nickname: nickname,
             agent_role: role,
           };
@@ -784,6 +800,16 @@ fn parse_session_file_once(
           reasoning_output_tokens: read_i64(total_usage, "reasoning_output_tokens"),
           total_tokens: read_total_tokens(total_usage),
         };
+        let last_token_usage = info
+          .get("last_token_usage")
+          .filter(|last_usage| !last_usage.is_null())
+          .map(|last_usage| TokenUsage {
+            input_tokens: read_i64(last_usage, "input_tokens"),
+            cached_input_tokens: read_i64(last_usage, "cached_input_tokens"),
+            output_tokens: read_i64(last_usage, "output_tokens"),
+            reasoning_output_tokens: read_i64(last_usage, "reasoning_output_tokens"),
+            total_tokens: read_total_tokens(last_usage),
+          });
 
         let plan_type = payload
           .get("rate_limits")
@@ -808,6 +834,7 @@ fn parse_session_file_once(
           timestamp: sample_timestamp,
           model_id,
           usage,
+          last_token_usage,
           plan_type,
           limit_id,
           limit_name,
@@ -821,6 +848,8 @@ fn parse_session_file_once(
   if let Some(candidate) = matching_session_meta.or(first_session_meta) {
     session_id = candidate.session_id;
     parent_session_id = candidate.parent_session_id.or(parent_session_id);
+    explicit_forked_from_id = candidate.explicit_forked_from_id;
+    explicit_fork_timestamp = candidate.explicit_fork_timestamp;
     agent_nickname = candidate.agent_nickname.or(agent_nickname);
     agent_role = candidate.agent_role.or(agent_role);
   }
@@ -862,6 +891,8 @@ fn parse_session_file_once(
     },
     snapshots,
     rate_limit_samples,
+    explicit_forked_from_id,
+    explicit_fork_timestamp,
     explicit_fast_mode,
     latest_plan_type,
     last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
@@ -896,6 +927,118 @@ fn looks_like_session_id(value: &str) -> bool {
     .all(|(segment, expected_len)| {
       segment.len() == *expected_len && segment.chars().all(|character| character.is_ascii_hexdigit())
     })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReplayKey {
+  total_token_usage: TokenUsage,
+  last_token_usage: TokenUsage,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CanonicalReplaySnapshot<'a> {
+  raw_index: usize,
+  snapshot: &'a UsageSnapshot,
+}
+
+impl CanonicalReplaySnapshot<'_> {
+  fn replay_key(&self) -> Option<ReplayKey> {
+    Some(ReplayKey {
+      total_token_usage: self.snapshot.usage.clone(),
+      last_token_usage: self.snapshot.last_token_usage.clone()?,
+    })
+  }
+}
+
+fn canonical_replay_snapshots(snapshots: &[UsageSnapshot]) -> Vec<CanonicalReplaySnapshot<'_>> {
+  let mut high_water: Option<i64> = None;
+  let mut canonical = Vec::new();
+
+  for (raw_index, snapshot) in snapshots.iter().enumerate() {
+    if high_water.is_some_and(|total| snapshot.usage.total_tokens <= total) {
+      continue;
+    }
+
+    high_water = Some(snapshot.usage.total_tokens);
+    canonical.push(CanonicalReplaySnapshot { raw_index, snapshot });
+  }
+
+  canonical
+}
+
+fn kmp_prefix_table(pattern: &[ReplayKey]) -> Vec<usize> {
+  let mut table = vec![0; pattern.len()];
+
+  for index in 1..pattern.len() {
+    let mut prefix_len = table[index - 1];
+    while prefix_len > 0 && pattern[index] != pattern[prefix_len] {
+      prefix_len = table[prefix_len - 1];
+    }
+    if pattern[index] == pattern[prefix_len] {
+      prefix_len += 1;
+    }
+    table[index] = prefix_len;
+  }
+
+  table
+}
+
+#[allow(dead_code)]
+fn replayed_child_snapshot_cutoff(
+  parent_snapshots: &[UsageSnapshot],
+  child_snapshots: &[UsageSnapshot],
+  explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
+) -> usize {
+  let Some(explicit_fork_timestamp) = explicit_fork_timestamp else {
+    return 0;
+  };
+
+  let child_canonical = canonical_replay_snapshots(child_snapshots);
+  let mut child_pattern = Vec::new();
+  for snapshot in &child_canonical {
+    let Some(key) = snapshot.replay_key() else {
+      break;
+    };
+    child_pattern.push(key);
+  }
+  if child_pattern.len() < 2 {
+    return 0;
+  }
+
+  let prefix_table = kmp_prefix_table(&child_pattern);
+  let mut matched = 0;
+  let mut longest_match = 0;
+
+  for parent in canonical_replay_snapshots(parent_snapshots) {
+    let Ok(parent_timestamp) = DateTime::parse_from_rfc3339(&parent.snapshot.timestamp) else {
+      continue;
+    };
+    if parent_timestamp > explicit_fork_timestamp {
+      continue;
+    }
+
+    let Some(parent_key) = parent.replay_key() else {
+      matched = 0;
+      continue;
+    };
+
+    while matched > 0 && child_pattern[matched] != parent_key {
+      matched = prefix_table[matched - 1];
+    }
+    if child_pattern[matched] == parent_key {
+      matched += 1;
+      longest_match = longest_match.max(matched);
+      if matched == child_pattern.len() {
+        break;
+      }
+    }
+  }
+
+  if longest_match < 2 {
+    0
+  } else {
+    child_canonical[longest_match - 1].raw_index + 1
+  }
 }
 
 fn persist_session(
@@ -1516,6 +1659,423 @@ mod tests {
         std::env::remove_var("CODEX_HOME");
       }
     }
+  }
+
+  fn replay_usage(values: (i64, i64, i64, i64, i64)) -> TokenUsage {
+    TokenUsage {
+      input_tokens: values.0,
+      cached_input_tokens: values.1,
+      output_tokens: values.2,
+      reasoning_output_tokens: values.3,
+      total_tokens: values.4,
+    }
+  }
+
+  fn replay_snapshot(
+    timestamp: &str,
+    model_id: &str,
+    total: (i64, i64, i64, i64, i64),
+    last: Option<(i64, i64, i64, i64, i64)>,
+  ) -> UsageSnapshot {
+    UsageSnapshot {
+      timestamp: timestamp.to_string(),
+      model_id: model_id.to_string(),
+      usage: replay_usage(total),
+      last_token_usage: last.map(replay_usage),
+      plan_type: None,
+      limit_id: None,
+      limit_name: None,
+      explicit_fast_mode: None,
+    }
+  }
+
+  fn fork_instant(timestamp: &str) -> chrono::DateTime<chrono::FixedOffset> {
+    chrono::DateTime::parse_from_rfc3339(timestamp).expect("valid fork instant")
+  }
+
+  #[test]
+  fn replay_matching_accepts_a_complete_three_record_match() {
+    let parent = vec![
+      replay_snapshot(
+        "2026-03-24T00:00:01Z",
+        "parent-a",
+        (100, 10, 20, 1, 121),
+        Some((100, 10, 20, 1, 121)),
+      ),
+      replay_snapshot(
+        "2026-03-24T00:01:01Z",
+        "parent-b",
+        (180, 20, 35, 2, 217),
+        Some((80, 10, 15, 1, 96)),
+      ),
+      replay_snapshot(
+        "2026-03-24T00:02:01Z",
+        "parent-c",
+        (260, 30, 50, 3, 313),
+        Some((80, 10, 15, 1, 96)),
+      ),
+    ];
+    let child = vec![
+      replay_snapshot(
+        "2026-03-24T00:10:00Z",
+        "child-x",
+        (100, 10, 20, 1, 121),
+        Some((100, 10, 20, 1, 121)),
+      ),
+      replay_snapshot(
+        "2026-03-24T00:10:00Z",
+        "child-y",
+        (180, 20, 35, 2, 217),
+        Some((80, 10, 15, 1, 96)),
+      ),
+      replay_snapshot(
+        "2026-03-24T00:10:00Z",
+        "child-z",
+        (260, 30, 50, 3, 313),
+        Some((80, 10, 15, 1, 96)),
+      ),
+    ];
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &parent,
+        &child,
+        Some(fork_instant("2026-03-24T00:05:00Z")),
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn replay_matching_finds_a_child_prefix_in_the_middle_of_the_parent() {
+    let unrelated = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "parent",
+      (20, 0, 5, 0, 25),
+      Some((20, 0, 5, 0, 25)),
+    );
+    let first = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "parent",
+      (100, 10, 20, 1, 121),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let second = replay_snapshot(
+      "2026-03-24T00:02:00Z",
+      "parent",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let third = replay_snapshot(
+      "2026-03-24T00:03:00Z",
+      "parent",
+      (260, 30, 50, 3, 313),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let parent = vec![unrelated, first.clone(), second.clone(), third.clone()];
+    let child = vec![first, second, third];
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &parent,
+        &child,
+        Some(fork_instant("2026-03-24T00:04:00Z")),
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn replay_matching_rejects_one_exact_record() {
+    let record = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        std::slice::from_ref(&record),
+        std::slice::from_ref(&record),
+        Some(fork_instant("2026-03-24T00:01:00Z")),
+      ),
+      0
+    );
+  }
+
+  #[test]
+  fn replay_matching_missing_last_usage_breaks_the_match() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let parent_second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let child_second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      None,
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), parent_second],
+        &[first, child_second],
+        Some(fork_instant("2026-03-24T00:02:00Z")),
+      ),
+      0
+    );
+  }
+
+  #[test]
+  fn replay_matching_omits_same_total_changed_last_from_the_canonical_sequence() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let changed_last = replay_snapshot(
+      "2026-03-24T00:00:30Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((1, 2, 3, 4, 10)),
+    );
+    let second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), second.clone()],
+        &[first, changed_last, second],
+        Some(fork_instant("2026-03-24T00:02:00Z")),
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn replay_matching_uses_cumulative_high_water_after_a_rollback() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let rollback = replay_snapshot(
+      "2026-03-24T00:00:30Z",
+      "model",
+      (70, 5, 10, 0, 80),
+      Some((5, 0, 2, 0, 7)),
+    );
+    let recovery = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (140, 15, 30, 2, 172),
+      Some((40, 5, 10, 1, 51)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), recovery.clone()],
+        &[first, rollback, recovery],
+        Some(fork_instant("2026-03-24T00:02:00Z")),
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn replay_matching_excludes_parent_records_after_the_fork_instant() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let post_fork = replay_snapshot(
+      "2026-03-24T00:06:00Z",
+      "model",
+      (260, 30, 50, 3, 313),
+      Some((80, 10, 15, 1, 96)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), second.clone(), post_fork.clone()],
+        &[first, second, post_fork],
+        Some(fork_instant("2026-03-24T00:05:00Z")),
+      ),
+      2
+    );
+  }
+
+  #[test]
+  fn replay_matching_without_a_valid_fork_instant_returns_zero() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), second.clone()],
+        &[first, second],
+        None,
+      ),
+      0
+    );
+  }
+
+  #[test]
+  fn parser_retains_last_usage_and_matching_explicit_fork_metadata() {
+    let directory = tempdir().expect("tempdir");
+    let child_id = "55555555-5555-5555-5555-555555555555";
+    let parent_id = "44444444-4444-4444-4444-444444444444";
+    let session_path = directory
+      .path()
+      .join(format!("rollout-2026-03-24T00-30-00-{child_id}.jsonl"));
+    std::fs::write(
+      &session_path,
+      format!(
+        concat!(
+          "{{\"timestamp\":\"2026-03-24T08:30:00+08:00\",\"type\":\"session_meta\",",
+          "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+          "{{\"timestamp\":\"2026-03-24T00:30:01Z\",\"type\":\"event_msg\",",
+          "\"payload\":{{\"type\":\"token_count\",\"info\":{{",
+          "\"total_token_usage\":{{\"input_tokens\":180,\"cached_input_tokens\":20,",
+          "\"output_tokens\":35,\"reasoning_output_tokens\":2,\"total_tokens\":217}},",
+          "\"last_token_usage\":{{\"input_tokens\":80,\"cached_input_tokens\":10,",
+          "\"output_tokens\":15,\"reasoning_output_tokens\":1,\"total_tokens\":96}}",
+          "}}}}}}\n",
+          "{{\"timestamp\":\"2026-03-24T00:30:02Z\",\"type\":\"session_meta\",",
+          "\"payload\":{{\"id\":\"{}\"}}}}\n"
+        ),
+        child_id, parent_id, parent_id,
+      ),
+    )
+    .expect("write fork session");
+
+    let parsed = parse_session_file(
+      &SessionFile {
+        path: session_path,
+        bucket: "active".to_string(),
+        file_size: 0,
+        file_mtime_ms: 0,
+      },
+      &HashMap::new(),
+    )
+    .expect("parse fork session");
+
+    assert_eq!(
+      parsed.snapshots[0].last_token_usage,
+      Some(replay_usage((80, 10, 15, 1, 96)))
+    );
+    assert_eq!(parsed.explicit_forked_from_id.as_deref(), Some(parent_id));
+    assert_eq!(
+      parsed.explicit_fork_timestamp,
+      Some(fork_instant("2026-03-24T08:30:00+08:00"))
+    );
+    let serialized = serde_json::to_value(&parsed.snapshots[0]).expect("serialize snapshot");
+    assert!(!serialized.as_object().expect("snapshot object").contains_key("lastTokenUsage"));
+  }
+
+  #[test]
+  fn parser_leaves_explicit_fork_fields_empty_for_thread_spawn_only_metadata() {
+    let directory = tempdir().expect("tempdir");
+    let child_id = "77777777-7777-7777-7777-777777777777";
+    let parent_id = "66666666-6666-6666-6666-666666666666";
+    let session_path = directory
+      .path()
+      .join(format!("rollout-2026-03-24T01-00-00-{child_id}.jsonl"));
+    std::fs::write(
+      &session_path,
+      format!(
+        concat!(
+          "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"session_meta\",",
+          "\"payload\":{{\"id\":\"{}\",\"source\":{{\"subagent\":{{\"thread_spawn\":{{",
+          "\"parent_thread_id\":\"{}\"}}}}}}}}}}\n"
+        ),
+        child_id, parent_id,
+      ),
+    )
+    .expect("write thread-spawn session");
+
+    let parsed = parse_session_file(
+      &SessionFile {
+        path: session_path,
+        bucket: "active".to_string(),
+        file_size: 0,
+        file_mtime_ms: 0,
+      },
+      &HashMap::new(),
+    )
+    .expect("parse thread-spawn session");
+
+    assert_eq!(parsed.raw_session.parent_session_id.as_deref(), Some(parent_id));
+    assert!(parsed.explicit_forked_from_id.is_none());
+    assert!(parsed.explicit_fork_timestamp.is_none());
+  }
+
+  #[test]
+  fn parser_invalid_explicit_fork_timestamp_disables_replay_metadata() {
+    let directory = tempdir().expect("tempdir");
+    let child_id = "99999999-9999-9999-9999-999999999999";
+    let parent_id = "88888888-8888-8888-8888-888888888888";
+    let session_path = directory
+      .path()
+      .join(format!("rollout-2026-03-24T01-30-00-{child_id}.jsonl"));
+    std::fs::write(
+      &session_path,
+      format!(
+        concat!(
+          "{{\"timestamp\":\"not-an-instant\",\"type\":\"session_meta\",",
+          "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n"
+        ),
+        child_id, parent_id,
+      ),
+    )
+    .expect("write invalid fork session");
+
+    let parsed = parse_session_file(
+      &SessionFile {
+        path: session_path,
+        bucket: "active".to_string(),
+        file_size: 0,
+        file_mtime_ms: 0,
+      },
+      &HashMap::new(),
+    )
+    .expect("parse invalid fork session");
+
+    assert_eq!(parsed.explicit_forked_from_id.as_deref(), Some(parent_id));
+    assert!(parsed.explicit_fork_timestamp.is_none());
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -68,6 +68,7 @@ enum SessionParseError {
 }
 
 const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
+const TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY: &str = "token_usage_fork_replay_v3";
 const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -128,10 +129,16 @@ fn perform_scan_with_scope(
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
   let pending_rate_limit_repair_paths =
     load_pending_data_repair_paths(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY).map_err(|error| error.to_string())?;
-  let needs_token_usage_repair_sweep =
+  let needs_token_usage_v2_repair_sweep =
     data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let pending_token_repair_paths =
+  let pending_token_v2_repair_paths =
     load_pending_data_repair_paths(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let needs_fork_replay_v3_repair_sweep =
+    data_repair_is_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let pending_fork_replay_v3_repair_paths =
+    load_pending_data_repair_paths(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let needs_token_usage_repair_sweep =
+    needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
   let effective_scope = effective_scan_scope(
     requested_scope,
     import_state.is_empty(),
@@ -161,7 +168,8 @@ fn perform_scan_with_scope(
     if needs_rate_limit_backfill
       || pending_rate_limit_repair_paths.contains(&source_path)
       || needs_token_usage_repair_sweep
-      || pending_token_repair_paths.contains(&source_path)
+      || pending_token_v2_repair_paths.contains(&source_path)
+      || pending_fork_replay_v3_repair_paths.contains(&source_path)
     {
       changed_files.push(session_file);
       continue;
@@ -200,8 +208,10 @@ fn perform_scan_with_scope(
       let source_path = session_file.path.to_string_lossy().to_string();
       let file_needs_rate_limit_repair =
         needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
-      let file_needs_token_repair =
-        needs_token_usage_repair_sweep || pending_token_repair_paths.contains(&source_path);
+      let file_needs_token_v2_repair =
+        needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
+      let file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
+        || pending_fork_replay_v3_repair_paths.contains(&source_path);
       let mut parsed = match parse_session_file(session_file, &titles) {
         Ok(parsed) => parsed,
         Err(error) => {
@@ -211,8 +221,12 @@ fn perform_scan_with_scope(
             session_file.path.display(),
             error
           );
-          if file_needs_token_repair {
+          if file_needs_token_v2_repair {
             mark_data_repair_file_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path, &error)
+              .map_err(|error| error.to_string())?;
+          }
+          if file_needs_fork_replay_v3_repair {
+            mark_data_repair_file_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path, &error)
               .map_err(|error| error.to_string())?;
           }
           if file_needs_rate_limit_repair {
@@ -248,8 +262,12 @@ fn perform_scan_with_scope(
         clear_pending_data_repair_file(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)
           .map_err(|error| error.to_string())?;
       }
-      if file_needs_token_repair {
+      if file_needs_token_v2_repair {
         clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)
+          .map_err(|error| error.to_string())?;
+      }
+      if file_needs_fork_replay_v3_repair {
+        clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
           .map_err(|error| error.to_string())?;
       }
       changed_sessions += 1;
@@ -299,8 +317,12 @@ fn perform_scan_with_scope(
     mark_data_repair_complete(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
-  if needs_token_usage_repair_sweep {
+  if needs_token_usage_v2_repair_sweep {
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
+      .map_err(|error| error.to_string())?;
+  }
+  if needs_fork_replay_v3_repair_sweep {
+    mark_data_repair_complete(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
   if scan_freshness_start.recorded {
@@ -3380,6 +3402,188 @@ mod tests {
       .optional()
       .expect("query data repair marker");
     assert!(repair_completed.is_some());
+  }
+
+  #[test]
+  fn v3_repair_rebuilds_unchanged_fork_usage() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "56565656-5656-4656-8656-565656565656";
+    let child_session_id = "57575757-5757-4757-8757-575757575757";
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    let repaired_session_id = "58585858-5858-4858-8858-585858585858";
+    let repaired_path = sessions_dir.join("unparseable-v3.jsonl");
+    let parent_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:00:01Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:10:01Z",
+        total: (180, 0, 0, 180),
+        last: (80, 0, 0, 80),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:20:01Z",
+        total: (260, 0, 0, 260),
+        last: (80, 0, 0, 80),
+      },
+    ];
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    for fixture in parent_fixtures.iter().copied() {
+      parent_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&parent_path, parent_body).expect("write parent session");
+
+    let child_created_at = "2026-03-24T00:30:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    for (index, fixture) in parent_fixtures.iter().copied().enumerate() {
+      let timestamp = match index {
+        0 => "2026-03-24T00:30:01Z",
+        1 => "2026-03-24T00:30:02Z",
+        _ => "2026-03-24T00:30:03Z",
+      };
+      child_body.push_str(&token_count_line(TokenFixture {
+        timestamp,
+        ..fixture
+      }));
+    }
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (310, 0, 0, 310),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write fork session");
+    std::fs::write(&repaired_path, "not json\n").expect("write unreadable repair fixture");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, parent_session_id).3, 260);
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 50);
+    conn
+      .execute(
+        "DELETE FROM usage_events WHERE session_id = ?1",
+        params![child_session_id],
+      )
+      .expect("delete corrected child usage");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
+          reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective
+        )
+        VALUES (?1, '2026-03-24T00:31:00Z', 'gpt-5.4', 310, 0, 0, 0, 310, 0.0, 0, 0)
+        ",
+        params![child_session_id],
+      )
+      .expect("insert legacy overcounted child usage");
+    conn
+      .execute(
+        "DELETE FROM data_repairs WHERE repair_key = 'token_usage_fork_replay_v3'",
+        [],
+      )
+      .expect("simulate database upgraded from v2");
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 310);
+    drop(conn);
+
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("v3 repair scan");
+
+    let conn = open_connection(&db_path).expect("open repaired db");
+    assert_eq!(result.updated_sessions, 2);
+    assert_eq!(session_usage_totals(&conn, parent_session_id).3, 260);
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 50);
+    let v2_completed: Option<String> = conn
+      .query_row(
+        "SELECT completed_at FROM data_repairs WHERE repair_key = 'token_usage_monotonic_v2'",
+        [],
+        |row| row.get(0),
+      )
+      .optional()
+      .expect("query v2 repair marker");
+    let v3_completed: Option<String> = conn
+      .query_row(
+        "SELECT completed_at FROM data_repairs WHERE repair_key = 'token_usage_fork_replay_v3'",
+        [],
+        |row| row.get(0),
+      )
+      .optional()
+      .expect("query v3 repair marker");
+    let pending_v3_path: Option<String> = conn
+      .query_row(
+        "
+        SELECT source_path
+        FROM data_repair_pending_files
+        WHERE repair_key = 'token_usage_fork_replay_v3'
+        ",
+        [],
+        |row| row.get(0),
+      )
+      .optional()
+      .expect("query pending v3 repair file");
+    assert!(v2_completed.is_some());
+    assert!(v3_completed.is_some());
+    assert_eq!(
+      pending_v3_path.as_deref(),
+      Some(repaired_path.to_string_lossy().as_ref())
+    );
+    drop(conn);
+
+    write_session_file(
+      &repaired_path,
+      repaired_session_id,
+      &[("2026-03-24T01:00:01Z", 40, 0, 10, 50)],
+    );
+    let retry = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("retry v3 repair file");
+
+    let conn = open_connection(&db_path).expect("open retried db");
+    assert_eq!(retry.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, repaired_session_id).3, 50);
+    let pending_v3_count: i64 = conn
+      .query_row(
+        "
+        SELECT COUNT(*)
+        FROM data_repair_pending_files
+        WHERE repair_key = 'token_usage_fork_replay_v3'
+        ",
+        [],
+        |row| row.get(0),
+      )
+      .expect("count pending v3 repair files");
+    assert_eq!(pending_v3_count, 0);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -87,7 +87,7 @@ fn perform_scan_with_scope(
   init_db(&conn).map_err(|error| error.to_string())?;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
 
-  let codex_home = resolve_codex_home(&conn, codex_home_override)?;
+  let codex_home = validate_codex_home(resolve_codex_home(&conn, codex_home_override)?, dirs::home_dir().as_deref())?;
   let scan_started_at = now_utc_string();
   set_last_scan_started(&conn, &scan_started_at).map_err(|error| error.to_string())?;
 
@@ -107,14 +107,15 @@ fn perform_scan_with_scope(
     ScanScope::Incremental
   };
 
-  let session_files = match effective_scope {
-    ScanScope::Full => collect_session_files(&codex_home),
-    ScanScope::Incremental => collect_active_session_files(&codex_home),
+  let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
+    ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
+    ScanScope::Incremental => collect_incremental_session_files(&codex_home, &import_state),
   };
-  let present_paths: HashSet<String> = session_files
+  let mut present_paths: HashSet<String> = session_files
     .iter()
     .map(|item| item.path.to_string_lossy().to_string())
     .collect();
+  present_paths.extend(active_paths_kept_for_archive_retry);
 
   let mut changed_sessions = 0usize;
   let mut imported_session_ids = HashSet::new();
@@ -143,10 +144,15 @@ fn perform_scan_with_scope(
     changed_files.push(session_file);
   }
 
+  let titles = if effective_scope == ScanScope::Full || !changed_files.is_empty() {
+    load_session_index(&codex_home)
+  } else {
+    HashMap::new()
+  };
+
   let mut topology_dirty = false;
   let mut new_root_session_ids = Vec::new();
   if !changed_files.is_empty() {
-    let titles = load_session_index(&codex_home);
     let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
     let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
 
@@ -195,12 +201,17 @@ fn perform_scan_with_scope(
   }
 
   if effective_scope == ScanScope::Full {
+    refresh_session_titles(&conn, &titles).map_err(|error| error.to_string())?;
+  }
+
+  if effective_scope == ScanScope::Full {
     mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
     prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
   } else {
     mark_missing_active_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
   }
-  if topology_dirty {
+  let topology_needs_repair = conversation_links_need_repair(&conn).map_err(|error| error.to_string())?;
+  if topology_dirty || topology_needs_repair {
     recompute_conversation_links(&conn).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
     upsert_root_conversation_links(&conn, &new_root_session_ids).map_err(|error| error.to_string())?;
@@ -354,6 +365,30 @@ fn resolve_codex_home(conn: &Connection, override_value: Option<String>) -> Resu
   Ok(home_dir.join(".codex"))
 }
 
+fn validate_codex_home(path: PathBuf, home_dir: Option<&Path>) -> Result<PathBuf, String> {
+  let expanded = expand_home_prefix(path, home_dir)?;
+  if !expanded.is_dir() {
+    return Err(format!(
+      "Codex home is not an existing directory: {}",
+      expanded.display()
+    ));
+  }
+  Ok(expanded)
+}
+
+fn expand_home_prefix(path: PathBuf, home_dir: Option<&Path>) -> Result<PathBuf, String> {
+  let Ok(suffix) = path.strip_prefix(Path::new("~")) else {
+    return Ok(path);
+  };
+  let Some(home_dir) = home_dir else {
+    return Err(format!(
+      "Unable to resolve home directory for Codex home path: {}",
+      path.display()
+    ));
+  };
+  Ok(home_dir.join(suffix))
+}
+
 fn load_session_index(codex_home: &Path) -> HashMap<String, String> {
   let mut titles = HashMap::new();
   let path = codex_home.join("session_index.jsonl");
@@ -380,6 +415,16 @@ fn load_session_index(codex_home: &Path) -> HashMap<String, String> {
   }
 
   titles
+}
+
+fn refresh_session_titles(conn: &Connection, titles: &HashMap<String, String>) -> rusqlite::Result<()> {
+  for (session_id, title) in titles {
+    conn.execute(
+      "UPDATE sessions SET title = ?1 WHERE session_id = ?2",
+      params![title, session_id],
+    )?;
+  }
+  Ok(())
 }
 
 fn collect_session_files(codex_home: &Path) -> Vec<SessionFile> {
@@ -413,6 +458,38 @@ fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
   }
   files.sort_by(|left, right| left.path.cmp(&right.path));
   files
+}
+
+fn collect_incremental_session_files(
+  codex_home: &Path,
+  import_state: &HashMap<String, ImportState>,
+) -> (Vec<SessionFile>, HashSet<String>) {
+  let mut files = collect_active_session_files(codex_home);
+  let mut collected_paths = files
+    .iter()
+    .map(|session_file| session_file.path.to_string_lossy().to_string())
+    .collect::<HashSet<_>>();
+  let mut active_paths_kept_for_archive_retry = HashSet::new();
+
+  for state in import_state.values() {
+    if state.source_bucket != "active" || collected_paths.contains(&state.source_path) {
+      continue;
+    }
+    let Some(filename) = Path::new(&state.source_path).file_name() else {
+      continue;
+    };
+    let archived_path = codex_home.join("archived_sessions").join(filename);
+    let Some(session_file) = session_file_from_path(archived_path, "archived") else {
+      continue;
+    };
+    active_paths_kept_for_archive_retry.insert(state.source_path.clone());
+    if collected_paths.insert(session_file.path.to_string_lossy().to_string()) {
+      files.push(session_file);
+    }
+  }
+
+  files.sort_by(|left, right| left.path.cmp(&right.path));
+  (files, active_paths_kept_for_archive_retry)
 }
 
 fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
@@ -473,7 +550,10 @@ fn parse_session_file_once(
   let mut first_session_meta: Option<SessionMetaCandidate> = None;
   let mut matching_session_meta: Option<SessionMetaCandidate> = None;
 
-  for line in BufReader::new(file).lines().map_while(Result::ok) {
+  for line_result in BufReader::new(file).lines() {
+    let line = line_result.map_err(|error| {
+      SessionParseError::Fatal(format!("Failed to read {}: {error}", session_file.path.display()))
+    })?;
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
     }
@@ -962,7 +1042,7 @@ fn normalize_local_timestamp(timestamp: chrono::DateTime<Local>) -> chrono::Date
 fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, ImportState>> {
   let mut stmt = conn.prepare(
     "
-    SELECT source_path, session_id, file_size, file_mtime_ms
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms
     FROM import_state
     ",
   )?;
@@ -971,8 +1051,9 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
     Ok(ImportState {
       source_path: row.get(0)?,
       session_id: row.get(1)?,
-      file_size: row.get(2)?,
-      file_mtime_ms: row.get(3)?,
+      source_bucket: row.get(2)?,
+      file_size: row.get(3)?,
+      file_mtime_ms: row.get(4)?,
     })
   })?;
 
@@ -1094,6 +1175,22 @@ fn upsert_root_conversation_links(conn: &Connection, session_ids: &[String]) -> 
   }
 
   Ok(())
+}
+
+fn conversation_links_need_repair(conn: &Connection) -> rusqlite::Result<bool> {
+  conn.query_row(
+    "
+    SELECT EXISTS (
+      SELECT 1
+      FROM sessions AS session
+      LEFT JOIN conversation_links AS link ON link.session_id = session.session_id
+      WHERE link.session_id IS NULL
+         OR link.parent_session_id IS NOT session.parent_session_id
+    )
+    ",
+    [],
+    |row| Ok(row.get::<_, i64>(0)? != 0),
+  )
 }
 
 fn mark_missing_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
@@ -1260,6 +1357,7 @@ fn read_percent(value: &Value, key: &str) -> Option<i64> {
 struct ImportState {
   source_path: String,
   session_id: Option<String>,
+  source_bucket: String,
   file_size: i64,
   file_mtime_ms: i64,
 }
@@ -2576,6 +2674,277 @@ mod tests {
     assert_eq!(
       import_state_session_id(&conn, &child_path),
       Some(child_session_id.to_string())
+    );
+  }
+
+  #[test]
+  fn invalid_custom_home_does_not_advance_completed_scan_time() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let missing = directory.path().join("missing-codex-home");
+
+    let error = perform_scan(&db_path, Some(missing.to_string_lossy().to_string()))
+      .expect_err("missing home must fail");
+    assert!(error.contains("existing directory"));
+
+    let conn = open_connection(&db_path).expect("open db");
+    let completed: Option<String> = conn
+      .query_row(
+        "SELECT last_scan_completed_at FROM sync_settings WHERE singleton_id = 1",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load completion");
+    assert!(completed.is_none());
+  }
+
+  #[test]
+  fn custom_home_path_expands_supported_tilde_forms() {
+    let directory = tempdir().expect("tempdir");
+    let nested = directory.path().join("codex-home");
+    std::fs::create_dir_all(&nested).expect("codex home");
+
+    assert_eq!(
+      validate_codex_home(PathBuf::from("~"), Some(directory.path())).expect("bare tilde"),
+      directory.path()
+    );
+    assert_eq!(
+      validate_codex_home(PathBuf::from("~/codex-home"), Some(directory.path())).expect("tilde prefix"),
+      nested
+    );
+  }
+
+  #[test]
+  fn incremental_scan_imports_final_snapshot_after_active_file_is_archived() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    let archived = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&archived).expect("archive");
+    let session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let archived_path = archived.join(active_path.file_name().expect("filename"));
+    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+
+    write_session_file(
+      &active_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+    std::fs::rename(&active_path, &archived_path).expect("archive session");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, session_id).3, 200);
+    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+  }
+
+  #[test]
+  fn incremental_scan_retries_moved_archive_after_read_error() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    let archived = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&archived).expect("archive");
+    let session_id = "a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1";
+    let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let archived_path = archived.join(active_path.file_name().expect("filename"));
+    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    write_session_file(
+      &sessions.join("other.jsonl"),
+      "a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2",
+      &[("2026-07-10T00:00:00Z", 50, 10, 5, 55)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+
+    let mut file = File::create(&active_path).expect("session file");
+    writeln!(
+      file,
+      "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session_id}\"}}}}"
+    )
+    .expect("meta");
+    file.write_all(&[0xff, b'\n']).expect("invalid utf8");
+    drop(file);
+    std::fs::rename(&active_path, &archived_path).expect("archive session");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("scan skips unreadable archive");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let retained_state: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM import_state WHERE source_path = ?1",
+        params![active_path.to_string_lossy().to_string()],
+        |row| row.get(0),
+      )
+      .expect("retained active state");
+    assert_eq!(retained_state, 1);
+    drop(conn);
+
+    write_session_file(
+      &archived_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("retry moved archive");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, session_id).3, 200);
+    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+  }
+
+  #[test]
+  fn full_scan_refreshes_title_when_only_session_index_changes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    write_session_file(
+      &sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl")),
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let index_path = codex_home.join("session_index.jsonl");
+    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"A\"}}\n"))
+      .expect("title A");
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"B\"}}\n"))
+      .expect("title B");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let title: String = conn
+      .query_row(
+        "SELECT title FROM sessions WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+      )
+      .expect("title");
+    assert_eq!(title, "B");
+  }
+
+  #[test]
+  fn invalid_utf8_does_not_commit_partial_session_or_import_state() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    let path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let mut file = File::create(&path).expect("session file");
+    writeln!(
+      file,
+      "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session_id}\"}}}}"
+    )
+    .expect("meta");
+    file.write_all(&[0xff, b'\n']).expect("invalid utf8");
+    writeln!(
+      file,
+      "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}"
+    )
+    .expect("tail");
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan skips bad file");
+    let conn = open_connection(&db_path).expect("open db");
+    let sessions_count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+      .expect("sessions");
+    let states_count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM import_state", [], |row| row.get(0))
+      .expect("states");
+    assert_eq!((sessions_count, states_count), (0, 0));
+  }
+
+  #[test]
+  fn incremental_scan_repairs_missing_conversation_link_without_source_change() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let parent = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let child = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    write_session_file_with_parent(
+      &sessions.join(format!("rollout-2026-07-10T00-00-00-{parent}.jsonl")),
+      parent,
+      None,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    write_session_file_with_parent(
+      &sessions.join(format!("rollout-2026-07-10T00-01-00-{child}.jsonl")),
+      child,
+      Some(parent),
+      &[("2026-07-10T00:01:00Z", 50, 10, 5, 55)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open db");
+    conn
+      .execute("DELETE FROM conversation_links WHERE session_id = ?1", params![child])
+      .expect("remove link");
+    drop(conn);
+
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("repair scan");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(conversation_link(&conn, child).expect("child link").0, parent);
+  }
+
+  #[test]
+  fn incremental_scan_repairs_conversation_link_parent_mismatch_without_source_change() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let parent = "f1f1f1f1-f1f1-f1f1-f1f1-f1f1f1f1f1f1";
+    let child = "f2f2f2f2-f2f2-f2f2-f2f2-f2f2f2f2f2f2";
+    write_session_file(
+      &sessions.join(format!("rollout-2026-07-10T00-00-00-{parent}.jsonl")),
+      parent,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    write_session_file_with_parent(
+      &sessions.join(format!("rollout-2026-07-10T00-01-00-{child}.jsonl")),
+      child,
+      Some(parent),
+      &[("2026-07-10T00:01:00Z", 50, 10, 5, 55)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open db");
+    conn
+      .execute(
+        "UPDATE conversation_links SET parent_session_id = NULL WHERE session_id = ?1",
+        params![child],
+      )
+      .expect("corrupt direct parent");
+    drop(conn);
+
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("repair scan");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(
+      conversation_link(&conn, child).expect("child link").1.as_deref(),
+      Some(parent)
     );
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3722,7 +3722,7 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
       .expect("full parent scan");
 
-    let conn = open_connection(&db_path).expect("open db to corrupt parent source path");
+    let conn = open_connection(&db_path).expect("open db to corrupt parent source paths");
     assert_eq!(
       conn
         .execute(
@@ -3732,7 +3732,17 @@ mod tests {
         .expect("corrupt parent source path"),
       1
     );
+    assert_eq!(
+      conn
+        .execute(
+          "UPDATE import_state SET source_path = ?1 WHERE session_id = ?2",
+          params![child_path.to_string_lossy().to_string(), parent_session_id],
+        )
+        .expect("corrupt parent import state path"),
+      1
+    );
     drop(conn);
+    std::fs::remove_file(&parent_path).expect("remove original parent source");
 
     let child_created_at = "2026-03-24T01:00:00Z";
     let mut child_body = format!(

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2821,6 +2821,159 @@ mod tests {
   }
 
   #[test]
+  fn fork_replay_counts_only_child_usage() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "99999999-9999-9999-9999-999999999999";
+    let child_session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    let parent_path =
+      sessions_dir.join(format!("rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"));
+    let child_path =
+      sessions_dir.join(format!("rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"));
+    let parent_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:00:01Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:10:01Z",
+        total: (180, 0, 0, 180),
+        last: (80, 0, 0, 80),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:20:01Z",
+        total: (260, 0, 0, 260),
+        last: (80, 0, 0, 80),
+      },
+    ];
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    for fixture in parent_fixtures.iter().copied() {
+      parent_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&parent_path, parent_body).expect("write parent session");
+
+    let child_created_at = "2026-03-24T00:30:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    for fixture in parent_fixtures.iter().copied() {
+      child_body.push_str(&token_count_line(TokenFixture {
+        timestamp: child_created_at,
+        ..fixture
+      }));
+    }
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (310, 0, 0, 310),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write fork session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let parent_total = session_usage_totals(&conn, parent_session_id).3;
+    let child_total = session_usage_totals(&conn, child_session_id).3;
+    assert_eq!(parent_total, 260);
+    assert_eq!(child_total, 50);
+    assert_eq!(parent_total + child_total, 310);
+  }
+
+  #[test]
+  fn fork_first_snapshot_uses_last_usage_as_baseline() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    let child_session_id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    let child_path =
+      sessions_dir.join(format!("rollout-2026-03-24T01-00-00-{child_session_id}.jsonl"));
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_session_id,
+      parent_session_id,
+    );
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T01:00:00Z",
+      total: (1000, 0, 0, 1000),
+      last: (40, 0, 0, 40),
+    }));
+    std::fs::write(child_path, child_body).expect("write fork session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 40);
+  }
+
+  #[test]
+  fn thread_spawn_without_fork_keeps_full_usage() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let child_session_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    let child_path =
+      sessions_dir.join(format!("rollout-2026-03-24T02-00-00-{child_session_id}.jsonl"));
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T02:00:00Z\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"source\":{{\"subagent\":{{\"thread_spawn\":{{",
+        "\"parent_thread_id\":\"{}\"}}}}}}}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T02:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_session_id,
+      parent_session_id,
+    );
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T02:00:00Z",
+      total: (1000, 0, 0, 1000),
+      last: (40, 0, 0, 40),
+    }));
+    std::fs::write(child_path, child_body).expect("write thread-spawn session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 1000);
+  }
+
+  #[test]
   fn invalid_custom_home_does_not_advance_completed_scan_time() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
@@ -3574,6 +3727,38 @@ mod tests {
       conversation_link(&conn, child).expect("child link").1.as_deref(),
       Some(parent)
     );
+  }
+
+  #[derive(Clone, Copy)]
+  struct TokenFixture {
+    timestamp: &'static str,
+    total: (i64, i64, i64, i64),
+    last: (i64, i64, i64, i64),
+  }
+
+  fn token_count_line(fixture: TokenFixture) -> String {
+    let (input, cached, output, total) = fixture.total;
+    let (last_input, last_cached, last_output, last_total) = fixture.last;
+    format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"event_msg\",\"payload\":{{",
+        "\"type\":\"token_count\",\"info\":{{",
+        "\"total_token_usage\":{{\"input_tokens\":{},\"cached_input_tokens\":{},",
+        "\"output_tokens\":{},\"reasoning_output_tokens\":0,\"total_tokens\":{}}},",
+        "\"last_token_usage\":{{\"input_tokens\":{},\"cached_input_tokens\":{},",
+        "\"output_tokens\":{},\"reasoning_output_tokens\":0,\"total_tokens\":{}}}",
+        "}}}}}}\n"
+      ),
+      fixture.timestamp,
+      input,
+      cached,
+      output,
+      total,
+      last_input,
+      last_cached,
+      last_output,
+      last_total,
+    )
   }
 
   fn write_session_file(path: &Path, session_id: &str, snapshots: &[(&str, i64, i64, i64, i64)]) {

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 
 use crate::database::{
   bool_to_i64, get_sync_settings, init_db, now_utc_string, open_connection,
-  replace_session_rate_limit_samples, set_last_full_scan_completed, set_last_scan_completed, set_last_scan_started,
+  replace_session_rate_limit_samples, set_last_scan_started_for_source, set_scan_completed_for_source,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
@@ -85,11 +85,30 @@ fn perform_scan_with_scope(
 ) -> Result<ScanResult, String> {
   let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
+  let scan_source_selector = get_sync_settings(&conn)
+    .map_err(|error| error.to_string())?
+    .codex_home;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
 
-  let codex_home = validate_codex_home(resolve_codex_home(&conn, codex_home_override)?, dirs::home_dir().as_deref())?;
+  let home_dir = dirs::home_dir();
+  let codex_home = validate_codex_home(
+    resolve_codex_home(
+      scan_source_selector.as_deref(),
+      codex_home_override,
+      home_dir.as_deref(),
+    )?,
+    home_dir.as_deref(),
+  )?;
+  let track_scan_freshness = freshness_source_matches(
+    scan_source_selector.as_deref(),
+    &codex_home,
+    home_dir.as_deref(),
+  );
   let scan_started_at = now_utc_string();
-  set_last_scan_started(&conn, &scan_started_at).map_err(|error| error.to_string())?;
+  if track_scan_freshness {
+    set_last_scan_started_for_source(&conn, &scan_started_at, scan_source_selector.as_deref())
+      .map_err(|error| error.to_string())?;
+  }
 
   let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
@@ -234,10 +253,15 @@ fn perform_scan_with_scope(
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
-  if effective_scope == ScanScope::Full {
-    set_last_full_scan_completed(&conn, &completed_at).map_err(|error| error.to_string())?;
+  if track_scan_freshness {
+    set_scan_completed_for_source(
+      &conn,
+      &completed_at,
+      scan_source_selector.as_deref(),
+      effective_scope == ScanScope::Full,
+    )
+    .map_err(|error| error.to_string())?;
   }
-  set_last_scan_completed(&conn, &completed_at).map_err(|error| error.to_string())?;
 
   Ok(ScanResult {
     codex_home: codex_home.to_string_lossy().to_string(),
@@ -339,16 +363,18 @@ pub fn recalculate_all_session_values(conn: &Connection) -> rusqlite::Result<()>
   Ok(())
 }
 
-fn resolve_codex_home(conn: &Connection, override_value: Option<String>) -> Result<PathBuf, String> {
+fn resolve_codex_home(
+  persisted_codex_home: Option<&str>,
+  override_value: Option<String>,
+  home_dir: Option<&Path>,
+) -> Result<PathBuf, String> {
   if let Some(path) = override_value {
     return Ok(PathBuf::from(path));
   }
 
-  if let Ok(settings) = get_sync_settings(conn) {
-    if let Some(path) = settings.codex_home {
-      if !path.trim().is_empty() {
-        return Ok(PathBuf::from(path));
-      }
+  if let Some(path) = persisted_codex_home {
+    if !path.trim().is_empty() {
+      return Ok(PathBuf::from(path));
     }
   }
 
@@ -358,11 +384,22 @@ fn resolve_codex_home(conn: &Connection, override_value: Option<String>) -> Resu
     }
   }
 
-  let Some(home_dir) = dirs::home_dir() else {
+  let Some(home_dir) = home_dir else {
     return Err("Unable to resolve home directory for CODEX_HOME fallback.".to_string());
   };
 
   Ok(home_dir.join(".codex"))
+}
+
+fn freshness_source_matches(
+  persisted_codex_home: Option<&str>,
+  scanned_codex_home: &Path,
+  home_dir: Option<&Path>,
+) -> bool {
+  resolve_codex_home(persisted_codex_home, None, home_dir)
+    .and_then(|path| expand_home_prefix(path, home_dir))
+    .map(|path| path == scanned_codex_home)
+    .unwrap_or(false)
 }
 
 fn validate_codex_home(path: PathBuf, home_dir: Option<&Path>) -> Result<PathBuf, String> {
@@ -1380,7 +1417,7 @@ struct ImportState {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::database::{init_db, now_utc_string, open_connection};
+  use crate::database::{init_db, now_utc_string, open_connection, save_sync_settings};
   use rusqlite::OptionalExtension;
   use tempfile::tempdir;
 
@@ -2705,6 +2742,163 @@ mod tests {
       )
       .expect("load completion");
     assert!(completed.is_none());
+  }
+
+  #[test]
+  fn scan_does_not_restore_freshness_after_source_changes_mid_import() {
+    let directory = tempdir().expect("tempdir");
+    let old_codex_home = directory.path().join("old-codex-home");
+    let new_codex_home = directory.path().join("new-codex-home");
+    let sessions_dir = old_codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("old sessions dir");
+    std::fs::create_dir_all(&new_codex_home).expect("new Codex home");
+
+    let session_path = sessions_dir.join("source-race.jsonl");
+    std::fs::write(
+      &session_path,
+      concat!(
+        "{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"abababab-abab-abab-abab-abababababab\"}}\n",
+        "{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.6-sol\"}}\n",
+        "{\"timestamp\":\"2026-07-10T00:00:02Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":10,\"reasoning_output_tokens\":0,\"total_tokens\":110}}}}\n"
+      ),
+    )
+    .expect("write session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.codex_home = Some(old_codex_home.to_string_lossy().to_string());
+    save_sync_settings(&conn, &settings).expect("save old source");
+
+    let new_home_sql = new_codex_home.to_string_lossy().replace('\'', "''");
+    conn
+      .execute_batch(&format!(
+        "
+        CREATE TRIGGER switch_codex_home_during_import
+        AFTER INSERT ON usage_events
+        BEGIN
+          UPDATE sync_settings
+          SET codex_home = '{new_home_sql}',
+              last_scan_started_at = NULL,
+              last_scan_completed_at = NULL,
+              last_full_scan_completed_at = NULL
+          WHERE singleton_id = 1;
+        END;
+        "
+      ))
+      .expect("create source switch trigger");
+    drop(conn);
+
+    perform_scan(
+      &db_path,
+      Some(old_codex_home.to_string_lossy().to_string()),
+    )
+    .expect("scan old source");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let (codex_home, started, completed, full_completed): (
+      Option<String>,
+      Option<String>,
+      Option<String>,
+      Option<String>,
+    ) = conn
+      .query_row(
+        "
+        SELECT codex_home, last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+      )
+      .expect("load scan freshness");
+
+    assert_eq!(
+      codex_home.as_deref(),
+      Some(new_codex_home.to_string_lossy().as_ref())
+    );
+    assert_eq!(started, None);
+    assert_eq!(completed, None);
+    assert_eq!(full_completed, None);
+  }
+
+  #[test]
+  fn scan_writes_freshness_when_source_selector_is_unchanged() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("Codex home");
+    let db_path = directory.path().join("usage.sqlite");
+
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.codex_home = Some(codex_home.to_string_lossy().to_string());
+    save_sync_settings(&conn, &settings).expect("save source");
+    drop(conn);
+
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("scan matching source");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) = conn
+      .query_row(
+        "
+        SELECT last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+      )
+      .expect("load scan freshness");
+
+    assert!(started.is_some());
+    assert!(completed.is_some());
+    assert!(full_completed.is_some());
+  }
+
+  #[test]
+  fn scan_does_not_write_freshness_for_an_override_from_the_previous_source() {
+    let directory = tempdir().expect("tempdir");
+    let old_codex_home = directory.path().join("old-codex-home");
+    let new_codex_home = directory.path().join("new-codex-home");
+    std::fs::create_dir_all(&old_codex_home).expect("old Codex home");
+    std::fs::create_dir_all(&new_codex_home).expect("new Codex home");
+    let db_path = directory.path().join("usage.sqlite");
+
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.codex_home = Some(new_codex_home.to_string_lossy().to_string());
+    save_sync_settings(&conn, &settings).expect("save new source");
+    drop(conn);
+
+    perform_scan(
+      &db_path,
+      Some(old_codex_home.to_string_lossy().to_string()),
+    )
+    .expect("scan previous source");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) = conn
+      .query_row(
+        "
+        SELECT last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+      )
+      .expect("load scan freshness");
+
+    assert_eq!(started, None);
+    assert_eq!(completed, None);
+    assert_eq!(full_completed, None);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -30,10 +30,9 @@ struct ParsedSession {
   raw_session: RawSession,
   snapshots: Vec<UsageSnapshot>,
   rate_limit_samples: Vec<RateLimitSampleRecord>,
-  #[allow(dead_code)]
   explicit_forked_from_id: Option<String>,
-  #[allow(dead_code)]
   explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
+  inherited_token_snapshot_cutoff: usize,
   explicit_fast_mode: Option<bool>,
   latest_plan_type: Option<String>,
   last_model_id: Option<String>,
@@ -144,6 +143,8 @@ fn perform_scan_with_scope(
     ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
     ScanScope::Incremental => collect_incremental_session_files(&codex_home, &import_state),
   };
+  let session_source_paths =
+    load_session_source_paths(&conn, &import_state, &session_files).map_err(|error| error.to_string())?;
   let mut present_paths: HashSet<String> = session_files
     .iter()
     .map(|item| item.path.to_string_lossy().to_string())
@@ -189,6 +190,7 @@ fn perform_scan_with_scope(
   let mut topology_dirty = false;
   let mut new_root_session_ids = Vec::new();
   let mut skipped_session_files = false;
+  let mut parent_snapshot_cache: HashMap<String, Option<Vec<UsageSnapshot>>> = HashMap::new();
   if !changed_files.is_empty() {
     let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
     let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
@@ -199,7 +201,7 @@ fn perform_scan_with_scope(
         needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
       let file_needs_token_repair =
         needs_token_usage_repair_sweep || pending_token_repair_paths.contains(&source_path);
-      let parsed = match parse_session_file(session_file, &titles) {
+      let mut parsed = match parse_session_file(session_file, &titles) {
         Ok(parsed) => parsed,
         Err(error) => {
           skipped_session_files = true;
@@ -219,6 +221,11 @@ fn perform_scan_with_scope(
           continue;
         }
       };
+      assign_inherited_token_snapshot_cutoff(
+        &mut parsed,
+        &session_source_paths,
+        &mut parent_snapshot_cache,
+      );
       imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
       match classify_topology_maintenance(
@@ -893,6 +900,7 @@ fn parse_session_file_once(
     rate_limit_samples,
     explicit_forked_from_id,
     explicit_fork_timestamp,
+    inherited_token_snapshot_cutoff: 0,
     explicit_fast_mode,
     latest_plan_type,
     last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
@@ -927,6 +935,204 @@ fn looks_like_session_id(value: &str) -> bool {
     .all(|(segment, expected_len)| {
       segment.len() == *expected_len && segment.chars().all(|character| character.is_ascii_hexdigit())
     })
+}
+
+fn load_session_source_paths(
+  conn: &Connection,
+  import_state: &HashMap<String, ImportState>,
+  session_files: &[SessionFile],
+) -> rusqlite::Result<HashMap<String, PathBuf>> {
+  let mut source_paths = HashMap::new();
+  let mut stmt = conn.prepare(
+    "SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL",
+  )?;
+  let rows = stmt.query_map([], |row| {
+    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+  })?;
+
+  for row in rows {
+    let (session_id, source_path) = row?;
+    source_paths.insert(session_id, PathBuf::from(source_path));
+  }
+  drop(stmt);
+
+  for state in import_state.values() {
+    let Some(session_id) = state.session_id.as_ref() else {
+      continue;
+    };
+    source_paths.insert(session_id.clone(), PathBuf::from(&state.source_path));
+  }
+
+  for session_file in session_files {
+    let Some(session_id) = fallback_session_id_from_filename(&session_file.path) else {
+      continue;
+    };
+    source_paths.insert(session_id, session_file.path.clone());
+  }
+
+  Ok(source_paths)
+}
+
+fn assign_inherited_token_snapshot_cutoff(
+  parsed: &mut ParsedSession,
+  session_source_paths: &HashMap<String, PathBuf>,
+  parent_snapshot_cache: &mut HashMap<String, Option<Vec<UsageSnapshot>>>,
+) {
+  let Some(parent_session_id) = parsed
+    .explicit_forked_from_id
+    .as_deref()
+    .filter(|session_id| !session_id.trim().is_empty())
+  else {
+    return;
+  };
+  let Some(fork_timestamp) = parsed.explicit_fork_timestamp else {
+    return;
+  };
+
+  if !parent_snapshot_cache.contains_key(parent_session_id) {
+    let parent_snapshots = match session_source_paths.get(parent_session_id) {
+      Some(source_path) => match read_parent_replay_snapshots(source_path, parent_session_id) {
+        Ok(snapshots) => Some(snapshots),
+        Err(()) => {
+          log::warn!(
+            "Replay parent unavailable: child_id={}, parent_id={}, source_path={}",
+            parsed.raw_session.session_id,
+            parent_session_id,
+            source_path.display()
+          );
+          None
+        }
+      },
+      None => {
+        log::warn!(
+          "Replay parent unavailable: child_id={}, parent_id={}",
+          parsed.raw_session.session_id,
+          parent_session_id
+        );
+        None
+      }
+    };
+    parent_snapshot_cache.insert(parent_session_id.to_string(), parent_snapshots);
+  }
+
+  let Some(parent_snapshots) = parent_snapshot_cache
+    .get(parent_session_id)
+    .and_then(Option::as_deref)
+  else {
+    return;
+  };
+
+  parsed.inherited_token_snapshot_cutoff = replayed_child_snapshot_cutoff(
+    parent_snapshots,
+    &parsed.snapshots,
+    Some(fork_timestamp),
+  );
+}
+
+fn read_parent_replay_snapshots(
+  source_path: &Path,
+  requested_parent_id: &str,
+) -> Result<Vec<UsageSnapshot>, ()> {
+  let filename_session_id = fallback_session_id_from_filename(source_path);
+  if filename_session_id
+    .as_deref()
+    .is_some_and(|session_id| session_id != requested_parent_id)
+  {
+    return Err(());
+  }
+
+  let file = File::open(source_path).map_err(|_| ())?;
+  let mut first_session_meta_id: Option<String> = None;
+  let mut snapshots = Vec::new();
+
+  for line_result in BufReader::new(file).lines() {
+    let line = line_result.map_err(|_| ())?;
+    let may_be_session_meta = json_line_has_string_field(&line, "type", "session_meta");
+    let may_be_token_count = json_line_has_string_field(&line, "type", "event_msg")
+      && json_line_has_string_field(&line, "type", "token_count");
+    if !may_be_session_meta && !may_be_token_count {
+      continue;
+    }
+
+    let Ok(value) = serde_json::from_str::<Value>(&line) else {
+      continue;
+    };
+    match value.get("type").and_then(Value::as_str) {
+      Some("session_meta") if first_session_meta_id.is_none() => {
+        let Some(session_id) = value
+          .get("payload")
+          .and_then(|payload| payload.get("id"))
+          .and_then(Value::as_str)
+        else {
+          continue;
+        };
+        if filename_session_id.is_none() && session_id != requested_parent_id {
+          return Err(());
+        }
+        first_session_meta_id = Some(session_id.to_string());
+      }
+      Some("event_msg") => {
+        let payload = value.get("payload").unwrap_or(&Value::Null);
+        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
+          continue;
+        }
+        let info = payload.get("info").unwrap_or(&Value::Null);
+        let total_usage = info.get("total_token_usage").unwrap_or(&Value::Null);
+        let Some(timestamp) = value.get("timestamp").and_then(Value::as_str) else {
+          continue;
+        };
+        if total_usage.is_null() {
+          continue;
+        }
+
+        snapshots.push(UsageSnapshot {
+          timestamp: timestamp.to_string(),
+          model_id: String::new(),
+          usage: token_usage_from_json(total_usage),
+          last_token_usage: info
+            .get("last_token_usage")
+            .filter(|last_usage| !last_usage.is_null())
+            .map(token_usage_from_json),
+          plan_type: None,
+          limit_id: None,
+          limit_name: None,
+          explicit_fast_mode: None,
+        });
+      }
+      _ => {}
+    }
+  }
+
+  if filename_session_id.is_none() && first_session_meta_id.is_none() {
+    return Err(());
+  }
+  if snapshots.is_empty() {
+    return Err(());
+  }
+
+  Ok(snapshots)
+}
+
+fn json_line_has_string_field(line: &str, field: &str, expected_value: &str) -> bool {
+  let field = format!("\"{field}\"");
+  let expected_value = format!("\"{expected_value}\"");
+
+  line.match_indices(&field).any(|(index, _)| {
+    line[index + field.len()..]
+      .trim_start()
+      .strip_prefix(':')
+      .is_some_and(|rest| rest.trim_start().starts_with(&expected_value))
+  })
+}
+
+fn token_usage_from_json(value: &Value) -> TokenUsage {
+  TokenUsage {
+    input_tokens: read_i64(value, "input_tokens"),
+    cached_input_tokens: read_i64(value, "cached_input_tokens"),
+    output_tokens: read_i64(value, "output_tokens"),
+    reasoning_output_tokens: read_i64(value, "reasoning_output_tokens"),
+    total_tokens: read_total_tokens(value),
+  }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -983,7 +1189,6 @@ fn kmp_prefix_table(pattern: &[ReplayKey]) -> Vec<usize> {
   table
 }
 
-#[allow(dead_code)]
 fn replayed_child_snapshot_cutoff(
   parent_snapshots: &[UsageSnapshot],
   child_snapshots: &[UsageSnapshot],
@@ -1104,9 +1309,13 @@ fn persist_session(
   )?;
   replace_session_rate_limit_samples(&tx, &parsed.raw_session.session_id, &parsed.rate_limit_samples)?;
 
-  let mut previous_usage: Option<TokenUsage> = None;
+  let snapshot_cutoff = parsed.inherited_token_snapshot_cutoff;
+  let mut previous_usage = snapshot_cutoff
+    .checked_sub(1)
+    .and_then(|index| parsed.snapshots.get(index))
+    .map(|snapshot| snapshot.usage.clone());
 
-  for snapshot in &parsed.snapshots {
+  for snapshot in parsed.snapshots.iter().skip(snapshot_cutoff) {
     if previous_usage.as_ref() == Some(&snapshot.usage) {
       continue;
     }
@@ -1116,6 +1325,11 @@ fn persist_session(
         continue;
       }
       diff_usage(previous, &snapshot.usage)
+    } else if parsed.explicit_forked_from_id.is_some() {
+      snapshot
+        .last_token_usage
+        .clone()
+        .unwrap_or_else(|| snapshot.usage.clone())
     } else {
       snapshot.usage.clone()
     };

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -104,11 +104,19 @@ fn perform_scan_with_scope(
     &codex_home,
     home_dir.as_deref(),
   );
+  let resolved_codex_home = codex_home.to_string_lossy().to_string();
   let scan_started_at = now_utc_string();
-  if track_scan_freshness {
-    set_last_scan_started_for_source(&conn, &scan_started_at, scan_source_selector.as_deref())
-      .map_err(|error| error.to_string())?;
-  }
+  let scan_freshness_start = if track_scan_freshness {
+    set_last_scan_started_for_source(
+      &conn,
+      &scan_started_at,
+      scan_source_selector.as_deref(),
+      &resolved_codex_home,
+    )
+    .map_err(|error| error.to_string())?
+  } else {
+    Default::default()
+  };
 
   let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
@@ -116,15 +124,13 @@ fn perform_scan_with_scope(
     data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
   let pending_token_repair_paths =
     load_pending_data_repair_paths(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let effective_scope = if requested_scope == ScanScope::Full
-    || import_state.is_empty()
-    || needs_rate_limit_backfill
-    || needs_token_usage_repair_sweep
-  {
-    ScanScope::Full
-  } else {
-    ScanScope::Incremental
-  };
+  let effective_scope = effective_scan_scope(
+    requested_scope,
+    import_state.is_empty(),
+    needs_rate_limit_backfill,
+    needs_token_usage_repair_sweep,
+    scan_freshness_start.full_scan_required,
+  );
 
   let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
     ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
@@ -253,11 +259,12 @@ fn perform_scan_with_scope(
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
-  if track_scan_freshness {
+  if scan_freshness_start.recorded {
     set_scan_completed_for_source(
       &conn,
       &completed_at,
       scan_source_selector.as_deref(),
+      &resolved_codex_home,
       effective_scope == ScanScope::Full,
     )
     .map_err(|error| error.to_string())?;
@@ -271,6 +278,25 @@ fn perform_scan_with_scope(
     missing_sessions,
     last_completed_at: completed_at,
   })
+}
+
+fn effective_scan_scope(
+  requested_scope: ScanScope,
+  import_state_is_empty: bool,
+  needs_rate_limit_backfill: bool,
+  needs_token_usage_repair_sweep: bool,
+  resolved_source_requires_full_scan: bool,
+) -> ScanScope {
+  if requested_scope == ScanScope::Full
+    || import_state_is_empty
+    || needs_rate_limit_backfill
+    || needs_token_usage_repair_sweep
+    || resolved_source_requires_full_scan
+  {
+    ScanScope::Full
+  } else {
+    ScanScope::Incremental
+  }
 }
 
 fn import_state_session_id_mismatch(state: &ImportState, session_file: &SessionFile) -> bool {
@@ -1419,7 +1445,33 @@ mod tests {
   use super::*;
   use crate::database::{init_db, now_utc_string, open_connection, save_sync_settings};
   use rusqlite::OptionalExtension;
+  use std::ffi::OsString;
+  use std::sync::Mutex;
   use tempfile::tempdir;
+
+  static CODEX_HOME_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+  struct CodexHomeEnvGuard {
+    previous: Option<OsString>,
+  }
+
+  impl CodexHomeEnvGuard {
+    fn set(path: &Path) -> Self {
+      let previous = std::env::var_os("CODEX_HOME");
+      std::env::set_var("CODEX_HOME", path);
+      Self { previous }
+    }
+  }
+
+  impl Drop for CodexHomeEnvGuard {
+    fn drop(&mut self) {
+      if let Some(previous) = self.previous.take() {
+        std::env::set_var("CODEX_HOME", previous);
+      } else {
+        std::env::remove_var("CODEX_HOME");
+      }
+    }
+  }
 
   #[test]
   fn diff_usage_handles_growth_and_component_rollbacks() {
@@ -2899,6 +2951,65 @@ mod tests {
     assert_eq!(started, None);
     assert_eq!(completed, None);
     assert_eq!(full_completed, None);
+  }
+
+  #[test]
+  fn changed_resolved_default_source_forces_full_scan() {
+    assert_eq!(
+      effective_scan_scope(ScanScope::Incremental, false, false, false, true),
+      ScanScope::Full
+    );
+  }
+
+  #[test]
+  fn incremental_scan_finds_untracked_archives_after_default_source_moves() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let first_codex_home = directory.path().join("codex-home-a");
+    let second_codex_home = directory.path().join("codex-home-b");
+    let first_sessions = first_codex_home.join("sessions");
+    let second_archives = second_codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&first_sessions).expect("first sessions");
+    std::fs::create_dir_all(&second_archives).expect("second archives");
+
+    let first_session_id = "18181818-1818-1818-1818-181818181818";
+    write_session_file(
+      &first_sessions.join("first.jsonl"),
+      first_session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let second_session_id = "28282828-2828-2828-2828-282828282828";
+    write_session_file(
+      &second_archives.join("second.jsonl"),
+      second_session_id,
+      &[("2026-07-10T01:00:00Z", 200, 40, 20, 220)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    let _environment = CodexHomeEnvGuard::set(&first_codex_home);
+    perform_scan(&db_path, None).expect("scan first default source");
+
+    std::env::set_var("CODEX_HOME", &second_codex_home);
+    let result = perform_incremental_scan(&db_path, None).expect("scan moved default source");
+
+    let conn = open_connection(&db_path).expect("open database");
+    let (selector, resolved_source): (Option<String>, Option<String>) = conn
+      .query_row(
+        "
+        SELECT codex_home, last_scan_codex_home
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+      )
+      .expect("load scan source identity");
+
+    assert_eq!(selector, None);
+    assert_eq!(resolved_source.as_deref(), Some(second_codex_home.to_string_lossy().as_ref()));
+    assert_eq!(result.scanned_files, 1);
+    assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
+    assert_eq!(session_usage_totals(&conn, first_session_id).3, 110);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1308,7 +1308,16 @@ fn replayed_child_snapshot_cutoff(
     };
     child_pattern.push(key);
   }
-  if child_pattern.len() < 2 {
+  let parent_canonical = canonical_replay_snapshots(parent_snapshots);
+  let eligible_parent_snapshot_count = parent_canonical
+    .iter()
+    .filter(|parent| {
+      DateTime::parse_from_rfc3339(&parent.snapshot.timestamp)
+        .is_ok_and(|timestamp| timestamp <= explicit_fork_timestamp)
+    })
+    .count();
+  let minimum_match_length = if eligible_parent_snapshot_count == 1 { 1 } else { 2 };
+  if child_pattern.len() < minimum_match_length {
     return 0;
   }
 
@@ -1316,7 +1325,7 @@ fn replayed_child_snapshot_cutoff(
   let mut matched = 0;
   let mut longest_match = 0;
 
-  for parent in canonical_replay_snapshots(parent_snapshots) {
+  for parent in parent_canonical {
     let Ok(parent_timestamp) = DateTime::parse_from_rfc3339(&parent.snapshot.timestamp) else {
       continue;
     };
@@ -1341,7 +1350,7 @@ fn replayed_child_snapshot_cutoff(
     }
   }
 
-  if longest_match < 2 {
+  if longest_match < minimum_match_length {
     0
   } else {
     child_canonical[longest_match - 1].raw_index + 1
@@ -2260,17 +2269,23 @@ mod tests {
   }
 
   #[test]
-  fn replay_matching_rejects_one_exact_record() {
+  fn replay_matching_rejects_one_exact_record_from_longer_parent() {
     let record = replay_snapshot(
       "2026-03-24T00:00:00Z",
       "model",
       (100, 10, 20, 1, 121),
       Some((100, 10, 20, 1, 121)),
     );
+    let parent_second = replay_snapshot(
+      "2026-03-24T00:00:30Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
 
     assert_eq!(
       replayed_child_snapshot_cutoff(
-        std::slice::from_ref(&record),
+        &[record.clone(), parent_second],
         std::slice::from_ref(&record),
         Some(fork_instant("2026-03-24T00:01:00Z")),
       ),
@@ -4195,6 +4210,74 @@ mod tests {
     assert_eq!(parent_total, 260);
     assert_eq!(child_total, 50);
     assert_eq!(parent_total + child_total, 310);
+  }
+
+  #[test]
+  fn single_snapshot_parent_replay_counts_only_child_usage() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "61616161-6161-4161-8161-616161616161";
+    let child_session_id = "62626262-6262-4262-8262-626262626262";
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    let inherited = TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    };
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    parent_body.push_str(&token_count_line(inherited));
+    std::fs::write(&parent_path, parent_body).expect("write single-snapshot parent");
+
+    let child_created_at = "2026-03-24T00:30:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:30:01Z",
+      ..inherited
+    }));
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (150, 0, 0, 150),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write fork child");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let parent_total = session_usage_totals(&conn, parent_session_id).3;
+    let child_total = session_usage_totals(&conn, child_session_id).3;
+    assert_eq!(parent_total, 100);
+    assert_eq!(child_total, 50);
+    assert_eq!(parent_total + child_total, 150);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -137,6 +137,14 @@ fn perform_scan_with_scope(
     data_repair_is_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
   let pending_fork_replay_v3_repair_paths =
     load_pending_data_repair_paths(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let pending_token_v2_repair_session_ids =
+    pending_repair_session_ids(&import_state, &pending_token_v2_repair_paths);
+  let pending_fork_replay_v3_repair_session_ids =
+    pending_repair_session_ids(&import_state, &pending_fork_replay_v3_repair_paths);
+  let pending_token_repair_session_ids = pending_token_v2_repair_session_ids
+    .union(&pending_fork_replay_v3_repair_session_ids)
+    .cloned()
+    .collect::<HashSet<_>>();
   let needs_token_usage_repair_sweep =
     needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
   let effective_scope = effective_scan_scope(
@@ -149,7 +157,9 @@ fn perform_scan_with_scope(
 
   let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
     ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
-    ScanScope::Incremental => collect_incremental_session_files(&codex_home, &import_state),
+    ScanScope::Incremental => {
+      collect_incremental_session_files(&codex_home, &import_state, &pending_token_repair_session_ids)
+    }
   };
   let session_source_paths =
     load_session_source_paths(&conn, &import_state, &session_files).map_err(|error| error.to_string())?;
@@ -165,11 +175,23 @@ fn perform_scan_with_scope(
   let mut changed_files = Vec::new();
   for session_file in &session_files {
     let source_path = session_file.path.to_string_lossy().to_string();
+    let session_id = import_state
+      .get(&source_path)
+      .and_then(|state| state.session_id.clone())
+      .or_else(|| fallback_session_id_from_filename(&session_file.path));
+    let session_has_pending_token_v2_repair = session_id
+      .as_ref()
+      .is_some_and(|session_id| pending_token_v2_repair_session_ids.contains(session_id));
+    let session_has_pending_fork_replay_v3_repair = session_id
+      .as_ref()
+      .is_some_and(|session_id| pending_fork_replay_v3_repair_session_ids.contains(session_id));
     if needs_rate_limit_backfill
       || pending_rate_limit_repair_paths.contains(&source_path)
       || needs_token_usage_repair_sweep
       || pending_token_v2_repair_paths.contains(&source_path)
       || pending_fork_replay_v3_repair_paths.contains(&source_path)
+      || session_has_pending_token_v2_repair
+      || session_has_pending_fork_replay_v3_repair
     {
       changed_files.push(session_file);
       continue;
@@ -208,9 +230,9 @@ fn perform_scan_with_scope(
       let source_path = session_file.path.to_string_lossy().to_string();
       let file_needs_rate_limit_repair =
         needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
-      let file_needs_token_v2_repair =
+      let mut file_needs_token_v2_repair =
         needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
-      let file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
+      let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
         || pending_fork_replay_v3_repair_paths.contains(&source_path);
       let mut parsed = match parse_session_file(session_file, &titles) {
         Ok(parsed) => parsed,
@@ -241,6 +263,18 @@ fn perform_scan_with_scope(
         &session_source_paths,
         &mut parent_snapshot_cache,
       );
+      let related_pending_token_v2_paths = pending_repair_paths_for_session(
+        &import_state,
+        &pending_token_v2_repair_paths,
+        &parsed.raw_session.session_id,
+      );
+      let related_pending_fork_replay_v3_paths = pending_repair_paths_for_session(
+        &import_state,
+        &pending_fork_replay_v3_repair_paths,
+        &parsed.raw_session.session_id,
+      );
+      file_needs_token_v2_repair |= !related_pending_token_v2_paths.is_empty();
+      file_needs_fork_replay_v3_repair |= !related_pending_fork_replay_v3_paths.is_empty();
       imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
       match classify_topology_maintenance(
@@ -265,10 +299,18 @@ fn perform_scan_with_scope(
       if file_needs_token_v2_repair {
         clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)
           .map_err(|error| error.to_string())?;
+        for related_source_path in related_pending_token_v2_paths {
+          clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &related_source_path)
+            .map_err(|error| error.to_string())?;
+        }
       }
       if file_needs_fork_replay_v3_repair {
         clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
           .map_err(|error| error.to_string())?;
+        for related_source_path in related_pending_fork_replay_v3_paths {
+          clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &related_source_path)
+            .map_err(|error| error.to_string())?;
+        }
       }
       changed_sessions += 1;
     }
@@ -593,6 +635,7 @@ fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
 fn collect_incremental_session_files(
   codex_home: &Path,
   import_state: &HashMap<String, ImportState>,
+  pending_repair_session_ids: &HashSet<String>,
 ) -> (Vec<SessionFile>, HashSet<String>) {
   let mut files = collect_active_session_files(codex_home);
   let mut collected_paths = files
@@ -609,7 +652,14 @@ fn collect_incremental_session_files(
       ) else {
         continue;
       };
-      if state.file_size == session_file.file_size && state.file_mtime_ms == session_file.file_mtime_ms {
+      let session_has_pending_repair = state
+        .session_id
+        .as_ref()
+        .is_some_and(|session_id| pending_repair_session_ids.contains(session_id));
+      if state.file_size == session_file.file_size
+        && state.file_mtime_ms == session_file.file_mtime_ms
+        && !session_has_pending_repair
+      {
         continue;
       }
       if collected_paths.insert(session_file.path.to_string_lossy().to_string()) {
@@ -1625,6 +1675,40 @@ fn load_pending_data_repair_paths(conn: &Connection, repair_key: &str) -> rusqli
     paths.insert(row?);
   }
   Ok(paths)
+}
+
+fn pending_repair_paths_for_session(
+  import_state: &HashMap<String, ImportState>,
+  pending_paths: &HashSet<String>,
+  session_id: &str,
+) -> Vec<String> {
+  pending_paths
+    .iter()
+    .filter(|source_path| {
+      let import_state_session_id = import_state
+        .get(*source_path)
+        .and_then(|state| state.session_id.as_deref());
+      import_state_session_id == Some(session_id)
+        || (import_state_session_id.is_none()
+          && fallback_session_id_from_filename(Path::new(source_path)).as_deref() == Some(session_id))
+    })
+    .cloned()
+    .collect()
+}
+
+fn pending_repair_session_ids(
+  import_state: &HashMap<String, ImportState>,
+  pending_paths: &HashSet<String>,
+) -> HashSet<String> {
+  pending_paths
+    .iter()
+    .filter_map(|source_path| {
+      import_state
+        .get(source_path)
+        .and_then(|state| state.session_id.clone())
+        .or_else(|| fallback_session_id_from_filename(Path::new(source_path)))
+    })
+    .collect()
 }
 
 fn mark_data_repair_file_pending(
@@ -3580,6 +3664,85 @@ mod tests {
         WHERE repair_key = 'token_usage_fork_replay_v3'
         ",
         [],
+        |row| row.get(0),
+      )
+      .expect("count pending v3 repair files");
+    assert_eq!(pending_v3_count, 0);
+  }
+
+  #[test]
+  fn moved_archive_clears_v3_pending_active_source() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions/2026/07/10");
+    let archived_sessions_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_sessions_dir).expect("archived sessions dir");
+
+    let session_id = "59595959-5959-4959-8959-595959595959";
+    let filename = format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl");
+    let active_path = sessions_dir.join(&filename);
+    let archived_path = archived_sessions_dir.join(&filename);
+    write_session_file(
+      &active_path,
+      session_id,
+      &[("2026-07-10T00:00:01Z", 80, 0, 20, 100)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+    std::fs::rename(&active_path, &archived_path).expect("archive session during repair");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("record archived source before stale pending retry");
+
+    let conn = open_connection(&db_path).expect("open db");
+    conn
+      .execute(
+        "DELETE FROM usage_events WHERE session_id = ?1",
+        params![session_id],
+      )
+      .expect("delete corrected usage");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
+          reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective
+        )
+        VALUES (?1, '2026-07-10T00:00:01Z', 'gpt-5.4', 160, 0, 40, 0, 200, 0.0, 0, 0)
+        ",
+        params![session_id],
+      )
+      .expect("insert stale usage");
+    conn
+      .execute(
+        "
+        INSERT INTO data_repair_pending_files (repair_key, source_path, last_error, updated_at)
+        VALUES (?1, ?2, 'source moved during repair', ?3)
+        ",
+        params![
+          TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+          active_path.to_string_lossy().to_string(),
+          now_utc_string(),
+        ],
+      )
+      .expect("insert pending active source");
+    drop(conn);
+
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("repair moved archive");
+
+    let conn = open_connection(&db_path).expect("open repaired db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, session_id).3, 100);
+    let pending_v3_count: i64 = conn
+      .query_row(
+        "
+        SELECT COUNT(*)
+        FROM data_repair_pending_files
+        WHERE repair_key = ?1
+        ",
+        params![TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY],
         |row| row.get(0),
       )
       .expect("count pending v3 repair files");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -472,6 +472,21 @@ fn collect_incremental_session_files(
   let mut active_paths_kept_for_archive_retry = HashSet::new();
 
   for state in import_state.values() {
+    if state.source_bucket == "archived" {
+      let Some(session_file) = session_file_from_path(
+        PathBuf::from(&state.source_path),
+        "archived",
+      ) else {
+        continue;
+      };
+      if state.file_size == session_file.file_size && state.file_mtime_ms == session_file.file_mtime_ms {
+        continue;
+      }
+      if collected_paths.insert(session_file.path.to_string_lossy().to_string()) {
+        files.push(session_file);
+      }
+      continue;
+    }
     if state.source_bucket != "active" || collected_paths.contains(&state.source_path) {
       continue;
     }
@@ -1936,7 +1951,7 @@ mod tests {
   }
 
   #[test]
-  fn incremental_scan_skips_archived_session_changes() {
+  fn incremental_scan_does_not_walk_archived_directory_for_untracked_files() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions_dir = codex_home.join("sessions");
@@ -1951,15 +1966,9 @@ mod tests {
       active_session_id,
       &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
-    let archived_path = archived_dir.join("archived.jsonl");
-    write_session_file(
-      &archived_path,
-      archived_session_id,
-      &[("2026-03-24T00:00:01Z", 150, 30, 40, 190)],
-    );
-
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+    let archived_path = archived_dir.join("archived.jsonl");
     write_session_file(
       &archived_path,
       archived_session_id,
@@ -1975,7 +1984,7 @@ mod tests {
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 0);
     assert_eq!(session_usage_totals(&conn, active_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, archived_session_id), (150, 30, 40, 190, 1));
+    assert_eq!(session_usage_totals(&conn, archived_session_id), (0, 0, 0, 0, 0));
   }
 
   #[test]
@@ -2743,6 +2752,78 @@ mod tests {
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(session_usage_totals(&conn, session_id).3, 200);
+    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+  }
+
+  #[test]
+  fn incremental_scan_reimports_archived_file_after_incomplete_tail_is_finished() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    let archived = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&archived).expect("archive");
+    let session_id = "a0a0a0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0";
+    let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let archived_path = archived.join(active_path.file_name().expect("filename"));
+    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&active_path)
+      .expect("open active session");
+    file
+      .write_all(
+        concat!(
+          "{\"timestamp\":\"2026-07-10T00:01:00Z\",\"type\":\"event_msg\",\"payload\":{",
+          "\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
+          "\"input_tokens\":180,\"cached_input_tokens\":40,\"output_tokens\":20,"
+        )
+        .as_bytes(),
+      )
+      .expect("write incomplete tail");
+    drop(file);
+    std::fs::rename(&active_path, &archived_path).expect("archive session");
+
+    let first_result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("import complete prefix from archive");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(first_result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 10, 110, 1));
+    let archived_state: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM import_state WHERE source_path = ?1 AND source_bucket = 'archived'",
+        params![archived_path.to_string_lossy().to_string()],
+        |row| row.get(0),
+      )
+      .expect("query archived state");
+    assert_eq!(archived_state, 1);
+    drop(conn);
+
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&archived_path)
+      .expect("open archived session");
+    file
+      .write_all(
+        concat!(
+          "\"reasoning_output_tokens\":0,\"total_tokens\":200}}",
+          ",\"rate_limits\":{\"plan_type\":\"pro\"}}}\n"
+        )
+        .as_bytes(),
+      )
+      .expect("finish archived tail");
+    drop(file);
+
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("reimport finished archive");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 20, 200, 2));
     assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -177,6 +177,7 @@ fn perform_scan_with_scope(
 
   let mut topology_dirty = false;
   let mut new_root_session_ids = Vec::new();
+  let mut skipped_session_files = false;
   if !changed_files.is_empty() {
     let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
     let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
@@ -188,6 +189,7 @@ fn perform_scan_with_scope(
       let parsed = match parse_session_file(session_file, &titles) {
         Ok(parsed) => parsed,
         Err(error) => {
+          skipped_session_files = true;
           log::warn!(
             "Skipping unreadable session file {}: {}",
             session_file.path.display(),
@@ -265,7 +267,7 @@ fn perform_scan_with_scope(
       &completed_at,
       scan_source_selector.as_deref(),
       &resolved_codex_home,
-      effective_scope == ScanScope::Full,
+      effective_scope == ScanScope::Full && !skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
@@ -1443,7 +1445,9 @@ struct ImportState {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::database::{init_db, now_utc_string, open_connection, save_sync_settings};
+  use crate::database::{
+    get_last_full_scan_completed, init_db, now_utc_string, open_connection, save_sync_settings,
+  };
   use rusqlite::OptionalExtension;
   use std::ffi::OsString;
   use std::sync::Mutex;
@@ -3010,6 +3014,57 @@ mod tests {
     assert_eq!(result.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
     assert_eq!(session_usage_totals(&conn, first_session_id).3, 110);
+  }
+
+  #[test]
+  fn skipped_archive_keeps_moved_default_source_due_for_full_retry() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let first_codex_home = directory.path().join("codex-home-a");
+    let second_codex_home = directory.path().join("codex-home-b");
+    let first_sessions = first_codex_home.join("sessions");
+    let second_sessions = second_codex_home.join("sessions");
+    let second_archives = second_codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&first_sessions).expect("first sessions");
+    std::fs::create_dir_all(&second_sessions).expect("second sessions");
+    std::fs::create_dir_all(&second_archives).expect("second archives");
+
+    write_session_file(
+      &first_sessions.join("first.jsonl"),
+      "38383838-3838-3838-3838-383838383838",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    write_session_file(
+      &second_sessions.join("tracked.jsonl"),
+      "48484848-4848-4848-4848-484848484848",
+      &[("2026-07-10T01:00:00Z", 150, 30, 15, 165)],
+    );
+    let repaired_session_id = "58585858-5858-5858-5858-585858585858";
+    let repaired_archive = second_archives.join("repaired.jsonl");
+    std::fs::write(&repaired_archive, [0xff, 0xfe, 0xfd]).expect("write unreadable archive");
+
+    let db_path = directory.path().join("usage.sqlite");
+    let _environment = CodexHomeEnvGuard::set(&first_codex_home);
+    perform_scan(&db_path, None).expect("scan first default source");
+
+    std::env::set_var("CODEX_HOME", &second_codex_home);
+    let partial = perform_incremental_scan(&db_path, None).expect("scan moved source with skipped archive");
+    assert_eq!(partial.scanned_files, 2);
+
+    let conn = open_connection(&db_path).expect("open partial database");
+    assert_eq!(get_last_full_scan_completed(&conn).expect("load full freshness"), None);
+    drop(conn);
+
+    write_session_file(
+      &repaired_archive,
+      repaired_session_id,
+      &[("2026-07-10T01:30:00Z", 200, 40, 20, 220)],
+    );
+    let retry = perform_incremental_scan(&db_path, None).expect("retry repaired archive");
+
+    let conn = open_connection(&db_path).expect("open repaired database");
+    assert_eq!(retry.scanned_files, 2);
+    assert_eq!(session_usage_totals(&conn, repaired_session_id).3, 220);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ struct AppState {
   app_handle: Option<AppHandle>,
   db_path: PathBuf,
   scan_in_progress: Arc<AtomicBool>,
+  usage_mutation_lock: Arc<Mutex<()>>,
   live_refresh_in_progress: Arc<AtomicBool>,
   menu_bar_refresh_in_progress: Arc<AtomicBool>,
   daily_value_tray: Option<TrayIcon>,
@@ -121,6 +122,13 @@ fn try_acquire_flag(flag: &Arc<AtomicBool>, busy_message: &str) -> Result<Atomic
   Ok(AtomicFlagGuard {
     flag: Arc::clone(flag),
   })
+}
+
+fn lock_usage_mutations(state: &AppState) -> std::sync::MutexGuard<'_, ()> {
+  state
+    .usage_mutation_lock
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[cfg(target_os = "macos")]
@@ -185,10 +193,18 @@ fn refreshPricing(state: State<'_, AppState>) -> Result<Vec<PricingCatalogEntry>
       None
     }
   };
-  let mut conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  let catalog = refresh_pricing_catalog_atomically(&mut conn, official_entries.as_deref())?;
+  let catalog = refresh_pricing_catalog_for_state(state.inner(), official_entries.as_deref())?;
   refresh_daily_value_menu_bar(state.inner());
   Ok(catalog)
+}
+
+fn refresh_pricing_catalog_for_state(
+  state: &AppState,
+  official_entries: Option<&[PricingCatalogEntry]>,
+) -> Result<Vec<PricingCatalogEntry>, String> {
+  let _mutation_guard = lock_usage_mutations(state);
+  let mut conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  refresh_pricing_catalog_atomically(&mut conn, official_entries)
 }
 
 fn refresh_pricing_catalog_atomically(
@@ -471,8 +487,10 @@ where
   F: FnOnce(&Path, Option<String>) -> Result<ScanResult, String>,
 {
   let guard = try_acquire_flag(&state.scan_in_progress, "A scan is already running.")?;
+  let mutation_guard = lock_usage_mutations(&state);
 
   let result = scan(&state.db_path, codex_home);
+  drop(mutation_guard);
   drop(guard);
   refresh_daily_value_menu_bar_with_live_refresh(&state, allow_menu_bar_live_refresh);
   result
@@ -2118,6 +2136,7 @@ pub fn run() {
         app_handle: Some(app_handle.clone()),
         db_path,
         scan_in_progress: Arc::new(AtomicBool::new(false)),
+        usage_mutation_lock: Arc::new(Mutex::new(())),
         live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         daily_value_tray,
@@ -2449,6 +2468,7 @@ mod tests {
       app_handle: None,
       db_path: db_path.clone(),
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
@@ -2979,6 +2999,119 @@ mod tests {
   }
 
   #[test]
+  fn pricing_refresh_waits_for_active_scan_before_recalculating() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let created_at = database::now_utc_string();
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, parent_session_id, title, source_state, source_path,
+          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+        )
+        VALUES ('refresh-race', 'refresh-race', NULL, NULL, 'active', NULL, 'active',
+          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?1, ?1)
+        ",
+        params![created_at],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('refresh-race', '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
+          0, 0, 1000000, 0, 1000000, 30.0, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage event");
+    let mut official_sol = load_catalog(&conn)
+      .expect("load catalog")
+      .into_iter()
+      .find(|entry| entry.model_id == "gpt-5.6-sol")
+      .expect("load GPT-5.6 Sol");
+    official_sol.output_price_per_million = 42.0;
+    official_sol.is_official = true;
+    official_sol.note = Some("serialized refresh test".to_string());
+    official_sol.updated_at = "serialized-refresh-test".to_string();
+    drop(conn);
+
+    let state = AppState {
+      app_handle: None,
+      db_path: db_path.clone(),
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+    let (scan_loaded_sender, scan_loaded_receiver) = std::sync::mpsc::channel();
+    let (release_scan_sender, release_scan_receiver) = std::sync::mpsc::channel();
+    let scan_state = state.clone();
+    let scan_thread = std::thread::spawn(move || {
+      run_scan_if_idle_with_live_refresh(scan_state, None, false, |db_path, _| {
+        let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+        let stale_output_price: f64 = conn
+          .query_row(
+            "SELECT output_price_per_million FROM pricing_catalog WHERE model_id = 'gpt-5.6-sol'",
+            [],
+            |row| row.get(0),
+          )
+          .map_err(|error| error.to_string())?;
+        scan_loaded_sender.send(()).map_err(|error| error.to_string())?;
+        release_scan_receiver.recv().map_err(|error| error.to_string())?;
+        conn
+          .execute(
+            "UPDATE usage_events SET value_usd = ?1 WHERE session_id = 'refresh-race'",
+            params![stale_output_price],
+          )
+          .map_err(|error| error.to_string())?;
+        Ok(ScanResult {
+          codex_home: "test".to_string(),
+          scanned_files: 1,
+          imported_sessions: 1,
+          updated_sessions: 1,
+          missing_sessions: 0,
+          last_completed_at: database::now_utc_string(),
+        })
+      })
+    });
+    scan_loaded_receiver.recv().expect("scan loaded stale pricing");
+    let release_thread = std::thread::spawn(move || {
+      std::thread::sleep(Duration::from_millis(100));
+      release_scan_sender.send(()).expect("release scan");
+    });
+
+    refresh_pricing_catalog_for_state(&state, Some(&[official_sol]))
+      .expect("refresh pricing after scan");
+    release_thread.join().expect("join release thread");
+    scan_thread
+      .join()
+      .expect("join scan thread")
+      .expect("complete scan");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let value_usd: f64 = conn
+      .query_row(
+        "SELECT value_usd FROM usage_events WHERE session_id = 'refresh-race'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load final value");
+    assert_eq!(value_usd, 42.0);
+  }
+
+  #[test]
   fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
@@ -3015,6 +3148,7 @@ mod tests {
       app_handle: None,
       db_path,
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
@@ -3077,6 +3211,7 @@ mod tests {
       app_handle: None,
       db_path,
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
@@ -3140,6 +3275,7 @@ mod tests {
       app_handle: None,
       db_path,
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
@@ -3209,6 +3345,7 @@ mod tests {
       app_handle: None,
       db_path,
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -489,14 +489,20 @@ fn run_due_background_refresh(
 }
 
 fn prepare_app_database(db_path: &Path) -> Result<(), String> {
-  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
-  let pricing_signature_before = load_pricing_value_signature(&conn).map_err(|error| error.to_string())?;
-  seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
-  let pricing_signature_after = load_pricing_value_signature(&conn).map_err(|error| error.to_string())?;
+  let transaction = conn
+    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+    .map_err(|error| error.to_string())?;
+  let pricing_signature_before =
+    load_pricing_value_signature(&transaction).map_err(|error| error.to_string())?;
+  seed_pricing_catalog(&transaction).map_err(|error| error.to_string())?;
+  let pricing_signature_after =
+    load_pricing_value_signature(&transaction).map_err(|error| error.to_string())?;
   if pricing_signature_before != pricing_signature_after {
-    recalculate_all_session_values(&conn).map_err(|error| error.to_string())?;
+    recalculate_all_session_values(&transaction).map_err(|error| error.to_string())?;
   }
+  transaction.commit().map_err(|error| error.to_string())?;
   Ok(())
 }
 
@@ -2612,6 +2618,128 @@ mod tests {
       .expect("load usage value");
 
     assert_eq!(value_usd, 30.0);
+  }
+
+  #[test]
+  fn startup_database_prepare_rolls_back_pricing_when_recalculation_fails() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    conn
+      .execute(
+        "
+        UPDATE pricing_catalog
+        SET output_price_per_million = 6.25,
+            is_official = 1,
+            note = 'malformed-official',
+            updated_at = 'malformed-official'
+        WHERE model_id = 'gpt-5.6-sol'
+        ",
+        [],
+      )
+      .expect("seed malformed GPT-5.6 Sol pricing");
+    let created_at = database::now_utc_string();
+    for (session_id, sentinel_value) in [("recalc-a", 11.0), ("recalc-b", 22.0)] {
+      conn
+        .execute(
+          "
+          INSERT INTO sessions (
+            session_id, root_session_id, parent_session_id, title, source_state, source_path,
+            source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+            fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+          )
+          VALUES (?1, ?1, NULL, NULL, 'active', NULL, 'active',
+            NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?2, ?2)
+          ",
+          params![session_id, created_at],
+        )
+        .expect("insert session");
+      conn
+        .execute(
+          "
+          INSERT INTO usage_events (
+            session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+            output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+            fast_mode_auto, fast_mode_effective
+          )
+          VALUES (?1, '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
+            0, 0, 1000000, 0, 1000000, ?2, 0, 0)
+          ",
+          params![session_id, sentinel_value],
+        )
+        .expect("insert usage event");
+    }
+    conn
+      .execute_batch(
+        "
+        CREATE TRIGGER fail_second_session_recalculation
+        BEFORE UPDATE OF value_usd ON usage_events
+        WHEN OLD.session_id = 'recalc-b'
+        BEGIN
+          SELECT RAISE(ABORT, 'injected recalculation failure');
+        END;
+        ",
+      )
+      .expect("create failure trigger");
+    drop(conn);
+
+    let error = prepare_app_database(&db_path).expect_err("recalculation should fail");
+    assert!(error.contains("injected recalculation failure"));
+
+    let conn = open_connection(&db_path).expect("reopen failed database");
+    let (output_price, is_official): (f64, i64) = conn
+      .query_row(
+        "
+        SELECT output_price_per_million, is_official
+        FROM pricing_catalog
+        WHERE model_id = 'gpt-5.6-sol'
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+      )
+      .expect("load rolled back pricing");
+    let failed_values = conn
+      .prepare("SELECT session_id, value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare failed values")
+      .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?)))
+      .expect("query failed values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect failed values");
+
+    assert_eq!(output_price, 6.25);
+    assert_eq!(is_official, 1);
+    assert_eq!(
+      failed_values,
+      vec![("recalc-a".to_string(), 11.0), ("recalc-b".to_string(), 22.0)]
+    );
+
+    conn
+      .execute_batch("DROP TRIGGER fail_second_session_recalculation;")
+      .expect("drop failure trigger");
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("retry prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen repaired database");
+    let repaired_output: f64 = conn
+      .query_row(
+        "SELECT output_price_per_million FROM pricing_catalog WHERE model_id = 'gpt-5.6-sol'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load repaired pricing");
+    let repaired_values = conn
+      .prepare("SELECT value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare repaired values")
+      .query_map([], |row| row.get::<_, f64>(0))
+      .expect("query repaired values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect repaired values");
+
+    assert_eq!(repaired_output, 30.0);
+    assert_eq!(repaired_values, vec![30.0, 30.0]);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1086,7 +1086,7 @@ fn load_latest_persisted_rate_limit_window(
       SELECT sample_timestamp, limit_id, limit_name, plan_type, window_start, resets_at, used_percent, remaining_percent
       FROM rate_limit_samples
       WHERE bucket = ?1 AND (?2 IS NULL OR source_kind = ?2)
-      ORDER BY sample_timestamp DESC
+      ORDER BY julianday(sample_timestamp) DESC, id DESC
       LIMIT 1
       ",
     )
@@ -1153,21 +1153,34 @@ fn load_persisted_live_rate_limits_for_source(
   source_kind: Option<&str>,
 ) -> Option<LiveRateLimitSnapshot> {
   let conn = open_connection(&state.db_path).ok()?;
-  let primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
+  let mut primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
     .ok()
     .flatten();
-  let secondary = load_latest_persisted_rate_limit_window(&conn, "seven_day", source_kind)
+  let mut secondary = load_latest_persisted_rate_limit_window(&conn, "seven_day", source_kind)
     .ok()
     .flatten();
-  if primary.is_none() && secondary.is_none() {
-    return None;
+  let primary_instant = primary
+    .as_ref()
+    .and_then(|window| DateTime::parse_from_rfc3339(&window.fetched_at).ok());
+  let secondary_instant = secondary
+    .as_ref()
+    .and_then(|window| DateTime::parse_from_rfc3339(&window.fetched_at).ok());
+  let newest_instant = [primary_instant.as_ref(), secondary_instant.as_ref()]
+    .into_iter()
+    .flatten()
+    .max()?;
+
+  if primary_instant.as_ref() != Some(newest_instant) {
+    primary = None;
+  }
+  if secondary_instant.as_ref() != Some(newest_instant) {
+    secondary = None;
   }
 
   let fetched_at = primary
     .as_ref()
     .map(|window| window.fetched_at.clone())
-    .or_else(|| secondary.as_ref().map(|window| window.fetched_at.clone()))
-    .unwrap_or_else(|| Local::now().to_rfc3339());
+    .or_else(|| secondary.as_ref().map(|window| window.fetched_at.clone()))?;
 
   Some(LiveRateLimitSnapshot {
     limit_id: primary
@@ -2652,6 +2665,139 @@ mod tests {
       snapshot.primary.as_ref().map(|window| window.remaining_percent),
       Some(88)
     );
+  }
+
+  #[test]
+  fn persisted_live_rate_limits_order_mixed_rfc3339_offsets_by_instant() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 10,
+          remaining_percent: 90,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-10T14:00:00+08:00".to_string()),
+          window_start: Some("2026-07-10T09:00:00+08:00".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-07-10T09:00:00+08:00".to_string(),
+      },
+    )
+    .expect("insert earlier offset sample");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 20,
+          remaining_percent: 80,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-10T07:00:00Z".to_string()),
+          window_start: Some("2026-07-10T02:00:00Z".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-07-10T02:00:00Z".to_string(),
+      },
+    )
+    .expect("insert later UTC sample");
+    drop(conn);
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+
+    let snapshot = load_persisted_live_rate_limits(&state).expect("load persisted sample");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-10T02:00:00Z");
+    assert_eq!(
+      snapshot.primary.as_ref().map(|window| window.remaining_percent),
+      Some(80)
+    );
+  }
+
+  #[test]
+  fn persisted_live_rate_limits_do_not_combine_windows_from_different_samples() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 30,
+          remaining_percent: 70,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-10T06:00:00Z".to_string()),
+          window_start: Some("2026-07-10T01:00:00Z".to_string()),
+        }),
+        secondary: Some(RateLimitWindowSnapshot {
+          used_percent: 40,
+          remaining_percent: 60,
+          window_duration_mins: Some(10_080),
+          resets_at: Some("2026-07-17T01:00:00Z".to_string()),
+          window_start: Some("2026-07-10T01:00:00Z".to_string()),
+        }),
+        fetched_at: "2026-07-10T01:00:00Z".to_string(),
+      },
+    )
+    .expect("insert older complete sample");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 25,
+          remaining_percent: 75,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-10T07:00:00Z".to_string()),
+          window_start: Some("2026-07-10T02:00:00Z".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-07-10T02:00:00Z".to_string(),
+      },
+    )
+    .expect("insert newer primary-only sample");
+    drop(conn);
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+
+    let snapshot = load_persisted_live_rate_limits(&state).expect("load persisted sample");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-10T02:00:00Z");
+    assert_eq!(
+      snapshot.primary.as_ref().map(|window| window.remaining_percent),
+      Some(75)
+    );
+    assert!(snapshot.secondary.is_none());
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -346,15 +346,11 @@ fn getSyncSettings(state: State<'_, AppState>) -> Result<SyncSettings, String> {
   get_sync_settings(&conn).map_err(|error| error.to_string())
 }
 
-#[allow(non_snake_case)]
-#[tauri::command(rename_all = "camelCase")]
-fn updateSyncSettings(
-  app: AppHandle,
-  state: State<'_, AppState>,
+fn save_normalized_sync_settings(
+  conn: &rusqlite::Connection,
   payload: SyncSettings,
-) -> Result<SyncSettings, String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  let current = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+) -> rusqlite::Result<SyncSettings> {
+  let current = get_sync_settings(conn)?;
   let auto_scan_interval_minutes = payload.auto_scan_interval_minutes.max(1);
   let updated = SyncSettings {
     codex_home: payload.codex_home,
@@ -382,7 +378,18 @@ fn updateSyncSettings(
     last_scan_completed_at: current.last_scan_completed_at,
     updated_at: current.updated_at,
   };
-  let saved = save_sync_settings(&conn, &updated).map_err(|error| error.to_string())?;
+  save_sync_settings(conn, &updated)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn updateSyncSettings(
+  app: AppHandle,
+  state: State<'_, AppState>,
+  payload: SyncSettings,
+) -> Result<SyncSettings, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  let saved = save_normalized_sync_settings(&conn, payload).map_err(|error| error.to_string())?;
   refresh_daily_value_menu_bar(state.inner());
   apply_dock_icon_visibility(&app, &saved, state.daily_value_tray.is_some());
   Ok(saved)
@@ -2128,6 +2135,61 @@ mod tests {
     DateTime::parse_from_rfc3339(value)
       .expect("parse test timestamp")
       .with_timezone(&chrono::Utc)
+  }
+
+  fn seed_scan_freshness(conn: &rusqlite::Connection, codex_home: &str) -> SyncSettings {
+    let initial = SyncSettings {
+      codex_home: Some(codex_home.to_string()),
+      ..get_sync_settings(conn).expect("load settings")
+    };
+    save_sync_settings(conn, &initial).expect("save initial source");
+
+    let settings = SyncSettings {
+      last_scan_started_at: Some("2026-07-10T08:00:00Z".to_string()),
+      last_scan_completed_at: Some("2026-07-10T08:01:00Z".to_string()),
+      ..get_sync_settings(conn).expect("reload initial source")
+    };
+    let saved = save_sync_settings(conn, &settings).expect("save scan freshness");
+    database::set_last_full_scan_completed(conn, "2026-07-10T08:01:00Z")
+      .expect("set full scan");
+    saved
+  }
+
+  #[test]
+  fn changing_codex_home_clears_scan_freshness() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let settings = seed_scan_freshness(&conn, "/tmp/codex-home-before");
+
+    let changed = SyncSettings {
+      codex_home: Some("/tmp/codex-home-after".to_string()),
+      ..settings
+    };
+    let saved = save_normalized_sync_settings(&conn, changed).expect("save changed settings");
+
+    assert_eq!(saved.last_scan_started_at, None);
+    assert_eq!(saved.last_scan_completed_at, None);
+    assert_eq!(get_last_full_scan_completed(&conn).expect("load full scan"), None);
+  }
+
+  #[test]
+  fn unchanged_codex_home_preserves_scan_freshness() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let settings = seed_scan_freshness(&conn, "/tmp/codex-home");
+
+    let saved = save_normalized_sync_settings(&conn, settings).expect("save unchanged source");
+
+    assert_eq!(saved.last_scan_started_at.as_deref(), Some("2026-07-10T08:00:00Z"));
+    assert_eq!(saved.last_scan_completed_at.as_deref(), Some("2026-07-10T08:01:00Z"));
+    assert_eq!(
+      get_last_full_scan_completed(&conn).expect("load full scan").as_deref(),
+      Some("2026-07-10T08:01:00Z")
+    );
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2477,6 +2477,69 @@ mod tests {
   }
 
   #[test]
+  fn startup_database_prepare_recalculates_new_gpt_56_values() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    conn
+      .execute(
+        "
+        UPDATE pricing_catalog
+        SET output_price_per_million = 6.25,
+            is_official = 1
+        WHERE model_id = 'gpt-5.6-sol'
+        ",
+        [],
+      )
+      .expect("seed malformed GPT-5.6 Sol pricing");
+    let created_at = database::now_utc_string();
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, parent_session_id, title, source_state, source_path,
+          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+        )
+        VALUES ('gpt-56-startup-session', 'gpt-56-startup-session', NULL, NULL, 'active', NULL, 'active',
+          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?1, ?1)
+        ",
+        params![created_at],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('gpt-56-startup-session', '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
+          0, 0, 1000000, 0, 1000000, 0.0, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage event");
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let value_usd: f64 = conn
+      .query_row(
+        "SELECT value_usd FROM usage_events WHERE session_id = 'gpt-56-startup-session'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load usage value");
+
+    assert_eq!(value_usd, 30.0);
+  }
+
+  #[test]
   fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,7 +33,10 @@ use models::{
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
   ScanResult, SubscriptionProfile, SyncSettings,
 };
-use pricing::{load_catalog, refresh_pricing_catalog_from_openai, seed_pricing_catalog};
+use pricing::{
+  apply_pricing_catalog_refresh, fetch_official_pricing_catalog, load_catalog,
+  seed_pricing_catalog, OPENAI_API_PRICING_URL,
+};
 use queries::{
   get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
 };
@@ -63,6 +66,7 @@ const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 const SCHEDULER_MAX_SLEEP_SECONDS: u64 = 5;
 const FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS: u64 = 5;
+const PRICING_VALUE_RESOLUTION_REPAIR_KEY: &str = "pricing_value_resolution_v2";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackgroundRefreshDecision {
@@ -172,11 +176,34 @@ fn refreshBackgroundData(state: State<'_, AppState>) -> Result<Option<ScanResult
 #[allow(non_snake_case)]
 #[tauri::command]
 fn refreshPricing(state: State<'_, AppState>) -> Result<Vec<PricingCatalogEntry>, String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  refresh_pricing_catalog_from_openai(&conn)?;
-  recalculate_all_session_values(&conn).map_err(|error| error.to_string())?;
-  let catalog = load_catalog(&conn).map_err(|error| error.to_string())?;
+  let official_entries = match fetch_official_pricing_catalog() {
+    Ok(entries) => Some(entries),
+    Err(error) => {
+      log::warn!(
+        "Failed to refresh OpenAI API pricing from {OPENAI_API_PRICING_URL}: {error}; using bundled fallback pricing."
+      );
+      None
+    }
+  };
+  let mut conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  let catalog = refresh_pricing_catalog_atomically(&mut conn, official_entries.as_deref())?;
   refresh_daily_value_menu_bar(state.inner());
+  Ok(catalog)
+}
+
+fn refresh_pricing_catalog_atomically(
+  conn: &mut rusqlite::Connection,
+  official_entries: Option<&[PricingCatalogEntry]>,
+) -> Result<Vec<PricingCatalogEntry>, String> {
+  let transaction = conn
+    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+    .map_err(|error| error.to_string())?;
+  apply_pricing_catalog_refresh(&transaction, official_entries)?;
+  recalculate_all_session_values(&transaction).map_err(|error| error.to_string())?;
+  mark_pricing_value_resolution_repair_complete(&transaction)
+    .map_err(|error| error.to_string())?;
+  let catalog = load_catalog(&transaction).map_err(|error| error.to_string())?;
+  transaction.commit().map_err(|error| error.to_string())?;
   Ok(catalog)
 }
 
@@ -494,15 +521,40 @@ fn prepare_app_database(db_path: &Path) -> Result<(), String> {
   let transaction = conn
     .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
     .map_err(|error| error.to_string())?;
+  let resolver_repair_pending =
+    pricing_value_resolution_repair_pending(&transaction).map_err(|error| error.to_string())?;
   let pricing_signature_before =
     load_pricing_value_signature(&transaction).map_err(|error| error.to_string())?;
   seed_pricing_catalog(&transaction).map_err(|error| error.to_string())?;
   let pricing_signature_after =
     load_pricing_value_signature(&transaction).map_err(|error| error.to_string())?;
-  if pricing_signature_before != pricing_signature_after {
+  if resolver_repair_pending || pricing_signature_before != pricing_signature_after {
     recalculate_all_session_values(&transaction).map_err(|error| error.to_string())?;
+    mark_pricing_value_resolution_repair_complete(&transaction)
+      .map_err(|error| error.to_string())?;
   }
   transaction.commit().map_err(|error| error.to_string())?;
+  Ok(())
+}
+
+fn pricing_value_resolution_repair_pending(conn: &rusqlite::Connection) -> rusqlite::Result<bool> {
+  let completed: i64 = conn.query_row(
+    "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+    params![PRICING_VALUE_RESOLUTION_REPAIR_KEY],
+    |row| row.get(0),
+  )?;
+  Ok(completed == 0)
+}
+
+fn mark_pricing_value_resolution_repair_complete(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
+  conn.execute(
+    "
+    INSERT INTO data_repairs (repair_key, completed_at)
+    VALUES (?1, ?2)
+    ON CONFLICT(repair_key) DO UPDATE SET completed_at = excluded.completed_at
+    ",
+    params![PRICING_VALUE_RESOLUTION_REPAIR_KEY, database::now_utc_string()],
+  )?;
   Ok(())
 }
 
@@ -2450,6 +2502,7 @@ mod tests {
     let conn = open_connection(&db_path).expect("open database");
     init_db(&conn).expect("init db");
     seed_pricing_catalog(&conn).expect("seed pricing");
+    mark_pricing_value_resolution_repair_complete(&conn).expect("mark resolver repair complete");
     let created_at = database::now_utc_string();
     conn
       .execute(
@@ -2493,6 +2546,77 @@ mod tests {
       .expect("load usage value");
 
     assert_eq!(value_usd, 123.45);
+  }
+
+  #[test]
+  fn startup_database_prepare_recalculates_gpt_56_aliases_when_resolver_repair_is_pending() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    let created_at = database::now_utc_string();
+    for (session_id, model_id, stale_value) in [
+      ("gpt-56-alias-exact", "gpt-5.6", 6.25),
+      ("gpt-56-alias-dated", "gpt-5.6-2026-07-09", 0.0),
+    ] {
+      conn
+        .execute(
+          "
+          INSERT INTO sessions (
+            session_id, root_session_id, parent_session_id, title, source_state, source_path,
+            source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+            fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+          )
+          VALUES (?1, ?1, NULL, NULL, 'active', NULL, 'active',
+            NULL, NULL, NULL, NULL, NULL, 0, NULL, ?2, 0, ?3, ?3)
+          ",
+          params![session_id, model_id, created_at],
+        )
+        .expect("insert session");
+      conn
+        .execute(
+          "
+          INSERT INTO usage_events (
+            session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+            output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+            fast_mode_auto, fast_mode_effective
+          )
+          VALUES (?1, '2026-07-09T00:00:00Z', ?2,
+            0, 0, 1000000, 0, 1000000, ?3, 0, 0)
+          ",
+          params![session_id, model_id, stale_value],
+        )
+        .expect("insert usage event");
+    }
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let values = conn
+      .prepare("SELECT session_id, value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare usage values")
+      .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?)))
+      .expect("query usage values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect usage values");
+    let repair_completed: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+        params![PRICING_VALUE_RESOLUTION_REPAIR_KEY],
+        |row| row.get(0),
+      )
+      .expect("load repair marker");
+
+    assert_eq!(
+      values,
+      vec![
+        ("gpt-56-alias-dated".to_string(), 30.0),
+        ("gpt-56-alias-exact".to_string(), 30.0),
+      ]
+    );
+    assert_eq!(repair_completed, 1);
   }
 
   #[test]
@@ -2714,6 +2838,7 @@ mod tests {
       failed_values,
       vec![("recalc-a".to_string(), 11.0), ("recalc-b".to_string(), 22.0)]
     );
+    assert!(pricing_value_resolution_repair_pending(&conn).expect("load rolled back repair marker"));
 
     conn
       .execute_batch("DROP TRIGGER fail_second_session_recalculation;")
@@ -2740,6 +2865,117 @@ mod tests {
 
     assert_eq!(repaired_output, 30.0);
     assert_eq!(repaired_values, vec![30.0, 30.0]);
+    assert!(!pricing_value_resolution_repair_pending(&conn).expect("load completed repair marker"));
+  }
+
+  #[test]
+  fn pricing_refresh_rolls_back_catalog_values_and_marker_before_retry() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let mut conn = open_connection(&db_path).expect("open database");
+    let created_at = database::now_utc_string();
+    for (session_id, sentinel_value) in [("refresh-a", 11.0), ("refresh-b", 22.0)] {
+      conn
+        .execute(
+          "
+          INSERT INTO sessions (
+            session_id, root_session_id, parent_session_id, title, source_state, source_path,
+            source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+            fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+          )
+          VALUES (?1, ?1, NULL, NULL, 'active', NULL, 'active',
+            NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?2, ?2)
+          ",
+          params![session_id, created_at],
+        )
+        .expect("insert session");
+      conn
+        .execute(
+          "
+          INSERT INTO usage_events (
+            session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+            output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+            fast_mode_auto, fast_mode_effective
+          )
+          VALUES (?1, '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
+            0, 0, 1000000, 0, 1000000, ?2, 0, 0)
+          ",
+          params![session_id, sentinel_value],
+        )
+        .expect("insert usage event");
+    }
+    conn
+      .execute(
+        "DELETE FROM data_repairs WHERE repair_key = ?1",
+        params![PRICING_VALUE_RESOLUTION_REPAIR_KEY],
+      )
+      .expect("clear repair marker");
+    conn
+      .execute_batch(
+        "
+        CREATE TRIGGER fail_second_refresh_recalculation
+        BEFORE UPDATE OF value_usd ON usage_events
+        WHEN OLD.session_id = 'refresh-b'
+        BEGIN
+          SELECT RAISE(ABORT, 'injected refresh failure');
+        END;
+        ",
+      )
+      .expect("create failure trigger");
+    let mut official_sol = load_catalog(&conn)
+      .expect("load catalog")
+      .into_iter()
+      .find(|entry| entry.model_id == "gpt-5.6-sol")
+      .expect("load GPT-5.6 Sol");
+    official_sol.output_price_per_million = 42.0;
+    official_sol.is_official = true;
+    official_sol.note = Some("atomic refresh test".to_string());
+    official_sol.updated_at = "atomic-refresh-test".to_string();
+    let official_entries = vec![official_sol];
+
+    let error = refresh_pricing_catalog_atomically(&mut conn, Some(&official_entries))
+      .expect_err("refresh should fail");
+    assert!(error.contains("injected refresh failure"));
+
+    let failed_output: f64 = conn
+      .query_row(
+        "SELECT output_price_per_million FROM pricing_catalog WHERE model_id = 'gpt-5.6-sol'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load rolled back pricing");
+    let failed_values = conn
+      .prepare("SELECT value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare failed values")
+      .query_map([], |row| row.get::<_, f64>(0))
+      .expect("query failed values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect failed values");
+    assert_eq!(failed_output, 30.0);
+    assert_eq!(failed_values, vec![11.0, 22.0]);
+    assert!(pricing_value_resolution_repair_pending(&conn).expect("load repair marker"));
+
+    conn
+      .execute_batch("DROP TRIGGER fail_second_refresh_recalculation;")
+      .expect("drop failure trigger");
+    let catalog = refresh_pricing_catalog_atomically(&mut conn, Some(&official_entries))
+      .expect("retry refresh");
+    let refreshed_sol = catalog
+      .iter()
+      .find(|entry| entry.model_id == "gpt-5.6-sol")
+      .expect("load refreshed GPT-5.6 Sol");
+    let refreshed_values = conn
+      .prepare("SELECT value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare refreshed values")
+      .query_map([], |row| row.get::<_, f64>(0))
+      .expect("query refreshed values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect refreshed values");
+
+    assert_eq!(refreshed_sol.output_price_per_million, 42.0);
+    assert_eq!(refreshed_values, vec![42.0, 42.0]);
+    assert!(!pricing_value_resolution_repair_pending(&conn).expect("load repair marker"));
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1300,13 +1300,10 @@ fn get_live_rate_limits_history_fallback(state: &AppState) -> Option<LiveRateLim
 }
 
 fn refresh_rate_limit_history_if_idle(state: &AppState) {
-  let Ok(guard) = try_acquire_flag(&state.scan_in_progress, "A scan is already running.") else {
-    return;
-  };
-
-  let result = perform_incremental_scan(&state.db_path, None);
-  drop(guard);
-  if let Err(error) = result {
+  if let Err(error) = run_background_incremental_scan_if_idle(state.clone(), None) {
+    if error == "A scan is already running." {
+      return;
+    }
     log::warn!("Failed to refresh Codex history rate-limit samples: {error}");
   }
 }
@@ -3109,6 +3106,54 @@ mod tests {
       )
       .expect("load final value");
     assert_eq!(value_usd, 42.0);
+  }
+
+  #[test]
+  fn history_fallback_scan_waits_for_usage_mutation_lock() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("create Codex home");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let settings = SyncSettings {
+      codex_home: Some(codex_home.to_string_lossy().to_string()),
+      ..get_sync_settings(&conn).expect("load settings")
+    };
+    save_sync_settings(&conn, &settings).expect("save settings");
+    drop(conn);
+
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+    let mutation_guard = lock_usage_mutations(&state);
+    let (completed_sender, completed_receiver) = std::sync::mpsc::channel();
+    let scan_state = state.clone();
+    let scan_thread = std::thread::spawn(move || {
+      refresh_rate_limit_history_if_idle(&scan_state);
+      completed_sender.send(()).expect("report completion");
+    });
+
+    let completed_while_locked = completed_receiver
+      .recv_timeout(Duration::from_millis(100))
+      .is_ok();
+    drop(mutation_guard);
+    if !completed_while_locked {
+      completed_receiver
+        .recv_timeout(Duration::from_secs(2))
+        .expect("history scan should complete after unlock");
+    }
+    scan_thread.join().expect("join history scan");
+
+    assert!(!completed_while_locked, "history scan bypassed the shared usage mutation lock");
   }
 
   #[test]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -33,6 +33,8 @@ pub struct UsageSnapshot {
   pub timestamp: String,
   pub model_id: String,
   pub usage: TokenUsage,
+  #[serde(skip)]
+  pub last_token_usage: Option<TokenUsage>,
   pub plan_type: Option<String>,
   pub limit_id: Option<String>,
   pub limit_name: Option<String>,

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -48,14 +48,7 @@ fn pricing_seed() -> Vec<PricingCatalogEntry> {
             source_url: OPENAI_API_PRICING_URL.to_string(),
             updated_at: updated_at.clone(),
         },
-        fallback_entry(
-            "gpt-5.6-sol",
-            "GPT-5.6 Sol",
-            5.00,
-            0.50,
-            30.00,
-            &updated_at,
-        ),
+        fallback_entry("gpt-5.6-sol", "GPT-5.6 Sol", 5.00, 0.50, 30.00, &updated_at),
         fallback_entry(
             "gpt-5.6-terra",
             "GPT-5.6 Terra",
@@ -196,33 +189,28 @@ fn official_entry(row: OfficialPricingRow, updated_at: &str) -> PricingCatalogEn
 
 pub fn seed_pricing_catalog(conn: &Connection) -> rusqlite::Result<Vec<PricingCatalogEntry>> {
     let entries = pricing_seed();
-    repair_misparsed_gpt_56_output_prices(conn, &entries)?;
+    repair_misparsed_gpt_56_output_prices(conn)?;
     upsert_pricing_entries(conn, &entries, PricingUpsertMode::PreserveOfficial)?;
     load_catalog(conn)
 }
 
-fn repair_misparsed_gpt_56_output_prices(
-    conn: &Connection,
-    entries: &[PricingCatalogEntry],
-) -> rusqlite::Result<()> {
-    for entry in entries {
-        if !matches!(
-            entry.model_id.as_str(),
-            "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
-        ) {
-            continue;
-        }
+fn repair_misparsed_gpt_56_output_prices(conn: &Connection) -> rusqlite::Result<()> {
+    for (model_id, input, cached_input, bad_output) in [
+        ("gpt-5.6-sol", 5.0, 0.5, 6.25),
+        ("gpt-5.6-terra", 2.5, 0.25, 3.125),
+        ("gpt-5.6-luna", 1.0, 0.1, 1.25),
+    ] {
         conn.execute(
             "
             UPDATE pricing_catalog
-            SET output_price_per_million = ?2
+            SET is_official = 0
             WHERE model_id = ?1
               AND is_official = 1
-              AND ABS(
-                output_price_per_million - input_price_per_million * 1.25
-              ) <= 1e-9
+              AND ABS(input_price_per_million - ?2) <= 1e-9
+              AND ABS(cached_input_price_per_million - ?3) <= 1e-9
+              AND ABS(output_price_per_million - ?4) <= 1e-9
             ",
-            params![entry.model_id, entry.output_price_per_million],
+            params![model_id, input, cached_input, bad_output],
         )?;
     }
 
@@ -576,7 +564,9 @@ pub fn resolve_pricing(
     model_id: &str,
 ) -> Option<ResolvedPricing> {
     let normalized = normalize_model_id(model_id);
-    let entry = if let Some(entry) = catalog.get(&normalized) {
+    let entry = if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6") {
+        catalog.get("gpt-5.6-sol")?.clone()
+    } else if let Some(entry) = catalog.get(&normalized) {
         entry.clone()
     } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-sol") {
         catalog.get("gpt-5.6-sol")?.clone()
@@ -820,6 +810,7 @@ mod tests {
 
         for (model, input, cached, output) in [
             ("gpt-5.6", 5.0, 0.5, 30.0),
+            ("gpt-5.6-2026-07-09", 5.0, 0.5, 30.0),
             ("gpt-5.6-sol", 5.0, 0.5, 30.0),
             ("gpt-5.6-sol-2026-07-09", 5.0, 0.5, 30.0),
             ("gpt-5.6-terra", 2.5, 0.25, 15.0),
@@ -850,6 +841,29 @@ mod tests {
     }
 
     #[test]
+    fn resolve_pricing_routes_gpt_56_aliases_to_current_sol_row() {
+        let mut catalog = pricing_seed()
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+        let alias = catalog.get_mut("gpt-5.6").expect("GPT-5.6 alias");
+        alias.input_price_per_million = 4.0;
+        alias.cached_input_price_per_million = 0.4;
+        alias.output_price_per_million = 24.0;
+        let sol = catalog.get_mut("gpt-5.6-sol").expect("GPT-5.6 Sol");
+        sol.input_price_per_million = 7.0;
+        sol.cached_input_price_per_million = 0.7;
+        sol.output_price_per_million = 42.0;
+
+        for model_id in ["gpt-5.6", "gpt-5.6-2026-07-09"] {
+            let pricing = resolve_pricing(&catalog, model_id).expect(model_id);
+            assert_eq!(pricing.input_price_per_million, 7.0);
+            assert_eq!(pricing.cached_input_price_per_million, 0.7);
+            assert_eq!(pricing.output_price_per_million, 42.0);
+        }
+    }
+
+    #[test]
     fn resolve_pricing_does_not_guess_unknown_gpt_56_ids() {
         let catalog = pricing_seed()
             .into_iter()
@@ -860,7 +874,9 @@ mod tests {
             "gpt-5.6-solaris",
             "gpt-5.6-neptune",
             "gpt-5.60",
-            "gpt-5.6-2026-07-09",
+            "gpt-5.6-2026-02-30",
+            "gpt-5.6-2026-7-09",
+            "gpt-5.6-2026-07-09-preview",
             "gpt-5.6-sol-2026-02-30",
             "gpt-5.6-sol-2026-7-09",
             "gpt-5.6-sol-2026-07-09-preview",
@@ -914,37 +930,98 @@ mod tests {
             .map(|entry| (entry.model_id.clone(), entry))
             .collect::<HashMap<_, _>>();
 
-        for (model_id, display_name, output, provenance, source_url) in [
-            (
-                "gpt-5.6-sol",
-                "Official Sol",
-                30.0,
-                "official-sol",
-                "https://example.com/sol",
-            ),
-            (
-                "gpt-5.6-terra",
-                "Official Terra",
-                15.0,
-                "official-terra",
-                "https://example.com/terra",
-            ),
-            (
-                "gpt-5.6-luna",
-                "Official Luna",
-                6.0,
-                "official-luna",
-                "https://example.com/luna",
-            ),
+        for (model_id, display_name, output, provenance) in [
+            ("gpt-5.6-sol", "GPT-5.6 Sol", 30.0, "official-sol"),
+            ("gpt-5.6-terra", "GPT-5.6 Terra", 15.0, "official-terra"),
+            ("gpt-5.6-luna", "GPT-5.6 Luna", 6.0, "official-luna"),
         ] {
             let entry = &catalog[model_id];
             assert_eq!(entry.output_price_per_million, output);
             assert_eq!(entry.display_name, display_name);
-            assert!(entry.is_official);
-            assert_eq!(entry.note.as_deref(), Some(provenance));
-            assert_eq!(entry.source_url, source_url);
-            assert_eq!(entry.updated_at, provenance);
+            assert!(!entry.is_official);
+            assert_eq!(entry.note.as_deref(), Some(FALLBACK_PRICING_NOTE));
+            assert_eq!(entry.source_url, OPENAI_API_PRICING_URL);
+            assert_ne!(entry.updated_at, provenance);
         }
+    }
+
+    #[test]
+    fn seed_preserves_future_official_gpt_56_price_at_one_point_two_five_ratio() {
+        let conn = Connection::open_in_memory().expect("open database");
+        crate::database::init_db(&conn).expect("init database");
+        conn.execute(
+            "
+            INSERT INTO pricing_catalog (
+                model_id, display_name, input_price_per_million, cached_input_price_per_million,
+                output_price_per_million, effective_model_id, is_official, note, source_url, updated_at
+            )
+            VALUES ('gpt-5.6-sol', 'Future Official Sol', 8.0, 0.8, 10.0,
+                    'gpt-5.6-sol', 1, 'future-official', 'https://example.com/future',
+                    'future-official-sol')
+            ",
+            [],
+        )
+        .expect("insert future official Sol pricing");
+
+        let catalog = seed_pricing_catalog(&conn)
+            .expect("seed pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+        let sol = &catalog["gpt-5.6-sol"];
+
+        assert_eq!(sol.input_price_per_million, 8.0);
+        assert_eq!(sol.cached_input_price_per_million, 0.8);
+        assert_eq!(sol.output_price_per_million, 10.0);
+        assert_eq!(sol.display_name, "Future Official Sol");
+        assert!(sol.is_official);
+        assert_eq!(sol.note.as_deref(), Some("future-official"));
+        assert_eq!(sol.source_url, "https://example.com/future");
+        assert_eq!(sol.updated_at, "future-official-sol");
+    }
+
+    #[test]
+    fn official_refresh_restores_repaired_gpt_56_provenance() {
+        let conn = Connection::open_in_memory().expect("open database");
+        crate::database::init_db(&conn).expect("init database");
+        conn.execute(
+            "
+            INSERT INTO pricing_catalog (
+                model_id, display_name, input_price_per_million, cached_input_price_per_million,
+                output_price_per_million, effective_model_id, is_official, note, source_url, updated_at
+            )
+            VALUES ('gpt-5.6-sol', 'Old Official Sol', 5.0, 0.5, 6.25,
+                    'gpt-5.6-sol', 1, 'old-official', 'https://example.com/old', 'old-official')
+            ",
+            [],
+        )
+        .expect("insert malformed official Sol pricing");
+
+        let repaired = seed_pricing_catalog(&conn).expect("repair malformed pricing");
+        assert!(repaired
+            .iter()
+            .find(|entry| entry.model_id == "gpt-5.6-sol")
+            .is_some_and(|entry| !entry.is_official));
+
+        let official_entries =
+            parse_official_pricing_catalog(&complete_standard_fixture_with_gpt56_rows())
+                .expect("parse official pricing");
+        upsert_pricing_entries(&conn, &official_entries, PricingUpsertMode::Overwrite)
+            .expect("write refreshed official pricing");
+        let catalog = seed_pricing_catalog(&conn)
+            .expect("seed refreshed pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+        let sol = &catalog["gpt-5.6-sol"];
+
+        assert!(sol.is_official);
+        assert_eq!(sol.output_price_per_million, 30.0);
+        assert_eq!(sol.source_url, OPENAI_API_PRICING_URL);
+        assert_eq!(
+            sol.note.as_deref(),
+            Some("OpenAI API Standard short-context pricing.")
+        );
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -36,6 +36,42 @@ struct OfficialPricingRow {
 fn pricing_seed() -> Vec<PricingCatalogEntry> {
     let updated_at = now_utc_string();
     vec![
+        PricingCatalogEntry {
+            model_id: "gpt-5.6".to_string(),
+            display_name: "GPT-5.6".to_string(),
+            input_price_per_million: 5.00,
+            cached_input_price_per_million: 0.50,
+            output_price_per_million: 30.00,
+            effective_model_id: "gpt-5.6-sol".to_string(),
+            is_official: false,
+            note: Some(FALLBACK_PRICING_NOTE.to_string()),
+            source_url: OPENAI_API_PRICING_URL.to_string(),
+            updated_at: updated_at.clone(),
+        },
+        fallback_entry(
+            "gpt-5.6-sol",
+            "GPT-5.6 Sol",
+            5.00,
+            0.50,
+            30.00,
+            &updated_at,
+        ),
+        fallback_entry(
+            "gpt-5.6-terra",
+            "GPT-5.6 Terra",
+            2.50,
+            0.25,
+            15.00,
+            &updated_at,
+        ),
+        fallback_entry(
+            "gpt-5.6-luna",
+            "GPT-5.6 Luna",
+            1.00,
+            0.10,
+            6.00,
+            &updated_at,
+        ),
         fallback_entry("gpt-5.5", "GPT-5.5", 5.00, 0.50, 30.00, &updated_at),
         fallback_entry("gpt-5.4", "GPT-5.4", 2.50, 0.25, 15.00, &updated_at),
         fallback_entry(
@@ -160,8 +196,37 @@ fn official_entry(row: OfficialPricingRow, updated_at: &str) -> PricingCatalogEn
 
 pub fn seed_pricing_catalog(conn: &Connection) -> rusqlite::Result<Vec<PricingCatalogEntry>> {
     let entries = pricing_seed();
+    repair_misparsed_gpt_56_output_prices(conn, &entries)?;
     upsert_pricing_entries(conn, &entries, PricingUpsertMode::PreserveOfficial)?;
     load_catalog(conn)
+}
+
+fn repair_misparsed_gpt_56_output_prices(
+    conn: &Connection,
+    entries: &[PricingCatalogEntry],
+) -> rusqlite::Result<()> {
+    for entry in entries {
+        if !matches!(
+            entry.model_id.as_str(),
+            "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+        ) {
+            continue;
+        }
+        conn.execute(
+            "
+            UPDATE pricing_catalog
+            SET output_price_per_million = ?2
+            WHERE model_id = ?1
+              AND is_official = 1
+              AND ABS(
+                output_price_per_million - input_price_per_million * 1.25
+              ) <= 1e-9
+            ",
+            params![entry.model_id, entry.output_price_per_million],
+        )?;
+    }
+
+    Ok(())
 }
 
 pub fn refresh_pricing_catalog_from_openai(
@@ -209,6 +274,9 @@ pub fn parse_official_pricing_catalog(document: &str) -> Result<Vec<PricingCatal
     }
 
     let required_models = [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -278,15 +346,24 @@ fn extract_pricing_rows(block: &str) -> Vec<OfficialPricingRow> {
         };
         let name_end = name_start + relative_name_end;
         let raw_name = html_unescape(&block[name_start..name_end]);
+        let next_row = block[name_end..]
+            .find(marker)
+            .map(|offset| name_end + offset)
+            .unwrap_or(block.len());
         if !is_standard_short_context_pricing_row(&raw_name) {
-            cursor = name_end;
+            cursor = next_row;
             continue;
         }
-        let mut value_cursor = name_end + "&quot;]".len();
+        let row_source = &block[name_end..next_row];
+        let mut value_cursor = 0usize;
+        let mut values = Vec::new();
+        while let Some(value) = parse_next_pricing_value(row_source, &mut value_cursor) {
+            values.push(value);
+        }
 
-        let input = parse_next_pricing_value(block, &mut value_cursor).flatten();
-        let cached_input = parse_next_pricing_value(block, &mut value_cursor).flatten();
-        let output = parse_next_pricing_value(block, &mut value_cursor).flatten();
+        let input = values.first().copied().flatten();
+        let cached_input = values.get(1).copied().flatten();
+        let output = values.last().copied().flatten();
 
         if let (Some(input), Some(output)) = (input, output) {
             let model_id = normalize_official_model_id(&raw_name);
@@ -300,7 +377,7 @@ fn extract_pricing_rows(block: &str) -> Vec<OfficialPricingRow> {
             }
         }
 
-        cursor = name_end;
+        cursor = next_row;
     }
 
     rows
@@ -501,6 +578,14 @@ pub fn resolve_pricing(
     let normalized = normalize_model_id(model_id);
     let entry = if let Some(entry) = catalog.get(&normalized) {
         entry.clone()
+    } else if normalized.starts_with("gpt-5.6-sol") {
+        catalog.get("gpt-5.6-sol")?.clone()
+    } else if normalized.starts_with("gpt-5.6-terra") {
+        catalog.get("gpt-5.6-terra")?.clone()
+    } else if normalized.starts_with("gpt-5.6-luna") {
+        catalog.get("gpt-5.6-luna")?.clone()
+    } else if normalized.starts_with("gpt-5.6") {
+        catalog.get("gpt-5.6")?.clone()
     } else if normalized.starts_with("gpt-5.5-pro") {
         catalog.get("gpt-5.5-pro")?.clone()
     } else if normalized.starts_with("gpt-5.5") {
@@ -553,6 +638,10 @@ pub fn display_name_for_model(model_id: &str) -> String {
     match normalize_model_id(model_id).as_str() {
         "codex-auto-review" => "Codex Auto Review".to_string(),
         "codex-mini-latest" => "Codex Mini Latest".to_string(),
+        "gpt-5.6" => "GPT-5.6".to_string(),
+        "gpt-5.6-sol" => "GPT-5.6 Sol".to_string(),
+        "gpt-5.6-terra" => "GPT-5.6 Terra".to_string(),
+        "gpt-5.6-luna" => "GPT-5.6 Luna".to_string(),
         "gpt-5.5" => "GPT-5.5".to_string(),
         "gpt-5.5-pro" => "GPT-5.5 Pro".to_string(),
         "gpt-5.4" => "GPT-5.4".to_string(),
@@ -581,6 +670,10 @@ pub fn display_name_for_model(model_id: &str) -> String {
 pub fn model_color(model_id: &str) -> &'static str {
     match normalize_model_id(model_id).as_str() {
         "codex-auto-review" => "#60a5fa",
+        "gpt-5.6" => "#f59e0b",
+        "gpt-5.6-sol" => "#ffd166",
+        "gpt-5.6-terra" => "#2ec4b6",
+        "gpt-5.6-luna" => "#8338ec",
         "gpt-5.5" => "#d946ef",
         "gpt-5.5-pro" => "#c026d3",
         "gpt-5.4" => "#ff6b35",
@@ -699,9 +792,155 @@ mod tests {
     }
 
     #[test]
+    fn resolve_pricing_includes_gpt_56_family_and_alias() {
+        let catalog = pricing_seed()
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        for (model, input, cached, output) in [
+            ("gpt-5.6", 5.0, 0.5, 30.0),
+            ("gpt-5.6-sol-2026-07-09", 5.0, 0.5, 30.0),
+            ("gpt-5.6-terra-2026-07-09", 2.5, 0.25, 15.0),
+            ("gpt-5.6-luna-2026-07-09", 1.0, 0.1, 6.0),
+        ] {
+            let pricing = resolve_pricing(&catalog, model).expect(model);
+            assert_eq!(pricing.input_price_per_million, input);
+            assert_eq!(pricing.cached_input_price_per_million, cached);
+            assert_eq!(pricing.output_price_per_million, output);
+        }
+
+        assert_eq!(catalog["gpt-5.6"].effective_model_id, "gpt-5.6-sol");
+        assert_eq!(catalog["gpt-5.6"].display_name, "GPT-5.6");
+        assert_eq!(catalog["gpt-5.6-sol"].display_name, "GPT-5.6 Sol");
+        assert_eq!(catalog["gpt-5.6-terra"].display_name, "GPT-5.6 Terra");
+        assert_eq!(catalog["gpt-5.6-luna"].display_name, "GPT-5.6 Luna");
+        for (model_id, display_name, color) in [
+            ("gpt-5.6", "GPT-5.6", "#f59e0b"),
+            ("gpt-5.6-sol", "GPT-5.6 Sol", "#ffd166"),
+            ("gpt-5.6-terra", "GPT-5.6 Terra", "#2ec4b6"),
+            ("gpt-5.6-luna", "GPT-5.6 Luna", "#8338ec"),
+        ] {
+            assert_eq!(display_name_for_model(model_id), display_name);
+            assert_eq!(model_color(model_id), color);
+        }
+    }
+
+    #[test]
+    fn parses_gpt_56_cache_write_price_without_treating_it_as_output() {
+        let html = complete_standard_fixture_with_gpt56_rows();
+        let catalog = parse_official_pricing_catalog(&html)
+            .expect("parse pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(catalog["gpt-5.6-sol"].output_price_per_million, 30.0);
+        assert_eq!(catalog["gpt-5.6-terra"].output_price_per_million, 15.0);
+        assert_eq!(catalog["gpt-5.6-luna"].output_price_per_million, 6.0);
+    }
+
+    #[test]
+    fn seed_repairs_misparsed_gpt_56_output_prices() {
+        let conn = Connection::open_in_memory().expect("open database");
+        crate::database::init_db(&conn).expect("init database");
+        conn.execute(
+            "
+            INSERT INTO pricing_catalog (
+                model_id, display_name, input_price_per_million, cached_input_price_per_million,
+                output_price_per_million, effective_model_id, is_official, note, source_url, updated_at
+            )
+            VALUES
+              ('gpt-5.6-sol', 'Official Sol', 5.0, 0.5, 6.25,
+               'gpt-5.6-sol', 1, 'official-sol', 'https://example.com/sol', 'official-sol'),
+              ('gpt-5.6-terra', 'Official Terra', 2.5, 0.25, 3.125,
+               'gpt-5.6-terra', 1, 'official-terra', 'https://example.com/terra', 'official-terra'),
+              ('gpt-5.6-luna', 'Official Luna', 1.0, 0.1, 1.25,
+               'gpt-5.6-luna', 1, 'official-luna', 'https://example.com/luna', 'official-luna')
+            ",
+            [],
+        )
+        .expect("insert malformed GPT-5.6 pricing");
+
+        let catalog = seed_pricing_catalog(&conn)
+            .expect("seed pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        for (model_id, display_name, output, provenance, source_url) in [
+            (
+                "gpt-5.6-sol",
+                "Official Sol",
+                30.0,
+                "official-sol",
+                "https://example.com/sol",
+            ),
+            (
+                "gpt-5.6-terra",
+                "Official Terra",
+                15.0,
+                "official-terra",
+                "https://example.com/terra",
+            ),
+            (
+                "gpt-5.6-luna",
+                "Official Luna",
+                6.0,
+                "official-luna",
+                "https://example.com/luna",
+            ),
+        ] {
+            let entry = &catalog[model_id];
+            assert_eq!(entry.output_price_per_million, output);
+            assert_eq!(entry.display_name, display_name);
+            assert!(entry.is_official);
+            assert_eq!(entry.note.as_deref(), Some(provenance));
+            assert_eq!(entry.source_url, source_url);
+            assert_eq!(entry.updated_at, provenance);
+        }
+    }
+
+    #[test]
+    fn seed_preserves_correct_official_gpt_56_prices() {
+        let conn = Connection::open_in_memory().expect("open database");
+        crate::database::init_db(&conn).expect("init database");
+        conn.execute(
+            "
+            INSERT INTO pricing_catalog (
+                model_id, display_name, input_price_per_million, cached_input_price_per_million,
+                output_price_per_million, effective_model_id, is_official, note, source_url, updated_at
+            )
+            VALUES ('gpt-5.6-terra', 'Official Terra', 2.5, 0.25, 15.0,
+                    'gpt-5.6-terra', 1, 'official', 'https://example.com', 'official-terra')
+            ",
+            [],
+        )
+        .expect("insert correct Terra pricing");
+
+        let catalog = seed_pricing_catalog(&conn)
+            .expect("seed pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(catalog["gpt-5.6-terra"].output_price_per_million, 15.0);
+        assert_eq!(catalog["gpt-5.6-terra"].display_name, "Official Terra");
+        assert_eq!(catalog["gpt-5.6-terra"].updated_at, "official-terra");
+        assert!(catalog["gpt-5.6-terra"].is_official);
+    }
+
+    fn complete_standard_fixture_with_gpt56_rows() -> String {
+        concat!(
+            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.6-sol&quot;],[0,5],[0,0.5],[0,6.25],[0,30]]],[1,[[0,&quot;gpt-5.6-terra&quot;],[0,2.5],[0,0.25],[0,3.125],[0,15]]],[1,[[0,&quot;gpt-5.6-luna&quot;],[0,1],[0,0.1],[0,1.25],[0,6]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
+            "<astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,1.75],[0,0.175],[0,14]]]]]}]]]}\"></astro-island>"
+        ).to_string()
+    }
+
+    #[test]
     fn parses_official_standard_short_context_pricing_rows() {
         let html = concat!(
-            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.5 (&gt;=272K context length)&quot;],[0,10],[0,1],[0,45]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
+            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.6-sol&quot;],[0,5],[0,0.5],[0,6.25],[0,30]]],[1,[[0,&quot;gpt-5.6-terra&quot;],[0,2.5],[0,0.25],[0,3.125],[0,15]]],[1,[[0,&quot;gpt-5.6-luna&quot;],[0,1],[0,0.1],[0,1.25],[0,6]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.5 (&gt;=272K context length)&quot;],[0,10],[0,1],[0,45]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
             "<astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,1.75],[0,0.175],[0,14]]]]]}]]]}\"></astro-island>"
         );
 
@@ -726,7 +965,7 @@ mod tests {
     #[test]
     fn prefers_standard_short_context_when_pricing_blocks_are_reordered() {
         let html = concat!(
-            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.5 (&gt;=272K context length)&quot;],[0,10],[0,1],[0,45]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
+            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.6-sol&quot;],[0,5],[0,0.5],[0,6.25],[0,30]]],[1,[[0,&quot;gpt-5.6-terra&quot;],[0,2.5],[0,0.25],[0,3.125],[0,15]]],[1,[[0,&quot;gpt-5.6-luna&quot;],[0,1],[0,0.1],[0,1.25],[0,6]]],[1,[[0,&quot;gpt-5.5 (&gt;=272K context length)&quot;],[0,10],[0,1],[0,45]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
             "<div data-content-switcher-pane=\"true\" data-value=\"priority\" hidden><div class=\"hidden\">Priority</div><astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,3.5],[0,0.35],[0,28]]]]]}]]]}\"></astro-island></div>",
             "<div data-content-switcher-pane=\"true\" data-value=\"standard\"><div class=\"hidden\">Standard</div><astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,1.75],[0,0.175],[0,14]]]]]}]]]}\"></astro-island></div>"
         );

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -578,14 +578,12 @@ pub fn resolve_pricing(
     let normalized = normalize_model_id(model_id);
     let entry = if let Some(entry) = catalog.get(&normalized) {
         entry.clone()
-    } else if normalized.starts_with("gpt-5.6-sol") {
+    } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-sol") {
         catalog.get("gpt-5.6-sol")?.clone()
-    } else if normalized.starts_with("gpt-5.6-terra") {
+    } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-terra") {
         catalog.get("gpt-5.6-terra")?.clone()
-    } else if normalized.starts_with("gpt-5.6-luna") {
+    } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-luna") {
         catalog.get("gpt-5.6-luna")?.clone()
-    } else if normalized.starts_with("gpt-5.6") {
-        catalog.get("gpt-5.6")?.clone()
     } else if normalized.starts_with("gpt-5.5-pro") {
         catalog.get("gpt-5.5-pro")?.clone()
     } else if normalized.starts_with("gpt-5.5") {
@@ -623,6 +621,28 @@ pub fn resolve_pricing(
         cached_input_price_per_million: entry.cached_input_price_per_million,
         output_price_per_million: entry.output_price_per_million,
     })
+}
+
+fn matches_canonical_or_dated_model_id(model_id: &str, canonical_model_id: &str) -> bool {
+    if model_id == canonical_model_id {
+        return true;
+    }
+
+    let Some(date_suffix) = model_id
+        .strip_prefix(canonical_model_id)
+        .and_then(|suffix| suffix.strip_prefix('-'))
+    else {
+        return false;
+    };
+    let bytes = date_suffix.as_bytes();
+    let has_iso_date_shape = bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && bytes[5..7].iter().all(u8::is_ascii_digit)
+        && bytes[8..].iter().all(u8::is_ascii_digit);
+
+    has_iso_date_shape && chrono::NaiveDate::parse_from_str(date_suffix, "%Y-%m-%d").is_ok()
 }
 
 pub fn normalize_model_id(model_id: &str) -> String {
@@ -800,8 +820,11 @@ mod tests {
 
         for (model, input, cached, output) in [
             ("gpt-5.6", 5.0, 0.5, 30.0),
+            ("gpt-5.6-sol", 5.0, 0.5, 30.0),
             ("gpt-5.6-sol-2026-07-09", 5.0, 0.5, 30.0),
+            ("gpt-5.6-terra", 2.5, 0.25, 15.0),
             ("gpt-5.6-terra-2026-07-09", 2.5, 0.25, 15.0),
+            ("gpt-5.6-luna", 1.0, 0.1, 6.0),
             ("gpt-5.6-luna-2026-07-09", 1.0, 0.1, 6.0),
         ] {
             let pricing = resolve_pricing(&catalog, model).expect(model);
@@ -823,6 +846,29 @@ mod tests {
         ] {
             assert_eq!(display_name_for_model(model_id), display_name);
             assert_eq!(model_color(model_id), color);
+        }
+    }
+
+    #[test]
+    fn resolve_pricing_does_not_guess_unknown_gpt_56_ids() {
+        let catalog = pricing_seed()
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        for model_id in [
+            "gpt-5.6-solaris",
+            "gpt-5.6-neptune",
+            "gpt-5.60",
+            "gpt-5.6-2026-07-09",
+            "gpt-5.6-sol-2026-02-30",
+            "gpt-5.6-sol-2026-7-09",
+            "gpt-5.6-sol-2026-07-09-preview",
+        ] {
+            assert!(
+                resolve_pricing(&catalog, model_id).is_none(),
+                "unexpected guessed pricing for {model_id}"
+            );
         }
     }
 

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -217,25 +217,20 @@ fn repair_misparsed_gpt_56_output_prices(conn: &Connection) -> rusqlite::Result<
     Ok(())
 }
 
-pub fn refresh_pricing_catalog_from_openai(
+pub fn apply_pricing_catalog_refresh(
     conn: &Connection,
-) -> Result<Vec<PricingCatalogEntry>, String> {
-    match fetch_official_pricing_catalog() {
-        Ok(entries) => {
-            upsert_pricing_entries(conn, &entries, PricingUpsertMode::Overwrite)
-                .map_err(|error| error.to_string())?;
-            seed_pricing_catalog(conn).map_err(|error| error.to_string())
-        }
-        Err(error) => {
-            log::warn!(
-                "Failed to refresh OpenAI API pricing from {OPENAI_API_PRICING_URL}: {error}; using bundled fallback pricing."
-            );
-            seed_pricing_catalog(conn).map_err(|error| error.to_string())
-        }
+    official_entries: Option<&[PricingCatalogEntry]>,
+) -> Result<(), String> {
+    if let Some(entries) = official_entries {
+        upsert_pricing_entries(conn, entries, PricingUpsertMode::Overwrite)
+            .map_err(|error| error.to_string())?;
     }
+
+    seed_pricing_catalog(conn).map_err(|error| error.to_string())?;
+    Ok(())
 }
 
-fn fetch_official_pricing_catalog() -> Result<Vec<PricingCatalogEntry>, String> {
+pub fn fetch_official_pricing_catalog() -> Result<Vec<PricingCatalogEntry>, String> {
     let response = ureq::get(OPENAI_API_PRICING_URL)
         .timeout(Duration::from_secs(20))
         .call()

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -439,10 +439,24 @@ fn codex_binary_candidates(app_data: Option<&OsStr>, _home_dir: Option<&Path>) -
 
 #[cfg(not(windows))]
 fn codex_binary_candidates(_app_data: Option<&OsStr>, home_dir: Option<&Path>) -> Vec<PathBuf> {
-  let mut candidates = vec![
+  let mut candidates = Vec::new();
+
+  #[cfg(target_os = "macos")]
+  {
+    candidates.push(PathBuf::from("/Applications/ChatGPT.app/Contents/Resources/codex"));
+    if let Some(home_dir) = home_dir {
+      candidates.push(home_dir.join("Applications/ChatGPT.app/Contents/Resources/codex"));
+    }
+    candidates.push(PathBuf::from("/Applications/Codex.app/Contents/Resources/codex"));
+    if let Some(home_dir) = home_dir {
+      candidates.push(home_dir.join("Applications/Codex.app/Contents/Resources/codex"));
+    }
+  }
+
+  candidates.extend([
     PathBuf::from("/opt/homebrew/bin/codex"),
     PathBuf::from("/usr/local/bin/codex"),
-  ];
+  ]);
 
   if let Some(home_dir) = home_dir {
     candidates.push(home_dir.join(".cargo/bin/codex"));
@@ -464,6 +478,7 @@ fn fallback_codex_binary() -> PathBuf {
 #[cfg(test)]
 mod tests {
   use super::convert_window;
+  #[cfg(windows)]
   use std::ffi::OsString;
   use std::path::{Path, PathBuf};
 
@@ -485,6 +500,33 @@ mod tests {
     assert_eq!(converted.window_duration_mins, Some(300));
     assert!(converted.resets_at.is_some());
     assert!(converted.window_start.is_some());
+  }
+
+  #[test]
+  #[cfg(target_os = "macos")]
+  fn resolve_codex_binary_prefers_chatgpt_app_bundle() {
+    let resolved = super::resolve_codex_binary_from_env(
+      None,
+      None,
+      Some(Path::new("/Users/CodexUser")),
+      existing_paths(&[
+        "/Applications/ChatGPT.app/Contents/Resources/codex",
+        "/opt/homebrew/bin/codex",
+      ]),
+    );
+    assert_eq!(resolved, PathBuf::from("/Applications/ChatGPT.app/Contents/Resources/codex"));
+  }
+
+  #[test]
+  #[cfg(target_os = "macos")]
+  fn resolve_codex_binary_uses_legacy_app_when_chatgpt_is_missing() {
+    let resolved = super::resolve_codex_binary_from_env(
+      None,
+      None,
+      Some(Path::new("/Users/CodexUser")),
+      existing_paths(&["/Applications/Codex.app/Contents/Resources/codex"]),
+    );
+    assert_eq!(resolved, PathBuf::from("/Applications/Codex.app/Contents/Resources/codex"));
   }
 
   #[test]

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -189,18 +189,16 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
     }
   }
 
-  if let Err(error) = send_app_server_request(
-    &mut child,
-    json!({
-      "id": READ_REQUEST_ID,
-      "method": "account/rateLimits/read",
-      "params": Value::Null,
-    }),
-    "Failed to request live rate limits after Codex app-server initialization",
-    "Failed to flush codex app-server rate-limit request",
-  ) {
-    stop_app_server(&mut child);
-    return Err(error);
+  for (message, write_context, flush_context) in post_initialize_messages() {
+    if let Err(error) = send_app_server_request(
+      &mut child,
+      message,
+      write_context,
+      flush_context,
+    ) {
+      stop_app_server(&mut child);
+      return Err(error);
+    }
   }
 
   let response = loop {
@@ -312,6 +310,27 @@ fn app_server_args() -> Vec<OsString> {
     OsString::from("app-server"),
     OsString::from("--listen"),
     OsString::from("stdio://"),
+  ]
+}
+
+fn post_initialize_messages() -> Vec<(Value, &'static str, &'static str)> {
+  vec![
+    (
+      json!({
+        "method": "initialized",
+        "params": {},
+      }),
+      "Failed to notify Codex app-server that initialization completed",
+      "Failed to flush Codex app-server initialized notification",
+    ),
+    (
+      json!({
+        "id": READ_REQUEST_ID,
+        "method": "account/rateLimits/read",
+      }),
+      "Failed to request live rate limits after Codex app-server initialization",
+      "Failed to flush Codex app-server rate-limit request",
+    ),
   ]
 }
 
@@ -500,6 +519,25 @@ mod tests {
     assert_eq!(converted.window_duration_mins, Some(300));
     assert!(converted.resets_at.is_some());
     assert!(converted.window_start.is_some());
+  }
+
+  #[test]
+  fn app_server_post_initialize_messages_follow_protocol_order() {
+    let messages = super::post_initialize_messages()
+      .into_iter()
+      .map(|(message, _, _)| message)
+      .collect::<Vec<_>>();
+
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].get("method").and_then(serde_json::Value::as_str), Some("initialized"));
+    assert!(messages[0].get("id").is_none());
+    assert_eq!(messages[0].get("params"), Some(&serde_json::json!({})));
+    assert_eq!(
+      messages[1].get("method").and_then(serde_json::Value::as_str),
+      Some("account/rateLimits/read")
+    );
+    assert_eq!(messages[1].get("id").and_then(serde_json::Value::as_str), Some(super::READ_REQUEST_ID));
+    assert!(messages[1].get("params").is_none());
   }
 
   #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Codex Pacer",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "identifier": "com.codex.counter",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,11 +24,13 @@ import {
   updateSyncSettings,
 } from './app/api'
 import {
+  loadConversationDetailForGeneration,
   refreshDashboardAfterBackgroundScan,
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
   waitForScanToSettleUntilCancelled,
 } from './app/dataFreshness'
+import { saveSettingsWithCodexHomeRollback } from './app/settingsSave'
 import {
   formatCompactDateTime,
   formatDateTime,
@@ -191,12 +193,16 @@ function App() {
           }
         }
 
+        latestDetailRequestIdRef.current += 1
         setOverview(snapshot.overview)
         setConversations(snapshot.conversations)
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
         setLiveRateLimits(snapshot.liveRateLimits)
         detailCacheRef.current = nextDetailCache
+        setDetail((current) =>
+          current && nextDetailCache.get(current.rootSessionId) === current ? current : null,
+        )
         setDashboardRevision((current) => current + 1)
         setLiveWindowOffset(snapshot.overview.liveWindowOffset)
         setLoadedQueryKey(
@@ -299,8 +305,12 @@ function App() {
 
     setDetail(null)
     try {
-      const nextDetail = await getConversationDetail(rootSessionId)
-      if (requestId !== latestDetailRequestIdRef.current) {
+      const nextDetail = await loadConversationDetailForGeneration(
+        () => getConversationDetail(rootSessionId),
+        requestId,
+        () => latestDetailRequestIdRef.current,
+      )
+      if (!nextDetail) {
         return
       }
       detailCacheRef.current.set(rootSessionId, nextDetail)
@@ -409,16 +419,31 @@ function App() {
     syncSettings: SyncSettings
     subscriptionProfile: SubscriptionProfile
   }) {
-    const previousCodexHome = syncSettingsRef.current?.codexHome ?? null
-    const [nextSyncSettings, nextSubscriptionProfile] = await Promise.all([
-      updateSyncSettings(payload.syncSettings),
-      updateSubscriptionProfile(payload.subscriptionProfile),
-    ])
-    const codexHomeChanged = previousCodexHome !== nextSyncSettings.codexHome
-    syncSettingsRef.current = nextSyncSettings
-    setSyncSettings(nextSyncSettings)
-    setSubscriptionProfile(nextSubscriptionProfile)
-    await loadShell(codexHomeChanged)
+    const previousSyncSettings = syncSettingsRef.current
+    const previousSubscriptionProfile = subscriptionProfile
+    if (!previousSyncSettings || !previousSubscriptionProfile) {
+      throw new Error(t.status.settingsStillLoading)
+    }
+
+    const saved = await saveSettingsWithCodexHomeRollback({
+      previousSyncSettings,
+      nextSyncSettings: payload.syncSettings,
+      previousSubscriptionProfile,
+      nextSubscriptionProfile: payload.subscriptionProfile,
+      updateSyncSettings,
+      updateSubscriptionProfile,
+      scanCodexHome: (codexHome) =>
+        runScanWithOverlapRetry(
+          () => scanCodexUsage(codexHome),
+          (error) => String(error).includes('already running'),
+          waitForScanToSettle,
+          () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
+        ),
+    })
+    syncSettingsRef.current = saved.syncSettings
+    setSyncSettings(saved.syncSettings)
+    setSubscriptionProfile(saved.subscriptionProfile)
+    await loadShell(false)
     if (isTauri()) {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,12 @@ import {
   updateSubscriptionProfile,
   updateSyncSettings,
 } from './app/api'
-import { shouldKeepConversationDetail, waitForOverlappingScan } from './app/dataFreshness'
+import {
+  refreshDashboardAfterBackgroundScan,
+  runScanWithOverlapRetry,
+  shouldKeepConversationDetail,
+  waitForScanToSettleUntilCancelled,
+} from './app/dataFreshness'
 import {
   formatCompactDateTime,
   formatDateTime,
@@ -115,10 +120,11 @@ function App() {
     const startedAt = Date.now()
     while (Date.now() - startedAt < timeoutMs) {
       if (!(await getScanInProgress())) {
-        return
+        return true
       }
       await new Promise((resolve) => window.setTimeout(resolve, 250))
     }
+    return false
   }, [])
 
   useEffect(() => {
@@ -148,17 +154,13 @@ function App() {
     }
     try {
       if (requestScan) {
-        try {
-          const scan = await scanCodexUsage(syncSettingsRef.current?.codexHome ?? null)
-          setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
-        } catch (error) {
-          const message = String(error)
-          if (!message.includes('already running')) {
-            throw error
-          }
-          setStatusMessage(t.status.backgroundScanAlreadyRunning)
-          await waitForScanToSettle()
-        }
+        const scan = await runScanWithOverlapRetry(
+          () => scanCodexUsage(syncSettingsRef.current?.codexHome ?? null),
+          (error) => String(error).includes('already running'),
+          waitForScanToSettle,
+          () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
+        )
+        setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
       }
 
       const snapshot = await loadDashboard(
@@ -317,7 +319,13 @@ function App() {
     let cancelled = false
 
     const bootstrap = async () => {
-      await waitForScanToSettle(60000)
+      const settled = await waitForScanToSettleUntilCancelled(
+        () => waitForScanToSettle(60000),
+        () => cancelled,
+      )
+      if (!settled || cancelled) {
+        return
+      }
       await loadShellRef.current(false)
       if (!cancelled) {
         setHasBootstrapped(true)
@@ -344,13 +352,21 @@ function App() {
 
   useEffect(() => {
     if (!hasBootstrapped || !syncSettings?.autoScanEnabled) return
-    const interval = window.setInterval(() => {
-      void refreshBackgroundData()
-        .catch(() => null)
-        .then(() => waitForOverlappingScan(getScanInProgress, waitForScanToSettle))
-        .then(() => loadShell(false))
-    }, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
-    return () => window.clearInterval(interval)
+    let cancelled = false
+    const refresh = () => {
+      void refreshDashboardAfterBackgroundScan(
+        refreshBackgroundData,
+        getScanInProgress,
+        waitForScanToSettle,
+        () => loadShell(false),
+        () => cancelled,
+      )
+    }
+    const interval = window.setInterval(refresh, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
   }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes, waitForScanToSettle])
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
   updateSubscriptionProfile,
   updateSyncSettings,
 } from './app/api'
+import { shouldKeepConversationDetail, waitForOverlappingScan } from './app/dataFreshness'
 import {
   formatCompactDateTime,
   formatDateTime,
@@ -176,7 +177,14 @@ function App() {
         const nextDetailCache = new Map<string, ConversationDetail>()
         for (const conversation of snapshot.conversations) {
           const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
-          if (cachedDetail && cachedDetail.updatedAt === conversation.updatedAt) {
+          if (
+            cachedDetail &&
+            shouldKeepConversationDetail(
+              cachedDetail,
+              conversation,
+              snapshot.subscriptionProfile.monthlyPrice,
+            )
+          ) {
             nextDetailCache.set(conversation.rootSessionId, cachedDetail)
           }
         }
@@ -339,10 +347,11 @@ function App() {
     const interval = window.setInterval(() => {
       void refreshBackgroundData()
         .catch(() => null)
+        .then(() => waitForOverlappingScan(getScanInProgress, waitForScanToSettle))
         .then(() => loadShell(false))
     }, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
     return () => window.clearInterval(interval)
-  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes])
+  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes, waitForScanToSettle])
 
   useEffect(() => {
     if (!settingsOpen || !syncSettings?.autoScanEnabled) return
@@ -384,13 +393,16 @@ function App() {
     syncSettings: SyncSettings
     subscriptionProfile: SubscriptionProfile
   }) {
+    const previousCodexHome = syncSettingsRef.current?.codexHome ?? null
     const [nextSyncSettings, nextSubscriptionProfile] = await Promise.all([
       updateSyncSettings(payload.syncSettings),
       updateSubscriptionProfile(payload.subscriptionProfile),
     ])
+    const codexHomeChanged = previousCodexHome !== nextSyncSettings.codexHome
+    syncSettingsRef.current = nextSyncSettings
     setSyncSettings(nextSyncSettings)
     setSubscriptionProfile(nextSubscriptionProfile)
-    await loadShell(false)
+    await loadShell(codexHomeChanged)
     if (isTauri()) {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
     }

--- a/src/app/dataFreshness.ts
+++ b/src/app/dataFreshness.ts
@@ -1,0 +1,30 @@
+import type { ConversationDetail, ConversationListItem } from './types.ts'
+
+const FLOAT_EPSILON = 1e-9
+
+function nearlyEqual(left: number, right: number): boolean {
+  return Math.abs(left - right) <= FLOAT_EPSILON
+}
+
+export function shouldKeepConversationDetail(
+  cached: ConversationDetail,
+  summary: ConversationListItem,
+  monthlyPrice: number,
+): boolean {
+  const expectedSubscriptionShare = monthlyPrice > 0 ? summary.apiValueUsd / monthlyPrice : 0
+
+  return (
+    cached.updatedAt === summary.updatedAt &&
+    nearlyEqual(cached.apiValueUsd, summary.apiValueUsd) &&
+    nearlyEqual(cached.subscriptionShare, expectedSubscriptionShare)
+  )
+}
+
+export async function waitForOverlappingScan(
+  getScanInProgress: () => Promise<boolean>,
+  waitForScanToSettle: () => Promise<void>,
+): Promise<void> {
+  if (await getScanInProgress()) {
+    await waitForScanToSettle()
+  }
+}

--- a/src/app/dataFreshness.ts
+++ b/src/app/dataFreshness.ts
@@ -22,9 +22,73 @@ export function shouldKeepConversationDetail(
 
 export async function waitForOverlappingScan(
   getScanInProgress: () => Promise<boolean>,
-  waitForScanToSettle: () => Promise<void>,
-): Promise<void> {
+  waitForScanToSettle: () => Promise<boolean>,
+): Promise<boolean> {
   if (await getScanInProgress()) {
-    await waitForScanToSettle()
+    return waitForScanToSettle()
   }
+  return true
+}
+
+export async function runScanWithOverlapRetry<T>(
+  runScan: () => Promise<T>,
+  isOverlappingScanError: (error: unknown) => boolean,
+  waitForScanToSettle: () => Promise<boolean>,
+  onOverlap: () => void = () => {},
+): Promise<T> {
+  try {
+    return await runScan()
+  } catch (error) {
+    if (!isOverlappingScanError(error)) {
+      throw error
+    }
+    onOverlap()
+    if (!(await waitForScanToSettle())) {
+      throw new Error('The active scan did not finish before the timeout.')
+    }
+    return runScan()
+  }
+}
+
+export async function refreshDashboardAfterBackgroundScan(
+  refreshBackgroundData: () => Promise<unknown>,
+  getScanInProgress: () => Promise<boolean>,
+  waitForScanToSettle: () => Promise<boolean>,
+  loadDashboard: () => Promise<void>,
+  isCancelled: () => boolean = () => false,
+): Promise<void> {
+  if (isCancelled()) {
+    return
+  }
+  try {
+    await refreshBackgroundData()
+  } catch {
+    // Keep loading persisted data when the background refresh itself fails.
+  }
+  if (isCancelled()) {
+    return
+  }
+
+  let settled: boolean
+  try {
+    settled = await waitForOverlappingScan(getScanInProgress, waitForScanToSettle)
+  } catch {
+    return
+  }
+  if (!settled || isCancelled()) {
+    return
+  }
+  await loadDashboard()
+}
+
+export async function waitForScanToSettleUntilCancelled(
+  waitForScanToSettle: () => Promise<boolean>,
+  isCancelled: () => boolean,
+): Promise<boolean> {
+  while (!isCancelled()) {
+    if (await waitForScanToSettle()) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/app/dataFreshness.ts
+++ b/src/app/dataFreshness.ts
@@ -6,18 +6,52 @@ function nearlyEqual(left: number, right: number): boolean {
   return Math.abs(left - right) <= FLOAT_EPSILON
 }
 
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false
+  const sortedLeft = [...left].sort()
+  const sortedRight = [...right].sort()
+  return sortedLeft.every((value, index) => value === sortedRight[index])
+}
+
 export function shouldKeepConversationDetail(
   cached: ConversationDetail,
   summary: ConversationListItem,
   monthlyPrice: number,
 ): boolean {
   const expectedSubscriptionShare = monthlyPrice > 0 ? summary.apiValueUsd / monthlyPrice : 0
+  const cachedModelIds = cached.modelBreakdown.map((item) => item.modelId)
+  const cachedSubagentCount = cached.sessions.filter((session) => session.isSubagent).length
+  const cachedHasFastMode = cached.sessions.some((session) => session.fastModeEffective)
 
   return (
+    cached.rootSessionId === summary.rootSessionId &&
+    cached.title === summary.title &&
+    cached.startedAt === summary.startedAt &&
     cached.updatedAt === summary.updatedAt &&
+    sameStringSet(cachedModelIds, summary.modelIds) &&
+    cached.inputTokens === summary.inputTokens &&
+    cached.cachedInputTokens === summary.cachedInputTokens &&
+    cached.outputTokens === summary.outputTokens &&
+    cached.reasoningOutputTokens === summary.reasoningOutputTokens &&
+    cached.totalTokens === summary.totalTokens &&
+    cached.sessions.length === summary.sessionCount &&
+    cachedSubagentCount === summary.subagentCount &&
+    cached.multipleAgent === (summary.sessionCount > 1) &&
+    cachedHasFastMode === summary.hasFastMode &&
     nearlyEqual(cached.apiValueUsd, summary.apiValueUsd) &&
-    nearlyEqual(cached.subscriptionShare, expectedSubscriptionShare)
+    nearlyEqual(summary.subscriptionShare, expectedSubscriptionShare) &&
+    nearlyEqual(cached.subscriptionShare, expectedSubscriptionShare) &&
+    sameStringSet(cached.sourceStates, summary.sourceStates)
   )
+}
+
+export async function loadConversationDetailForGeneration<T>(
+  loadDetail: () => Promise<T>,
+  requestGeneration: number,
+  getCurrentGeneration: () => number,
+): Promise<T | null> {
+  const detail = await loadDetail()
+  return requestGeneration === getCurrentGeneration() ? detail : null
 }
 
 export async function waitForOverlappingScan(

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -59,6 +59,8 @@ export type TranslationSet = {
     failedToLoad: (bucketLabel: string, error: string) => string
     pricingRefreshed: string
     settingsSaved: string
+    settingsSaveFailed: (error: string) => string
+    settingsStillLoading: string
     waitingLiveQuota: string
   }
   buckets: Record<OverviewBucket, string>
@@ -296,6 +298,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       failedToLoad: (bucketLabel, error) => `加载${bucketLabel}失败：${error}`,
       pricingRefreshed: '已按 OpenAI 标准短上下文定价刷新目录。',
       settingsSaved: '设置已保存。',
+      settingsSaveFailed: (error) => `设置未保存：${error}`,
+      settingsStillLoading: '设置仍在加载，请稍后重试。',
       waitingLiveQuota: '等待 live quota',
     },
     buckets: {
@@ -536,6 +540,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       failedToLoad: (bucketLabel, error) => `Failed to load ${bucketLabel}: ${error}`,
       pricingRefreshed: 'Pricing catalog refreshed from OpenAI Standard short-context pricing.',
       settingsSaved: 'Settings saved.',
+      settingsSaveFailed: (error) => `Settings were not saved: ${error}`,
+      settingsStillLoading: 'Settings are still loading. Try again in a moment.',
       waitingLiveQuota: 'Waiting for live quota',
     },
     buckets: {

--- a/src/app/settingsSave.ts
+++ b/src/app/settingsSave.ts
@@ -1,0 +1,98 @@
+interface CodexHomeSettings {
+  codexHome: string | null
+}
+
+interface SaveSettingsOptions<TSyncSettings extends CodexHomeSettings, TSubscriptionProfile> {
+  previousSyncSettings: TSyncSettings
+  nextSyncSettings: TSyncSettings
+  previousSubscriptionProfile: TSubscriptionProfile
+  nextSubscriptionProfile: TSubscriptionProfile
+  updateSyncSettings: (settings: TSyncSettings) => Promise<TSyncSettings>
+  updateSubscriptionProfile: (profile: TSubscriptionProfile) => Promise<TSubscriptionProfile>
+  scanCodexHome: (codexHome: string | null) => Promise<unknown>
+}
+
+interface SavedSettings<TSyncSettings, TSubscriptionProfile> {
+  syncSettings: TSyncSettings
+  subscriptionProfile: TSubscriptionProfile
+  codexHomeChanged: boolean
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function closeSettingsPanelIfIdle(saving: boolean, onClose: () => void): boolean {
+  if (saving) return false
+  onClose()
+  return true
+}
+
+export async function saveSettingsWithCodexHomeRollback<
+  TSyncSettings extends CodexHomeSettings,
+  TSubscriptionProfile,
+>({
+  previousSyncSettings,
+  nextSyncSettings,
+  previousSubscriptionProfile,
+  nextSubscriptionProfile,
+  updateSyncSettings,
+  updateSubscriptionProfile,
+  scanCodexHome,
+}: SaveSettingsOptions<TSyncSettings, TSubscriptionProfile>): Promise<
+  SavedSettings<TSyncSettings, TSubscriptionProfile>
+> {
+  let savedSyncSettings: TSyncSettings | null = null
+  let savedSubscriptionProfile: TSubscriptionProfile | null = null
+
+  try {
+    savedSyncSettings = await updateSyncSettings(nextSyncSettings)
+    savedSubscriptionProfile = await updateSubscriptionProfile(nextSubscriptionProfile)
+    const codexHomeChanged = previousSyncSettings.codexHome !== savedSyncSettings.codexHome
+    if (codexHomeChanged) {
+      await scanCodexHome(savedSyncSettings.codexHome)
+    }
+
+    return {
+      syncSettings: savedSyncSettings,
+      subscriptionProfile: savedSubscriptionProfile,
+      codexHomeChanged,
+    }
+  } catch (error) {
+    const rollbackErrors: string[] = []
+    let syncSettingsRestored = savedSyncSettings === null
+    if (savedSyncSettings) {
+      try {
+        await updateSyncSettings(previousSyncSettings)
+        syncSettingsRestored = true
+      } catch (rollbackError) {
+        rollbackErrors.push(errorMessage(rollbackError))
+      }
+    }
+    if (savedSubscriptionProfile) {
+      try {
+        await updateSubscriptionProfile(previousSubscriptionProfile)
+      } catch (rollbackError) {
+        rollbackErrors.push(errorMessage(rollbackError))
+      }
+    }
+    if (
+      savedSyncSettings &&
+      syncSettingsRestored &&
+      previousSyncSettings.codexHome !== savedSyncSettings.codexHome
+    ) {
+      try {
+        await scanCodexHome(previousSyncSettings.codexHome)
+      } catch (rollbackError) {
+        rollbackErrors.push(errorMessage(rollbackError))
+      }
+    }
+
+    if (rollbackErrors.length > 0) {
+      throw new Error(
+        `${errorMessage(error)} Previous settings could not be fully restored: ${rollbackErrors.join('; ')}`,
+      )
+    }
+    throw error
+  }
+}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 
 import { formatPercent, formatRemainingDuration } from '../app/format'
 import { SUPPORTED_LANGUAGES, type AppLanguage } from '../app/i18n'
+import { closeSettingsPanelIfIdle } from '../app/settingsSave'
 import { useI18n } from '../app/useI18n'
 import type {
   LiveRateLimitSnapshot,
@@ -72,8 +73,10 @@ export function SettingsPanel({
     subscriptionProfile,
   )
   const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const wasOpenRef = useRef(false)
   const showDockSettings = isMacOs()
+  const handleClose = () => closeSettingsPanelIfIdle(saving, onClose)
 
   useEffect(() => {
     const justOpened = isOpen && !wasOpenRef.current
@@ -82,10 +85,12 @@ export function SettingsPanel({
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
       setSaving(false)
+      setSaveError(null)
     } else if (!isOpen && wasOpenRef.current) {
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
       setSaving(false)
+      setSaveError(null)
     }
 
     wasOpenRef.current = isOpen
@@ -165,6 +170,7 @@ export function SettingsPanel({
   async function handleSubmit() {
     if (!draftSync || !draftSubscription) return
     setSaving(true)
+    setSaveError(null)
     try {
       const nextSync = draftSync
       const nextSubscription = draftSubscription
@@ -173,20 +179,22 @@ export function SettingsPanel({
         subscriptionProfile: nextSubscription,
       })
       onClose()
+    } catch (error) {
+      setSaveError(t.status.settingsSaveFailed(String(error)))
     } finally {
       setSaving(false)
     }
   }
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <div className="modal-backdrop" onClick={handleClose}>
       <div className="modal-panel settings-modal-panel" onClick={(event) => event.stopPropagation()}>
         <div className="modal-header">
           <div>
             <p className="eyebrow">{t.settings.appSettings}</p>
             <h3>{t.settings.syncAndSubscriptionProfile}</h3>
           </div>
-          <button className="ghost-button" onClick={onClose} type="button">
+          <button className="ghost-button" disabled={saving} onClick={handleClose} type="button">
             {t.actions.close}
           </button>
         </div>
@@ -757,8 +765,14 @@ export function SettingsPanel({
           </div>
         </div>
 
+        {saveError ? (
+          <p className="settings-save-error" role="alert">
+            {saveError}
+          </p>
+        ) : null}
+
         <div className="modal-actions">
-          <button className="ghost-button" onClick={onClose} type="button">
+          <button className="ghost-button" disabled={saving} onClick={handleClose} type="button">
             {t.actions.cancel}
           </button>
           <button className="accent-button" disabled={saving} onClick={handleSubmit} type="button">

--- a/src/styles.css
+++ b/src/styles.css
@@ -1887,6 +1887,16 @@ select:focus-visible {
   flex: none;
 }
 
+.settings-save-error {
+  margin: 16px 0 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  border-radius: 14px;
+  background: rgba(127, 29, 29, 0.18);
+  color: #fecaca;
+  overflow-wrap: anywhere;
+}
+
 @media (max-width: 1240px) {
   .app-frame {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary

This updates Codex Pacer for current ChatGPT and Codex session data, fixes token overcounting in forked sessions, and bumps the app version to 1.2.0.

- Recognizes GPT-5.6 Sol, Terra, and Luna, with conservative pricing fallback and durable value repair.
- Finds the Codex executable bundled with the ChatGPT macOS app and completes the current app-server handshake.
- Keeps dashboard refreshes, scan freshness, pricing updates, and settings saves coherent when work overlaps.
- Removes direct-parent token history copied into explicit fork files. A v3 repair sweep rebuilds unchanged historical sessions and retries files that move into the archive during the scan.
- Updates npm, Cargo, and Tauri release metadata to 1.2.0.

## Root cause

Codex fork files can start with cumulative token snapshots copied from their direct parent. The importer previously treated those inherited snapshots as new child usage. The first implementation corrected newly imported files but reused the completed v2 repair marker, so existing databases did not rebuild unchanged sessions.

The importer now matches the exact inherited snapshot prefix using cumulative and last-turn usage pairs, starts the child from the inherited baseline, and records a separate `token_usage_fork_replay_v3` repair. Pending repairs follow the session when an active file moves to `archived_sessions`.

## User impact

Existing installations run a one-time rebuild of session usage. Parent history is no longer billed again under forked children, and later scans keep the corrected totals. The replay reader uses token metadata only and does not load message bodies.

## Target branch

- [x] `develop`
- [ ] `main (release-only)`

## Verification

- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --locked`

Additional checks:

- 154 Rust tests passed.
- The macOS release script regression passed.
- A signed local DMG passed `codesign`, `hdiutil verify`, and SHA-256 verification.
- A copied production database completed the v3 rebuild with zero pending repair files, zero exact duplicate usage rows, and `PRAGMA quick_check = ok`.

## Checklist

- [x] Branch created from `develop`
- [x] Scope is focused
- [x] Docs updated where needed
- [x] No unrelated changes
