### PR TITLE
Improve refresh performance and background stability

### DIFF
--- a/.superpowers/sdd/task-3c2-report.md
+++ b/.superpowers/sdd/task-3c2-report.md
@@ -1,0 +1,83 @@
+# Refresh Task 3C2 report
+
+## Result
+
+Refresh work now runs on three persistent named threads: one coordinator, one token worker, and one live worker. Token parsing and commit no longer delay live fetching, and the coordinator remains available while either lane executes or waits for the usage mutation lock.
+
+Manual token and live requests return blocking tickets with typed `Result<Arc<T>, RefreshError>` outcomes. Callers that join the same generation receive the same `Arc`, including the exact `ScanResult` or live snapshot produced by that generation. Intake channels, worker channels, and waiter registries have fixed capacities. A full registry returns `Busy` instead of growing without limit.
+
+## Runtime behavior
+
+- The coordinator processes Task 3C1 action vectors in order and owns the only `PreparedSlot`. A parsed token payload moves from the worker to that slot, then moves once into commit or is dropped synchronously on discard. Missing, duplicate, or mismatched payload events become typed failures and cannot strand a waiter.
+- Worker outcomes carry the exact completion payload. The coordinator keeps that `Arc` only while it resolves the corresponding action vector, so the runtime has no generation history or unbounded result cache.
+- Token parsing happens before the refresh mutation ticket is requested. Only commit uses `UsageMutationCoordinator` at refresh priority. The worker records queue wait and rechecks shutdown plus source generation after acquiring the mutation slot.
+- The live worker never takes the usage mutation lock. It calls the fetcher with the existing ten-second timeout and keeps the single fetch and persist path bounded.
+- Parse, commit, fetch, and persist calls are wrapped with panic recovery. A panic resolves the affected waiters as a typed failure, clears the lane state, and leaves the persistent worker available for later requests.
+- Shared status changes to running before work is dispatched. Status and metrics use atomics and fixed histogram buckets. They cover planned due time, actual worker start, start lag, duration, success age, failure streak, retry time, coalescing, missed deadlines, waiter counts, live timeouts, token work statistics, mutation wait, and database busy results. Saturating counters use compare-and-exchange loops.
+- Start lag above five seconds and more than one active live executor increment fixed warning counters. Error detail is length bounded, and append-fast-path count remains zero because importer append work belongs to a later task.
+
+## Shutdown and source changes
+
+Shutdown is explicit and idempotent. The first call closes intake, rejects queued manual waiters with `Shutdown`, drops any prepared payload, marks the workers for shutdown, closes their command senders, drains bounded outcome channels, and joins all three threads. A repeated call returns the same completed teardown result without sending more commands.
+
+An executor call that has already entered its body may finish during teardown, but shutdown prevents a later publish. A token worker waiting for the mutation lock checks shutdown again after it acquires the permit and skips commit when teardown has begun. Source generation is checked at the same boundary. Token commit and live persist also check for a source change before reporting success, so stale results do not resolve tickets or publish events.
+
+## Power activity scope
+
+The macOS activity guard now lives in `refresh/power.rs` and uses `NSActivityOptions::Background`. Guards cover only token parse, token commit, live fetch, and live persist. Mutation queue waits, coordinator waits, scheduler sleeps, cache fallback, and rendering hold no activity.
+
+The remaining legacy paths use the same narrow guard around the combined scan body, live query, and database snapshot insert. The previous scheduler-loop guard was removed. An injectable activity factory lets the concurrency tests verify guard entry and release without depending on macOS.
+
+## TDD record
+
+The first focused RED run failed to compile with exit code 101 because the runtime types, activity counter, and panic hooks did not exist. The complete set of 30 required tests was then added before the implementation; that run also exited 101 on the missing runtime contracts.
+
+The first compiling runtime suite exposed two useful ordering defects. Duplicate gate entry did not match the intended generation, and the startup-lag test was measuring coordinator setup instead of the actual worker start boundary. Later concurrency runs also exercised source changes during token commit and live persist, persisted success age after short monotonic uptime, and extreme interval timestamp conversion. Those four regressions remain as extra coverage, bringing the focused runtime suite to 34 tests.
+
+All required cases now pass, including independent lane starts, exact shared results, one pending follow-up, bounded duplicate storms, panic recovery, disabled scheduling with manual work, start-lag warnings, mutation lock ordering, prepared-payload discard, source invalidation, bounded capacities, saturating counters, and every specified shutdown point. The activity tests also prove that queue and wait time are outside the guard.
+
+## Verification
+
+The final implementation passed:
+
+```text
+cargo check --manifest-path src-tauri/Cargo.toml --locked --lib
+finished successfully with no warnings
+
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests
+34 passed; 0 failed
+
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::power::tests
+2 passed; 0 failed
+
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::
+114 passed; 0 failed
+
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+296 library tests passed; 0 failed
+main tests: 0 failed
+doc tests: 0 failed
+```
+
+Scoped `rustfmt --check` passed for `runtime.rs`, `power.rs`, and `refresh/mod.rs`. `git diff --check` also passed.
+
+An independent contract review found no unresolved Critical or Important issue in the runtime, shutdown/channel cycles, prepared ownership, result pairing, action order, source checks, panic recovery, fixed metrics, power scope, or legacy guard changes. It also repeated the refresh and full Rust suites. A separate race scan ran the saturated shutdown case 25 times without a failure.
+
+## Deferred work and caveats
+
+Task 3C3 still owns concrete child-process reap coverage. Task 4 owns publish-before-persist and persistence retry behavior. Task 5 owns Tauri command routing and removal of the remaining legacy refresh paths. Append parsing and frontend work also remain out of scope.
+
+Two low-priority review notes remain. The rare partial thread-spawn failure path does not explicitly join every thread that started before the failure, although normal runtime shutdown joins all three. Event sink callbacks are trusted not to panic or re-enter the runtime. Neither affects the required Task 3C2 paths or the verified teardown behavior.
+
+## Self-review
+
+- Exactly three long-lived runtime threads are created, with no thread per trigger or generation.
+- The coordinator never runs executor work or waits for the mutation lock.
+- Prepared token data has one owner at every point and is dropped on discard, stale work, failure, or shutdown.
+- Successful tickets are paired with their generation's exact immutable result.
+- Public intake and waiter registration are linearized with shutdown and remain bounded.
+- Live execution stays independent of token parsing and commit.
+- Activity guards exclude coordinator wait, mutation wait, scheduler sleep, rendering, and cache fallback.
+- No importer, frontend, Task 4 persistence semantics, or Task 5 command routing was added early.
+
+No unresolved Task 3C2 defect is known.

--- a/docs/superpowers/plans/2026-07-10-importer-write-amplification.md
+++ b/docs/superpowers/plans/2026-07-10-importer-write-amplification.md
@@ -1,0 +1,470 @@
+# Importer and write amplification implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make active JSONL imports append-only in the normal case, preserve a safe full-rebuild fallback, skip unchanged pricing and title writes, and prune redundant quota history in bounded batches.
+
+**Architecture:** `import_state` gains a durable byte checkpoint with source fingerprints and cumulative token state. A typed parser reads complete records after that offset and persists derived rows plus the next checkpoint in one transaction. Identity, repair, topology, or parser changes select the existing full rebuild path. Pricing, title, and history maintenance use semantic no-op checks and bounded transactions.
+
+**Tech Stack:** Rust 2021, Rusqlite 0.37, Serde, Serde JSON, SHA-256 fingerprints, Chrono, existing importer integration fixtures.
+
+## Global constraints
+
+- Prerequisite: complete and verify the refresh-correctness and presentation plans first. In particular, this slice reuses presentation Tasks 1 and 2 for epoch and rate-limit writers.
+- Slice 2 owns usage epoch writes, latest quota, and change-point persistence. This plan calls those helpers and does not duplicate their SQL.
+- A typical append reads no old JSON payload beyond two fingerprint blocks totaling at most 8 KiB, then reads only bytes after the saved offset.
+- Checkpoint and derived data commit in the same SQLite transaction. A failure advances neither.
+- Checkpoints stop at the last complete newline. An incomplete tail is reread on the next scan.
+- File shrink, replacement, fingerprint mismatch, parser version change, repair, or topology change uses a full rebuild.
+- Full fallback produces the same sessions, usage events, quota points, persisted turns, and import state as a clean full import.
+- Unchanged pricing, titles, and repeated quota values cause no semantic row rewrite.
+- Cleanup performs one bounded transaction per dispatch and never runs `VACUUM` automatically.
+
+---
+
+### Task 1: Add durable append checkpoints and validation
+
+**Files:**
+- Modify: `src-tauri/sql/schema.sql:104-111`
+- Create: `src-tauri/src/database/import_state.rs`
+- Modify: `src-tauri/src/database.rs:1-55`
+- Modify: `src-tauri/src/importer.rs:1631-1655`
+- Modify: `src-tauri/src/importer.rs:1991-1998`
+- Test: `src-tauri/src/database/import_state.rs`
+
+**Interfaces:**
+- Consumes: legacy `import_state` rows.
+- Produces: `ImportCheckpoint`, `ImportCheckpointState`, validated `ImportState`, schema migration, load, and transactional upsert helpers.
+
+- [ ] **Step 1: Write failing migration and validation tests**
+
+Add `init_db_adds_append_checkpoint_columns_to_legacy_import_state`, `legacy_row_loads_with_missing_checkpoint_state`, `partial_cumulative_checkpoint_loads_as_invalid`, `negative_or_mismatched_offsets_load_as_invalid`, and `valid_checkpoint_round_trips`.
+
+```rust
+let state = load_import_state_row(&conn, "/tmp/session.jsonl").unwrap().unwrap();
+assert!(matches!(state.checkpoint, ImportCheckpointState::Missing));
+conn.execute("UPDATE import_state SET parsed_offset = 20, last_complete_line_offset = 10 WHERE source_path = ?1", [state.source_path]).unwrap();
+let state = load_import_state_row(&conn, "/tmp/session.jsonl").unwrap().unwrap();
+assert!(matches!(state.checkpoint, ImportCheckpointState::Invalid(_)));
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked append_checkpoint -- --nocapture`.
+
+Expected: migration columns and import-state module are missing.
+
+- [ ] **Step 3: Add nullable migration columns**
+
+Add:
+
+```text
+parsed_offset
+parsed_file_size
+prefix_fingerprint
+checkpoint_tail_fingerprint
+last_complete_line_offset
+last_cumulative_input_tokens
+last_cumulative_cached_input_tokens
+last_cumulative_output_tokens
+last_cumulative_reasoning_output_tokens
+last_cumulative_total_tokens
+last_model_id
+parser_schema_version
+```
+
+`ensure_import_state_schema` follows the existing `PRAGMA table_info` migration pattern. It never opens or scans source files.
+
+- [ ] **Step 4: Implement exact checkpoint contracts**
+
+```rust
+pub const SESSION_PARSER_SCHEMA_VERSION: i64 = 1;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImportCheckpoint {
+  pub parsed_offset: u64,
+  pub parsed_file_size: u64,
+  pub prefix_fingerprint: String,
+  pub checkpoint_tail_fingerprint: String,
+  pub last_complete_line_offset: u64,
+  pub last_cumulative_usage: Option<TokenUsage>,
+  pub last_model_id: Option<String>,
+  pub parser_schema_version: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CheckpointValidationError {
+  PartialFields,
+  NegativeOffset,
+  OffsetMismatch,
+  OffsetBeyondFile,
+  MissingFingerprint,
+  UnsupportedVersion,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ImportCheckpointState {
+  Missing,
+  Valid(ImportCheckpoint),
+  Invalid(CheckpointValidationError),
+}
+```
+
+Five token columns must be all NULL or all present. Require `parsed_offset == last_complete_line_offset`, nonnegative offsets, and `parsed_offset <= parsed_file_size`. SQLite read failures still return `Err`; malformed checkpoint content returns a usable `ImportState` with `Invalid`, allowing the importer to select a safe rebuild rather than aborting the scan.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked append_checkpoint
+git add src-tauri/sql/schema.sql src-tauri/src/database.rs src-tauri/src/database/import_state.rs src-tauri/src/importer.rs
+git commit -m "feat: add durable session append checkpoints"
+```
+
+### Task 2: Parse typed complete records and produce full checkpoints
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/Cargo.lock`
+- Create: `src-tauri/src/importer/session_parser.rs`
+- Modify: `src-tauri/src/importer.rs:1-20`
+- Modify: `src-tauri/src/importer.rs:727-992`
+- Modify: `src-tauri/src/database/conversation_turns.rs`
+- Test: `src-tauri/src/importer/session_parser.rs`
+
+**Interfaces:**
+- Consumes: current JSONL record formats, Slice 2 durable turn contracts, and the typed replay-envelope pattern in `importer.rs:1189-1249`.
+- Produces: borrowed record envelopes, complete-line reading, stable fingerprints, `SessionImport::Full`, turn upserts, and parse-byte diagnostics.
+
+- [ ] **Step 1: Write failing parser-equivalence tests**
+
+Add `typed_parser_matches_existing_usage_quota_and_turn_output`, `valid_json_without_terminal_newline_does_not_advance_checkpoint`, `typed_parser_ignores_unrelated_nested_token_fields`, `typed_parser_preserves_user_and_final_assistant_messages`, `invalid_utf8_is_fatal`, and `full_parse_reports_bytes_and_checkpoint`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked typed_parser -- --nocapture`.
+
+Expected: typed parser module is absent.
+
+- [ ] **Step 3: Add SHA-256 and exact parser result types**
+
+Add `sha2 = "0.10"` and define:
+
+```rust
+pub enum SessionImport {
+  Full {
+    parsed: ParsedSession,
+    checkpoint: ImportCheckpoint,
+    parsed_bytes: u64,
+  },
+  Append {
+    parsed: ParsedSessionTail,
+    checkpoint: ImportCheckpoint,
+    parsed_bytes: u64,
+  },
+}
+
+#[derive(serde::Deserialize)]
+struct SessionRecordEnvelope<'a> {
+  #[serde(default)]
+  timestamp: Option<&'a str>,
+  #[serde(rename = "type", default)]
+  record_type: Option<&'a str>,
+  #[serde(default, borrow)]
+  payload: Option<SessionPayloadEnvelope<'a>>,
+}
+```
+
+Parse detailed payloads only for the records needed by persisted derivatives: `session_meta`, `turn_context`, `event_msg/token_count`, task start/complete, user messages, agent messages, and final-answer response items. Emit the same `ConversationTurnPoint` values as the existing turn builder. Unknown records remain ignored and unrelated nested token-looking fields never affect totals.
+
+- [ ] **Step 4: Implement complete-line reading and fingerprints**
+
+Use `BufRead::read_until(b'\n', &mut bytes)`. Parse only buffers ending in newline. Keep the offset before an incomplete EOF buffer. SHA-256 covers at most the first 4 KiB and the 4 KiB ending at `parsed_offset`; store lowercase hex. A full parse returns the checkpoint and exact bytes passed through the JSON parser.
+
+- [ ] **Step 5: Run equivalence tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked typed_parser
+cargo test --manifest-path src-tauri/Cargo.toml --locked parent_replay_reader
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/src/importer.rs src-tauri/src/importer/session_parser.rs src-tauri/src/database/conversation_turns.rs
+git commit -m "refactor: parse typed complete session records"
+```
+
+### Task 3: Add the append fast path and atomic persistence
+
+**Files:**
+- Modify: `src-tauri/src/importer/session_parser.rs`
+- Modify: `src-tauri/src/importer.rs:175-327`
+- Modify: `src-tauri/src/importer.rs:1372-1526`
+- Modify: `src-tauri/src/database/import_state.rs`
+- Modify: `src-tauri/src/database/usage_events.rs`
+- Modify: `src-tauri/src/database/rate_limit_samples.rs`
+- Modify: `src-tauri/src/database/conversation_turns.rs`
+- Modify: `src-tauri/src/models.rs:421-430`
+- Modify: `src/app/types.ts:58-66`
+- Modify: `src/app/api.ts:202-213`
+- Test: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+- Consumes: Tasks 1 and 2 checkpoints plus Slice 2 append writers.
+- Produces: `ParsedSessionTail`, `parse_session_update`, `persist_session_update`, append metrics, and unchanged full rebuild behavior.
+
+- [ ] **Step 1: Write failing append and rollback tests**
+
+Add `append_growth_preserves_existing_usage_event_ids`, `append_growth_parses_only_new_bytes`, `append_uses_checkpoint_cumulative_usage`, `append_writes_quota_through_change_point_helper`, `append_updates_active_turn_without_rebuilding_older_turns`, and `checkpoint_rolls_back_with_usage_quota_and_turn_rows`.
+
+```rust
+let before_ids = usage_event_ids(&conn, session_id);
+append_token_record(&session_path, cumulative_usage(200));
+let result = perform_incremental_scan(&db_path, None).unwrap();
+let after_ids = usage_event_ids(&conn, session_id);
+assert_eq!(&after_ids[..before_ids.len()], before_ids.as_slice());
+assert_eq!(result.append_fast_path_files, 1);
+assert!(result.source_bytes_read < appended_bytes + 8_192);
+```
+
+- [ ] **Step 2: Run tests and verify current rebuild behavior**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked append_growth -- --nocapture`.
+
+Expected: old event IDs are replaced and diagnostics are absent.
+
+- [ ] **Step 3: Add import selection and tail contracts**
+
+```rust
+pub enum FullRebuildReason {
+  MissingCheckpoint,
+  InvalidCheckpoint,
+  FileShrank,
+  FingerprintMismatch,
+  ParserSchemaChanged,
+  PendingRepair,
+  TopologyChanged,
+  ReplacedSource,
+}
+
+pub struct TurnResumeState {
+  pub active_turn: Option<ConversationTurnPoint>,
+  pub next_synthetic_sequence: u64,
+}
+
+pub(super) fn parse_session_update(
+  session_file: &SessionFile,
+  state: Option<&ImportState>,
+  turn_resume: TurnResumeState,
+  titles: &HashMap<String, String>,
+  force_full_rebuild: bool,
+) -> Result<SessionImport, SessionParseError>;
+```
+
+`TurnResumeState` contains the last persisted active turn and next synthetic turn sequence for that session. Tail parsing begins with it, checkpoint cumulative usage, and last model. A `session_meta` record or parent/fork change returns `TopologyChanged` before any transaction begins.
+
+- [ ] **Step 4: Append derived rows and checkpoint in one transaction**
+
+`persist_session_update` uses Slice 2 `insert_usage_events`, `append_session_rate_limit_samples`, and `upsert_session_turns`. It updates session metadata and checkpoint in the same transaction. It never deletes existing rows on `SessionImport::Append`; the currently active turn may be updated in place while completed older turns retain their IDs. Keep the current delete-and-rebuild code for `SessionImport::Full`.
+
+Extend the serialized Rust and TypeScript `ScanResult` contracts with `source_bytes_read`/`sourceBytesRead`, `append_fast_path_files`/`appendFastPathFiles`, and `full_rebuild_files`/`fullRebuildFiles`. Update the frontend mock to return zero for all three fields. Tests and bounded token metrics use them to verify behavior without accumulating per-file history.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked append_growth
+cargo test --manifest-path src-tauri/Cargo.toml --locked checkpoint_rolls_back
+git add src-tauri/src/importer.rs src-tauri/src/importer/session_parser.rs src-tauri/src/database/import_state.rs src-tauri/src/database/usage_events.rs src-tauri/src/database/rate_limit_samples.rs src-tauri/src/database/conversation_turns.rs src-tauri/src/models.rs src/app/types.ts src/app/api.ts
+git commit -m "feat: append new session records transactionally"
+```
+
+### Task 4: Enforce the full-rebuild fallback matrix
+
+**Files:**
+- Modify: `src-tauri/src/importer/session_parser.rs`
+- Modify: `src-tauri/src/importer.rs:128-327`
+- Test: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+- Consumes: Task 3 import selection and current repair, fork replay, archive, and topology logic.
+- Produces: deterministic `FullRebuildReason` selection and clean-import equivalence.
+
+- [ ] **Step 1: Write failing fallback tests**
+
+Add `append_fallback_rebuilds_truncated_file`, `append_fallback_rebuilds_replaced_same_path`, `append_fallback_rebuilds_on_prefix_mismatch`, `append_fallback_rebuilds_on_tail_mismatch`, `append_fallback_rebuilds_on_parser_version_change`, `partial_checkpoint_selects_invalid_checkpoint_rebuild`, `malformed_checkpoint_selects_invalid_checkpoint_rebuild`, `append_fallback_rebuilds_on_topology_record`, and `append_fallback_matches_clean_full_import`.
+
+- [ ] **Step 2: Run tests and verify missing fallback classifications**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked append_fallback -- --nocapture`.
+
+- [ ] **Step 3: Implement identity validation before parsing the tail**
+
+Map `ImportCheckpointState::Missing` to `MissingCheckpoint`, `Invalid(_)` to `InvalidCheckpoint`, and only `Valid` to append validation. Require current size at least `parsed_file_size` as well as `parsed_offset`, matching prefix and checkpoint-tail hashes, matching schema version, and no pending repair. Archive path changes take one full parse. Never copy a checkpoint across paths merely because session IDs match. A successful full rebuild replaces malformed fields with one valid checkpoint in the same transaction.
+
+- [ ] **Step 4: Compare fallback output with a clean database**
+
+The equivalence test sorts and compares all session fields, usage-event value fields, quota change points, persisted conversation turns, links, and checkpoint values. Preserve existing fork replay, archive completion, invalid UTF-8, and incomplete-tail tests.
+
+- [ ] **Step 5: Run regression tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked append_fallback
+cargo test --manifest-path src-tauri/Cargo.toml --locked fork_replay
+cargo test --manifest-path src-tauri/Cargo.toml --locked archived
+git add src-tauri/src/importer.rs src-tauri/src/importer/session_parser.rs
+git commit -m "fix: rebuild safely when append identity changes"
+```
+
+### Task 5: Skip unchanged pricing writes and event recalculation
+
+**Files:**
+- Modify: `src-tauri/src/pricing.rs:36-230`
+- Modify: `src-tauri/src/pricing.rs:452-518`
+- Modify: `src-tauri/src/database.rs`
+- Modify: `src-tauri/src/importer.rs:88-99`
+- Modify: `src-tauri/src/lib.rs:201-224`
+- Modify: `src-tauri/src/lib.rs:580-608`
+- Test: `src-tauri/src/pricing.rs`
+- Test: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: existing value-bearing pricing signature and repair marker.
+- Produces: `PricingCatalogChange`, one-time startup initialization, no-op upsert, and read-only scan catalog loading.
+
+- [ ] **Step 1: Write failing no-op and rollback tests**
+
+Add `repeated_initializer_does_not_rewrite_unchanged_rows`, `unchanged_scan_does_not_invoke_catalog_initializer`, `unchanged_signature_does_not_update_usage_events`, and `metadata_only_change_does_not_recalculate_values`. Keep existing rollback and malformed GPT-5.6 repair tests.
+
+- [ ] **Step 2: Run tests and record current writes**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked pricing_signature -- --nocapture`.
+
+Expected: `updated_at` and usage-event update counters change on an identical refresh.
+
+- [ ] **Step 3: Add semantic change classification**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PricingCatalogChange { Unchanged, MetadataOnly, ValueChanged }
+
+pub fn apply_pricing_catalog_refresh(
+  conn: &Connection,
+  official_entries: Option<&[PricingCatalogEntry]>,
+) -> Result<PricingCatalogChange, String>;
+
+pub fn initialize_pricing_catalog(
+  conn: &Connection,
+) -> Result<PricingCatalogChange, String>;
+
+pub fn load_catalog_map(
+  conn: &Connection,
+) -> rusqlite::Result<HashMap<String, PricingCatalogEntry>>;
+```
+
+Upsert rows only when a semantic field differs. Ignore incoming `updated_at` when deciding equality. `initialize_pricing_catalog` seeds only when the catalog is empty or the known repair is pending, and is called from database/app startup migration wiring, never from a scan.
+
+- [ ] **Step 4: Recalculate only value changes**
+
+Remove `seed_pricing_catalog` and repair checks from `perform_scan_with_scope`; scans call read-only `load_catalog_map`. `refresh_pricing_catalog_atomically` recalculates all session values only for `ValueChanged` or an incomplete resolver repair. A metadata-only result updates catalog provenance in the same transaction but performs no usage-event update.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked pricing
+cargo test --manifest-path src-tauri/Cargo.toml --locked pricing_refresh_rolls_back
+git add src-tauri/src/pricing.rs src-tauri/src/database.rs src-tauri/src/importer.rs src-tauri/src/lib.rs
+git commit -m "perf: skip unchanged pricing and event rewrites"
+```
+
+### Task 6: Update titles only when values change
+
+**Files:**
+- Modify: `src-tauri/src/importer.rs:575-611`
+- Modify: `src-tauri/src/importer.rs:215-219`
+- Test: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+- Consumes: current `session_index.jsonl` title map.
+- Produces: one conditional title transaction and changed-row count.
+
+- [ ] **Step 1: Write failing title-write tests**
+
+Add `full_scan_does_not_update_unchanged_titles`, `changed_title_updates_once`, and `title_batch_rolls_back_together`. Preserve `full_scan_refreshes_title_when_only_session_index_changes`.
+
+- [ ] **Step 2: Run tests and verify unconditional updates**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked session_titles -- --nocapture`.
+
+- [ ] **Step 3: Implement conditional prepared updates**
+
+Sort by session ID, open one transaction, reuse one statement, and execute:
+
+```sql
+UPDATE sessions
+SET title = ?1
+WHERE session_id = ?2
+  AND title IS NOT ?1
+```
+
+Return the total changed rows for diagnostics.
+
+- [ ] **Step 4: Run title tests**
+
+Run the focused command and the existing title-only change test. Expected: unchanged scan reports zero title writes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/importer.rs
+git commit -m "perf: update only changed session titles"
+```
+
+### Task 7: Prune old quota duplicates in bounded batches
+
+**Files:**
+- Modify: `src-tauri/src/database/rate_limit_samples.rs`
+- Modify: `src-tauri/src/database.rs`
+- Modify: `src-tauri/src/refresh/runtime.rs`
+- Test: `src-tauri/src/database/rate_limit_samples.rs`
+- Test: `src-tauri/src/refresh/runtime.rs`
+
+**Interfaces:**
+- Consumes: Slice 2 epoch fields and new change-point writer.
+- Produces: `QuotaCleanupBatchResult`, idempotent old-row cleanup, and coordinator deadline guard.
+
+- [ ] **Step 1: Write failing cleanup and scheduling tests**
+
+Add `cleanup_keeps_first_and_last_of_constant_run`, `cleanup_keeps_percent_changes`, `cleanup_deletes_at_most_batch_size`, `cleanup_resume_is_idempotent`, `cleanup_waits_for_epoch_backfill_completion`, `cleanup_never_touches_legacy_null_epoch_rows`, and `cleanup_does_not_start_within_thirty_seconds_of_refresh_deadline`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked quota_cleanup -- --nocapture`.
+
+- [ ] **Step 3: Implement one bounded batch**
+
+```rust
+pub struct QuotaCleanupBatchResult {
+  pub deleted_rows: usize,
+  pub complete: bool,
+}
+
+pub fn prune_redundant_rate_limit_samples_batch(
+  conn: &mut Connection,
+  batch_size: usize,
+) -> rusqlite::Result<QuotaCleanupBatchResult>;
+```
+
+Return without mutation unless the Slice 2 epoch repair marker is complete. Select redundant IDs with `LAG` and `LEAD`, restricted by `sample_timestamp_ms IS NOT NULL AND window_start_ms IS NOT NULL AND resets_at_ms IS NOT NULL`, partitioned by `(bucket, window_start_ms, resets_at_ms)`, and ordered by `(sample_timestamp_ms, id)`. Delete at most 500 IDs in one transaction. Preserve first, last, every percent change, and every legacy NULL-epoch row. Mark `quota_history_change_point_cleanup_v1` complete only when a post-backfill batch deletes zero rows.
+
+- [ ] **Step 4: Dispatch only in a safe idle window**
+
+The coordinator gives epoch backfill priority and does not enqueue quota cleanup until that repair is complete. It starts one cleanup batch only when token and live are idle and the next deadline is more than 30 seconds away. Completion may queue another batch through the event channel. It never loops inside one worker and never runs `VACUUM`.
+
+- [ ] **Step 5: Run full slice verification and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+cargo clippy --manifest-path src-tauri/Cargo.toml --locked --lib
+npm test
+npm run lint
+npm run build
+git add src-tauri/src/database.rs src-tauri/src/database/rate_limit_samples.rs src-tauri/src/refresh/runtime.rs
+git commit -m "perf: prune redundant quota history in bounded batches"
+```
+
+Expected: append tests read only new bytes, fallback equivalence holds, unchanged scans avoid pricing and title writes, cleanup remains bounded, and all existing fork, archive, freshness, and pricing tests pass. Clippy exits successfully; compare its output with the recorded 16-warning repository baseline and fix every new warning in changed files.

--- a/docs/superpowers/plans/2026-07-10-presentation-bounded-queries.md
+++ b/docs/superpowers/plans/2026-07-10-presentation-bounded-queries.md
@@ -1,0 +1,656 @@
+# Presentation and bounded queries implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make tray and popup reads bounded, move all tray computation off the UI thread, reduce database row materialization, split the popup bundle, and cap dashboard caches.
+
+**Architecture:** Indexed epoch fields and compact latest-quota storage feed a versioned `DisplaySnapshotStore`. A background snapshot service consumes Slice 1 invalidations and publishes immutable presentation revisions. Tray setters receive precomputed diffs, while the popup and dashboard consume revisioned snapshots without polling.
+
+**Tech Stack:** Rust 2021, Tauri 2.10, Rusqlite 0.37 with bundled SQLite, React 19 for the dashboard, plain TypeScript DOM for the lightweight popup, Vite 8, Node 22.18 test scripts.
+
+## Global constraints
+
+- Prerequisite: complete and verify the refresh-correctness plan first. This slice consumes its coordinator invalidations and completion events.
+- Snapshot getters perform no source I/O and remain below 5 ms p95.
+- Tray main-thread apply remains below 2 ms p95 and contains no database, file, process, or formatting work.
+- Token or quota commit reaches the visible tray within 100 ms p95 and the visible popup within 150 ms p95.
+- Popup payload is at most 64 KB. Popup JavaScript is at most 150 KB minified and 50 KB gzip and contains no dashboard, Recharts, React, or ReactDOM dependency.
+- The popup is created on first tray use. Hidden popup and dashboard surfaces execute zero data queries during a 10-minute observation.
+- Existing popup structure, colors, keyboard Escape behavior, visible focus, accessible labels, stable loading layout, and reduced-motion behavior remain intact.
+- Conversation detail cache is limited to 20 entries and 32 MB. Default detail response includes the newest 40 turns.
+- Existing mixed-offset timestamp and live-window correctness tests remain passing.
+
+---
+
+### Task 1: Add indexed epoch fields and bounded backfill
+
+**Files:**
+- Modify: `src-tauri/sql/schema.sql:29-42`
+- Modify: `src-tauri/sql/schema.sql:126-140`
+- Modify: `src-tauri/sql/indexes.sql`
+- Create: `src-tauri/src/database/epoch_backfill.rs`
+- Create: `src-tauri/src/database/usage_events.rs`
+- Modify: `src-tauri/src/database.rs:1-55`
+- Modify: `src-tauri/src/importer.rs:1469-1490`
+- Modify: `src-tauri/src/refresh/runtime.rs`
+- Test: `src-tauri/src/database/epoch_backfill.rs`
+- Test: `src-tauri/src/database/usage_events.rs`
+- Test: `src-tauri/src/refresh/runtime.rs`
+
+**Interfaces:**
+- Consumes: RFC3339 timestamps already stored by the importer.
+- Produces: `timestamp_ms`, quota epoch columns, partial compatibility indexes, `parse_epoch_millis`, `insert_usage_events`, bounded backfill progress, and resumable maintenance dispatch.
+
+- [ ] **Step 1: Write failing schema, parser, and batch tests**
+
+Add `init_db_adds_epoch_columns_without_scanning_history`, `epoch_parser_orders_mixed_offsets_by_instant`, `new_usage_event_writes_timestamp_ms`, `backfill_updates_at_most_requested_batch_size`, `compatibility_query_includes_null_epoch_rows`, `integrity_check_is_ok_after_epoch_migration`, `epoch_backfill_runs_one_batch_per_maintenance_dispatch`, `epoch_backfill_resumes_from_null_rows_after_restart`, and `snapshot_getter_remains_available_while_epoch_backfill_waits`.
+
+```rust
+assert!(parse_epoch_millis("2026-07-10T10:00:00+08:00").unwrap()
+  < parse_epoch_millis("2026-07-10T03:00:01Z").unwrap());
+let progress = backfill_epoch_batch(&conn, 1_000).unwrap();
+assert!(progress.usage_rows_updated + progress.quota_rows_updated <= 1_000);
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::epoch_backfill::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::usage_events::tests
+```
+
+Expected: schema columns and modules are missing.
+
+- [ ] **Step 3: Add nullable migration fields and partial indexes**
+
+New installs include:
+
+```sql
+timestamp_ms INTEGER
+sample_timestamp_ms INTEGER
+window_start_ms INTEGER
+resets_at_ms INTEGER
+```
+
+Existing installs use `ensure_epoch_schema` with `ALTER TABLE` only. Add:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_ms
+  ON usage_events(timestamp_ms, id) WHERE timestamp_ms IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_missing_epoch
+  ON usage_events(id) WHERE timestamp_ms IS NULL;
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_window_ms
+  ON rate_limit_samples(bucket, window_start_ms, resets_at_ms, sample_timestamp_ms, id)
+  WHERE window_start_ms IS NOT NULL AND resets_at_ms IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_missing_epoch
+  ON rate_limit_samples(id) WHERE sample_timestamp_ms IS NULL;
+```
+
+- [ ] **Step 4: Implement bounded write and backfill helpers**
+
+Use:
+
+```rust
+pub struct EpochBackfillProgress {
+  pub usage_rows_updated: usize,
+  pub quota_rows_updated: usize,
+  pub complete: bool,
+}
+
+pub fn parse_epoch_millis(value: &str) -> Result<i64, String> {
+  DateTime::parse_from_rfc3339(value)
+    .map(|value| value.timestamp_millis())
+    .map_err(|error| error.to_string())
+}
+
+pub fn backfill_epoch_batch(conn: &Connection, batch_size: usize) -> rusqlite::Result<EpochBackfillProgress>;
+```
+
+Each batch reads at most 1,000 NULL rows by ID and commits once. The remaining NULL rows are the durable progress marker; write the corresponding `data_repairs` completion row only when none remain. Change `persist_session` to call `insert_usage_events`, which always binds `timestamp_ms` for new rows.
+
+Register `EpochBackfill` as a low-priority `BackgroundMaintenance` intent with the Slice 1 coordinator. Startup checks the repair marker without scanning source data. A maintenance worker runs exactly one batch, yields through the coordinator event channel, and queues another only when both refresh lanes are idle and the next deadline is more than 30 seconds away. NULL rows are the restart cursor, so termination between batches resumes safely. Foreground snapshot reads continue to use the compatibility branch and never wait for migration completion.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::epoch_backfill::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::usage_events::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked epoch_backfill_runs_one_batch_per_maintenance_dispatch
+git add src-tauri/sql src-tauri/src/database.rs src-tauri/src/database/epoch_backfill.rs src-tauri/src/database/usage_events.rs src-tauri/src/importer.rs src-tauri/src/refresh/runtime.rs
+git commit -m "perf: add indexed epoch timestamps and bounded backfill"
+```
+
+### Task 2: Store latest quota separately and compact new history
+
+**Files:**
+- Modify: `src-tauri/sql/schema.sql`
+- Modify: `src-tauri/sql/indexes.sql`
+- Modify: `src-tauri/src/database/rate_limit_samples.rs`
+- Modify: `src-tauri/src/database.rs:8-18`
+- Modify: `src-tauri/src/lib.rs:1152-1285`
+- Modify: `src-tauri/src/models.rs:170-224`
+- Test: `src-tauri/src/database/rate_limit_samples.rs`
+
+**Interfaces:**
+- Consumes: Task 1 epoch parser and current rate-limit records.
+- Produces: `latest_rate_limits`, `RateLimitWriteStats`, exact fallback lookup, and shared append/replace writers for Slice 3.
+
+- [ ] **Step 1: Write failing latest and change-point tests**
+
+Add `repeated_live_percent_updates_latest_without_growing_history`, `changed_percent_adds_one_history_point`, `new_window_keeps_previous_close_and_new_start`, `session_batch_keeps_first_change_and_last`, `latest_quota_uses_epoch_order`, and `latest_lookup_does_not_scan_history`.
+
+```rust
+let first = insert_live_rate_limit_snapshot(&conn, &live_snapshot(40, "2026-07-10T10:00:00Z")).unwrap();
+let repeated = insert_live_rate_limit_snapshot(&conn, &live_snapshot(40, "2026-07-10T10:05:00Z")).unwrap();
+assert_eq!(first.historical_inserted, 2);
+assert_eq!(repeated.historical_inserted, 0);
+assert_eq!(repeated.latest_updated, 2);
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked database::rate_limit_samples::tests`.
+
+Expected: latest table and write statistics are missing.
+
+- [ ] **Step 3: Add latest table and common write contracts**
+
+Create a two-row-per-source table keyed by `(source_kind, bucket)` with snapshot timestamp, epoch fields, limit metadata, window bounds, and percent fields. Define:
+
+```rust
+pub struct RateLimitWriteStats {
+  pub observed: usize,
+  pub historical_inserted: usize,
+  pub latest_updated: usize,
+}
+
+pub fn append_session_rate_limit_samples(
+  conn: &Connection,
+  session_id: &str,
+  samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<RateLimitWriteStats>;
+
+pub fn replace_session_rate_limit_samples(
+  conn: &Connection,
+  session_id: &str,
+  samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<RateLimitWriteStats>;
+```
+
+- [ ] **Step 4: Implement step-change writes and fallback reads**
+
+Within one transaction, upsert latest first. Insert historical data for a window start, a percent change, and the previous window close. Repeated equal values only update latest. `load_latest_rate_limits` orders by integer epoch and combines primary and secondary only when they share a snapshot timestamp; it never runs `ORDER BY julianday(...)` over history.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::rate_limit_samples::tests
+git add src-tauri/sql src-tauri/src/database.rs src-tauri/src/database/rate_limit_samples.rs src-tauri/src/lib.rs src-tauri/src/models.rs
+git commit -m "perf: store latest quota and compact new history"
+```
+
+### Task 3: Replace full-table presentation reads with bounded window queries
+
+**Files:**
+- Create: `src-tauri/src/queries/presentation.rs`
+- Create: `src-tauri/sql/queries/usage_events_window.sql`
+- Create: `src-tauri/sql/queries/conversation_page.sql`
+- Create: `src-tauri/sql/queries/presentation_usage_summary.sql`
+- Modify: `src-tauri/sql/queries/quota_samples.sql`
+- Modify: `src-tauri/sql/queries/rate_limit_windows.sql`
+- Modify: `src-tauri/src/queries.rs:32-257`
+- Modify: `src-tauri/src/queries.rs:1153-1207`
+- Modify: `src-tauri/src/queries.rs:1324-1669`
+- Test: `src-tauri/src/queries/presentation.rs`
+
+**Interfaces:**
+- Consumes: Task 1 time indexes, Task 2 quota storage, and existing `ResolvedWindow` rules.
+- Produces: window summary, one-pass trend accumulation, exact quota-window reads, and bounded conversation pages.
+
+- [ ] **Step 1: Write failing query-plan and row-visit tests**
+
+Add `presentation_summary_filters_before_materialization`, `quota_query_selects_exact_window`, `quota_plan_uses_window_index`, `usage_plan_uses_timestamp_index`, `window_accumulator_visits_selected_rows_only`, `total_overview_streams_without_event_vector`, `mixed_offset_compatibility_matches_backfill`, and `compatibility_millisecond_boundaries_match_epoch_branch`.
+
+- [ ] **Step 2: Run tests and verify current amplification**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked queries::presentation::tests -- --nocapture`.
+
+Expected: new tests fail; the fixture observes full event and bucket row counts.
+
+- [ ] **Step 3: Add bounded summary and window-event SQL**
+
+```rust
+pub struct WindowUsageSummary {
+  pub api_value_usd: f64,
+  pub total_tokens: i64,
+  pub conversation_count: usize,
+}
+
+pub fn load_window_usage_summary(
+  conn: &Connection,
+  window: &ResolvedWindow,
+) -> rusqlite::Result<WindowUsageSummary>;
+```
+
+The SQL uses `SUM` and `COUNT(DISTINCT sessions.root_session_id)` with `timestamp_ms >= start` and `< end`. While backfill is incomplete, a UNION branch reads only the partial NULL-epoch index and compares `unixepoch(timestamp) * 1000` with the same millisecond bounds. Add exact start-inclusive/end-exclusive boundary assertions so the compatibility and epoch branches cannot diverge by units. `total` uses aggregate `MIN/MAX` instead of loading events.
+
+Change the existing `ResolvedWindow` visibility to `pub(super)` so `queries::presentation` can reuse the single canonical local-time and live-window resolver instead of duplicating its rules.
+
+- [ ] **Step 4: Make trend and quota accumulation one pass**
+
+Stream selected rows ordered by epoch and advance a bin cursor once per event. Change quota SQL to bind `(bucket, window_start_ms, resets_at_ms)`. Limit historical live windows to 512. Preserve current local-time labels and live-window correctness tests.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked queries::presentation::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked menu_bar_api_value_uses_selected_live_window
+git add src-tauri/sql/queries src-tauri/src/queries.rs src-tauri/src/queries
+git commit -m "perf: bound presentation and dashboard window reads"
+```
+
+### Task 4: Publish versioned display snapshots
+
+**Files:**
+- Create: `src-tauri/src/presentation.rs`
+- Create: `src-tauri/src/presentation/snapshot.rs`
+- Modify: `src-tauri/src/models.rs`
+- Modify: `src-tauri/src/lib.rs:1-102`
+- Modify: `src-tauri/src/lib.rs:268-275`
+- Modify: `src-tauri/src/lib.rs:1341-1418`
+- Modify: `src-tauri/src/refresh/live_cache.rs`
+- Modify: `src/App.tsx`
+- Modify: `src/menu-bar-popup/MenuBarPopup.tsx`
+- Modify: `src/app/refreshEvents.ts`
+- Modify: `src/app/types.ts`
+- Modify: `src/app/api.ts`
+- Test: `src-tauri/src/presentation/snapshot.rs`
+
+**Interfaces:**
+- Consumes: Slice 1 `DisplayInvalidation`, `LiveQuotaCache`, and Task 3 bounded queries.
+- Produces: `DisplaySnapshotStore`, `DisplaySnapshotService`, `DisplaySnapshotEvent`, and passive memory getters.
+
+- [ ] **Step 1: Write failing revision and getter tests**
+
+Add `snapshot_getter_performs_no_source_io`, `builder_discards_stale_source_revisions`, `revision_during_build_queues_one_rebuild`, `presentation_revision_increases_after_publish`, `fresh_live_cache_overlays_unpersisted_quota`, `blocked_live_persistence_does_not_delay_snapshot_or_tray`, `raw_refresh_completion_does_not_reload_surface_data`, `failed_completion_clears_refreshing_without_replacing_data`, and `popup_payload_is_at_most_65536_bytes`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked presentation::snapshot::tests`.
+
+- [ ] **Step 3: Add exact snapshot types**
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisplaySourceRevisions {
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub settings_revision: u64,
+  pub source_generation: u64,
+}
+
+pub struct DisplaySnapshot {
+  pub source_revisions: DisplaySourceRevisions,
+  pub source_commit: CommitMarker,
+  pub presentation_revision: u64,
+  pub popup: MenuBarPopupSnapshot,
+  pub tray: TraySnapshotInput,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisplaySnapshotEvent {
+  pub presentation_revision: u64,
+  pub popup: MenuBarPopupSnapshot,
+}
+
+impl DisplaySnapshotStore {
+  pub fn current(&self) -> Arc<DisplaySnapshot>;
+  pub fn current_event(&self) -> DisplaySnapshotEvent;
+}
+
+impl DisplaySnapshotBuilder {
+  pub fn build(
+    &self,
+    conn: &Connection,
+    live: &LiveQuotaState,
+    revisions: &DisplaySourceRevisions,
+    source_commit: CommitMarker,
+  ) -> Result<DisplaySnapshot, String>;
+}
+```
+
+`DisplaySnapshotBuilder::build` receives a cloned `LiveQuotaState`, source revisions, and the latest `CommitMarker` alongside the database connection. It overlays the in-memory live primary/secondary values and a terminal trend point on bounded historical SQL results. The resulting snapshot carries the monotonic marker for the newest represented token/quota commit, and the builder never waits for live-history persistence.
+
+- [ ] **Step 4: Implement latest-wins rebuild and passive commands**
+
+Publish an empty revision-zero snapshot at startup. Capture source revisions before build; discard a result if they change and queue one latest rebuild. Replace `getMenuBarPopupSnapshot(force_refresh)` with a memory clone that has no force parameter. Manual refresh uses the Slice 1 coordinator. Emit `codex-counter://display-snapshot-updated` only after a consistent snapshot is published.
+
+Replace the interim Slice 1 data gate on both surfaces: `codex-counter://refresh-completed` may only settle the matching manual spinner or error state, while `codex-counter://display-snapshot-updated` is the sole event that may apply data. Accept only a strictly higher `presentationRevision`; hidden surfaces retain only the highest pending revision. Remove the raw-refresh reload path and test its absence in source.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked presentation::snapshot::tests
+git add src-tauri/src/presentation.rs src-tauri/src/presentation src-tauri/src/models.rs src-tauri/src/lib.rs src-tauri/src/refresh/live_cache.rs src/App.tsx src/menu-bar-popup/MenuBarPopup.tsx src/app/api.ts src/app/refreshEvents.ts src/app/types.ts
+git commit -m "feat: publish versioned bounded display snapshots"
+```
+
+### Task 5: Move tray computation off the main thread
+
+**Files:**
+- Create: `src-tauri/src/presentation/tray.rs`
+- Modify: `src-tauri/src/lib.rs:610-673`
+- Modify: `src-tauri/src/lib.rs:1847-1908`
+- Modify: `src-tauri/src/lib.rs:2132-2158`
+- Test: `src-tauri/src/presentation/tray.rs`
+
+**Interfaces:**
+- Consumes: Task 4 immutable display snapshots.
+- Produces: `TrayPresentation`, `TrayPresentationDiff`, and latest-wins `TrayPresenter`.
+
+- [ ] **Step 1: Write failing diff and ordering tests**
+
+Add `unchanged_snapshot_calls_no_setters`, `diff_contains_changed_fields_only`, `newer_revision_during_apply_runs_one_follow_up`, `older_revision_cannot_replace_newer`, and `main_thread_receives_precomputed_values`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked presentation::tray::tests`.
+
+- [ ] **Step 3: Implement presentation values and diffs**
+
+```rust
+pub struct TrayPresentation {
+  pub title: Option<String>,
+  pub tooltip: Option<String>,
+  pub show_logo: bool,
+  pub visible: bool,
+}
+
+pub fn diff_tray_presentation(
+  previous: Option<&TrayPresentation>,
+  next: &TrayPresentation,
+) -> TrayPresentationDiff;
+```
+
+Compute strings, settings, live values, and icon choice on the worker. The main-thread closure captures only the tray handle and diff, then calls the necessary setters.
+
+- [ ] **Step 4: Replace the dropped-refresh flag**
+
+Store `rendering_revision` and `pending_revision`. A busy presenter records the highest pending revision. Completion applies at most one follow-up using the newest snapshot. Remove `menu_bar_refresh_in_progress` and all database access from the main-thread closure.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked presentation::tray::tests
+git add src-tauri/src/presentation/tray.rs src-tauri/src/lib.rs
+git commit -m "perf: move tray rendering off the UI thread"
+```
+
+### Task 6: Lazy-load a lightweight popup without layout shifts
+
+**Files:**
+- Create: `src/app/bootstrap.tsx`
+- Create: `src/menu-bar-popup/bootstrap.ts`
+- Create: `src/menu-bar-popup/render.ts`
+- Create: `src/menu-bar-popup/sevenDayChart.ts`
+- Create: `src/menu-bar-popup/icons.ts`
+- Delete: `src/menu-bar-popup/MenuBarPopup.tsx`
+- Modify: `src/main.tsx`
+- Modify: `src/styles.css:1-33`
+- Modify: `src-tauri/src/lib.rs:1505-1560`
+- Modify: `src-tauri/src/lib.rs:2150-2152`
+- Create: `scripts/test-presentation.mjs`
+- Create: `scripts/check-popup-bundle.mjs`
+- Modify: `vite.config.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: Task 4 display snapshot events and passive getter.
+- Produces: dynamic surface entry points, a plain DOM popup renderer, and enforced bundle budgets.
+
+- [ ] **Step 1: Write failing behavior and bundle-source tests**
+
+Test `popup_accepts_higher_revision_only`, `manual_refresh_keeps_snapshot_visible`, `hidden_popup_performs_no_getter`, `popup_has_no_set_interval`, `main_has_no_static_surface_import`, and `popup_keeps_escape_and_accessible_labels`.
+
+- [ ] **Step 2: Register tests and verify failure**
+
+Add `test:presentation` and run `npm run test:presentation`.
+
+Expected: static imports, React popup, and polling assertions fail.
+
+- [ ] **Step 3: Split entry points and preserve UI semantics**
+
+`main.tsx` imports shared CSS, detects the surface, then dynamically imports `app/bootstrap.tsx` or `menu-bar-popup/bootstrap.ts`. The popup uses DOM elements with the existing CSS class names. Inline Lucide-compatible SVG paths provide dashboard and refresh icons. Buttons retain `aria-label`, keyboard focus, Escape handling, and click feedback. Existing content remains mounted while `refreshing` changes.
+
+Replace the remote Google font import with platform UI and monospace fallback stacks to avoid network work and font layout shift. Keep current font weights and element dimensions. Respect the existing reduced-motion media rule for the refresh icon.
+
+- [ ] **Step 4: Create popup on first tray click and enforce the bundle**
+
+Remove popup creation from setup. `toggle_menu_bar_popup` creates it only when absent and reads enablement from the current display snapshot instead of SQLite. Configure Vite manifest output. `check-popup-bundle.mjs` follows the popup chunk imports, rejects React, ReactDOM, Recharts, and dashboard modules, then checks 150 KB minified and 50 KB gzip limits.
+
+- [ ] **Step 5: Run tests, build, and commit**
+
+```bash
+npm run test:presentation
+npm run build
+node scripts/check-popup-bundle.mjs
+git add package.json scripts/check-popup-bundle.mjs scripts/test-presentation.mjs src/main.tsx src/app/bootstrap.tsx src/menu-bar-popup src/styles.css src-tauri/src/lib.rs vite.config.ts
+git commit -m "perf: lazy load an event-driven popup surface"
+```
+
+### Task 7: Bound conversation pages, turns, search, and detail cache
+
+**Files:**
+- Modify: `src-tauri/sql/schema.sql`
+- Modify: `src-tauri/sql/indexes.sql`
+- Create: `src-tauri/sql/queries/conversation_detail_summary.sql`
+- Create: `src-tauri/sql/queries/conversation_detail_breakdowns.sql`
+- Create: `src-tauri/sql/queries/conversation_turn_page.sql`
+- Create: `src-tauri/src/database/conversation_turns.rs`
+- Create: `src-tauri/src/queries/pagination.rs`
+- Modify: `src-tauri/src/database.rs`
+- Modify: `src-tauri/src/importer.rs`
+- Modify: `src-tauri/src/refresh/runtime.rs`
+- Modify: `src-tauri/src/models.rs:159-168`
+- Modify: `src-tauri/src/models.rs:321-417`
+- Modify: `src-tauri/src/queries.rs:195-257`
+- Modify: `src-tauri/src/queries.rs:483-655`
+- Modify: `src-tauri/src/lib.rs:248-349`
+- Create: `src/app/sizedLru.ts`
+- Create: `src/app/requestGeneration.ts`
+- Create: `src/app/surfaceRevision.ts`
+- Modify: `src/app/types.ts`
+- Modify: `src/app/api.ts`
+- Modify: `src/App.tsx:99-399`
+- Modify: `scripts/test-data-freshness.mjs`
+
+**Interfaces:**
+- Consumes: Task 3 bounded query primitives and Task 4 revisions.
+- Produces: indexed durable turn rows, resumable turn-index repair, `ConversationPage`, turn cursor pages, 250 ms search debounce, stale-response rejection, and a dual-limit LRU.
+
+- [ ] **Step 1: Write failing Rust and Node tests**
+
+Add `conversation_page_clamps_limit_to_100`, `pages_do_not_duplicate_items`, `detail_query_plan_uses_turn_cursor_index`, `detail_reads_at_most_41_turn_rows_for_newest_40`, `turn_cursor_returns_strictly_older_turns`, `legacy_turn_index_repair_runs_one_bounded_batch`, `foreground_detail_never_parses_source_jsonl`, `browsing_one_thousand_details_keeps_at_most_20_entries`, `browsing_one_thousand_details_never_exceeds_32mb`, `oversized_detail_is_not_cached`, `search_debounces_250ms`, `superseded_search_response_is_ignored`, and `superseded_detail_response_is_ignored`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked queries::pagination::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked conversation_turns
+npm run test:data-freshness
+```
+
+- [ ] **Step 3: Add exact page and cursor contracts**
+
+```rust
+pub struct ConversationPage {
+  pub items: Vec<ConversationListItem>,
+  pub offset: u32,
+  pub next_offset: Option<u32>,
+  pub total_count: u64,
+}
+
+pub struct ConversationTurnCursor {
+  pub last_activity_at_ms: i64,
+  pub session_id: String,
+  pub turn_id: String,
+}
+
+pub struct ConversationTurnPage {
+  pub items: Vec<ConversationTurnPoint>,
+  pub next_cursor: Option<ConversationTurnCursor>,
+}
+```
+
+Default conversation-list page size is 50 and maximum is 100. Add `conversation_turns` keyed by `(session_id, turn_id)`, with explicit turn/message/token columns, `root_session_id`, and `last_activity_at_ms`. Index `(root_session_id, last_activity_at_ms DESC, session_id DESC, turn_id DESC)`. The first page runs `ORDER BY` on that tuple with `LIMIT 41`, returns 40, and uses the extra row only to determine `next_cursor`; older pages add a strict tuple cursor predicate. Detail totals, per-session values, model breakdown, and composition breakdown use SQL aggregate/group queries over indexed session joins rather than an event `Vec`. The foreground path never calls `build_turns_for_session` or opens a source JSONL file.
+
+Full and incremental imports transactionally replace or upsert derived turn rows. Add nullable `import_state.turn_index_version`; legacy rows remain queryable but report turns pending until a low-priority coordinator repair parses at most eight files or 8 MB per dispatch, then yields. The repair uses the same refresh-deadline guard as epoch backfill, persists progress per session, and emits an invalidation after each committed batch. Foreground detail commands never perform this repair.
+
+- [ ] **Step 4: Add the dual-limit cache and visibility gate**
+
+```typescript
+const detailCache = new SizedLruCache<string, ConversationDetail>({
+  maxEntries: 20,
+  maxBytes: 32 * 1024 * 1024,
+  sizeOf: estimateConversationDetailBytes,
+})
+```
+
+Reject one entry larger than 32 MB. Use explicit 250 ms debounce rather than `useDeferredValue` as a network debounce. Hidden surfaces record the highest revision and reload once when shown.
+
+`estimateConversationDetailBytes` walks retained strings and arrays once using their encoded/string storage lengths; it must not call `JSON.stringify`, clone the detail, or retain a second serialized copy merely to measure cache size.
+
+Use a monotonically increasing `RequestGeneration` for conversation search, pagination, and selected-detail requests. Starting a newer request invalidates older in-flight responses; where Tauri invoke cannot be cancelled, completion checks `isCurrent(generation)` before changing rows, selection, cache, error, or loading state.
+
+```typescript
+export class RequestGeneration {
+  private current = 0
+  begin(): number { return ++this.current }
+  isCurrent(generation: number): boolean { return generation === this.current }
+  invalidate(): void { this.current += 1 }
+}
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked queries::pagination::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked conversation_turns
+npm run test:data-freshness
+npm run test:presentation
+git add src-tauri/sql src-tauri/src/database.rs src-tauri/src/database/conversation_turns.rs src-tauri/src/importer.rs src-tauri/src/refresh/runtime.rs src-tauri/src/queries/pagination.rs src-tauri/src/queries.rs src-tauri/src/models.rs src-tauri/src/lib.rs src/app/sizedLru.ts src/app/requestGeneration.ts src/app/surfaceRevision.ts src/app/types.ts src/app/api.ts src/App.tsx scripts/test-data-freshness.mjs
+git commit -m "perf: bound conversation pages and detail cache"
+```
+
+### Task 8: Enforce presentation performance budgets
+
+**Files:**
+- Create: `.github/workflows/release-build.yml`
+- Create: `scripts/check-hidden-surface-activity.mjs`
+- Create: `scripts/perf/assert-runtime-budgets.mjs`
+- Create: `scripts/perf/measure-macos-runtime.sh`
+- Create: `scripts/perf/parse-xctrace-wakeups.mjs`
+- Create: `src-tauri/src/presentation/metrics.rs`
+- Modify: `scripts/check-popup-bundle.mjs`
+- Modify: `package.json`
+- Modify: `src-tauri/src/database.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/presentation.rs`
+- Modify: `src-tauri/src/presentation/snapshot.rs`
+- Modify: `src-tauri/src/presentation/tray.rs`
+- Modify: `src/menu-bar-popup/bootstrap.ts`
+- Test: changed Rust presentation modules and Node scripts.
+
+**Interfaces:**
+- Consumes: metrics exposed by snapshot, tray, and query test probes.
+- Produces: repeatable CI budget checks and a local hidden-window probe.
+
+- [ ] **Step 1: Add failing threshold assertions**
+
+The scripts must reject payloads above 65,536 bytes, popup bundles above either size limit, any hidden data getter call, and any detail cache above either cap. Rust tests assert snapshot getter p95 below 5 ms on the 200,000-usage/400,000-quota fixture, tray main-thread apply p95 below 2 ms with no I/O, that the main-thread backend receives precomputed values only, and `PRAGMA integrity_check` returns exactly `ok` after all migrations, backfills, and cleanup fixtures.
+
+The macOS probe enforces every awake-process runtime budget from the approved design: scheduled start lag p95 at most 2 seconds and maximum 5 seconds, resume catch-up at most 5 seconds, active app-server children at most one, live timeout at most 10 seconds, commit-to-tray p95 at most 100 ms, commit-to-popup p95 at most 150 ms, refresh-related main-thread tasks p99 below 16 ms, reused popup content p95 below 100 ms, first popup creation p95 below 300 ms, fully hidden CPU average below 0.2 percent and p95 below 0.5 percent, at most two total process wakeups per minute, zero hidden queries for ten minutes, and stable resident memory rather than growth proportional to history.
+
+Do not calculate a percentile from one observation. Deterministic fake-clock tests execute at least 100 scheduled starts. The release-app probe requires at least 30 production-path samples for commit-to-tray, commit-to-popup, reused popup, and cold popup creation, plus at least eight real scheduled starts during the hidden run. `assert-runtime-budgets.mjs` fails on an insufficient sample count before checking percentiles.
+
+- [ ] **Step 2: Run the budget scripts before final wiring**
+
+Run `npm run build && node scripts/check-popup-bundle.mjs && node scripts/check-hidden-surface-activity.mjs`.
+
+Expected: scripts fail until manifest names and probes are wired.
+
+- [ ] **Step 3: Wire deterministic test probes**
+
+Use counters compiled under `cfg(test)` for source row visits, snapshot getter duration, tray apply calls, and hidden getter calls. Production `PerformanceCounters` use atomics plus fixed latency buckets and never retain an accumulating sample vector:
+
+```rust
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PerformanceSnapshot {
+  pub scheduler_wakeups: u64,
+  pub scheduled_start_lag_samples: u64,
+  pub scheduled_start_lag_p95_ms: f64,
+  pub scheduled_start_lag_max_ms: f64,
+  pub resume_catch_up_max_ms: f64,
+  pub active_live_children_max: u64,
+  pub live_query_duration_max_ms: f64,
+  pub live_timeout_count: u64,
+  pub snapshot_build_p95_ms: f64,
+  pub snapshot_getter_p95_ms: f64,
+  pub tray_queue_p95_ms: f64,
+  pub tray_apply_p95_ms: f64,
+  pub main_thread_task_p99_ms: f64,
+  pub commit_to_tray_visible_p95_ms: f64,
+  pub commit_to_tray_visible_samples: u64,
+  pub publish_to_tray_visible_p95_ms: f64,
+  pub commit_to_popup_visible_p95_ms: f64,
+  pub commit_to_popup_visible_samples: u64,
+  pub publish_to_popup_visible_p95_ms: f64,
+  pub reused_popup_p95_ms: f64,
+  pub reused_popup_samples: u64,
+  pub first_popup_p95_ms: f64,
+  pub first_popup_samples: u64,
+  pub popup_payload_bytes_max: u64,
+  pub hidden_query_count: u64,
+}
+```
+
+Keep both source-commit and snapshot-publish timestamps for at most the newest 32 presentation revisions. `DisplayInvalidation` passes the monotonic source commit through the builder into `DisplaySnapshot`; coalesced rebuilds retain the newest represented commit. After a visible surface applies a revision, it sends one revision acknowledgment. The acceptance histogram measures source commit-to-visible, which includes snapshot build and event delivery; publish-to-visible remains a separate diagnostic. The backend then removes both timestamps. Duplicate, hidden, and stale acknowledgments are ignored, so observability cannot grow memory with refresh history.
+
+When `CODEX_PACER_PERF_REPORT_PATH` is present, an opt-in diagnostic reporter writes one final JSON snapshot at shutdown; ordinary launches perform no report-file I/O. Every probe points `CODEX_PACER_DATA_DIR` at a temporary fixture directory, and diagnostic iteration mode refuses to start against the normal application data path.
+
+`measure-macos-runtime.sh` uses separate phases and report files:
+
+1. Launch the release binary, hide both windows, and leave it uninterrupted for 600 seconds. No popup, manual refresh, synthetic revision, or visibility action is allowed. Sample `%CPU` and RSS once per second and measure hidden queries, scheduled starts, and process wakeups. Reject an RSS increase above both 16 MB and five percent between the post-warmup and final windows.
+2. Start a fresh fixture process, keep the target surfaces visible, and drive at least 30 revisions through the production commit, snapshot, tray, event, and acknowledgment path for commit-to-visible percentiles.
+3. Start a fresh fixture process and recreate the popup at least 30 times for the cold-creation percentile; measure reused cached content separately without contributing to hidden-phase samples.
+
+The script merges the phase reports only after validating their labels and sample counts, then passes them to `assert-runtime-budgets.mjs`. The fake-clock runtime test from Slice 1 enforces the resume allowance without putting the developer machine to sleep.
+
+During the uninterrupted hidden phase only, record the target process with `xcrun xctrace record --template "Power Profiler"`. `parse-xctrace-wakeups.mjs` exports the trace, filters the Codex Pacer PID/coalition, and calculates total application wakeups per minute. The gate fails if the process-level measurement is unavailable; the coordinator's internal `scheduler_wakeups` counter is diagnostic only and cannot substitute for the acceptance measurement.
+
+Add a GitHub Actions matrix for `macos-14` and `windows-latest` that installs Node 22.18 and the declared Rust toolchain, runs `npm ci`, frontend tests/lint/build, Rust tests, and `npm run tauri build`. Runtime CPU thresholds remain a local macOS gate because hosted-runner load is nondeterministic; Windows must complete the release build.
+
+- [ ] **Step 4: Run full slice verification**
+
+```bash
+npm test
+npm run lint
+npm run build
+node scripts/check-popup-bundle.mjs
+node scripts/check-hidden-surface-activity.mjs
+bash scripts/perf/measure-macos-runtime.sh --duration 600
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+cargo test --manifest-path src-tauri/Cargo.toml --locked database_integrity_after_all_migrations
+cargo clippy --manifest-path src-tauri/Cargo.toml --locked --lib
+```
+
+Expected: all functional tests and budgets pass. Clippy exits successfully; compare its output with the recorded 16-warning repository baseline and fix every new warning in changed files. Whole-repository pre-existing Clippy debt outside changed modules remains separately documented.
+
+- [ ] **Step 5: Commit the performance gates**
+
+```bash
+git add .github/workflows/release-build.yml package.json scripts src-tauri/src src/menu-bar-popup/bootstrap.ts
+git commit -m "test: enforce presentation resource budgets"
+```

--- a/docs/superpowers/plans/2026-07-10-refresh-correctness.md
+++ b/docs/superpowers/plans/2026-07-10-refresh-correctness.md
@@ -1,0 +1,553 @@
+# Refresh correctness implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the coupled polling scheduler with independent token and live quota lanes that use fixed deadlines, singleflight, coalesced triggers, truthful freshness, and completion events.
+
+**Architecture:** A pure state machine decides when work starts and how triggers merge. A channel runtime launches token and live workers independently, then publishes typed completion and invalidation events. Tauri commands become adapters around one coordinator; passive reads never start work.
+
+**Tech Stack:** Rust 2021, Tauri 2.10, `std::sync::mpsc`, Chrono, Rusqlite, React 19, TypeScript 5.9, Node 22.18 test scripts.
+
+## Global constraints
+
+- Execute this slice first. Run its full verification and review checkpoint before starting the presentation or importer plans.
+- `auto_scan_enabled` is the master switch. When enabled, token and live quota refresh on independent schedules even while windows are hidden. When disabled, scheduled work stops and manual work remains available.
+- The live app-server timeout is exactly 10 seconds, and at most one live child process may run.
+- A trigger received during active work produces at most one follow-up generation and is never discarded.
+- Runtime deadlines use a monotonic clock. Wall time restores state after launch and displays freshness only.
+- Passive getters do not scan files, query the app-server, or wait for active work.
+- Frontend automatic refresh timers are removed. Existing content, focus visibility, and reduced-motion behavior remain stable during manual refresh.
+
+---
+
+### Task 1: Add the deterministic lane state machine
+
+**Files:**
+- Create: `src-tauri/src/refresh/mod.rs`
+- Create: `src-tauri/src/refresh/schedule.rs`
+- Modify: `src-tauri/src/lib.rs:1-6`
+- Test: `src-tauri/src/refresh/schedule.rs`
+
+**Interfaces:**
+- Consumes: persisted success timestamps and normalized refresh settings.
+- Produces: `RefreshConfig`, `RefreshLane`, `RefreshReason`, `TokenScanKind`, `CoordinatorEvent`, `CoordinatorAction`, and `CoordinatorState`.
+
+- [ ] **Step 1: Write failing deadline and lane-independence tests**
+
+Add `persisted_success_maps_remaining_wall_time_to_monotonic_deadline`, `missing_persisted_success_starts_one_immediate_catch_up`, `invalid_persisted_success_starts_one_immediate_catch_up`, `overdue_persisted_success_starts_one_immediate_catch_up`, `due_lanes_start_together_and_advance_from_planned_deadlines`, `token_running_does_not_block_due_live_lane`, `missed_intervals_coalesce_into_one_catch_up`, `shorter_interval_recalculates_deadline_immediately`, and `backward_wall_clock_does_not_move_runtime_deadline`.
+
+Use this central assertion:
+
+```rust
+let base = Instant::now();
+let wall = utc("2026-07-10T10:00:00Z");
+let config = test_config(Duration::from_secs(300), Some(wall));
+let mut state = CoordinatorState::new(config, base, wall);
+let actions = state.handle(base + Duration::from_secs(300), CoordinatorEvent::Timer);
+assert!(actions.iter().any(|value| matches!(value, CoordinatorAction::StartToken(_))));
+assert!(actions.iter().any(|value| matches!(value, CoordinatorAction::StartLive(_))));
+assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
+assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::schedule::tests
+```
+
+Expected: compilation fails because the refresh module does not exist.
+
+- [ ] **Step 3: Implement the public scheduling contracts**
+
+Add to `refresh/mod.rs`:
+
+```rust
+pub(crate) const LIVE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RefreshLane { Token, Live }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshReason { Startup, Scheduled, Manual, SettingsChanged, Wake, Fallback }
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum TokenScanKind { Incremental, Full }
+
+#[derive(Clone, Debug)]
+pub(crate) struct RefreshConfig {
+  pub auto_scan_enabled: bool,
+  pub interval: Duration,
+  pub codex_home: Option<String>,
+  pub token_last_success_wall: Option<DateTime<Utc>>,
+  pub live_last_success_wall: Option<DateTime<Utc>>,
+}
+```
+
+Keep `CoordinatorState` pure and pass `Instant` to `handle`. Advance from the planned deadline:
+
+```rust
+fn advance_fixed_deadline(mut deadline: Instant, interval: Duration, now: Instant) -> (Instant, u64) {
+  let mut elapsed_intervals = 0;
+  while deadline <= now {
+    deadline += interval;
+    elapsed_intervals += 1;
+  }
+  (deadline, elapsed_intervals.saturating_sub(1))
+}
+
+fn initial_deadline(
+  monotonic_now: Instant,
+  wall_now: DateTime<Utc>,
+  last_success: Option<DateTime<Utc>>,
+  interval: Duration,
+) -> Instant {
+  let Some(age) = last_success.and_then(|value| wall_now.signed_duration_since(value).to_std().ok()) else {
+    return monotonic_now;
+  };
+  monotonic_now + interval.saturating_sub(age)
+}
+```
+
+The settings adapter maps a malformed persisted timestamp to `None`. Missing, malformed, future, and overdue values produce one startup intent; once that generation is recorded as running they cannot enqueue a duplicate catch-up.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::schedule::tests`.
+
+Expected: all Task 1 tests pass without real sleeps.
+
+- [ ] **Step 5: Commit the scheduler model**
+
+```bash
+git add src-tauri/src/refresh src-tauri/src/lib.rs
+git commit -m "feat: add deterministic refresh lane scheduler"
+```
+
+### Task 2: Coalesce overlap, back off independently, and guard source generations
+
+**Files:**
+- Modify: `src-tauri/src/refresh/mod.rs`
+- Modify: `src-tauri/src/refresh/schedule.rs`
+- Test: `src-tauri/src/refresh/schedule.rs`
+
+**Interfaces:**
+- Consumes: Task 1 lane state.
+- Produces: reason sets, generation-tagged execution requests, waiter IDs, retry deadlines, and `DisplayInvalidation`.
+
+- [ ] **Step 1: Write failing overlap and retry tests**
+
+Add `triggers_during_run_create_one_follow_up_generation`, `multiple_triggers_merge_reason_bits`, `manual_live_waiter_joins_running_generation`, `failed_lanes_back_off_independently`, `source_change_rejects_old_completion`, and `source_change_discards_prepared_token_before_commit`.
+
+```rust
+let first = start_token_generation(&mut state, base);
+state.handle(base + Duration::from_secs(1), CoordinatorEvent::RequestToken(TokenRequest::scheduled()));
+state.handle(base + Duration::from_secs(2), CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)));
+let actions = state.handle(base + Duration::from_secs(3), CoordinatorEvent::TokenFinished(success(first)));
+assert_eq!(actions.iter().filter(|value| matches!(value, CoordinatorAction::StartToken(_))).count(), 1);
+assert!(matches!(actions.last(), Some(CoordinatorAction::StartToken(request)) if request.kind == TokenScanKind::Full));
+```
+
+- [ ] **Step 2: Run tests and verify behavioral failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::schedule::tests`.
+
+Expected: new assertions fail because pending and retry state are absent.
+
+- [ ] **Step 3: Implement merge and retry rules**
+
+Use a dependency-free reason set and bounded delay:
+
+```rust
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ReasonSet(u8);
+
+impl ReasonSet {
+  pub fn insert(&mut self, reason: RefreshReason) { self.0 |= 1 << reason as u8; }
+  pub fn is_empty(self) -> bool { self.0 == 0 }
+}
+
+fn retry_delay(failure_streak: u32, interval: Duration, jitter: Duration) -> Duration {
+  const STEPS: [u64; 6] = [5, 15, 30, 60, 120, 300];
+  let index = failure_streak.saturating_sub(1) as usize;
+  Duration::from_secs(STEPS[index.min(STEPS.len() - 1)])
+    .saturating_add(jitter)
+    .min(interval)
+    .min(Duration::from_secs(300))
+}
+```
+
+Production jitter is capped at one second; tests pass zero. Keep normal deadlines unchanged by retries. Before a prepared token refresh enters the mutation queue, recheck its source generation; discard it without database writes when the source changed. Increment revisions only when both worker generation and source generation match.
+
+Use these generation and event contracts throughout all three slices:
+
+```rust
+#[derive(Clone, Debug)]
+pub(crate) struct TokenRequest {
+  pub reasons: ReasonSet,
+  pub kind: TokenScanKind,
+  pub codex_home: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TokenExecutionRequest {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub request: TokenRequest,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LiveExecutionRequest {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub reasons: ReasonSet,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CommitMarker {
+  pub sequence: u64,
+  pub committed_at: Instant,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DisplayInvalidation {
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub settings_revision: u64,
+  pub source_generation: u64,
+  pub commit: CommitMarker,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshCompletedEvent {
+  pub refresh_revision: u64,
+  pub lane: RefreshLane,
+  pub generation: u64,
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub source_generation: u64,
+  pub succeeded: bool,
+  pub failure: Option<String>,
+  pub completed_at: String,
+}
+```
+
+- [ ] **Step 4: Run schedule tests**
+
+Run the same focused command. Expected: one follow-up is produced, retry caps hold, and stale completions do not publish.
+
+- [ ] **Step 5: Commit overlap handling**
+
+```bash
+git add src-tauri/src/refresh
+git commit -m "feat: coalesce refresh triggers and guard source generations"
+```
+
+### Task 3: Add the channel runtime and independent workers
+
+**Files:**
+- Create: `src-tauri/src/refresh/runtime.rs`
+- Create: `src-tauri/src/refresh/power.rs`
+- Create: `src-tauri/src/refresh/mutation.rs`
+- Modify: `src-tauri/src/refresh/mod.rs`
+- Modify: `src-tauri/src/importer.rs`
+- Test: `src-tauri/src/refresh/runtime.rs`
+- Test: `src-tauri/src/refresh/mutation.rs`
+
+**Interfaces:**
+- Consumes: Task 2 coordinator actions.
+- Produces: `RefreshCoordinatorHandle`, executor traits, `RefreshStatus`, blocking manual tickets, `RefreshEventSink`, and serialized usage-mutation arbitration.
+
+- [ ] **Step 1: Write channel-gated concurrency tests**
+
+Add `token_worker_does_not_delay_live_worker_start`, `concurrent_live_callers_share_one_executor_generation`, `active_live_children_never_exceeds_one`, `live_timeout_terminates_and_reaps_child`, `startup_status_is_busy_before_worker_body_runs`, `completion_services_one_pending_follow_up`, `worker_panic_becomes_failure`, `disabled_scheduler_runs_manual_requests`, `scheduled_start_lag_is_recorded`, `start_lag_above_five_seconds_warns`, `resume_starts_overdue_lanes_within_five_seconds`, `token_parse_runs_before_usage_commit_lock`, `held_usage_commit_lock_does_not_delay_live_lane`, and `pricing_waits_behind_refresh_mutation`.
+
+- [ ] **Step 2: Run tests and verify compilation failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests -- --nocapture`.
+
+Expected: runtime types are missing.
+
+- [ ] **Step 3: Implement runtime traits and `recv_timeout` loop**
+
+```rust
+pub(crate) trait TokenRefreshExecutor: Send + Sync {
+  fn parse(&self, request: TokenExecutionRequest) -> Result<PreparedTokenRefresh, String>;
+  fn commit(&self, prepared: PreparedTokenRefresh) -> Result<ScanResult, String>;
+}
+
+pub(crate) struct PreparedTokenRefresh {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub started_at: DateTime<Utc>,
+  pub prepared_scan: PreparedScan,
+}
+
+pub(crate) trait LiveQuotaFetcher: Send + Sync {
+  fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String>;
+  fn fallback(&self) -> Option<LiveRateLimitSnapshot>;
+}
+
+pub(crate) trait LiveQuotaPersister: Send + Sync {
+  fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String>;
+}
+
+pub(crate) trait RefreshEventSink: Send + Sync {
+  fn publish_invalidation(&self, value: DisplayInvalidation);
+  fn publish_completion(&self, value: RefreshCompletedEvent);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MutationPhase { Queued, Parsing, WaitingToCommit, Committed, Failed }
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum MutationPriority { Pricing, Maintenance, Refresh }
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LaneStatus {
+  pub running: bool,
+  pub generation: Option<u64>,
+  pub pending: bool,
+  pub last_success_at: Option<String>,
+  pub next_due_at: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshStatus {
+  pub token: LaneStatus,
+  pub live: LaneStatus,
+  pub mutation_phase: Option<MutationPhase>,
+  pub source_generation: u64,
+}
+```
+
+The runtime calls `rx.recv_timeout(state.next_wait(clock.monotonic_now()))`, marks running state before spawn, and launches token and live actions on separate named threads. Catch worker panics and convert them into failure completions.
+
+Refactor the importer entry point into a read-only `prepare_scan` that produces `PreparedTokenRefresh` and a transactional `commit_prepared_scan`. Preparation performs no freshness, repair, title, pricing, or derived-row write; the coordinator owns attempt state until commit. `UsageMutationCoordinator` serializes only the commit closure. Token discovery and JSON parsing run in `Parsing` before requesting the lock; the phase changes to `WaitingToCommit` only around the writer queue. Refresh commits outrank maintenance, which outranks pricing recalculation. Waiting for this queue never holds the coordinator channel or live singleflight, and live publication does not acquire the usage-mutation lock.
+
+Add fixed-bucket histograms and counters rather than retaining per-run samples. `RefreshLaneMetrics` exposes `scheduled_due_at`, `started_at`, `start_lag_ms`, `duration_ms`, `last_success_age_ms`, `failure_streak`, `retry_at`, `missed_deadline_count`, `coalesced_trigger_count`, `running_generation`, and `pending_reasons`. Live metrics add app-server duration, timeout count, active child count, fallback age, and waiter count. Token metrics add files visited, bytes read, append fast-path count, full-rebuild count, mutation-lock wait, and database-busy count. Warn when start lag exceeds five seconds, active live children exceeds one, or success age exceeds the interval plus active retry allowance.
+
+- [ ] **Step 4: Scope macOS activity to actual work**
+
+Move `SchedulerActivity` to `refresh/power.rs`. Use `NSActivityOptions::Background`. Construct the guard immediately before an executor call and drop it immediately afterward. The coordinator wait loop holds no activity guard.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests
+git add src-tauri/src/refresh src-tauri/src/importer.rs
+git commit -m "feat: coordinate independent refresh workers"
+```
+
+### Task 4: Publish truthful live quota before persistence
+
+**Files:**
+- Create: `src-tauri/src/refresh/live_cache.rs`
+- Modify: `src-tauri/src/refresh/mod.rs`
+- Modify: `src-tauri/src/refresh/runtime.rs`
+- Modify: `src-tauri/src/models.rs:215-224`
+- Modify: `src-tauri/src/lib.rs:1084-1328`
+- Test: `src-tauri/src/refresh/live_cache.rs`
+
+**Interfaces:**
+- Consumes: Task 3 live fetcher and persister.
+- Produces: `LiveQuotaState`, `LiveQuotaCache`, fixed timeout behavior, fallback metadata, and persistence retry actions.
+
+- [ ] **Step 1: Write failing freshness tests**
+
+Add `fallback_never_becomes_fresh_for_ttl`, `fallback_preserves_source_and_last_success`, `fresh_value_is_visible_before_persistence_finishes`, `fetch_receives_ten_second_timeout`, `live_failure_does_not_run_token_inline`, `persistence_failure_retries_without_refetch`, `newer_live_snapshot_supersedes_pending_persistence_retry`, `persistence_retry_is_capped`, and `persistence_retry_does_not_move_live_deadline`.
+
+```rust
+let fallback = store.publish_fallback(old_snapshot(), utc("2026-07-10T10:00:00Z"));
+assert!(fallback.is_fallback);
+assert_eq!(fallback.source_fetched_at.as_deref(), Some("2026-07-09T10:00:00+00:00"));
+assert_eq!(fallback.last_live_success_at, None);
+assert!(store.needs_live_refresh(Duration::from_secs(300)));
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::live_cache::tests`.
+
+Expected: cache state types are missing.
+
+- [ ] **Step 3: Add serialized live state**
+
+```rust
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveQuotaState {
+  pub rate_limits: Option<LiveRateLimitSnapshot>,
+  pub source_fetched_at: Option<String>,
+  pub cached_at: String,
+  pub is_fallback: bool,
+  pub last_live_success_at: Option<String>,
+  pub refreshing: bool,
+}
+
+pub(crate) struct LivePersistenceRetryState {
+  pub latest_pending: Option<Arc<LiveRateLimitSnapshot>>,
+  pub failure_streak: u32,
+  pub retry_at: Option<Instant>,
+  pub running: bool,
+}
+```
+
+`publish_live` updates source and success time. `publish_fallback` updates cache time only and remains due for retry.
+
+- [ ] **Step 4: Publish before persistence and remove inline fallback scans**
+
+On live success, update cache, increment quota revision, emit an invalidation carrying a monotonic `CommitMarker`, and emit completion before starting persistence. A persistence failure stores only the latest pending snapshot and schedules `CoordinatorAction::PersistLive` with the same 5/15/30/60/120/300-second sequence, capped by the configured interval and 300 seconds. It never runs the live fetcher, increments the live fetch failure streak, or changes the normal live deadline. Only one persistence action runs; a newer live snapshot replaces an older pending retry, and success clears the independent persistence state. Replace `get_live_rate_limits_history_fallback` synchronous scanning with an asynchronous `RefreshReason::Fallback` token intent.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::live_cache::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests
+git add src-tauri/src/refresh src-tauri/src/models.rs src-tauri/src/lib.rs
+git commit -m "fix: preserve truthful live quota freshness"
+```
+
+### Task 5: Route Tauri lifecycle and settings through the coordinator
+
+**Files:**
+- Modify: `src-tauri/src/database/sync_settings.rs:407-500`
+- Modify: `src-tauri/src/database.rs:10-18`
+- Modify: `src-tauri/src/lib.rs:92-102`
+- Modify: `src-tauri/src/lib.rs:166-466`
+- Modify: `src-tauri/src/lib.rs:1919-2181`
+- Modify: `src-tauri/src/models.rs`
+- Test: `src-tauri/src/database/sync_settings.rs`
+- Test: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: coordinator handle and live cache.
+- Produces: one coordinator in `AppState`, passive getters, manual waiters, immediate config updates, and resume forwarding.
+
+- [ ] **Step 1: Write failing integration tests**
+
+Add `settings_save_does_not_overwrite_newer_scan_freshness`, `settings_change_wakes_coordinator_immediately`, `codex_home_change_requests_full_scan`, `passive_live_getter_does_not_start_fetch`, `popup_snapshot_read_does_not_start_scan`, `manual_scan_uses_coordinator_generation`, and `pricing_recalculation_uses_lower_priority_mutation_ticket`.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked settings_save_does_not_overwrite_newer_scan_freshness
+cargo test --manifest-path src-tauri/Cargo.toml --locked passive_live_getter_does_not_start_fetch
+```
+
+- [ ] **Step 3: Make settings saves configuration-only**
+
+For an unchanged Codex home, stop updating `last_scan_started_at` and `last_scan_completed_at` in the conflict clause. For a changed home, clear freshness in the same transaction. `updateSyncSettings` sends the normalized config to the coordinator before returning.
+
+- [ ] **Step 4: Replace scheduler and command paths**
+
+Store `refresh: RefreshCoordinatorHandle` and the Task 3 mutation coordinator in `AppState`; remove scan and live atomic flags, the coarse `usage_mutation_lock`, and old spawn functions. `getScanInProgress` derives its compatibility boolean from `RefreshStatus`, while `getRefreshStatus` exposes the exact mutation phase. `getLiveRateLimits` returns cache, and manual commands request waiters. Pricing requests take a lower-priority mutation ticket and never hold the refresh coordinator. Build the app and forward resume:
+
+```rust
+let app = builder.build(tauri::generate_context!())
+  .expect("error while building tauri application");
+app.run(|app_handle, event| {
+  if matches!(event, tauri::RunEvent::Resumed) {
+    let _ = app_handle.state::<AppState>().refresh.notify_resume();
+  }
+});
+```
+
+Setup queues startup intents and does not call the three old scheduler entry points.
+
+- [ ] **Step 5: Run Rust tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+git add src-tauri/src/database.rs src-tauri/src/database/sync_settings.rs src-tauri/src/lib.rs src-tauri/src/models.rs
+git commit -m "refactor: route refresh commands through coordinator"
+```
+
+### Task 6: Replace frontend polling with revision-gated events
+
+**Files:**
+- Create: `src/app/refreshEvents.ts`
+- Create: `scripts/test-refresh-events.mjs`
+- Modify: `src/App.tsx:1-399`
+- Modify: `src/menu-bar-popup/MenuBarPopup.tsx:50-149`
+- Modify: `src/app/api.ts:202-280`
+- Modify: `src/app/dataFreshness.ts:87-116`
+- Modify: `src/app/types.ts:82-135`
+- Modify: `scripts/test-data-freshness.mjs`
+- Modify: `package.json:9-18`
+
+**Interfaces:**
+- Consumes: `codex-counter://refresh-completed` and passive getters.
+- Produces: `SurfaceRevisionGate`, visible reloads, hidden coalescing, and event-driven manual refresh state.
+
+- [ ] **Step 1: Write the failing Node tests**
+
+```javascript
+const gate = new SurfaceRevisionGate()
+assert.equal(gate.accept({ refreshRevision: 1, succeeded: true }, true), 'reload')
+assert.equal(gate.accept({ refreshRevision: 1, succeeded: true }, true), 'ignore')
+assert.equal(gate.accept({ refreshRevision: 2, succeeded: true }, false), 'defer')
+assert.equal(gate.accept({ refreshRevision: 3, succeeded: true }, false), 'defer')
+assert.equal(gate.onVisible(), 'reload')
+assert.equal(gate.onVisible(), 'ignore')
+```
+
+The script also asserts that refresh effects in `App.tsx` and `MenuBarPopup.tsx` contain no `setInterval`, `refreshBackgroundData`, or settings-open live polling. Add `failed_completion_does_not_reload_data` and `manual_waiter_failure_clears_refreshing_and_keeps_previous_data`.
+
+- [ ] **Step 2: Register the script and verify failure**
+
+Add `test:refresh-events` to `package.json` and `npm test`, then run `npm run test:refresh-events`.
+
+Expected: module import or source assertions fail.
+
+- [ ] **Step 3: Implement the pure revision gate**
+
+```typescript
+export class SurfaceRevisionGate {
+  private appliedRevision = 0
+  private pendingRevision = 0
+
+  accept(event: RefreshCompletedEvent, visible: boolean): 'reload' | 'defer' | 'ignore' {
+    if (!event.succeeded || event.refreshRevision <= Math.max(this.appliedRevision, this.pendingRevision)) return 'ignore'
+    if (!visible) {
+      this.pendingRevision = event.refreshRevision
+      return 'defer'
+    }
+    this.appliedRevision = event.refreshRevision
+    return 'reload'
+  }
+
+  onVisible(): 'reload' | 'ignore' {
+    if (this.pendingRevision <= this.appliedRevision) return 'ignore'
+    this.appliedRevision = this.pendingRevision
+    return 'reload'
+  }
+}
+```
+
+- [ ] **Step 4: Wire both surfaces without automatic timers**
+
+As an interim Slice 1 bridge, App listens for successful completion, checks Tauri window visibility, and reloads only for `reload`. Popup removes its interval; showing it performs one passive read. A failed completion never reloads data. Manual commands await their coordinator ticket and clear `refreshing` in `finally`, so failure leaves the prior cards and source timestamp visible. Preserve Escape handling, labels, focus states, and stable height.
+
+This raw-completion data reload is deliberately removed in presentation Task 4. In the final architecture, `refresh-completed` controls spinner/error state only; `display-snapshot-updated` is the sole trigger allowed to apply new data.
+
+- [ ] **Step 5: Run full slice verification and commit**
+
+```bash
+npm test
+npm run lint
+npm run build
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+cargo clippy --manifest-path src-tauri/Cargo.toml --locked --lib
+git add package.json scripts/test-data-freshness.mjs scripts/test-refresh-events.mjs src/App.tsx src/menu-bar-popup/MenuBarPopup.tsx src/app/api.ts src/app/dataFreshness.ts src/app/refreshEvents.ts src/app/types.ts
+git commit -m "perf: replace frontend refresh polling with events"
+```
+
+Expected: all tests, lint, build, and Rust tests pass. Clippy exits successfully; compare its output with the recorded 16-warning repository baseline and fix every new warning in changed files. Frontend sources have no automatic refresh timer.

--- a/docs/superpowers/specs/2026-07-10-refresh-performance-stability-design.md
+++ b/docs/superpowers/specs/2026-07-10-refresh-performance-stability-design.md
@@ -1,0 +1,290 @@
+# Refresh performance and stability design
+
+## Problem
+
+Codex Pacer cannot currently guarantee that token statistics and live quota data refresh on the configured schedule. The token scanner, live quota query, tray renderer, popup snapshot builder, and frontend timers can all initiate overlapping work. Several of those paths are synchronous, and some run database or process I/O on the macOS main thread.
+
+The scheduler starts a token scan before it starts the live quota query. It schedules the next token run from the previous completion time, so scan duration becomes part of the refresh interval. A failed scan remains due and can be retried by the five-second scheduler poll. Live and tray work use atomic running flags; a trigger that arrives while a worker is busy is discarded instead of being queued.
+
+The presentation path amplifies the problem. Opening or polling the menu-bar popup can run a due token scan, load all usage events, build a full overview, load the events again for the seven-day quota trend, and read every historical quota sample for the selected bucket. Tray rendering performs database work inside `run_on_main_thread`, and a stale live cache can also start the Codex app-server from that path.
+
+The production database measured during this review was 245.4 MB and contained 2,247 sessions, about 167,600 usage events, and about 419,900 quota samples. A current seven-day view needed about 4,800 usage events and 5,000 quota samples, but the existing queries loaded about 167,600 and 209,300 rows. Quota history and its indexes accounted for about 82.8 percent of the database. Within a quota window, retaining value changes instead of every repeated observation could remove about 83 percent of five-hour rows and 92 percent of seven-day rows.
+
+Changed session files have a second source of write amplification. The incremental importer parses a changed JSONL file from the beginning, deletes every derived usage event and quota sample for the session, then rebuilds them. This is expensive for active files that grow by a few lines but are already tens of megabytes long.
+
+## Goals
+
+The design has six goals:
+
+1. Token and live quota refreshes start on independent fixed schedules and cannot delay one another.
+2. A trigger that arrives during active work is coalesced and eventually serviced. It is never silently lost.
+3. Passive UI reads never start a scan, launch a process, or perform an unbounded database query.
+4. Tray rendering performs no file, database, or process I/O on the UI thread.
+5. Normal background work reads and writes only data that changed, while memory use remains bounded as history grows.
+6. Failures expose stale data honestly, retry with bounded backoff, and recover after settings changes, sleep, clock changes, truncation, and database contention.
+
+## User-visible refresh semantics
+
+`auto_scan_enabled` remains the master automatic-refresh switch.
+
+When automatic refresh is enabled, the token lane and live quota lane use the configured refresh interval but maintain independent deadlines. They continue to run when the dashboard and popup are hidden. Menu visibility and the selected dashboard bucket do not determine whether live quota data stays fresh.
+
+When automatic refresh is disabled, both scheduled lanes pause. Manual token scans and manual live quota refreshes remain available. Opening a window or popup only reads the latest snapshot; it does not silently override the disabled setting.
+
+A passive read may return stale data with explicit freshness metadata. A manual refresh may wait for the current singleflight generation for up to the fixed live-query timeout. If that generation fails, the UI keeps the prior data and shows its source timestamp instead of presenting it as fresh.
+
+## Selected architecture
+
+One `RefreshCoordinator` owns the scheduling state for token, live quota, and display snapshot work. Callers submit intents through a channel. Only the coordinator decides whether to start work, merge a trigger into a running generation, schedule a retry, or publish a completion.
+
+The coordinator owns state, not the work itself. Token parsing, app-server queries, SQLite persistence, and display snapshot construction run on bounded workers. Workers send typed completion messages back to the coordinator. This keeps scheduling responsive while a scan or external process is slow.
+
+The main units are:
+
+- `RefreshCoordinator`: owns deadlines, lane generations, pending reasons, retry state, and configuration changes.
+- `TokenRefreshExecutor`: runs incremental or full imports and reports timing, source generation, and committed usage revision.
+- `LiveQuotaExecutor`: owns the only app-server singleflight and reports source time separately from cache time.
+- `DisplaySnapshotStore`: keeps one small immutable snapshot with usage, quota, settings, and presentation revisions.
+- `DisplaySnapshotBuilder`: uses bounded SQL queries to rebuild the snapshot off the UI thread.
+- `TrayPresenter`: compares the new presentation with the last applied presentation. The main-thread closure only calls tray setters.
+- Surface event bridges: notify the popup and visible dashboard that a newer revision is available.
+
+The existing `lib.rs` command layer will become a thin adapter around these units. Refresh and presentation logic should move into focused modules instead of expanding the current file.
+
+## Coordinator state and scheduling
+
+Each data lane stores:
+
+```text
+interval
+next_deadline
+running_generation
+pending_reasons
+last_attempt_at
+last_success_at
+failure_streak
+retry_at
+source_generation
+```
+
+The in-process deadline uses a monotonic clock. On startup, the coordinator maps the persisted wall-clock success time to the current monotonic clock. Invalid, missing, or overdue persisted timestamps produce one immediate catch-up run.
+
+After a scheduled run starts, the next normal deadline advances from the prior planned deadline until it lies in the future. It does not use the worker completion time. If the application misses several intervals while asleep, the coordinator records the missed count and starts one catch-up generation. It does not replay every missed interval.
+
+Manual, startup, settings, scheduled, wake, and fallback triggers are represented as reason bits. If a lane is idle, a trigger may start it. If it is running, the coordinator merges the reason into `pending_reasons`. When the generation completes, the coordinator starts at most one follow-up generation if the pending reasons still require newer data.
+
+The coordinator records pending or running state before a worker is spawned. The UI cannot observe a false idle state during startup.
+
+Configuration changes wake the coordinator through its channel. Shortening the interval recalculates deadlines immediately. Changing the resolved Codex home increments `source_generation`, clears freshness for the previous source, and queues a full scan. A completion from an older source generation cannot publish freshness for the new source.
+
+The coordinator is the only owner of refresh freshness. A settings save updates configuration fields without reading and rewriting `last_scan_*` or live success fields. This removes the race where an older settings snapshot can overwrite a newer completion.
+
+Runtime scheduling never derives elapsed time from the wall clock after startup. A backward wall-clock change can affect display timestamps but cannot pause a monotonic deadline. An application resume signal wakes the coordinator, which recalculates overdue work and queues one catch-up per lane.
+
+## Retry and timeout behavior
+
+Token and live failures have separate counters. A failure schedules a retry with jittered delays based on 5, 15, 30, 60, 120, and 300 seconds. The delay is capped by the configured interval and five minutes. A successful generation resets the lane's failure counter.
+
+Retry deadlines do not move the normal fixed-rate deadline. A retry and a scheduled trigger that become due together merge into one generation. A failure in one lane never forces or delays the other lane.
+
+The live app-server timeout is fixed at 10 seconds. It never scales with the refresh interval. Foreground and background requests join the same generation, so at most one app-server child process is active.
+
+Fallback data records these fields separately:
+
+```text
+source_fetched_at
+cached_at
+is_fallback
+last_live_success_at
+```
+
+Loading a persisted fallback may update `cached_at`, but it cannot update `source_fetched_at` or `last_live_success_at`. A fallback therefore remains stale and does not suppress the next retry.
+
+Live fallback reads the in-memory snapshot or `latest_rate_limits` only. It never starts a token scan on the caller thread. If a repair requires session-derived quota history, the fallback path submits a token intent to the coordinator and returns without waiting for it.
+
+Fresh live data is published to the in-memory snapshot before historical persistence. SQLite persistence follows on a worker. A persistence failure records a metric and queues a bounded retry, but it does not hide a successfully fetched quota value from the tray or popup.
+
+Usage mutations remain serialized at commit time because SQLite has one writer. Parsing can proceed before the mutation lock is available. State distinguishes queued, parsing, waiting-to-commit, and committed work instead of reporting all four as scanning. Pricing recalculation is a lower-priority mutation and cannot block the live lane.
+
+## Versioned display snapshots
+
+`DisplaySnapshotStore` keeps one bounded value:
+
+```text
+usage_revision
+quota_revision
+settings_revision
+presentation_revision
+generated_at
+token_summary
+quota_summary
+quota_trend
+menu_settings
+freshness
+```
+
+The store does not cache all events, conversations, or quota history. Its serialized popup payload must remain at or below 64 KB.
+
+A committed token scan increments `usage_revision`. A successful live fetch increments `quota_revision`. A relevant settings update increments `settings_revision`. The snapshot builder captures those three revisions before querying. If any source revision changes while the snapshot is being built, it publishes only the consistent result and queues one latest-wins rebuild.
+
+Snapshot getters only clone the current bounded snapshot. They do not invoke the coordinator, query SQLite, or run the app-server. Refresh commands submit an intent and return a ticket or the current stale snapshot as appropriate.
+
+The dashboard and popup only accept events with a higher presentation revision. This prevents an older asynchronous response from replacing newer data.
+
+## Tray and popup behavior
+
+The tray presentation is computed on a worker from the display snapshot. The main-thread closure receives preformatted title, tooltip, icon visibility, and tray visibility values. It compares them with the last applied values and only calls setters whose values changed.
+
+If a new display revision arrives while tray work is active, the presenter marks itself dirty. When the current apply finishes, it performs one follow-up render using the newest revision. The final update cannot be discarded because a previous update was running.
+
+The popup WebView is created on first tray use instead of application startup. Once created, it may remain hidden for fast subsequent opens, but it runs no periodic data timer while hidden. Its entry point uses a dynamic import so the popup bundle does not load the dashboard or Recharts code.
+
+The popup opens with the latest in-memory snapshot. Existing content remains visible during a manual refresh. A small refreshing state may change, but the data panel and measured window height do not collapse. The backend sends a versioned snapshot event when fresh work completes.
+
+The main dashboard also removes its independent automatic-refresh timer. When hidden, it records the newest revision without loading the dashboard. It performs one reload when shown. Search requests use a 250 ms debounce and ignore or cancel superseded work so hidden or obsolete queries do not compete with tray updates.
+
+## Query and storage changes
+
+Presentation queries must filter before rows enter Rust.
+
+Menu and popup summaries use dedicated SQL for API-equivalent value, total tokens, and distinct root conversation count. Trend queries group events into the required time bins in one pass. The popup does not call the full dashboard overview builder. Dashboard overview queries use the same indexed window predicates, and the conversation list uses bounded pages instead of rebuilding every conversation for each search.
+
+Quota history queries select the exact `(bucket, window_start, resets_at)` window through the existing composite index. A small `latest_rate_limits` table stores the newest primary and secondary values for fallback reads. The latest lookup no longer sorts an entire bucket with `julianday(sample_timestamp)`.
+
+Indexed time comparisons use integer epoch milliseconds. New usage events and quota samples populate the epoch fields at ingest. Existing rows are backfilled in bounded batches with a durable progress marker. Foreground presentation remains usable between batches. The compatibility query includes rows without an epoch until the backfill completes.
+
+Quota history stores step changes rather than every repeated observation. The latest table is updated for freshness. The historical table inserts a row when a window begins, when used percent changes, and when a prior window closes. Repeating the same value does not grow history. Existing redundant rows are pruned in bounded background batches. Each cleanup transaction yields before the next batch and does not begin when a refresh deadline is within 30 seconds. The migration does not run an automatic full `VACUUM`; freed pages remain available for SQLite reuse.
+
+Database initialization and bundled pricing seed work run at startup or migration time, not on every scan. Pricing refresh compares a value-bearing catalog signature before recalculating events. An unchanged signature performs no event update. Title maintenance updates only changed values and uses one transaction.
+
+## Append-only session import
+
+The import-state row gains a durable append checkpoint:
+
+```text
+parsed_offset
+parsed_file_size
+prefix_fingerprint
+checkpoint_tail_fingerprint
+last_complete_line_offset
+last_cumulative_usage
+last_model_id
+parser_schema_version
+```
+
+The fingerprint covers a fixed prefix and a small block ending at the saved offset. If the file still has the same identity, its size is at least the saved offset, and both fingerprints match, the importer seeks directly to `parsed_offset`. It parses only complete new JSONL records and appends derived usage and quota changes.
+
+The checkpoint stops at the last complete newline. An incomplete trailing record is read again on the next scan. Derived rows and the new checkpoint commit in the same transaction, so a failure cannot advance the offset beyond persisted data.
+
+The importer falls back to the existing full parse and session rebuild when any of these conditions holds:
+
+- the file shrank or was replaced;
+- a fingerprint does not match;
+- the parser schema version changed;
+- a pending historical repair requires a rebuild;
+- fork or topology metadata changed in a way that invalidates the checkpoint;
+- the saved checkpoint is malformed or incomplete.
+
+New files, archived moves, and explicit repair paths may take the full path once, then establish a fresh checkpoint. The parser uses typed record envelopes and borrows fields where practical so unrelated JSON payloads do not become large generic value trees.
+
+## Memory limits
+
+No new cache may grow with the number of usage events, quota samples, or conversations.
+
+Conversation details use an LRU with both count and byte limits. The default limits are 20 entries and 32 MB. The detail command returns the newest 40 turns by default; older turns require cursor pagination. Conversation lists use bounded pages instead of returning every root conversation.
+
+Workers stream SQLite rows into aggregates where possible. They do not materialize a full usage-event vector merely to compute a tray or popup value. The display snapshot and refresh state remain small fixed-size structures.
+
+## Power behavior
+
+The scheduler waits on its event channel until the next real deadline or configuration message. It no longer opens SQLite every five seconds to check settings.
+
+On macOS, process activity guards cover the actual scan or live query only. Background work uses a background-appropriate activity classification. The application does not hold a user-initiated activity for the lifetime of the scheduler thread.
+
+## Observability
+
+Debug logs and test probes record these fields per lane:
+
+```text
+scheduled_due_at
+started_at
+start_lag_ms
+duration_ms
+last_success_age_ms
+failure_streak
+retry_at
+missed_deadline_count
+coalesced_trigger_count
+running_generation
+pending_reasons
+```
+
+Live metrics also record app-server duration, timeout count, active child count, fallback age, and singleflight waiters. Token metrics record files visited, bytes read, append fast-path count, full-rebuild count, mutation-lock wait, and database busy count. Presentation metrics record snapshot build time, tray queue time, main-thread apply time, payload size, and event-to-visible lag.
+
+Warnings are emitted when start lag exceeds five seconds, live child count exceeds one, or last success age exceeds the interval plus the active retry allowance. Metrics are bounded counters and timings, not an unbounded event history.
+
+## Delivery slices
+
+The work is delivered in three independently testable slices on the same development branch. Each slice receives its own implementation plan and review checkpoint so later storage work cannot obscure refresh regressions in the earlier slices.
+
+### Slice 1: refresh correctness
+
+Introduce the coordinator, independent token and live lanes, fixed deadlines, singleflight, pending-trigger coalescing, bounded timeout, backoff, source generations, and truthful fallback freshness. Replace frontend-driven automatic refresh with completion events.
+
+This slice is complete when token and live work cannot block each other's scheduled start and no trigger is lost during overlap.
+
+### Slice 2: presentation and bounded queries
+
+Add versioned display snapshots, worker-side tray computation, lazy popup loading, dynamic bundle splitting, indexed window queries, latest quota storage, quota change points, and bounded UI caches.
+
+This slice is complete when passive getters are bounded memory reads and tray main-thread work contains no I/O.
+
+### Slice 3: importer and write amplification
+
+Add append checkpoints, typed tail parsing, transactional fallback, pricing signature skips, conditional title updates, and bounded historical cleanup.
+
+This slice is complete when a normal active-session append reads only new bytes and does not delete or rebuild the session's existing derived history.
+
+## Acceptance budgets
+
+All timing budgets apply while the process is awake on a supported machine. Sleep recovery has a separate catch-up allowance.
+
+| Measure | Required result |
+| --- | ---: |
+| Scheduled lane start lag | p95 at or below 2 seconds, maximum 5 seconds |
+| Wake catch-up start | at or below 5 seconds after resume is observed |
+| Active app-server children | at most 1 |
+| Live query timeout | at most 10 seconds |
+| Token or quota commit to visible tray | p95 at or below 100 ms |
+| Token or quota commit to visible popup | p95 at or below 150 ms |
+| Snapshot memory getter | p95 below 5 ms |
+| Tray main-thread apply | p95 below 2 ms, no I/O |
+| Main-thread longest task from refresh work | p99 below 16 ms |
+| Reused popup cached content | p95 below 100 ms |
+| First lazy popup creation | p95 below 300 ms |
+| Popup serialized snapshot | at or below 64 KB |
+| Popup JavaScript | at or below 150 KB minified and 50 KB gzip |
+| Hidden-window dashboard and popup queries | 0 during a 10-minute observation |
+| Fully hidden idle CPU | average below 0.2 percent, p95 below 0.5 percent |
+| Application idle wakeups | at most 2 per minute |
+| Conversation detail cache | at most 20 entries and 32 MB |
+
+An unchanged automatic cycle performs no pricing rewrite, title rewrite, full event-table load, full quota-bucket load, or historical quota insert. A typical active JSONL append reads only bytes after the saved offset. Resident memory does not grow linearly with historical row count.
+
+## Verification
+
+Coordinator tests use a fake monotonic clock and injected token, live, persistence, and event executors. They cover independent deadlines, fixed-rate scheduling, overlap coalescing, interval changes, retry caps, startup pending state, stale fallback behavior, source-generation invalidation, sleep catch-up, backward wall-clock changes, and one active live child.
+
+Presentation tests cover revision ordering, a revision arriving during tray rendering, diff-only tray setters, no I/O in the main-thread closure, stable popup content during refresh, stale response rejection, hidden-window inactivity, popup bundle composition, payload size, and event-to-visible timing.
+
+Database tests use a fixture with at least 200,000 usage events and 400,000 quota samples. Query plans must use the selected time and window indexes. Snapshot getters must stay below their budget, and repeated quota values must not add historical rows.
+
+Importer tests cover append-only growth, incomplete trailing lines, truncation, replacement with the same path, fingerprint mismatch, parser-version changes, fork repair, archived moves, transaction rollback, and a full-rebuild fallback that produces exactly the same derived rows as a clean import.
+
+Memory tests browse 1,000 conversation details and verify both LRU limits. Long-running tests hide both windows for ten minutes and record query count, scheduler wakeups, CPU, and resident-memory stability.
+
+Final verification runs frontend tests, ESLint, the production frontend build, Rust tests, targeted Clippy checks for changed modules, SQLite integrity checks, query-plan assertions, a local macOS release build, and the Windows release build in CI. Existing unrelated whole-repository formatting and Clippy debt is not mixed into this work.
+
+## Out of scope
+
+This design does not keep a persistent app-server process, add an external telemetry service, cache the complete event history, or run an automatic full database vacuum. It also does not redesign dashboard visuals. Unrelated correctness and release-pipeline findings from the broader audit remain separate work so they do not delay the refresh and performance fixes.

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness && npm run test:settings-save",
+    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness && npm run test:refresh-events && npm run test:settings-save",
     "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
     "test:issue-3": "node scripts/test-issue-3-custom-range.mjs",
     "test:data-freshness": "node --experimental-strip-types scripts/test-data-freshness.mjs",
+    "test:refresh-events": "node --experimental-strip-types scripts/test-refresh-events.mjs",
     "test:settings-save": "node --experimental-strip-types scripts/test-settings-save.mjs",
     "preview": "vite preview",
     "tauri": "tauri"

--- a/scripts/test-data-freshness.mjs
+++ b/scripts/test-data-freshness.mjs
@@ -5,11 +5,8 @@ import { fileURLToPath } from 'node:url'
 
 import {
   loadConversationDetailForGeneration,
-  refreshDashboardAfterBackgroundScan,
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
-  waitForOverlappingScan,
-  waitForScanToSettleUntilCancelled,
 } from '../src/app/dataFreshness.ts'
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
@@ -155,42 +152,6 @@ assert.equal(
   'detail cache should retain matching derived values within floating-point tolerance',
 )
 
-let scanChecks = 0
-let settleWaits = 0
-const settledAfterOverlap = await waitForOverlappingScan(
-  async () => {
-    scanChecks += 1
-    return true
-  },
-  async () => {
-    settleWaits += 1
-    return true
-  },
-)
-
-assert.equal(scanChecks, 1, 'overlapping refresh should check scan state once')
-assert.equal(settleWaits, 1, 'overlapping refresh should wait once for an active scan')
-assert.equal(settledAfterOverlap, true, 'overlapping refresh should report a settled scan')
-
-const timedOutAfterOverlap = await waitForOverlappingScan(
-  async () => true,
-  async () => false,
-)
-
-assert.equal(timedOutAfterOverlap, false, 'overlapping refresh should report a settle timeout')
-
-settleWaits = 0
-const settledWithoutOverlap = await waitForOverlappingScan(
-  async () => false,
-  async () => {
-    settleWaits += 1
-    return true
-  },
-)
-
-assert.equal(settleWaits, 0, 'refresh should not wait when no scan is active')
-assert.equal(settledWithoutOverlap, true, 'refresh should be ready when no scan is active')
-
 let scanAttempts = 0
 let overlapNotices = 0
 const retriedScan = await runScanWithOverlapRetry(
@@ -226,99 +187,3 @@ await assert.rejects(
   'source switch should fail instead of reading the dashboard after a settle timeout',
 )
 assert.equal(scanAttempts, 1, 'source switch should not retry while the old scan is still active')
-
-let dashboardLoads = 0
-await refreshDashboardAfterBackgroundScan(
-  async () => {
-    throw new Error('background refresh failed')
-  },
-  async () => false,
-  async () => true,
-  async () => {
-    dashboardLoads += 1
-  },
-)
-assert.equal(dashboardLoads, 1, 'background refresh errors should still allow a current dashboard load')
-
-dashboardLoads = 0
-await refreshDashboardAfterBackgroundScan(
-  async () => null,
-  async () => true,
-  async () => false,
-  async () => {
-    dashboardLoads += 1
-  },
-)
-assert.equal(dashboardLoads, 0, 'a settle timeout should skip the current background dashboard load')
-
-let cancelled = false
-let releaseWait
-let markWaitStarted
-const waitStarted = new Promise((resolve) => {
-  markWaitStarted = resolve
-})
-const pendingRefresh = refreshDashboardAfterBackgroundScan(
-  async () => null,
-  async () => true,
-  async () => {
-    markWaitStarted()
-    return new Promise((resolve) => {
-      releaseWait = resolve
-    })
-  },
-  async () => {
-    dashboardLoads += 1
-  },
-  () => cancelled,
-)
-
-await waitStarted
-cancelled = true
-releaseWait(true)
-await pendingRefresh
-assert.equal(dashboardLoads, 0, 'effect cleanup should cancel a refresh that was waiting on a scan')
-
-await refreshDashboardAfterBackgroundScan(
-  async () => null,
-  async () => {
-    throw new Error('scan state unavailable')
-  },
-  async () => true,
-  async () => {
-    dashboardLoads += 1
-  },
-)
-assert.equal(dashboardLoads, 0, 'scan-state errors should not load or reject the interval task')
-
-await refreshDashboardAfterBackgroundScan(
-  async () => null,
-  async () => true,
-  async () => {
-    throw new Error('settle state unavailable')
-  },
-  async () => {
-    dashboardLoads += 1
-  },
-)
-assert.equal(dashboardLoads, 0, 'settle errors should not load or reject the interval task')
-
-let bootstrapWaits = 0
-const bootstrapSettled = await waitForScanToSettleUntilCancelled(
-  async () => {
-    bootstrapWaits += 1
-    return bootstrapWaits > 1
-  },
-  () => false,
-)
-assert.equal(bootstrapSettled, true, 'bootstrap should keep waiting after one settle timeout')
-assert.equal(bootstrapWaits, 2, 'bootstrap should retry its settle wait after a timeout')
-
-let bootstrapCancelled = false
-const cancelledBootstrapSettled = await waitForScanToSettleUntilCancelled(
-  async () => {
-    bootstrapCancelled = true
-    return false
-  },
-  () => bootstrapCancelled,
-)
-assert.equal(cancelledBootstrapSettled, false, 'bootstrap should stop retrying after cleanup')

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -4,7 +4,9 @@ import { dirname, join } from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
-import { settleRefreshFailure, SurfaceRevisionGate } from '../src/app/refreshEvents.ts'
+import * as refreshEvents from '../src/app/refreshEvents.ts'
+
+const { settleRefreshFailure, SurfaceRevisionGate } = refreshEvents
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
@@ -24,6 +26,28 @@ function completion(refreshRevision, succeeded = true) {
     failure: succeeded ? null : 'refresh failed',
     completedAt: '2026-07-11T00:00:00Z',
   }
+}
+
+function deferred() {
+  let resolve
+  const promise = new Promise((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+function extractFunction(source, signature) {
+  const signatureStart = source.indexOf(signature)
+  assert.notEqual(signatureStart, -1, `missing function: ${signature}`)
+  const bodyStart = source.indexOf(') {', signatureStart) + 2
+  assert.ok(bodyStart > 1, `missing function body: ${signature}`)
+  let depth = 0
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1
+    if (source[index] === '}') depth -= 1
+    if (depth === 0) return source.slice(signatureStart, index + 1)
+  }
+  assert.fail(`unterminated function: ${signature}`)
 }
 
 test('surface_revision_gate_deduplicates_visible_completions', () => {
@@ -117,9 +141,121 @@ test('frontend_refresh_sources_are_event_driven_without_automatic_polling', () =
 })
 
 test('manual_rescan_waits_for_its_ticket_without_loading_dashboard_twice', () => {
-  const handleRescan = appSource.match(/async function handleRescan\(\) \{([\s\S]*?)\n  \}/)?.[1]
-  assert.ok(handleRescan, 'App should retain the manual rescan handler')
+  const handleRescan = extractFunction(appSource, 'async function handleRescan()')
   assert.match(handleRescan, /scanCodexUsage/)
-  assert.doesNotMatch(handleRescan, /loadShell|loadDashboard/)
   assert.match(handleRescan, /finally[\s\S]*setIsBusy\(false\)/)
+})
+
+test('app_manual_reload_decisions_use_completion_only_when_listener_is_ready', () => {
+  const manualDecision = refreshEvents.shouldLoadDashboardAfterManualRefresh
+  const settingsDecision = refreshEvents.shouldLoadDashboardAfterSettingsSave
+
+  assert.equal(typeof manualDecision, 'function')
+  assert.equal(typeof settingsDecision, 'function')
+  assert.equal(manualDecision(true), false, 'a registered listener owns the manual scan reload')
+  assert.equal(manualDecision(false), true, 'a missing listener requires one post-ticket fallback')
+  assert.equal(settingsDecision(true, true), false, 'a source change with a listener must not read twice')
+  assert.equal(settingsDecision(true, false), true, 'a source change without a listener needs a fallback')
+  assert.equal(settingsDecision(false, true), true, 'a normal settings save still needs an explicit read')
+})
+
+test('app_awaits_listener_readiness_and_does_not_bypass_hidden_source_change_defer', () => {
+  const handleRescan = extractFunction(appSource, 'async function handleRescan()')
+  const handleSaveSettings = extractFunction(appSource, 'async function handleSaveSettings(')
+  const rescanReady = handleRescan.indexOf('await refreshCompletionListenerReadyRef.current')
+  const rescanCommand = handleRescan.indexOf('scanCodexUsage(')
+  const settingsReady = handleSaveSettings.indexOf('await refreshCompletionListenerReadyRef.current')
+  const settingsSave = handleSaveSettings.indexOf('saveSettingsWithCodexHomeRollback(')
+
+  assert.ok(rescanReady >= 0 && rescanReady < rescanCommand)
+  assert.ok(settingsReady >= 0 && settingsReady < settingsSave)
+  assert.match(
+    handleRescan,
+    /shouldLoadDashboardAfterManualRefresh\(listenerReady\)[\s\S]*await loadShell\(true\)/,
+  )
+  assert.match(
+    handleSaveSettings,
+    /shouldLoadDashboardAfterSettingsSave\(saved\.codexHomeChanged, listenerReady\)[\s\S]*await loadShell\(true\)/,
+  )
+  assert.match(appSource, /const completionRegistration = listen<RefreshCompletedEvent>/)
+  assert.match(
+    appSource,
+    /refreshCompletionListenerReadyRef\.current = completionRegistration[\s\S]*\.then\([\s\S]*return true[\s\S]*\.catch\([\s\S]*false/,
+  )
+})
+
+test('surface_request_controller_ignores_an_older_response_that_finishes_last', async () => {
+  const Controller = refreshEvents.SurfaceRequestController
+  assert.equal(typeof Controller, 'function')
+  const controller = new Controller()
+  const older = deferred()
+  const newer = deferred()
+  let displayed = 'initial'
+
+  const load = async (pending) => {
+    const claim = controller.claim('passive')
+    const value = await pending
+    if (controller.isLatest(claim)) displayed = value
+    controller.finish(claim)
+  }
+  const olderLoad = load(older.promise)
+  const newerLoad = load(newer.promise)
+
+  newer.resolve('newer snapshot')
+  await newerLoad
+  older.resolve('older snapshot')
+  await olderLoad
+
+  assert.equal(displayed, 'newer snapshot')
+})
+
+test('surface_request_controller_keeps_manual_spinner_single_flight_and_independent', async () => {
+  const Controller = refreshEvents.SurfaceRequestController
+  assert.equal(typeof Controller, 'function')
+  const controller = new Controller()
+  const manual = deferred()
+  const passive = deferred()
+  let displayed = 'existing snapshot'
+  let refreshing = false
+
+  const load = async (kind, pending) => {
+    const claim = controller.claim(kind)
+    if (claim === null) return false
+    refreshing = controller.manualInFlight
+    try {
+      const value = await pending
+      if (controller.isLatest(claim)) displayed = value
+    } finally {
+      controller.finish(claim)
+      refreshing = controller.manualInFlight
+    }
+    return true
+  }
+
+  const manualLoad = load('manual', manual.promise)
+  await Promise.resolve()
+  assert.equal(refreshing, true)
+  assert.equal(controller.claim('manual'), null, 'a second manual request must be rejected synchronously')
+
+  const passiveLoad = load('passive', passive.promise)
+  passive.resolve('newer passive snapshot')
+  await passiveLoad
+  assert.equal(displayed, 'newer passive snapshot')
+  assert.equal(refreshing, true, 'a passive completion must not clear a manual spinner')
+
+  manual.resolve('older forced snapshot')
+  await manualLoad
+  assert.equal(displayed, 'newer passive snapshot')
+  assert.equal(refreshing, false)
+})
+
+test('popup_wires_latest_request_controller_and_disables_duplicate_manual_refresh', () => {
+  assert.match(popupSource, /useRef\(new SurfaceRequestController\(\)\)/)
+  assert.match(popupSource, /\.claim\(forceRefresh \? 'manual' : 'passive'\)/)
+  assert.match(popupSource, /\.isLatest\(claim\)/)
+  assert.match(popupSource, /\.finish\(claim\)/)
+  assert.match(
+    popupSource,
+    /aria-label=\{t\.popup\.actions\.refresh\}[\s\S]{0,220}disabled=\{refreshing\}/,
+  )
 })

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { settleRefreshFailure, SurfaceRevisionGate } from '../src/app/refreshEvents.ts'
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
+const popupSource = readFileSync(join(repoRoot, 'src/menu-bar-popup/MenuBarPopup.tsx'), 'utf8')
+const apiSource = readFileSync(join(repoRoot, 'src/app/api.ts'), 'utf8')
+const dataFreshnessSource = readFileSync(join(repoRoot, 'src/app/dataFreshness.ts'), 'utf8')
+
+function completion(refreshRevision, succeeded = true) {
+  return {
+    refreshRevision,
+    lane: 'token',
+    generation: refreshRevision,
+    usageRevision: refreshRevision,
+    quotaRevision: 0,
+    sourceGeneration: 1,
+    succeeded,
+    failure: succeeded ? null : 'refresh failed',
+    completedAt: '2026-07-11T00:00:00Z',
+  }
+}
+
+test('surface_revision_gate_deduplicates_visible_completions', () => {
+  const gate = new SurfaceRevisionGate()
+
+  assert.equal(gate.accept(completion(1), true), 'reload')
+  assert.equal(gate.accept(completion(1), true), 'ignore')
+})
+
+test('surface_revision_gate_keeps_only_latest_hidden_revision_until_visible', () => {
+  const gate = new SurfaceRevisionGate()
+
+  assert.equal(gate.accept(completion(1), true), 'reload')
+  assert.equal(gate.accept(completion(2), false), 'defer')
+  assert.equal(gate.accept(completion(3), false), 'defer')
+  assert.equal(gate.onVisible(), 'reload')
+  assert.equal(gate.onVisible(), 'ignore')
+})
+
+test('failed_completion_does_not_reload_data', () => {
+  const gate = new SurfaceRevisionGate()
+  const previousData = Object.freeze({ cards: ['existing-card'], sourceTimestamp: '2026-07-10T00:00:00Z' })
+  const currentSurface = { data: previousData, reloads: 0 }
+
+  const decision = gate.accept(completion(1, false), true)
+  const nextSurface =
+    decision === 'reload'
+      ? { data: { cards: ['replacement-card'], sourceTimestamp: null }, reloads: 1 }
+      : currentSurface
+
+  assert.equal(decision, 'ignore')
+  assert.strictEqual(nextSurface.data, previousData)
+  assert.equal(nextSurface.reloads, 0)
+})
+
+test('manual_waiter_failure_clears_refreshing_and_keeps_previous_data', () => {
+  const previousData = Object.freeze({ cards: ['existing-card'], sourceTimestamp: '2026-07-10T00:00:00Z' })
+  const failed = settleRefreshFailure(
+    {
+      data: previousData,
+      loading: false,
+      refreshing: true,
+      error: null,
+    },
+    new Error('coordinator ticket failed'),
+  )
+
+  assert.strictEqual(failed.data, previousData)
+  assert.equal(failed.loading, false)
+  assert.equal(failed.refreshing, false)
+  assert.equal(failed.error, null, 'existing cards should remain the display state instead of an error replacement')
+
+  const firstLoadFailure = settleRefreshFailure(
+    {
+      data: null,
+      loading: true,
+      refreshing: false,
+      error: null,
+    },
+    new Error('initial snapshot failed'),
+  )
+  assert.match(firstLoadFailure.error ?? '', /initial snapshot failed/)
+})
+
+test('frontend_refresh_sources_are_event_driven_without_automatic_polling', () => {
+  assert.doesNotMatch(appSource, /setInterval/)
+  assert.doesNotMatch(popupSource, /setInterval/)
+  assert.doesNotMatch(appSource, /refreshBackgroundData/)
+  assert.doesNotMatch(apiSource, /refreshBackgroundData/)
+  assert.doesNotMatch(dataFreshnessSource, /refreshDashboardAfterBackgroundScan/)
+  assert.doesNotMatch(dataFreshnessSource, /waitForScanToSettleUntilCancelled/)
+  assert.doesNotMatch(appSource, /getLiveRateLimits/)
+  assert.doesNotMatch(appSource, /setLoadedQueryKey\(null\)/)
+
+  assert.match(appSource, /codex-counter:\/\/refresh-completed/)
+  assert.match(appSource, /SurfaceRevisionGate/)
+  assert.match(appSource, /getCurrentWindow\(\)\.isVisible\(\)/)
+  assert.match(appSource, /onFocusChanged/)
+  assert.match(appSource, /visibilitychange/)
+
+  assert.equal(
+    popupSource.match(/codex-counter:\/\/menu-bar-popup-refresh/g)?.length,
+    1,
+    'Popup should have one dedicated refresh listener',
+  )
+  assert.match(
+    popupSource,
+    /listen\('codex-counter:\/\/menu-bar-popup-refresh'[\s\S]{0,220}loadSnapshot\(false\)/,
+  )
+  assert.doesNotMatch(popupSource, /codex-counter:\/\/refresh-completed/)
+})
+
+test('manual_rescan_waits_for_its_ticket_without_loading_dashboard_twice', () => {
+  const handleRescan = appSource.match(/async function handleRescan\(\) \{([\s\S]*?)\n  \}/)?.[1]
+  assert.ok(handleRescan, 'App should retain the manual rescan handler')
+  assert.match(handleRescan, /scanCodexUsage/)
+  assert.doesNotMatch(handleRescan, /loadShell|loadDashboard/)
+  assert.match(handleRescan, /finally[\s\S]*setIsBusy\(false\)/)
+})

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -50,6 +50,14 @@ function extractFunction(source, signature) {
   assert.fail(`unterminated function: ${signature}`)
 }
 
+function enclosingEffect(source, needle) {
+  const needleIndex = source.indexOf(needle)
+  assert.notEqual(needleIndex, -1, `missing effect content: ${needle}`)
+  const layoutEffectIndex = source.lastIndexOf('useLayoutEffect(() => {', needleIndex)
+  const passiveEffectIndex = source.lastIndexOf('useEffect(() => {', needleIndex)
+  return layoutEffectIndex > passiveEffectIndex ? 'layout' : 'passive'
+}
+
 test('surface_revision_gate_deduplicates_visible_completions', () => {
   const gate = new SurfaceRevisionGate()
 
@@ -171,17 +179,60 @@ test('app_awaits_listener_readiness_and_does_not_bypass_hidden_source_change_def
   assert.ok(settingsReady >= 0 && settingsReady < settingsSave)
   assert.match(
     handleRescan,
-    /shouldLoadDashboardAfterManualRefresh\(listenerReady\)[\s\S]*await loadShell\(true\)/,
+    /shouldLoadDashboardAfterManualRefresh\(listenerReady\)[\s\S]*await loadShellRef\.current\(true\)/,
   )
   assert.match(
     handleSaveSettings,
-    /shouldLoadDashboardAfterSettingsSave\(saved\.codexHomeChanged, listenerReady\)[\s\S]*await loadShell\(true\)/,
+    /shouldLoadDashboardAfterSettingsSave\(saved\.codexHomeChanged, listenerReady\)[\s\S]*await loadShellRef\.current\(true\)/,
   )
+  assert.doesNotMatch(handleRescan, /await loadShell\(true\)/)
+  assert.doesNotMatch(handleSaveSettings, /await loadShell\(true\)/)
   assert.match(appSource, /const completionRegistration = listen<RefreshCompletedEvent>/)
   assert.match(
     appSource,
     /refreshCompletionListenerReadyRef\.current = completionRegistration[\s\S]*\.then\([\s\S]*return true[\s\S]*\.catch\([\s\S]*false/,
   )
+})
+
+test('app_commits_listener_readiness_and_latest_loader_before_browser_interaction', () => {
+  assert.equal(
+    enclosingEffect(appSource, 'loadShellRef.current = loadShell'),
+    'layout',
+    'query changes must update the latest loader before paint',
+  )
+  assert.equal(
+    enclosingEffect(appSource, 'const completionRegistration = listen<RefreshCompletedEvent>'),
+    'layout',
+    'manual actions must see the real registration promise before paint',
+  )
+})
+
+test('manual_fallback_after_a_pending_ticket_uses_the_latest_loader_once', async () => {
+  const handleRescan = extractFunction(appSource, 'async function handleRescan()')
+  assert.match(handleRescan, /await loadShellRef\.current\(true\)/)
+  const ticket = deferred()
+  const calls = []
+  const loaderRef = {
+    current: async (quiet) => {
+      calls.push(['old query', quiet])
+    },
+  }
+  const runManual = async () => {
+    const listenerReady = await Promise.resolve(false)
+    await ticket.promise
+    if (refreshEvents.shouldLoadDashboardAfterManualRefresh(listenerReady)) {
+      await loaderRef.current(true)
+    }
+  }
+
+  const pending = runManual()
+  loaderRef.current = async (quiet) => {
+    calls.push(['latest query', quiet])
+  }
+  ticket.resolve()
+  await pending
+
+  assert.deepEqual(calls, [['latest query', true]])
 })
 
 test('surface_request_controller_ignores_an_older_response_that_finishes_last', async () => {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -574,6 +574,7 @@ version = "1.2.0"
 dependencies = [
  "chrono",
  "dirs",
+ "flate2",
  "log",
  "objc2",
  "objc2-foundation",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "dirs",
  "flate2",
  "log",
+ "mimalloc",
  "objc2",
  "objc2-foundation",
  "rusqlite",
@@ -2132,6 +2133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2252,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2.5.6", features = [] }
 [dependencies]
 chrono = { version = "0.4.42", features = ["serde"] }
 dirs = "6.0.0"
+flate2 = "1.1.9"
 log = "0.4"
 objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", features = ["NSProcessInfo", "NSString"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.42", features = ["serde"] }
 dirs = "6.0.0"
 flate2 = "1.1.9"
 log = "0.4"
+mimalloc = "0.1.52"
 objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", features = ["NSProcessInfo", "NSString"] }
 rusqlite = { version = "0.37.0", features = ["bundled", "chrono"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,12 +28,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "2.10.3", features = ["tray-icon"] }
 tauri-plugin-log = "2"
+tempfile = "3.23.0"
 tokio = { version = "1.48.0", features = ["time"] }
 ureq = "2.12.1"
 walkdir = "2.5.0"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2"
-
-[dev-dependencies]
-tempfile = "3.23.0"

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -3,6 +3,9 @@ CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp)
 CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_ms
   ON usage_events(timestamp_ms, id)
   WHERE timestamp_ms IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_missing_timestamp_ms
+  ON usage_events(id)
+  WHERE timestamp_ms IS NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -16,3 +16,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
   ON rate_limit_samples(
     bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
   );
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_owner
+  ON rate_limit_samples(source_kind, source_session_id, bucket, sample_timestamp_ms, id);
+CREATE INDEX IF NOT EXISTS idx_latest_rate_limits_lookup
+  ON latest_rate_limits(bucket, source_kind, sample_timestamp_ms DESC, source_session_id);

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -1,11 +1,17 @@
 CREATE INDEX IF NOT EXISTS idx_usage_events_session_id ON usage_events(session_id);
 CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_ms
+  ON usage_events(timestamp_ms, id)
+  WHERE timestamp_ms IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
 CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
 CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
   ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_window_ms
+  ON rate_limit_samples(bucket, window_start_ms, resets_at_ms, sample_timestamp_ms, id)
+  WHERE window_start_ms IS NOT NULL AND resets_at_ms IS NOT NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
   ON rate_limit_samples(
     bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -109,6 +109,7 @@ CREATE TABLE IF NOT EXISTS import_state (
   source_bucket TEXT NOT NULL,
   file_size INTEGER NOT NULL,
   file_mtime_ms INTEGER NOT NULL,
+  parser_checkpoint TEXT,
   last_imported_at TEXT NOT NULL
 );
 

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -161,3 +161,22 @@ CREATE TABLE IF NOT EXISTS rate_limit_samples (
   remaining_percent INTEGER NOT NULL,
   created_at TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS latest_rate_limits (
+  source_kind TEXT NOT NULL,
+  source_session_id TEXT NOT NULL DEFAULT '',
+  bucket TEXT NOT NULL,
+  sample_timestamp TEXT NOT NULL,
+  sample_timestamp_ms INTEGER NOT NULL,
+  limit_id TEXT NOT NULL DEFAULT '',
+  limit_name TEXT NOT NULL DEFAULT '',
+  plan_type TEXT NOT NULL DEFAULT '',
+  window_start TEXT NOT NULL,
+  window_start_ms INTEGER NOT NULL,
+  resets_at TEXT NOT NULL,
+  resets_at_ms INTEGER NOT NULL,
+  used_percent INTEGER NOT NULL,
+  remaining_percent INTEGER NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (source_kind, source_session_id, bucket)
+);

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -72,6 +72,7 @@ CREATE TABLE IF NOT EXISTS session_overrides (
 CREATE TABLE IF NOT EXISTS sync_settings (
   singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
   sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
+  scan_commit_revision INTEGER NOT NULL DEFAULT 0,
   codex_home TEXT,
   auto_scan_enabled INTEGER NOT NULL,
   auto_scan_interval_minutes INTEGER NOT NULL,

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS usage_events (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   session_id TEXT NOT NULL,
   timestamp TEXT NOT NULL,
+  timestamp_ms INTEGER,
   model_id TEXT NOT NULL,
   input_tokens INTEGER NOT NULL,
   cached_input_tokens INTEGER NOT NULL,
@@ -116,6 +117,24 @@ CREATE TABLE IF NOT EXISTS data_repairs (
   completed_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS data_repair_progress (
+  repair_key TEXT NOT NULL,
+  stream_key TEXT NOT NULL,
+  progress_value INTEGER NOT NULL,
+  PRIMARY KEY (repair_key, stream_key)
+);
+
+CREATE TABLE IF NOT EXISTS data_repair_quarantine (
+  repair_key TEXT NOT NULL,
+  table_name TEXT NOT NULL,
+  row_id INTEGER NOT NULL,
+  column_name TEXT NOT NULL,
+  raw_value TEXT NOT NULL,
+  error_message TEXT NOT NULL,
+  quarantined_at TEXT NOT NULL,
+  PRIMARY KEY (repair_key, table_name, row_id, column_name)
+);
+
 CREATE TABLE IF NOT EXISTS data_repair_pending_files (
   repair_key TEXT NOT NULL,
   source_path TEXT NOT NULL,
@@ -130,11 +149,14 @@ CREATE TABLE IF NOT EXISTS rate_limit_samples (
   source_session_id TEXT NOT NULL DEFAULT '',
   bucket TEXT NOT NULL,
   sample_timestamp TEXT NOT NULL,
+  sample_timestamp_ms INTEGER,
   limit_id TEXT NOT NULL DEFAULT '',
   limit_name TEXT NOT NULL DEFAULT '',
   plan_type TEXT NOT NULL DEFAULT '',
   window_start TEXT NOT NULL,
+  window_start_ms INTEGER,
   resets_at TEXT NOT NULL,
+  resets_at_ms INTEGER,
   used_percent INTEGER NOT NULL,
   remaining_percent INTEGER NOT NULL,
   created_at TEXT NOT NULL

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -16,7 +16,11 @@ pub use epoch_backfill::{
     backfill_epoch_batch, backfill_epoch_batch_cancellable, epoch_backfill_pending,
     parse_epoch_millis, EpochBackfillProgress,
 };
-pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
+#[allow(unused_imports)]
+pub use rate_limit_samples::{
+    append_session_rate_limit_samples, insert_live_rate_limit_snapshot, load_latest_rate_limits,
+    replace_session_rate_limit_samples, RateLimitWriteStats,
+};
 pub use subscriptions::{
     canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
 };

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -14,10 +14,13 @@ pub use subscriptions::{
 };
 pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
-    set_last_scan_started_for_source, set_scan_completed_for_source,
+    set_scan_completed_for_source,
+};
+pub(crate) use sync_settings::{
+    preview_scan_freshness_for_source, set_last_scan_started_for_source_in_transaction,
 };
 #[cfg(test)]
-pub use sync_settings::set_last_full_scan_completed;
+pub use sync_settings::{set_last_full_scan_completed, set_last_scan_started_for_source};
 
 pub fn now_utc_string() -> String {
     Utc::now().to_rfc3339()
@@ -99,6 +102,41 @@ mod tests {
     use crate::models::{SubscriptionProfile, SyncSettings};
 
     #[test]
+    fn init_db_adds_scan_commit_revision_to_existing_sync_settings() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        conn.execute_batch(
+            "
+            CREATE TABLE sync_settings (
+              singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+              codex_home TEXT,
+              auto_scan_enabled INTEGER NOT NULL,
+              auto_scan_interval_minutes INTEGER NOT NULL,
+              last_scan_started_at TEXT,
+              last_scan_completed_at TEXT,
+              updated_at TEXT NOT NULL
+            );
+            INSERT INTO sync_settings (
+              singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
+              last_scan_started_at, last_scan_completed_at, updated_at
+            )
+            VALUES (1, NULL, 1, 5, NULL, NULL, '2026-07-10T00:00:00Z');
+            ",
+        )
+        .expect("seed legacy schema");
+
+        init_db(&conn).expect("migrate schema");
+        let revision: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load scan commit revision");
+
+        assert_eq!(revision, 0);
+    }
+
+    #[test]
     fn init_db_adds_menu_bar_flag_to_existing_sync_settings() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
 
@@ -146,7 +184,9 @@ mod tests {
         );
         assert!(settings.menu_bar_popup_show_reset_timeline);
         assert!(settings.menu_bar_popup_show_actions);
-        assert!(get_last_full_scan_completed(&conn).expect("load last full scan").is_none());
+        assert!(get_last_full_scan_completed(&conn)
+            .expect("load last full scan")
+            .is_none());
         assert!(!settings.hide_dock_icon_when_menu_bar_visible);
     }
 
@@ -210,9 +250,12 @@ mod tests {
         let conn = Connection::open_in_memory().expect("open in-memory database");
         init_db(&conn).expect("init database");
 
-        assert!(get_last_full_scan_completed(&conn).expect("load initial value").is_none());
+        assert!(get_last_full_scan_completed(&conn)
+            .expect("load initial value")
+            .is_none());
 
-        set_last_full_scan_completed(&conn, "2026-03-27T00:00:00Z").expect("set full scan timestamp");
+        set_last_full_scan_completed(&conn, "2026-03-27T00:00:00Z")
+            .expect("set full scan timestamp");
 
         assert_eq!(
             get_last_full_scan_completed(&conn).expect("load saved value"),

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -438,6 +438,291 @@ mod tests {
     }
 
     #[test]
+    fn settings_save_does_not_overwrite_newer_scan_freshness() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let mut stale_settings = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save initial settings");
+
+        set_last_scan_started_for_source(
+            &conn,
+            "2026-07-11T01:00:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/codex-home-a",
+        )
+        .expect("record newer scan start");
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-11T01:01:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/codex-home-a",
+            true,
+            false,
+        )
+        .expect("record newer scan completion"));
+
+        stale_settings.auto_scan_interval_minutes = 17;
+        save_sync_settings(&conn, &stale_settings).expect("save stale config snapshot");
+
+        let saved = get_sync_settings(&conn).expect("reload settings");
+        assert_eq!(
+            saved.last_scan_started_at.as_deref(),
+            Some("2026-07-11T01:00:00Z")
+        );
+        assert_eq!(
+            saved.last_scan_completed_at.as_deref(),
+            Some("2026-07-11T01:01:00Z")
+        );
+    }
+
+    #[test]
+    fn home_change_clears_all_scan_freshness_in_one_transaction() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let settings = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save first Codex home");
+        set_last_scan_started_for_source(
+            &conn,
+            "2026-07-11T02:00:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/resolved-home-a",
+        )
+        .expect("record scan start");
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-11T02:01:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/resolved-home-a",
+            true,
+            false,
+        )
+        .expect("record full scan completion"));
+        let revision_before: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load revision before home change");
+
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-b".to_string()),
+                ..settings
+            },
+        )
+        .expect("change Codex home");
+
+        let (started, completed, full_completed, resolved_home, revision): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i64,
+        ) = conn
+            .query_row(
+                "
+                SELECT last_scan_started_at, last_scan_completed_at,
+                       last_full_scan_completed_at, last_scan_codex_home,
+                       scan_commit_revision
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .expect("load freshness after home change");
+
+        assert_eq!(
+            (started, completed, full_completed, resolved_home),
+            (None, None, None, None)
+        );
+        assert_eq!(revision, revision_before + 1);
+    }
+
+    #[test]
+    fn codex_home_aba_advances_scan_commit_revision() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let initial_revision: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load initial revision");
+        let settings_a = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save home A");
+        let revision_a: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load home A revision");
+        let settings_b = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-b".to_string()),
+                ..settings_a
+            },
+        )
+        .expect("save home B");
+        let revision_b: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load home B revision");
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..settings_b
+            },
+        )
+        .expect("return to home A");
+        let final_revision: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load final revision");
+
+        assert_eq!(revision_a, initial_revision + 1);
+        assert_eq!(revision_b, revision_a + 1);
+        assert_eq!(final_revision, revision_b + 1);
+    }
+
+    #[test]
+    fn unchanged_home_config_save_preserves_revision_and_hidden_freshness_columns() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let mut settings = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save Codex home");
+        set_last_scan_started_for_source(
+            &conn,
+            "2026-07-11T03:00:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/resolved-home-a",
+        )
+        .expect("record scan start");
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-11T03:01:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/resolved-home-a",
+            true,
+            false,
+        )
+        .expect("record full scan completion"));
+        conn.execute(
+            "UPDATE sync_settings SET scan_commit_revision = 41 WHERE singleton_id = 1",
+            [],
+        )
+        .expect("seed revision");
+        let before: (i64, Option<String>, Option<String>) = conn
+            .query_row(
+                "
+                SELECT scan_commit_revision, last_scan_codex_home,
+                       last_full_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load hidden freshness before save");
+
+        settings.auto_scan_interval_minutes = 19;
+        save_sync_settings(&conn, &settings).expect("save unchanged-home config");
+
+        let after: (i64, Option<String>, Option<String>) = conn
+            .query_row(
+                "
+                SELECT scan_commit_revision, last_scan_codex_home,
+                       last_full_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load hidden freshness after save");
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn settings_insert_ignores_payload_freshness() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+        conn.execute("DELETE FROM sync_settings WHERE singleton_id = 1", [])
+            .expect("remove singleton to exercise insert path");
+
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                last_scan_started_at: Some("stale-start".to_string()),
+                last_scan_completed_at: Some("stale-complete".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("insert settings singleton");
+
+        let freshness: (Option<String>, Option<String>) = conn
+            .query_row(
+                "
+                SELECT last_scan_started_at, last_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("load inserted freshness");
+        assert_eq!(freshness, (None, None));
+    }
+
+    #[test]
     fn init_db_migrates_old_default_refresh_and_disables_legacy_fast_mode_once() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -28,7 +28,7 @@ pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
     set_scan_completed_for_source,
 };
-pub use usage_events::{insert_usage_events, NewUsageEvent};
+pub use usage_events::{replace_session_usage_events, NewUsageEvent};
 pub(crate) use sync_settings::{
     preview_scan_freshness_for_source, set_last_scan_started_for_source_in_transaction,
 };

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -12,7 +12,10 @@ mod sync_settings;
 mod usage_events;
 
 #[allow(unused_imports)]
-pub use epoch_backfill::{backfill_epoch_batch, parse_epoch_millis, EpochBackfillProgress};
+pub use epoch_backfill::{
+    backfill_epoch_batch, backfill_epoch_batch_cancellable, epoch_backfill_pending,
+    parse_epoch_millis, EpochBackfillProgress,
+};
 pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
 pub use subscriptions::{
     canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
@@ -45,8 +48,21 @@ pub fn i64_to_bool(value: i64) -> bool {
 }
 
 pub fn open_connection(db_path: &Path) -> rusqlite::Result<Connection> {
+    open_connection_with_busy_timeout(db_path, Duration::from_secs(10))
+}
+
+pub(crate) fn open_epoch_maintenance_connection(
+    db_path: &Path,
+) -> rusqlite::Result<Connection> {
+    open_connection_with_busy_timeout(db_path, Duration::from_millis(200))
+}
+
+fn open_connection_with_busy_timeout(
+    db_path: &Path,
+    busy_timeout: Duration,
+) -> rusqlite::Result<Connection> {
     let conn = Connection::open(db_path)?;
-    conn.busy_timeout(Duration::from_secs(10))?;
+    conn.busy_timeout(busy_timeout)?;
     conn.pragma_update(None, "foreign_keys", "ON")?;
     conn.pragma_update(None, "journal_mode", "WAL")?;
     conn.pragma_update(None, "synchronous", "NORMAL")?;
@@ -107,6 +123,32 @@ fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {
 mod tests {
     use super::*;
     use crate::models::{SubscriptionProfile, SyncSettings};
+
+    #[test]
+    fn epoch_maintenance_connection_uses_short_busy_timeout_and_normal_pragmas() {
+        let directory = tempfile::tempdir().expect("create maintenance connection directory");
+        let path = directory.path().join("maintenance.sqlite3");
+
+        let conn = open_epoch_maintenance_connection(&path)
+            .expect("open epoch maintenance connection");
+
+        let busy_timeout: i64 = conn
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .expect("read busy timeout");
+        let foreign_keys: i64 = conn
+            .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+            .expect("read foreign key mode");
+        let journal_mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .expect("read journal mode");
+        let synchronous: i64 = conn
+            .query_row("PRAGMA synchronous", [], |row| row.get(0))
+            .expect("read synchronous mode");
+        assert_eq!(busy_timeout, 200);
+        assert_eq!(foreign_keys, 1);
+        assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
+        assert_eq!(synchronous, 1, "SQLite NORMAL synchronous mode");
+    }
 
     #[test]
     fn init_db_adds_scan_commit_revision_to_existing_sync_settings() {

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -28,7 +28,9 @@ pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
     set_scan_completed_for_source,
 };
-pub use usage_events::{replace_session_usage_events, NewUsageEvent};
+pub use usage_events::{
+    append_session_usage_events, replace_session_usage_events, NewUsageEvent,
+};
 pub(crate) use sync_settings::{
     preview_scan_freshness_for_source, set_last_scan_started_for_source_in_transaction,
 };
@@ -75,10 +77,22 @@ fn open_connection_with_busy_timeout(
 
 pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(include_str!("../sql/schema.sql"))?;
+    ensure_import_state_schema(conn)?;
     epoch_backfill::ensure_epoch_schema(conn)?;
     sync_settings::ensure_sync_settings_schema(conn)?;
     ensure_singletons(conn)?;
     conn.execute_batch(include_str!("../sql/indexes.sql"))?;
+    Ok(())
+}
+
+fn ensure_import_state_schema(conn: &Connection) -> rusqlite::Result<()> {
+    let mut statement = conn.prepare("PRAGMA table_info(import_state)")?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if !columns.iter().any(|column| column == "parser_checkpoint") {
+        conn.execute("ALTER TABLE import_state ADD COLUMN parser_checkpoint TEXT", [])?;
+    }
     Ok(())
 }
 
@@ -152,6 +166,34 @@ mod tests {
         assert_eq!(foreign_keys, 1);
         assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
         assert_eq!(synchronous, 1, "SQLite NORMAL synchronous mode");
+    }
+
+    #[test]
+    fn init_db_adds_parser_checkpoint_to_legacy_import_state() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        conn.execute_batch(
+            "
+            CREATE TABLE import_state (
+              source_path TEXT PRIMARY KEY,
+              session_id TEXT,
+              source_bucket TEXT NOT NULL,
+              file_size INTEGER NOT NULL,
+              file_mtime_ms INTEGER NOT NULL,
+              last_imported_at TEXT NOT NULL
+            );
+            ",
+        )
+        .expect("seed legacy import state");
+
+        init_db(&conn).expect("migrate database");
+        let columns = conn
+            .prepare("PRAGMA table_info(import_state)")
+            .expect("prepare column query")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query columns")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect columns");
+        assert!(columns.iter().any(|column| column == "parser_checkpoint"));
     }
 
     #[test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -4,10 +4,14 @@ use std::time::Duration;
 use chrono::Utc;
 use rusqlite::{params, Connection};
 
+#[allow(dead_code)]
+mod epoch_backfill;
 mod rate_limit_samples;
 mod subscriptions;
 mod sync_settings;
 
+#[allow(unused_imports)]
+pub use epoch_backfill::{backfill_epoch_batch, parse_epoch_millis, EpochBackfillProgress};
 pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
 pub use subscriptions::{
     canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
@@ -49,6 +53,7 @@ pub fn open_connection(db_path: &Path) -> rusqlite::Result<Connection> {
 
 pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(include_str!("../sql/schema.sql"))?;
+    epoch_backfill::ensure_epoch_schema(conn)?;
     sync_settings::ensure_sync_settings_schema(conn)?;
     ensure_singletons(conn)?;
     conn.execute_batch(include_str!("../sql/indexes.sql"))?;

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -9,6 +9,7 @@ mod epoch_backfill;
 mod rate_limit_samples;
 mod subscriptions;
 mod sync_settings;
+mod usage_events;
 
 #[allow(unused_imports)]
 pub use epoch_backfill::{backfill_epoch_batch, parse_epoch_millis, EpochBackfillProgress};
@@ -20,6 +21,7 @@ pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
     set_scan_completed_for_source,
 };
+pub use usage_events::{insert_usage_events, NewUsageEvent};
 pub(crate) use sync_settings::{
     preview_scan_freshness_for_source, set_last_scan_started_for_source_in_transaction,
 };

--- a/src-tauri/src/database/epoch_backfill.rs
+++ b/src-tauri/src/database/epoch_backfill.rs
@@ -1,5 +1,6 @@
 use chrono::DateTime;
 use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::now_utc_string;
 
@@ -13,6 +14,15 @@ pub struct EpochBackfillProgress {
     pub usage_rows_updated: usize,
     pub quota_rows_updated: usize,
     pub complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EpochBackfillCancellationPoint {
+    Transaction,
+    UsageRow,
+    QuotaRow,
+    CompletionMarker,
+    Commit,
 }
 
 struct UsageEpochRow {
@@ -69,23 +79,48 @@ pub fn backfill_epoch_batch(
     conn: &Connection,
     batch_size: usize,
 ) -> rusqlite::Result<EpochBackfillProgress> {
+    backfill_epoch_batch_with_cancel_check(conn, batch_size, |_| false)
+        .map(|progress| progress.expect("non-cancellable epoch backfill returns progress"))
+}
+
+pub fn backfill_epoch_batch_cancellable(
+    conn: &Connection,
+    batch_size: usize,
+    cancelled: &AtomicBool,
+) -> rusqlite::Result<Option<EpochBackfillProgress>> {
+    backfill_epoch_batch_with_cancel_check(conn, batch_size, |_| {
+        cancelled.load(Ordering::Acquire)
+    })
+}
+
+fn backfill_epoch_batch_with_cancel_check(
+    conn: &Connection,
+    batch_size: usize,
+    mut is_cancelled: impl FnMut(EpochBackfillCancellationPoint) -> bool,
+) -> rusqlite::Result<Option<EpochBackfillProgress>> {
+    if is_cancelled(EpochBackfillCancellationPoint::Transaction) {
+        return Ok(None);
+    }
     let batch_size = batch_size.min(MAX_BATCH_SIZE);
     if batch_size == 0 {
-        return Ok(EpochBackfillProgress {
+        return Ok(Some(EpochBackfillProgress {
             usage_rows_updated: 0,
             quota_rows_updated: 0,
             complete: repair_is_complete(conn)?,
-        });
+        }));
     }
 
     let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     if repair_is_complete(&transaction)? {
+        if is_cancelled(EpochBackfillCancellationPoint::Commit) {
+            return Ok(None);
+        }
         transaction.commit()?;
-        return Ok(EpochBackfillProgress {
+        return Ok(Some(EpochBackfillProgress {
             usage_rows_updated: 0,
             quota_rows_updated: 0,
             complete: true,
-        });
+        }));
     }
 
     ensure_cursor(&transaction, USAGE_STREAM)?;
@@ -96,6 +131,9 @@ pub fn backfill_epoch_batch(
     let usage_rows_updated = usage_rows.len();
     let usage_exhausted = usage_rows_updated < batch_size;
     for row in &usage_rows {
+        if is_cancelled(EpochBackfillCancellationPoint::UsageRow) {
+            return Ok(None);
+        }
         migrate_usage_row(&transaction, row)?;
     }
     if let Some(last_row) = usage_rows.last() {
@@ -109,6 +147,9 @@ pub fn backfill_epoch_batch(
         let rows_updated = quota_rows.len();
         let exhausted = rows_updated < remaining;
         for row in &quota_rows {
+            if is_cancelled(EpochBackfillCancellationPoint::QuotaRow) {
+                return Ok(None);
+            }
             migrate_quota_row(&transaction, row)?;
         }
         if let Some(last_row) = quota_rows.last() {
@@ -121,6 +162,9 @@ pub fn backfill_epoch_batch(
 
     let complete = usage_exhausted && quota_exhausted;
     if complete {
+        if is_cancelled(EpochBackfillCancellationPoint::CompletionMarker) {
+            return Ok(None);
+        }
         transaction.execute(
             "
             INSERT INTO data_repairs (repair_key, completed_at)
@@ -130,23 +174,30 @@ pub fn backfill_epoch_batch(
             params![REPAIR_KEY, now_utc_string()],
         )?;
     }
+    if is_cancelled(EpochBackfillCancellationPoint::Commit) {
+        return Ok(None);
+    }
     transaction.commit()?;
 
-    Ok(EpochBackfillProgress {
+    Ok(Some(EpochBackfillProgress {
         usage_rows_updated,
         quota_rows_updated,
         complete,
-    })
+    }))
 }
 
 fn repair_is_complete(conn: &Connection) -> rusqlite::Result<bool> {
+    epoch_backfill_pending(conn).map(|pending| !pending)
+}
+
+pub fn epoch_backfill_pending(conn: &Connection) -> rusqlite::Result<bool> {
     conn.query_row(
         "SELECT 1 FROM data_repairs WHERE repair_key = ?1",
         params![REPAIR_KEY],
         |_| Ok(()),
     )
     .optional()
-    .map(|value| value.is_some())
+    .map(|value| value.is_none())
 }
 
 fn ensure_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::Result<()> {
@@ -391,14 +442,64 @@ fn quarantine_value(
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use rusqlite::{params, Connection};
     use tempfile::tempdir;
 
-    use super::{backfill_epoch_batch, parse_epoch_millis};
+    use super::{
+        backfill_epoch_batch, backfill_epoch_batch_cancellable,
+        backfill_epoch_batch_with_cancel_check, epoch_backfill_pending,
+        EpochBackfillCancellationPoint, parse_epoch_millis,
+    };
     use crate::database::init_db;
 
     const REPAIR_KEY: &str = "epoch_timestamp_backfill_v1";
+
+    fn assert_repair_transaction_is_empty(conn: &Connection) {
+        let usage_epochs: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM usage_events WHERE timestamp_ms IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count usage epochs");
+        let quota_epochs: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM rate_limit_samples WHERE sample_timestamp_ms IS NOT NULL OR window_start_ms IS NOT NULL OR resets_at_ms IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count quota epochs");
+        let cursors: i64 = conn
+            .query_row("SELECT COUNT(*) FROM data_repair_progress", [], |row| row.get(0))
+            .expect("count repair cursors");
+        let quarantine: i64 = conn
+            .query_row("SELECT COUNT(*) FROM data_repair_quarantine", [], |row| row.get(0))
+            .expect("count quarantine rows");
+        let completion: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count completion markers");
+        assert_eq!((usage_epochs, quota_epochs, cursors, quarantine, completion), (0, 0, 0, 0, 0));
+    }
+
+    fn assert_cancel_at(point: EpochBackfillCancellationPoint, seed: impl FnOnce(&Connection)) {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        seed(&conn);
+
+        let outcome = backfill_epoch_batch_with_cancel_check(&conn, 1_000, |observed| {
+            observed == point
+        })
+        .expect("cancel bounded epoch repair");
+
+        assert!(outcome.is_none(), "cancelled repair returns no progress");
+        assert_repair_transaction_is_empty(&conn);
+    }
 
     fn create_legacy_epoch_tables(conn: &Connection) {
         conn.execute_batch(
@@ -539,6 +640,75 @@ mod tests {
             )
             .expect("load migrated quota sample");
         assert_eq!(quota_epochs, (None, None, None));
+    }
+
+    #[test]
+    fn epoch_backfill_pending_reads_only_completion_marker() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        conn.execute_batch(
+            "
+            DROP TABLE usage_events;
+            DROP TABLE rate_limit_samples;
+            DROP TABLE data_repair_progress;
+            DROP TABLE data_repair_quarantine;
+            ",
+        )
+        .expect("remove every repair history source");
+
+        assert!(epoch_backfill_pending(&conn).expect("read pending marker"));
+        conn.execute(
+            "INSERT INTO data_repairs (repair_key, completed_at) VALUES (?1, ?2)",
+            params![REPAIR_KEY, "2026-07-11T00:00:00Z"],
+        )
+        .expect("mark repair complete");
+        assert!(!epoch_backfill_pending(&conn).expect("read completed marker"));
+    }
+
+    #[test]
+    fn pre_cancelled_epoch_backfill_does_not_open_a_transaction() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        insert_usage(&conn, "2026-07-10T03:00:00Z");
+        let cancelled = AtomicBool::new(true);
+
+        let outcome = backfill_epoch_batch_cancellable(&conn, 1_000, &cancelled)
+            .expect("observe pre-cancelled repair");
+
+        assert!(outcome.is_none());
+        assert!(cancelled.load(Ordering::Acquire));
+        assert_repair_transaction_is_empty(&conn);
+    }
+
+    #[test]
+    fn epoch_backfill_cancellation_before_usage_mutation_rolls_back_everything() {
+        assert_cancel_at(EpochBackfillCancellationPoint::UsageRow, |conn| {
+            insert_usage(conn, "2026-07-10T03:00:00Z");
+        });
+    }
+
+    #[test]
+    fn epoch_backfill_cancellation_before_quota_mutation_rolls_back_everything() {
+        assert_cancel_at(EpochBackfillCancellationPoint::QuotaRow, |conn| {
+            insert_usage(conn, "malformed-usage");
+            insert_quota(conn, "2026-07-10T03:00:00Z");
+        });
+    }
+
+    #[test]
+    fn epoch_backfill_cancellation_before_completion_marker_rolls_back_everything() {
+        assert_cancel_at(EpochBackfillCancellationPoint::CompletionMarker, |conn| {
+            insert_usage(conn, "malformed-usage");
+            insert_quota(conn, "malformed-quota");
+        });
+    }
+
+    #[test]
+    fn epoch_backfill_cancellation_before_commit_rolls_back_everything() {
+        assert_cancel_at(EpochBackfillCancellationPoint::Commit, |conn| {
+            insert_usage(conn, "malformed-usage");
+            insert_quota(conn, "malformed-quota");
+        });
     }
 
     #[test]

--- a/src-tauri/src/database/epoch_backfill.rs
+++ b/src-tauri/src/database/epoch_backfill.rs
@@ -785,11 +785,7 @@ mod tests {
                     FROM sqlite_master
                     WHERE type = 'index'
                       AND sql IS NOT NULL
-                      AND (
-                        sql LIKE '%timestamp_ms%'
-                        OR sql LIKE '%window_start_ms%'
-                        OR sql LIKE '%resets_at_ms%'
-                      )
+                      AND name IN ('idx_rate_limit_samples_window_ms', 'idx_usage_events_timestamp_ms')
                     ORDER BY name
                     ",
                 )

--- a/src-tauri/src/database/epoch_backfill.rs
+++ b/src-tauri/src/database/epoch_backfill.rs
@@ -1,0 +1,1103 @@
+use chrono::DateTime;
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+
+use super::now_utc_string;
+
+const REPAIR_KEY: &str = "epoch_timestamp_backfill_v1";
+const USAGE_STREAM: &str = "usage_events";
+const QUOTA_STREAM: &str = "rate_limit_samples";
+const MAX_BATCH_SIZE: usize = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EpochBackfillProgress {
+    pub usage_rows_updated: usize,
+    pub quota_rows_updated: usize,
+    pub complete: bool,
+}
+
+struct UsageEpochRow {
+    id: i64,
+    timestamp: String,
+    timestamp_ms: Option<i64>,
+}
+
+struct QuotaEpochRow {
+    id: i64,
+    sample_timestamp: String,
+    sample_timestamp_ms: Option<i64>,
+    window_start: String,
+    window_start_ms: Option<i64>,
+    resets_at: String,
+    resets_at_ms: Option<i64>,
+}
+
+pub(super) fn ensure_epoch_schema(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_integer_column(conn, "usage_events", "timestamp_ms")?;
+    ensure_integer_column(conn, "rate_limit_samples", "sample_timestamp_ms")?;
+    ensure_integer_column(conn, "rate_limit_samples", "window_start_ms")?;
+    ensure_integer_column(conn, "rate_limit_samples", "resets_at_ms")?;
+    Ok(())
+}
+
+fn ensure_integer_column(
+    conn: &Connection,
+    table_name: &str,
+    column_name: &str,
+) -> rusqlite::Result<()> {
+    let mut statement = conn.prepare(&format!("PRAGMA table_info({table_name})"))?;
+    let mut rows = statement.query([])?;
+    while let Some(row) = rows.next()? {
+        if row.get::<_, String>(1)? == column_name {
+            return Ok(());
+        }
+    }
+    drop(rows);
+    drop(statement);
+
+    conn.execute_batch(&format!(
+        "ALTER TABLE {table_name} ADD COLUMN {column_name} INTEGER"
+    ))
+}
+
+pub fn parse_epoch_millis(value: &str) -> Result<i64, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.timestamp_millis())
+        .map_err(|error| error.to_string())
+}
+
+pub fn backfill_epoch_batch(
+    conn: &Connection,
+    batch_size: usize,
+) -> rusqlite::Result<EpochBackfillProgress> {
+    let batch_size = batch_size.min(MAX_BATCH_SIZE);
+    if batch_size == 0 {
+        return Ok(EpochBackfillProgress {
+            usage_rows_updated: 0,
+            quota_rows_updated: 0,
+            complete: repair_is_complete(conn)?,
+        });
+    }
+
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    if repair_is_complete(&transaction)? {
+        transaction.commit()?;
+        return Ok(EpochBackfillProgress {
+            usage_rows_updated: 0,
+            quota_rows_updated: 0,
+            complete: true,
+        });
+    }
+
+    ensure_cursor(&transaction, USAGE_STREAM)?;
+    ensure_cursor(&transaction, QUOTA_STREAM)?;
+
+    let usage_cursor = load_cursor(&transaction, USAGE_STREAM)?;
+    let usage_rows = load_usage_rows(&transaction, usage_cursor, batch_size)?;
+    let usage_rows_updated = usage_rows.len();
+    let usage_exhausted = usage_rows_updated < batch_size;
+    for row in &usage_rows {
+        migrate_usage_row(&transaction, row)?;
+    }
+    if let Some(last_row) = usage_rows.last() {
+        save_cursor(&transaction, USAGE_STREAM, last_row.id)?;
+    }
+
+    let remaining = batch_size - usage_rows_updated;
+    let (quota_rows_updated, quota_exhausted) = if usage_exhausted {
+        let quota_cursor = load_cursor(&transaction, QUOTA_STREAM)?;
+        let quota_rows = load_quota_rows(&transaction, quota_cursor, remaining)?;
+        let rows_updated = quota_rows.len();
+        let exhausted = rows_updated < remaining;
+        for row in &quota_rows {
+            migrate_quota_row(&transaction, row)?;
+        }
+        if let Some(last_row) = quota_rows.last() {
+            save_cursor(&transaction, QUOTA_STREAM, last_row.id)?;
+        }
+        (rows_updated, exhausted)
+    } else {
+        (0, false)
+    };
+
+    let complete = usage_exhausted && quota_exhausted;
+    if complete {
+        transaction.execute(
+            "
+            INSERT INTO data_repairs (repair_key, completed_at)
+            VALUES (?1, ?2)
+            ON CONFLICT(repair_key) DO NOTHING
+            ",
+            params![REPAIR_KEY, now_utc_string()],
+        )?;
+    }
+    transaction.commit()?;
+
+    Ok(EpochBackfillProgress {
+        usage_rows_updated,
+        quota_rows_updated,
+        complete,
+    })
+}
+
+fn repair_is_complete(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT 1 FROM data_repairs WHERE repair_key = ?1",
+        params![REPAIR_KEY],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|value| value.is_some())
+}
+
+fn ensure_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::Result<()> {
+    transaction.execute(
+        "
+        INSERT INTO data_repair_progress (repair_key, stream_key, progress_value)
+        VALUES (?1, ?2, 0)
+        ON CONFLICT(repair_key, stream_key) DO NOTHING
+        ",
+        params![REPAIR_KEY, stream_key],
+    )?;
+    Ok(())
+}
+
+fn load_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::Result<i64> {
+    transaction.query_row(
+        "
+        SELECT progress_value
+        FROM data_repair_progress
+        WHERE repair_key = ?1 AND stream_key = ?2
+        ",
+        params![REPAIR_KEY, stream_key],
+        |row| row.get(0),
+    )
+}
+
+fn save_cursor(
+    transaction: &Transaction<'_>,
+    stream_key: &str,
+    progress_value: i64,
+) -> rusqlite::Result<()> {
+    transaction.execute(
+        "
+        UPDATE data_repair_progress
+        SET progress_value = ?3
+        WHERE repair_key = ?1 AND stream_key = ?2
+        ",
+        params![REPAIR_KEY, stream_key, progress_value],
+    )?;
+    Ok(())
+}
+
+fn load_usage_rows(
+    transaction: &Transaction<'_>,
+    cursor: i64,
+    limit: usize,
+) -> rusqlite::Result<Vec<UsageEpochRow>> {
+    let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+    let mut statement = transaction.prepare(
+        "
+        SELECT id, timestamp, timestamp_ms
+        FROM usage_events
+        WHERE id > ?1
+        ORDER BY id
+        LIMIT ?2
+        ",
+    )?;
+    let rows = statement
+        .query_map(params![cursor, limit], |row| {
+            Ok(UsageEpochRow {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                timestamp_ms: row.get(2)?,
+            })
+        })?
+        .collect();
+    rows
+}
+
+fn load_quota_rows(
+    transaction: &Transaction<'_>,
+    cursor: i64,
+    limit: usize,
+) -> rusqlite::Result<Vec<QuotaEpochRow>> {
+    let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+    let mut statement = transaction.prepare(
+        "
+        SELECT id,
+               sample_timestamp, sample_timestamp_ms,
+               window_start, window_start_ms,
+               resets_at, resets_at_ms
+        FROM rate_limit_samples
+        WHERE id > ?1
+        ORDER BY id
+        LIMIT ?2
+        ",
+    )?;
+    let rows = statement
+        .query_map(params![cursor, limit], |row| {
+            Ok(QuotaEpochRow {
+                id: row.get(0)?,
+                sample_timestamp: row.get(1)?,
+                sample_timestamp_ms: row.get(2)?,
+                window_start: row.get(3)?,
+                window_start_ms: row.get(4)?,
+                resets_at: row.get(5)?,
+                resets_at_ms: row.get(6)?,
+            })
+        })?
+        .collect();
+    rows
+}
+
+fn migrate_usage_row(
+    transaction: &Transaction<'_>,
+    row: &UsageEpochRow,
+) -> rusqlite::Result<()> {
+    if row.timestamp_ms.is_some() {
+        return Ok(());
+    }
+
+    match parse_epoch_millis(&row.timestamp) {
+        Ok(timestamp_ms) => {
+            transaction.execute(
+                "
+                UPDATE usage_events
+                SET timestamp_ms = ?1
+                WHERE id = ?2 AND timestamp_ms IS NULL
+                ",
+                params![timestamp_ms, row.id],
+            )?;
+        }
+        Err(error) => quarantine_value(
+            transaction,
+            "usage_events",
+            row.id,
+            "timestamp",
+            &row.timestamp,
+            &error,
+        )?,
+    }
+    Ok(())
+}
+
+fn migrate_quota_row(
+    transaction: &Transaction<'_>,
+    row: &QuotaEpochRow,
+) -> rusqlite::Result<()> {
+    let sample_timestamp_ms = parse_missing_value(
+        transaction,
+        "rate_limit_samples",
+        row.id,
+        "sample_timestamp",
+        &row.sample_timestamp,
+        row.sample_timestamp_ms,
+    )?;
+    let window_start_ms = parse_missing_value(
+        transaction,
+        "rate_limit_samples",
+        row.id,
+        "window_start",
+        &row.window_start,
+        row.window_start_ms,
+    )?;
+    let resets_at_ms = parse_missing_value(
+        transaction,
+        "rate_limit_samples",
+        row.id,
+        "resets_at",
+        &row.resets_at,
+        row.resets_at_ms,
+    )?;
+
+    if sample_timestamp_ms.is_none() && window_start_ms.is_none() && resets_at_ms.is_none() {
+        return Ok(());
+    }
+
+    transaction.execute(
+        "
+        UPDATE rate_limit_samples
+        SET sample_timestamp_ms = COALESCE(sample_timestamp_ms, ?1),
+            window_start_ms = COALESCE(window_start_ms, ?2),
+            resets_at_ms = COALESCE(resets_at_ms, ?3)
+        WHERE id = ?4
+        ",
+        params![sample_timestamp_ms, window_start_ms, resets_at_ms, row.id],
+    )?;
+    Ok(())
+}
+
+fn parse_missing_value(
+    transaction: &Transaction<'_>,
+    table_name: &str,
+    row_id: i64,
+    column_name: &str,
+    raw_value: &str,
+    current_value: Option<i64>,
+) -> rusqlite::Result<Option<i64>> {
+    if current_value.is_some() {
+        return Ok(None);
+    }
+
+    match parse_epoch_millis(raw_value) {
+        Ok(value) => Ok(Some(value)),
+        Err(error) => {
+            quarantine_value(
+                transaction,
+                table_name,
+                row_id,
+                column_name,
+                raw_value,
+                &error,
+            )?;
+            Ok(None)
+        }
+    }
+}
+
+fn quarantine_value(
+    transaction: &Transaction<'_>,
+    table_name: &str,
+    row_id: i64,
+    column_name: &str,
+    raw_value: &str,
+    error_message: &str,
+) -> rusqlite::Result<()> {
+    transaction.execute(
+        "
+        INSERT INTO data_repair_quarantine (
+          repair_key, table_name, row_id, column_name,
+          raw_value, error_message, quarantined_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        ON CONFLICT(repair_key, table_name, row_id, column_name) DO UPDATE SET
+          raw_value = excluded.raw_value,
+          error_message = excluded.error_message,
+          quarantined_at = excluded.quarantined_at
+        ",
+        params![
+            REPAIR_KEY,
+            table_name,
+            row_id,
+            column_name,
+            raw_value,
+            error_message,
+            now_utc_string()
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use rusqlite::{params, Connection};
+    use tempfile::tempdir;
+
+    use super::{backfill_epoch_batch, parse_epoch_millis};
+    use crate::database::init_db;
+
+    const REPAIR_KEY: &str = "epoch_timestamp_backfill_v1";
+
+    fn create_legacy_epoch_tables(conn: &Connection) {
+        conn.execute_batch(
+            "
+            CREATE TABLE usage_events (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              timestamp TEXT NOT NULL,
+              model_id TEXT NOT NULL,
+              input_tokens INTEGER NOT NULL,
+              cached_input_tokens INTEGER NOT NULL,
+              output_tokens INTEGER NOT NULL,
+              reasoning_output_tokens INTEGER NOT NULL,
+              total_tokens INTEGER NOT NULL,
+              value_usd REAL NOT NULL,
+              fast_mode_auto INTEGER NOT NULL,
+              fast_mode_effective INTEGER NOT NULL
+            );
+
+            CREATE TABLE rate_limit_samples (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              source_kind TEXT NOT NULL,
+              source_session_id TEXT NOT NULL DEFAULT '',
+              bucket TEXT NOT NULL,
+              sample_timestamp TEXT NOT NULL,
+              limit_id TEXT NOT NULL DEFAULT '',
+              limit_name TEXT NOT NULL DEFAULT '',
+              plan_type TEXT NOT NULL DEFAULT '',
+              window_start TEXT NOT NULL,
+              resets_at TEXT NOT NULL,
+              used_percent INTEGER NOT NULL,
+              remaining_percent INTEGER NOT NULL,
+              created_at TEXT NOT NULL
+            );
+            ",
+        )
+        .expect("create legacy epoch tables");
+    }
+
+    fn insert_usage(conn: &Connection, timestamp: &str) -> i64 {
+        conn.execute(
+            "
+            INSERT INTO usage_events (
+              session_id, timestamp, model_id,
+              input_tokens, cached_input_tokens, output_tokens,
+              reasoning_output_tokens, total_tokens, value_usd,
+              fast_mode_auto, fast_mode_effective
+            )
+            VALUES ('session', ?1, 'gpt-5', 1, 0, 1, 0, 2, 0.01, 0, 0)
+            ",
+            params![timestamp],
+        )
+        .expect("insert usage event");
+        conn.last_insert_rowid()
+    }
+
+    fn insert_quota(conn: &Connection, timestamp: &str) -> i64 {
+        insert_quota_fields(conn, timestamp, timestamp, timestamp)
+    }
+
+    fn insert_quota_fields(
+        conn: &Connection,
+        sample_timestamp: &str,
+        window_start: &str,
+        resets_at: &str,
+    ) -> i64 {
+        conn.execute(
+            "
+            INSERT INTO rate_limit_samples (
+              source_kind, source_session_id, bucket,
+              sample_timestamp, limit_id, limit_name, plan_type,
+              window_start, resets_at, used_percent, remaining_percent, created_at
+            )
+            VALUES (
+              'session', '', 'five_hour',
+              ?1, '', '', 'plus',
+              ?2, ?3, 25, 75, ?1
+            )
+            ",
+            params![sample_timestamp, window_start, resets_at],
+        )
+        .expect("insert quota sample");
+        conn.last_insert_rowid()
+    }
+
+    fn column_names(conn: &Connection, table: &str) -> Vec<String> {
+        let mut statement = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .expect("prepare table info");
+        statement
+            .query_map([], |row| row.get(1))
+            .expect("query table info")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect column names")
+    }
+
+    fn open_initialized(path: &Path) -> Connection {
+        let conn = Connection::open(path).expect("open database");
+        init_db(&conn).expect("initialize database");
+        conn
+    }
+
+    #[test]
+    fn init_db_adds_epoch_columns_without_updating_history() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        create_legacy_epoch_tables(&conn);
+        let usage_id = insert_usage(&conn, "2026-07-10T10:00:00+08:00");
+        let quota_id = insert_quota(&conn, "2026-07-10T03:00:01Z");
+
+        init_db(&conn).expect("migrate legacy database");
+
+        let usage_columns = column_names(&conn, "usage_events");
+        assert!(usage_columns.iter().any(|name| name == "timestamp_ms"));
+        let quota_columns = column_names(&conn, "rate_limit_samples");
+        for expected in ["sample_timestamp_ms", "window_start_ms", "resets_at_ms"] {
+            assert!(quota_columns.iter().any(|name| name == expected));
+        }
+
+        let (usage_timestamp, usage_epoch): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT timestamp, timestamp_ms FROM usage_events WHERE id = ?1",
+                params![usage_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("load migrated usage event");
+        assert_eq!(usage_timestamp, "2026-07-10T10:00:00+08:00");
+        assert_eq!(usage_epoch, None);
+
+        let quota_epochs: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![quota_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load migrated quota sample");
+        assert_eq!(quota_epochs, (None, None, None));
+    }
+
+    #[test]
+    fn epoch_schema_omits_large_missing_indexes() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+
+        let epoch_indexes: Vec<(String, String)> = {
+            let mut statement = conn
+                .prepare(
+                    "
+                    SELECT name, sql
+                    FROM sqlite_master
+                    WHERE type = 'index'
+                      AND sql IS NOT NULL
+                      AND (
+                        sql LIKE '%timestamp_ms%'
+                        OR sql LIKE '%window_start_ms%'
+                        OR sql LIKE '%resets_at_ms%'
+                      )
+                    ORDER BY name
+                    ",
+                )
+                .expect("prepare epoch index query");
+            statement
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query epoch indexes")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("collect epoch indexes")
+        };
+
+        assert_eq!(
+            epoch_indexes
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "idx_rate_limit_samples_window_ms",
+                "idx_usage_events_timestamp_ms"
+            ]
+        );
+        assert!(epoch_indexes.iter().all(|(_, sql)| {
+            let normalized = sql.to_ascii_lowercase();
+            normalized.contains(" where ") && !normalized.contains(" is null")
+        }));
+    }
+
+    #[test]
+    fn epoch_parser_orders_mixed_offsets_by_instant() {
+        let earlier = parse_epoch_millis("2026-07-10T10:00:00+08:00")
+            .expect("parse timestamp with positive offset");
+        let later = parse_epoch_millis("2026-07-10T03:00:01Z")
+            .expect("parse timestamp in UTC");
+
+        assert!(earlier < later);
+    }
+
+    #[test]
+    fn backfill_updates_at_most_requested_batch_size() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        for second in 0..4 {
+            insert_usage(&conn, &format!("2026-07-10T03:00:0{second}Z"));
+            insert_quota(&conn, &format!("2026-07-10T04:00:0{second}Z"));
+        }
+
+        let progress = backfill_epoch_batch(&conn, 3).expect("backfill one bounded batch");
+
+        assert_eq!(progress.usage_rows_updated + progress.quota_rows_updated, 3);
+        assert!(!progress.complete);
+        let usage_migrated: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM usage_events WHERE timestamp_ms IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count migrated usage rows");
+        let quota_migrated: i64 = conn
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM rate_limit_samples
+                WHERE sample_timestamp_ms IS NOT NULL
+                  AND window_start_ms IS NOT NULL
+                  AND resets_at_ms IS NOT NULL
+                ",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count migrated quota rows");
+        assert_eq!(usage_migrated + quota_migrated, 3);
+    }
+
+    #[test]
+    fn backfill_caps_oversized_batches_at_one_thousand_rows() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        for _ in 0..1_001 {
+            insert_usage(&conn, "2026-07-10T03:00:00Z");
+        }
+
+        let progress =
+            backfill_epoch_batch(&conn, 1_001).expect("backfill oversized requested batch");
+
+        assert_eq!(progress.usage_rows_updated + progress.quota_rows_updated, 1_000);
+        assert!(!progress.complete);
+    }
+
+    #[test]
+    fn backfill_zero_batch_does_not_complete_unfinished_repair() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        insert_usage(&conn, "2026-07-10T03:00:00Z");
+
+        let progress = backfill_epoch_batch(&conn, 0).expect("run zero-sized batch");
+
+        assert_eq!(progress.usage_rows_updated, 0);
+        assert_eq!(progress.quota_rows_updated, 0);
+        assert!(!progress.complete);
+        let completion_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count completion markers");
+        assert_eq!(completion_count, 0);
+    }
+
+    #[test]
+    fn epoch_backfill_resumes_from_durable_cursors_after_restart() {
+        let directory = tempdir().expect("create temporary directory");
+        let db_path = directory.path().join("epoch-resume.sqlite3");
+        let conn = open_initialized(&db_path);
+        let first_id = insert_usage(&conn, "2026-07-10T03:00:00Z");
+        let second_id = insert_usage(&conn, "2026-07-10T03:00:01Z");
+        insert_usage(&conn, "2026-07-10T03:00:02Z");
+
+        let first = backfill_epoch_batch(&conn, 1).expect("run first batch");
+        assert_eq!(first.usage_rows_updated, 1);
+        conn.execute(
+            "UPDATE usage_events SET timestamp_ms = NULL WHERE id = ?1",
+            params![first_id],
+        )
+        .expect("clear migrated value behind durable cursor");
+        drop(conn);
+
+        let reopened = open_initialized(&db_path);
+        let second = backfill_epoch_batch(&reopened, 1).expect("resume after restart");
+
+        assert_eq!(second.usage_rows_updated, 1);
+        let first_epoch: Option<i64> = reopened
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![first_id],
+                |row| row.get(0),
+            )
+            .expect("load first epoch");
+        let second_epoch: Option<i64> = reopened
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![second_id],
+                |row| row.get(0),
+            )
+            .expect("load second epoch");
+        assert_eq!(first_epoch, None);
+        assert!(second_epoch.is_some());
+        let cursor: i64 = reopened
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'usage_events'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load durable usage cursor");
+        assert_eq!(cursor, second_id);
+    }
+
+    #[test]
+    fn malformed_epoch_is_quarantined_without_blocking_later_rows() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        let malformed_id = insert_usage(&conn, "not-a-timestamp");
+        let valid_id = insert_usage(&conn, "2026-07-10T03:00:01Z");
+
+        let progress = backfill_epoch_batch(&conn, 10).expect("backfill malformed row");
+
+        assert!(progress.complete);
+        let malformed_epoch: Option<i64> = conn
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![malformed_id],
+                |row| row.get(0),
+            )
+            .expect("load malformed epoch");
+        let valid_epoch: Option<i64> = conn
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![valid_id],
+                |row| row.get(0),
+            )
+            .expect("load valid epoch");
+        assert_eq!(malformed_epoch, None);
+        assert_eq!(
+            valid_epoch,
+            Some(parse_epoch_millis("2026-07-10T03:00:01Z").expect("parse expected epoch"))
+        );
+        let quarantined: (String, i64, String, String) = conn
+            .query_row(
+                "
+                SELECT table_name, row_id, column_name, raw_value
+                FROM data_repair_quarantine
+                WHERE repair_key = ?1
+                ",
+                params![REPAIR_KEY],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("load quarantine row");
+        assert_eq!(
+            quarantined,
+            (
+                "usage_events".to_string(),
+                malformed_id,
+                "timestamp".to_string(),
+                "not-a-timestamp".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn malformed_quota_epochs_are_quarantined_per_column_without_blocking_later_rows() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        let partial_id = insert_quota_fields(
+            &conn,
+            "bad-sample",
+            "2026-07-10T05:00:00Z",
+            "2026-07-10T10:00:00Z",
+        );
+        let malformed_id =
+            insert_quota_fields(&conn, "bad-sample-2", "bad-window", "bad-reset");
+        let valid_id = insert_quota_fields(
+            &conn,
+            "2026-07-10T06:00:00Z",
+            "2026-07-10T06:00:00Z",
+            "2026-07-10T11:00:00Z",
+        );
+
+        let progress = backfill_epoch_batch(&conn, 10).expect("backfill quota rows");
+
+        assert!(progress.complete);
+        let partial_epochs: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![partial_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load partially malformed quota epochs");
+        assert_eq!(partial_epochs.0, None);
+        assert_eq!(
+            partial_epochs.1,
+            Some(parse_epoch_millis("2026-07-10T05:00:00Z").expect("parse window"))
+        );
+        assert_eq!(
+            partial_epochs.2,
+            Some(parse_epoch_millis("2026-07-10T10:00:00Z").expect("parse reset"))
+        );
+
+        let malformed_epochs: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![malformed_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load malformed quota epochs");
+        assert_eq!(malformed_epochs, (None, None, None));
+
+        let valid_epochs: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![valid_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load valid quota epochs");
+        assert!(valid_epochs.0.is_some());
+        assert!(valid_epochs.1.is_some());
+        assert!(valid_epochs.2.is_some());
+
+        let quarantine_rows: Vec<(i64, String, String)> = {
+            let mut statement = conn
+                .prepare(
+                    "
+                    SELECT row_id, column_name, raw_value
+                    FROM data_repair_quarantine
+                    WHERE repair_key = ?1 AND table_name = 'rate_limit_samples'
+                    ORDER BY row_id, column_name
+                    ",
+                )
+                .expect("prepare quota quarantine query");
+            statement
+                .query_map(params![REPAIR_KEY], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })
+                .expect("query quota quarantine")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("collect quota quarantine")
+        };
+        assert_eq!(
+            quarantine_rows,
+            vec![
+                (partial_id, "sample_timestamp".to_string(), "bad-sample".to_string()),
+                (malformed_id, "resets_at".to_string(), "bad-reset".to_string()),
+                (
+                    malformed_id,
+                    "sample_timestamp".to_string(),
+                    "bad-sample-2".to_string()
+                ),
+                (
+                    malformed_id,
+                    "window_start".to_string(),
+                    "bad-window".to_string()
+                )
+            ]
+        );
+        let quota_cursor: i64 = conn
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'rate_limit_samples'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load durable quota cursor");
+        assert_eq!(quota_cursor, valid_id);
+    }
+
+    #[test]
+    fn quota_backfill_skips_updates_when_no_epoch_value_can_change() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        let populated_id = insert_quota(&conn, "2026-07-10T05:00:00Z");
+        conn.execute(
+            "
+            UPDATE rate_limit_samples
+            SET sample_timestamp_ms = 1, window_start_ms = 2, resets_at_ms = 3
+            WHERE id = ?1
+            ",
+            params![populated_id],
+        )
+        .expect("prepopulate epoch fields");
+        insert_quota_fields(&conn, "bad-sample", "bad-window", "bad-reset");
+        conn.execute_batch(
+            "
+            CREATE TRIGGER reject_noop_quota_update
+            BEFORE UPDATE ON rate_limit_samples
+            BEGIN
+              SELECT RAISE(ABORT, 'unexpected quota update');
+            END;
+            ",
+        )
+        .expect("install quota update guard");
+
+        let progress = backfill_epoch_batch(&conn, 10).expect("backfill no-op quota rows");
+
+        assert!(progress.complete);
+        assert_eq!(progress.quota_rows_updated, 2);
+        let populated_epochs: (i64, i64, i64) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![populated_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load prepopulated epochs");
+        assert_eq!(populated_epochs, (1, 2, 3));
+        let quarantined: i64 = conn
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM data_repair_quarantine
+                WHERE repair_key = ?1 AND table_name = 'rate_limit_samples'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count malformed quota fields");
+        assert_eq!(quarantined, 3);
+    }
+
+    #[test]
+    fn epoch_backfill_rolls_back_rows_quarantine_cursors_and_completion_together() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        let malformed_id = insert_usage(&conn, "bad-timestamp");
+        let valid_id = insert_usage(&conn, "2026-07-10T03:00:01Z");
+        conn.execute_batch(
+            "
+            CREATE TRIGGER fail_epoch_completion
+            BEFORE INSERT ON data_repairs
+            WHEN NEW.repair_key = 'epoch_timestamp_backfill_v1'
+            BEGIN
+              SELECT RAISE(ABORT, 'injected completion failure');
+            END;
+            ",
+        )
+        .expect("install completion failure trigger");
+
+        let error = backfill_epoch_batch(&conn, 10).expect_err("inject transaction failure");
+
+        assert!(error.to_string().contains("injected completion failure"));
+        for row_id in [malformed_id, valid_id] {
+            let epoch: Option<i64> = conn
+                .query_row(
+                    "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                    params![row_id],
+                    |row| row.get(0),
+                )
+                .expect("load rolled-back usage epoch");
+            assert_eq!(epoch, None);
+        }
+        let quarantine_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM data_repair_quarantine", [], |row| {
+                row.get(0)
+            })
+            .expect("count rolled-back quarantine rows");
+        assert_eq!(quarantine_count, 0);
+        let cursor_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM data_repair_progress", [], |row| {
+                row.get(0)
+            })
+            .expect("count rolled-back cursors");
+        assert_eq!(cursor_count, 0);
+        let completion_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count rolled-back completion markers");
+        assert_eq!(completion_count, 0);
+    }
+
+    #[test]
+    fn epoch_backfill_completion_is_idempotent() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        insert_usage(&conn, "2026-07-10T03:00:00Z");
+        insert_quota(&conn, "2026-07-10T04:00:00Z");
+
+        let first = backfill_epoch_batch(&conn, 10).expect("complete backfill");
+        assert!(first.complete);
+        let completed_at: String = conn
+            .query_row(
+                "SELECT completed_at FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load completion time");
+        let cursor_snapshot: Vec<(String, i64)> = {
+            let mut statement = conn
+                .prepare(
+                    "
+                    SELECT stream_key, progress_value
+                    FROM data_repair_progress
+                    WHERE repair_key = ?1
+                    ORDER BY stream_key
+                    ",
+                )
+                .expect("prepare cursor snapshot");
+            statement
+                .query_map(params![REPAIR_KEY], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query cursor snapshot")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("collect cursor snapshot")
+        };
+
+        let second = backfill_epoch_batch(&conn, 10).expect("rerun completed backfill");
+
+        assert!(second.complete);
+        assert_eq!(second.usage_rows_updated, 0);
+        assert_eq!(second.quota_rows_updated, 0);
+        let completion_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count completion rows");
+        assert_eq!(completion_rows, 1);
+        let rerun_completed_at: String = conn
+            .query_row(
+                "SELECT completed_at FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("reload completion time");
+        assert_eq!(rerun_completed_at, completed_at);
+        let rerun_cursor_snapshot: Vec<(String, i64)> = {
+            let mut statement = conn
+                .prepare(
+                    "
+                    SELECT stream_key, progress_value
+                    FROM data_repair_progress
+                    WHERE repair_key = ?1
+                    ORDER BY stream_key
+                    ",
+                )
+                .expect("prepare rerun cursor snapshot");
+            statement
+                .query_map(params![REPAIR_KEY], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query rerun cursor snapshot")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("collect rerun cursor snapshot")
+        };
+        assert_eq!(rerun_cursor_snapshot, cursor_snapshot);
+    }
+
+    #[test]
+    fn integrity_check_is_ok_after_epoch_migration() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        create_legacy_epoch_tables(&conn);
+        insert_usage(&conn, "2026-07-10T03:00:00Z");
+        insert_usage(&conn, "malformed");
+        insert_quota(&conn, "2026-07-10T04:00:00Z");
+        init_db(&conn).expect("migrate legacy database");
+
+        let mut complete = false;
+        for _ in 0..10 {
+            complete = backfill_epoch_batch(&conn, 1)
+                .expect("run bounded migration batch")
+                .complete;
+            if complete {
+                break;
+            }
+        }
+        assert!(complete);
+        let integrity: String = conn
+            .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+            .expect("run integrity check");
+        assert_eq!(integrity, "ok");
+    }
+}

--- a/src-tauri/src/database/epoch_backfill.rs
+++ b/src-tauri/src/database/epoch_backfill.rs
@@ -7,6 +7,10 @@ use super::now_utc_string;
 const REPAIR_KEY: &str = "epoch_timestamp_backfill_v1";
 const USAGE_STREAM: &str = "usage_events";
 const QUOTA_STREAM: &str = "rate_limit_samples";
+// Production writers populate epoch fields, so a repair must not chase rows
+// appended after it starts.
+const USAGE_HIGH_WATER_STREAM: &str = "usage_events_high_water";
+const QUOTA_HIGH_WATER_STREAM: &str = "rate_limit_samples_high_water";
 const MAX_BATCH_SIZE: usize = 1_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,9 +129,25 @@ fn backfill_epoch_batch_with_cancel_check(
 
     ensure_cursor(&transaction, USAGE_STREAM)?;
     ensure_cursor(&transaction, QUOTA_STREAM)?;
+    ensure_high_water(
+        &transaction,
+        USAGE_HIGH_WATER_STREAM,
+        "SELECT COALESCE(MAX(id), 0) FROM usage_events",
+    )?;
+    ensure_high_water(
+        &transaction,
+        QUOTA_HIGH_WATER_STREAM,
+        "SELECT COALESCE(MAX(id), 0) FROM rate_limit_samples",
+    )?;
 
     let usage_cursor = load_cursor(&transaction, USAGE_STREAM)?;
-    let usage_rows = load_usage_rows(&transaction, usage_cursor, batch_size)?;
+    let usage_high_water = load_cursor(&transaction, USAGE_HIGH_WATER_STREAM)?;
+    let usage_rows = load_usage_rows(
+        &transaction,
+        usage_cursor,
+        usage_high_water,
+        batch_size,
+    )?;
     let usage_rows_updated = usage_rows.len();
     let usage_exhausted = usage_rows_updated < batch_size;
     for row in &usage_rows {
@@ -143,7 +163,13 @@ fn backfill_epoch_batch_with_cancel_check(
     let remaining = batch_size - usage_rows_updated;
     let (quota_rows_updated, quota_exhausted) = if usage_exhausted {
         let quota_cursor = load_cursor(&transaction, QUOTA_STREAM)?;
-        let quota_rows = load_quota_rows(&transaction, quota_cursor, remaining)?;
+        let quota_high_water = load_cursor(&transaction, QUOTA_HIGH_WATER_STREAM)?;
+        let quota_rows = load_quota_rows(
+            &transaction,
+            quota_cursor,
+            quota_high_water,
+            remaining,
+        )?;
         let rows_updated = quota_rows.len();
         let exhausted = rows_updated < remaining;
         for row in &quota_rows {
@@ -212,6 +238,39 @@ fn ensure_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::R
     Ok(())
 }
 
+fn ensure_high_water(
+    transaction: &Transaction<'_>,
+    stream_key: &str,
+    max_id_sql: &str,
+) -> rusqlite::Result<()> {
+    let exists = transaction
+        .query_row(
+            "
+            SELECT 1
+            FROM data_repair_progress
+            WHERE repair_key = ?1 AND stream_key = ?2
+            ",
+            params![REPAIR_KEY, stream_key],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    if exists {
+        return Ok(());
+    }
+
+    let high_water = transaction.query_row(max_id_sql, [], |row| row.get::<_, i64>(0))?;
+    transaction.execute(
+        "
+        INSERT INTO data_repair_progress (repair_key, stream_key, progress_value)
+        VALUES (?1, ?2, ?3)
+        ON CONFLICT(repair_key, stream_key) DO NOTHING
+        ",
+        params![REPAIR_KEY, stream_key, high_water],
+    )?;
+    Ok(())
+}
+
 fn load_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::Result<i64> {
     transaction.query_row(
         "
@@ -243,6 +302,7 @@ fn save_cursor(
 fn load_usage_rows(
     transaction: &Transaction<'_>,
     cursor: i64,
+    high_water: i64,
     limit: usize,
 ) -> rusqlite::Result<Vec<UsageEpochRow>> {
     let limit = i64::try_from(limit).unwrap_or(i64::MAX);
@@ -250,13 +310,13 @@ fn load_usage_rows(
         "
         SELECT id, timestamp, timestamp_ms
         FROM usage_events
-        WHERE id > ?1
+        WHERE id > ?1 AND id <= ?2
         ORDER BY id
-        LIMIT ?2
+        LIMIT ?3
         ",
     )?;
     let rows = statement
-        .query_map(params![cursor, limit], |row| {
+        .query_map(params![cursor, high_water, limit], |row| {
             Ok(UsageEpochRow {
                 id: row.get(0)?,
                 timestamp: row.get(1)?,
@@ -270,6 +330,7 @@ fn load_usage_rows(
 fn load_quota_rows(
     transaction: &Transaction<'_>,
     cursor: i64,
+    high_water: i64,
     limit: usize,
 ) -> rusqlite::Result<Vec<QuotaEpochRow>> {
     let limit = i64::try_from(limit).unwrap_or(i64::MAX);
@@ -280,13 +341,13 @@ fn load_quota_rows(
                window_start, window_start_ms,
                resets_at, resets_at_ms
         FROM rate_limit_samples
-        WHERE id > ?1
+        WHERE id > ?1 AND id <= ?2
         ORDER BY id
-        LIMIT ?2
+        LIMIT ?3
         ",
     )?;
     let rows = statement
-        .query_map(params![cursor, limit], |row| {
+        .query_map(params![cursor, high_water, limit], |row| {
             Ok(QuotaEpochRow {
                 id: row.get(0)?,
                 sample_timestamp: row.get(1)?,
@@ -888,6 +949,166 @@ mod tests {
             )
             .expect("load durable usage cursor");
         assert_eq!(cursor, second_id);
+    }
+
+    #[test]
+    fn backfill_completion_ignores_new_epoch_rows_beyond_initial_high_water() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        insert_quota(&conn, "2026-07-10T03:00:00Z");
+        let malformed_id =
+            insert_quota_fields(&conn, "bad-sample", "bad-window", "bad-reset");
+
+        let first = backfill_epoch_batch(&conn, 1).expect("backfill initial quota row");
+        assert!(!first.complete);
+        assert_eq!(first.quota_rows_updated, 1);
+
+        let mut progress = first;
+        for minute in 1..=4 {
+            let appended_id = insert_quota(
+                &conn,
+                &format!("2026-07-10T03:0{minute}:00Z"),
+            );
+            conn.execute(
+                "
+                UPDATE rate_limit_samples
+                SET sample_timestamp_ms = 1, window_start_ms = 1, resets_at_ms = 1
+                WHERE id = ?1
+                ",
+                params![appended_id],
+            )
+            .expect("simulate an epoch-aware production append");
+            progress = backfill_epoch_batch(&conn, 1).expect("continue bounded legacy repair");
+            if progress.complete {
+                break;
+            }
+        }
+
+        assert!(
+            progress.complete,
+            "repair chased epoch-aware rows beyond its initial high-water"
+        );
+        let high_water: i64 = conn
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'rate_limit_samples_high_water'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load quota high-water");
+        assert_eq!(high_water, malformed_id);
+        let quarantined: i64 = conn
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM data_repair_quarantine
+                WHERE repair_key = ?1 AND table_name = 'rate_limit_samples'
+                  AND row_id = ?2
+                ",
+                params![REPAIR_KEY, malformed_id],
+                |row| row.get(0),
+            )
+            .expect("count malformed quota fields");
+        assert_eq!(quarantined, 3);
+        assert!(!epoch_backfill_pending(&conn).expect("read completion marker"));
+    }
+
+    #[test]
+    fn legacy_cursor_upgrade_persists_high_water_across_restart() {
+        let directory = tempdir().expect("create temporary directory");
+        let db_path = directory.path().join("epoch-high-water-upgrade.sqlite3");
+        let conn = open_initialized(&db_path);
+        let processed_id = insert_usage(&conn, "2026-07-10T03:00:00Z");
+        conn.execute(
+            "UPDATE usage_events SET timestamp_ms = 1 WHERE id = ?1",
+            params![processed_id],
+        )
+        .expect("simulate an already processed legacy row");
+        let valid_id = insert_usage(&conn, "2026-07-10T03:00:01Z");
+        let malformed_id = insert_usage(&conn, "bad-timestamp");
+        conn.execute(
+            "
+            INSERT INTO data_repair_progress (repair_key, stream_key, progress_value)
+            VALUES (?1, 'usage_events', ?2)
+            ",
+            params![REPAIR_KEY, processed_id],
+        )
+        .expect("seed legacy cursor without high-water");
+
+        let first = backfill_epoch_batch(&conn, 1).expect("upgrade legacy repair progress");
+
+        assert!(!first.complete);
+        let captured_high_water: i64 = conn
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'usage_events_high_water'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load captured usage high-water");
+        assert_eq!(captured_high_water, malformed_id);
+        let valid_epoch: Option<i64> = conn
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![valid_id],
+                |row| row.get(0),
+            )
+            .expect("load upgraded usage epoch");
+        assert!(valid_epoch.is_some());
+        drop(conn);
+
+        let reopened = open_initialized(&db_path);
+        let appended_id = insert_usage(&reopened, "2026-07-10T03:00:03Z");
+        reopened
+            .execute(
+                "UPDATE usage_events SET timestamp_ms = 1 WHERE id = ?1",
+                params![appended_id],
+            )
+            .expect("append epoch-aware row after captured high-water");
+        let second = backfill_epoch_batch(&reopened, 1).expect("resume bounded repair");
+        assert!(!second.complete);
+        let third = backfill_epoch_batch(&reopened, 1).expect("complete bounded repair");
+
+        assert!(third.complete);
+        let final_cursor: i64 = reopened
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'usage_events'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load final usage cursor");
+        assert_eq!(final_cursor, malformed_id);
+        let quarantine_count: i64 = reopened
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM data_repair_quarantine
+                WHERE repair_key = ?1 AND table_name = 'usage_events' AND row_id = ?2
+                ",
+                params![REPAIR_KEY, malformed_id],
+                |row| row.get(0),
+            )
+            .expect("count quarantined legacy row");
+        assert_eq!(quarantine_count, 1);
+        let appended_epoch: Option<i64> = reopened
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![appended_id],
+                |row| row.get(0),
+            )
+            .expect("load appended epoch-aware row");
+        assert_eq!(appended_epoch, Some(1));
+        assert!(!epoch_backfill_pending(&reopened).expect("read completion marker"));
     }
 
     #[test]

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -1,58 +1,127 @@
 use std::io::{Error as IoError, ErrorKind};
 
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
-use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord};
+use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord, RateLimitWindowSnapshot};
 
 use super::{now_utc_string, parse_epoch_millis};
 
-struct ParsedRateLimitSample<'a> {
-    sample: &'a RateLimitSampleRecord,
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ParsedRateLimitSample {
+    source_kind: String,
+    source_session_id: String,
+    bucket: String,
+    sample_timestamp: String,
     sample_timestamp_ms: i64,
+    limit_id: String,
+    limit_name: String,
+    plan_type: String,
+    window_start: String,
     window_start_ms: i64,
+    resets_at: String,
     resets_at_ms: i64,
+    used_percent: i64,
+    remaining_percent: i64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RateLimitWriteStats {
+    pub observed: usize,
+    pub historical_inserted: usize,
+    pub latest_updated: usize,
 }
 
 pub fn replace_session_rate_limit_samples(
     conn: &Connection,
     session_id: &str,
     samples: &[RateLimitSampleRecord],
-) -> rusqlite::Result<()> {
-    let parsed = parse_rate_limit_samples(samples)?;
-    conn.execute(
-        "
-    DELETE FROM rate_limit_samples
-    WHERE source_kind = 'session' AND source_session_id = ?1
-    ",
-        params![session_id],
-    )?;
-    insert_parsed_rate_limit_samples(conn, &parsed)
+) -> rusqlite::Result<RateLimitWriteStats> {
+    let mut parsed = parse_rate_limit_samples(samples)?;
+    normalize_session_owner(&mut parsed, session_id);
+    let compacted = compact_complete_session_history(&parsed);
+    with_rate_limit_savepoint(conn, |conn| {
+        let mut stats = RateLimitWriteStats {
+            observed: parsed.len(),
+            ..RateLimitWriteStats::default()
+        };
+        if load_session_history(conn, session_id)? != compacted {
+            conn.execute(
+                "DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1",
+                params![session_id],
+            )?;
+            stats.historical_inserted = insert_parsed_rate_limit_samples(conn, &compacted)?;
+        }
+        let buckets = compacted
+            .iter()
+            .map(|sample| sample.bucket.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        for bucket in ["five_hour", "seven_day"] {
+            if !buckets.contains(bucket) {
+                conn.execute(
+                    "DELETE FROM latest_rate_limits WHERE source_kind = 'session' AND source_session_id = ?1 AND bucket = ?2",
+                    params![session_id, bucket],
+                )?;
+            }
+        }
+        for sample in newest_per_owner_bucket(&parsed) {
+            stats.latest_updated += upsert_latest(conn, sample)?;
+        }
+        Ok(stats)
+    })
 }
 
+#[allow(dead_code)]
+pub fn append_session_rate_limit_samples(
+    conn: &Connection,
+    session_id: &str,
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<RateLimitWriteStats> {
+    let mut parsed = parse_rate_limit_samples(samples)?;
+    normalize_session_owner(&mut parsed, session_id);
+    with_rate_limit_savepoint(conn, |conn| append_parsed_samples(conn, &parsed))
+}
+
+#[cfg(test)]
 pub fn insert_rate_limit_samples(
     conn: &Connection,
     samples: &[RateLimitSampleRecord],
 ) -> rusqlite::Result<()> {
     let parsed = parse_rate_limit_samples(samples)?;
-    insert_parsed_rate_limit_samples(conn, &parsed)
+    with_rate_limit_savepoint(conn, |conn| {
+        insert_parsed_rate_limit_samples(conn, &parsed).map(|_| ())
+    })
 }
 
 fn parse_rate_limit_samples(
     samples: &[RateLimitSampleRecord],
-) -> rusqlite::Result<Vec<ParsedRateLimitSample<'_>>> {
+) -> rusqlite::Result<Vec<ParsedRateLimitSample>> {
     let mut parsed = Vec::with_capacity(samples.len());
     for sample in samples {
         parsed.push(ParsedRateLimitSample {
-            sample,
-            sample_timestamp_ms: parse_epoch_field(
-                "sample_timestamp",
-                &sample.sample_timestamp,
-            )?,
+            source_kind: sample.source_kind.clone(),
+            source_session_id: sample.source_session_id.clone().unwrap_or_default(),
+            bucket: sample.bucket.clone(),
+            sample_timestamp: sample.sample_timestamp.clone(),
+            sample_timestamp_ms: parse_epoch_field("sample_timestamp", &sample.sample_timestamp)?,
+            limit_id: sample.limit_id.clone().unwrap_or_default(),
+            limit_name: sample.limit_name.clone().unwrap_or_default(),
+            plan_type: sample.plan_type.clone().unwrap_or_default(),
+            window_start: sample.window_start.clone(),
             window_start_ms: parse_epoch_field("window_start", &sample.window_start)?,
+            resets_at: sample.resets_at.clone(),
             resets_at_ms: parse_epoch_field("resets_at", &sample.resets_at)?,
+            used_percent: sample.used_percent.clamp(0, 100),
+            remaining_percent: sample.remaining_percent.clamp(0, 100),
         });
     }
     Ok(parsed)
+}
+
+fn normalize_session_owner(samples: &mut [ParsedRateLimitSample], session_id: &str) {
+    for sample in samples {
+        sample.source_kind = "session".to_string();
+        sample.source_session_id = session_id.to_string();
+    }
 }
 
 fn parse_epoch_field(field_name: &str, value: &str) -> rusqlite::Result<i64> {
@@ -66,10 +135,10 @@ fn parse_epoch_field(field_name: &str, value: &str) -> rusqlite::Result<i64> {
 
 fn insert_parsed_rate_limit_samples(
     conn: &Connection,
-    samples: &[ParsedRateLimitSample<'_>],
-) -> rusqlite::Result<()> {
+    samples: &[ParsedRateLimitSample],
+) -> rusqlite::Result<usize> {
     if samples.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
     let created_at = now_utc_string();
     let mut stmt = conn.prepare(
@@ -83,34 +152,34 @@ fn insert_parsed_rate_limit_samples(
     ",
     )?;
 
-    for parsed in samples {
-        let sample = parsed.sample;
-        stmt.execute(params![
+    let mut inserted = 0;
+    for sample in samples {
+        inserted += stmt.execute(params![
             sample.source_kind,
-            sample.source_session_id.as_deref().unwrap_or_default(),
+            sample.source_session_id,
             sample.bucket,
             sample.sample_timestamp,
-            parsed.sample_timestamp_ms,
-            sample.limit_id.as_deref().unwrap_or_default(),
-            sample.limit_name.as_deref().unwrap_or_default(),
-            sample.plan_type.as_deref().unwrap_or_default(),
+            sample.sample_timestamp_ms,
+            sample.limit_id,
+            sample.limit_name,
+            sample.plan_type,
             sample.window_start,
-            parsed.window_start_ms,
+            sample.window_start_ms,
             sample.resets_at,
-            parsed.resets_at_ms,
-            sample.used_percent.clamp(0, 100),
-            sample.remaining_percent.clamp(0, 100),
+            sample.resets_at_ms,
+            sample.used_percent,
+            sample.remaining_percent,
             created_at,
         ])?;
     }
 
-    Ok(())
+    Ok(inserted)
 }
 
 pub fn insert_live_rate_limit_snapshot(
     conn: &Connection,
     snapshot: &LiveRateLimitSnapshot,
-) -> rusqlite::Result<()> {
+) -> rusqlite::Result<RateLimitWriteStats> {
     let mut samples = Vec::new();
     for (bucket, window) in [
         ("five_hour", snapshot.primary.as_ref()),
@@ -138,7 +207,387 @@ pub fn insert_live_rate_limit_snapshot(
             remaining_percent: window.remaining_percent,
         });
     }
-    insert_rate_limit_samples(conn, &samples)
+    let parsed = parse_rate_limit_samples(&samples)?;
+    with_rate_limit_savepoint(conn, |conn| append_parsed_samples(conn, &parsed))
+}
+
+fn with_rate_limit_savepoint<T>(
+    conn: &Connection,
+    operation: impl FnOnce(&Connection) -> rusqlite::Result<T>,
+) -> rusqlite::Result<T> {
+    conn.execute_batch("SAVEPOINT codex_pacer_rate_limit_write")?;
+    match operation(conn) {
+        Ok(value) => {
+            conn.execute_batch("RELEASE SAVEPOINT codex_pacer_rate_limit_write")?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT codex_pacer_rate_limit_write; RELEASE SAVEPOINT codex_pacer_rate_limit_write",
+            );
+            Err(error)
+        }
+    }
+}
+
+fn same_window(left: &ParsedRateLimitSample, right: &ParsedRateLimitSample) -> bool {
+    left.window_start_ms == right.window_start_ms && left.resets_at_ms == right.resets_at_ms
+}
+
+fn same_value(left: &ParsedRateLimitSample, right: &ParsedRateLimitSample) -> bool {
+    left.used_percent == right.used_percent && left.remaining_percent == right.remaining_percent
+}
+
+fn same_history_point(left: &ParsedRateLimitSample, right: &ParsedRateLimitSample) -> bool {
+    left.source_kind == right.source_kind
+        && left.source_session_id == right.source_session_id
+        && left.bucket == right.bucket
+        && left.sample_timestamp_ms == right.sample_timestamp_ms
+        && left.limit_id == right.limit_id
+        && left.limit_name == right.limit_name
+        && left.plan_type == right.plan_type
+        && same_window(left, right)
+        && same_value(left, right)
+}
+
+fn grouped_sorted(samples: &[ParsedRateLimitSample]) -> Vec<Vec<ParsedRateLimitSample>> {
+    let mut ordered = samples.to_vec();
+    ordered.sort_by(|left, right| {
+        (
+            &left.source_kind,
+            &left.source_session_id,
+            &left.bucket,
+            left.sample_timestamp_ms,
+        )
+            .cmp(&(
+                &right.source_kind,
+                &right.source_session_id,
+                &right.bucket,
+                right.sample_timestamp_ms,
+            ))
+    });
+    let mut groups: Vec<Vec<ParsedRateLimitSample>> = Vec::new();
+    for sample in ordered {
+        if groups
+            .last()
+            .and_then(|group| group.first())
+            .is_some_and(|first| {
+                first.source_kind == sample.source_kind
+                    && first.source_session_id == sample.source_session_id
+                    && first.bucket == sample.bucket
+            })
+        {
+            groups.last_mut().expect("group exists").push(sample);
+        } else {
+            groups.push(vec![sample]);
+        }
+    }
+    groups
+}
+
+fn compact_complete_session_history(
+    samples: &[ParsedRateLimitSample],
+) -> Vec<ParsedRateLimitSample> {
+    let mut compacted = Vec::new();
+    for group in grouped_sorted(samples) {
+        let Some(first) = group.first() else { continue };
+        compacted.push(first.clone());
+        let mut previous = first;
+        for sample in group.iter().skip(1) {
+            if !same_window(previous, sample) || !same_value(previous, sample) {
+                compacted.push(sample.clone());
+            }
+            previous = sample;
+        }
+        if let Some(last) = group.last() {
+            if compacted
+                .last()
+                .map_or(true, |point| !same_history_point(point, last))
+            {
+                compacted.push(last.clone());
+            }
+        }
+    }
+    compacted
+}
+
+fn newest_per_owner_bucket(samples: &[ParsedRateLimitSample]) -> Vec<&ParsedRateLimitSample> {
+    grouped_sorted(samples)
+        .iter()
+        .filter_map(|group| group.last())
+        .map(|sample| {
+            samples
+                .iter()
+                .find(|candidate| same_history_point(candidate, sample))
+                .expect("newest sample belongs to input")
+        })
+        .collect()
+}
+
+fn append_parsed_samples(
+    conn: &Connection,
+    samples: &[ParsedRateLimitSample],
+) -> rusqlite::Result<RateLimitWriteStats> {
+    let mut stats = RateLimitWriteStats {
+        observed: samples.len(),
+        ..RateLimitWriteStats::default()
+    };
+    for group in grouped_sorted(samples) {
+        let Some(first) = group.first() else { continue };
+        let mut previous = load_latest_owner_bucket(
+            conn,
+            &first.source_kind,
+            &first.source_session_id,
+            &first.bucket,
+        )?;
+        let mut history = Vec::new();
+        for sample in &group {
+            if previous
+                .as_ref()
+                .is_some_and(|current| sample.sample_timestamp_ms < current.sample_timestamp_ms)
+            {
+                continue;
+            }
+            match previous.as_ref() {
+                None => history.push(sample.clone()),
+                Some(current) if !same_window(current, sample) => {
+                    history.push(current.clone());
+                    history.push(sample.clone());
+                }
+                Some(current) if !same_value(current, sample) => history.push(sample.clone()),
+                Some(_) => {}
+            }
+            previous = Some(sample.clone());
+        }
+        history.dedup_by(|left, right| same_history_point(left, right));
+        stats.historical_inserted += insert_parsed_rate_limit_samples(conn, &history)?;
+        if let Some(latest) = previous.as_ref() {
+            stats.latest_updated += upsert_latest(conn, latest)?;
+        }
+    }
+    Ok(stats)
+}
+
+fn upsert_latest(conn: &Connection, sample: &ParsedRateLimitSample) -> rusqlite::Result<usize> {
+    conn.execute(
+        "
+        INSERT INTO latest_rate_limits (
+          source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+          limit_id, limit_name, plan_type, window_start, window_start_ms,
+          resets_at, resets_at_ms, used_percent, remaining_percent, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+        ON CONFLICT(source_kind, source_session_id, bucket) DO UPDATE SET
+          sample_timestamp = excluded.sample_timestamp,
+          sample_timestamp_ms = excluded.sample_timestamp_ms,
+          limit_id = excluded.limit_id,
+          limit_name = excluded.limit_name,
+          plan_type = excluded.plan_type,
+          window_start = excluded.window_start,
+          window_start_ms = excluded.window_start_ms,
+          resets_at = excluded.resets_at,
+          resets_at_ms = excluded.resets_at_ms,
+          used_percent = excluded.used_percent,
+          remaining_percent = excluded.remaining_percent,
+          updated_at = excluded.updated_at
+        WHERE excluded.sample_timestamp_ms >= latest_rate_limits.sample_timestamp_ms
+          AND (
+            excluded.sample_timestamp_ms <> latest_rate_limits.sample_timestamp_ms
+            OR excluded.limit_id <> latest_rate_limits.limit_id
+            OR excluded.limit_name <> latest_rate_limits.limit_name
+            OR excluded.plan_type <> latest_rate_limits.plan_type
+            OR excluded.window_start_ms <> latest_rate_limits.window_start_ms
+            OR excluded.resets_at_ms <> latest_rate_limits.resets_at_ms
+            OR excluded.used_percent <> latest_rate_limits.used_percent
+            OR excluded.remaining_percent <> latest_rate_limits.remaining_percent
+          )
+        ",
+        params![
+            sample.source_kind,
+            sample.source_session_id,
+            sample.bucket,
+            sample.sample_timestamp,
+            sample.sample_timestamp_ms,
+            sample.limit_id,
+            sample.limit_name,
+            sample.plan_type,
+            sample.window_start,
+            sample.window_start_ms,
+            sample.resets_at,
+            sample.resets_at_ms,
+            sample.used_percent,
+            sample.remaining_percent,
+            now_utc_string(),
+        ],
+    )
+}
+
+fn load_latest_owner_bucket(
+    conn: &Connection,
+    source_kind: &str,
+    source_session_id: &str,
+    bucket: &str,
+) -> rusqlite::Result<Option<ParsedRateLimitSample>> {
+    conn.query_row(
+        "
+        SELECT source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+               limit_id, limit_name, plan_type, window_start, window_start_ms,
+               resets_at, resets_at_ms, used_percent, remaining_percent
+        FROM latest_rate_limits
+        WHERE source_kind = ?1 AND source_session_id = ?2 AND bucket = ?3
+        ",
+        params![source_kind, source_session_id, bucket],
+        parsed_sample_from_row,
+    )
+    .optional()
+}
+
+fn parsed_sample_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ParsedRateLimitSample> {
+    Ok(ParsedRateLimitSample {
+        source_kind: row.get(0)?,
+        source_session_id: row.get(1)?,
+        bucket: row.get(2)?,
+        sample_timestamp: row.get(3)?,
+        sample_timestamp_ms: row.get(4)?,
+        limit_id: row.get(5)?,
+        limit_name: row.get(6)?,
+        plan_type: row.get(7)?,
+        window_start: row.get(8)?,
+        window_start_ms: row.get(9)?,
+        resets_at: row.get(10)?,
+        resets_at_ms: row.get(11)?,
+        used_percent: row.get(12)?,
+        remaining_percent: row.get(13)?,
+    })
+}
+
+fn load_session_history(
+    conn: &Connection,
+    session_id: &str,
+) -> rusqlite::Result<Vec<ParsedRateLimitSample>> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+               limit_id, limit_name, plan_type, window_start, window_start_ms,
+               resets_at, resets_at_ms, used_percent, remaining_percent
+        FROM rate_limit_samples
+        WHERE source_kind = 'session' AND source_session_id = ?1
+        ORDER BY bucket, sample_timestamp_ms, id
+        ",
+    )?;
+    let rows = stmt.query_map(params![session_id], |row| {
+        Ok(ParsedRateLimitSample {
+            source_kind: row.get(0)?,
+            source_session_id: row.get(1)?,
+            bucket: row.get(2)?,
+            sample_timestamp: row.get(3)?,
+            sample_timestamp_ms: row.get::<_, Option<i64>>(4)?.unwrap_or(i64::MIN),
+            limit_id: row.get(5)?,
+            limit_name: row.get(6)?,
+            plan_type: row.get(7)?,
+            window_start: row.get(8)?,
+            window_start_ms: row.get::<_, Option<i64>>(9)?.unwrap_or(i64::MIN),
+            resets_at: row.get(10)?,
+            resets_at_ms: row.get::<_, Option<i64>>(11)?.unwrap_or(i64::MIN),
+            used_percent: row.get(12)?,
+            remaining_percent: row.get(13)?,
+        })
+    })?;
+    rows.collect()
+}
+
+#[derive(Clone)]
+struct LatestWindow {
+    owner: (String, String),
+    sample: ParsedRateLimitSample,
+}
+
+fn load_latest_window(
+    conn: &Connection,
+    bucket: &str,
+    source_kind: Option<&str>,
+) -> rusqlite::Result<Option<LatestWindow>> {
+    conn.query_row(
+        "
+        SELECT source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+               limit_id, limit_name, plan_type, window_start, window_start_ms,
+               resets_at, resets_at_ms, used_percent, remaining_percent
+        FROM latest_rate_limits
+        WHERE bucket = ?1 AND (?2 IS NULL OR source_kind = ?2)
+        ORDER BY sample_timestamp_ms DESC, rowid DESC
+        LIMIT 1
+        ",
+        params![bucket, source_kind],
+        |row| {
+            let sample = parsed_sample_from_row(row)?;
+            Ok(LatestWindow {
+                owner: (sample.source_kind.clone(), sample.source_session_id.clone()),
+                sample,
+            })
+        },
+    )
+    .optional()
+}
+
+pub fn load_latest_rate_limits(
+    conn: &Connection,
+    source_kind: Option<&str>,
+) -> rusqlite::Result<Option<LiveRateLimitSnapshot>> {
+    let mut primary = load_latest_window(conn, "five_hour", source_kind)?;
+    let mut secondary = load_latest_window(conn, "seven_day", source_kind)?;
+    let newest = match (primary.as_ref(), secondary.as_ref()) {
+        (Some(left), Some(right)) => {
+            if right.sample.sample_timestamp_ms > left.sample.sample_timestamp_ms {
+                right
+            } else {
+                left
+            }
+        }
+        (Some(left), None) => left,
+        (None, Some(right)) => right,
+        (None, None) => return Ok(None),
+    };
+    let newest_owner = newest.owner.clone();
+    let newest_timestamp = newest.sample.sample_timestamp_ms;
+    if primary.as_ref().is_some_and(|window| {
+        window.owner != newest_owner || window.sample.sample_timestamp_ms != newest_timestamp
+    }) {
+        primary = None;
+    }
+    if secondary.as_ref().is_some_and(|window| {
+        window.owner != newest_owner || window.sample.sample_timestamp_ms != newest_timestamp
+    }) {
+        secondary = None;
+    }
+    let reference = primary
+        .as_ref()
+        .or(secondary.as_ref())
+        .expect("latest window exists");
+    let limit_id =
+        (!reference.sample.limit_id.is_empty()).then(|| reference.sample.limit_id.clone());
+    let limit_name =
+        (!reference.sample.limit_name.is_empty()).then(|| reference.sample.limit_name.clone());
+    let plan_type =
+        (!reference.sample.plan_type.is_empty()).then(|| reference.sample.plan_type.clone());
+    let fetched_at = reference.sample.sample_timestamp.clone();
+    let window_snapshot = |window: LatestWindow| RateLimitWindowSnapshot {
+        used_percent: window.sample.used_percent,
+        remaining_percent: window.sample.remaining_percent,
+        window_duration_mins: Some(
+            (window.sample.resets_at_ms - window.sample.window_start_ms)
+                .div_euclid(60_000)
+                .max(0),
+        ),
+        resets_at: Some(window.sample.resets_at),
+        window_start: Some(window.sample.window_start),
+    };
+    Ok(Some(LiveRateLimitSnapshot {
+        limit_id,
+        limit_name,
+        plan_type,
+        primary: primary.map(window_snapshot),
+        secondary: secondary.map(window_snapshot),
+        fetched_at,
+    }))
 }
 
 #[cfg(test)]
@@ -146,13 +595,11 @@ mod tests {
     use rusqlite::Connection;
 
     use crate::database::{init_db, parse_epoch_millis};
-    use crate::models::{
-        LiveRateLimitSnapshot, RateLimitSampleRecord, RateLimitWindowSnapshot,
-    };
+    use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord, RateLimitWindowSnapshot};
 
     use super::{
-        insert_live_rate_limit_snapshot, insert_rate_limit_samples,
-        replace_session_rate_limit_samples,
+        append_session_rate_limit_samples, insert_live_rate_limit_snapshot,
+        insert_rate_limit_samples, load_latest_rate_limits, replace_session_rate_limit_samples,
     };
 
     fn session_sample(
@@ -173,6 +620,346 @@ mod tests {
             used_percent: 25,
             remaining_percent: 75,
         }
+    }
+
+    fn live_snapshot(
+        fetched_at: &str,
+        primary_used: i64,
+        secondary_used: i64,
+        primary_window_start: &str,
+        primary_resets_at: &str,
+    ) -> LiveRateLimitSnapshot {
+        LiveRateLimitSnapshot {
+            limit_id: Some("codex".to_string()),
+            limit_name: Some("Codex".to_string()),
+            plan_type: Some("pro".to_string()),
+            primary: Some(RateLimitWindowSnapshot {
+                used_percent: primary_used,
+                remaining_percent: 100 - primary_used,
+                window_duration_mins: Some(300),
+                window_start: Some(primary_window_start.to_string()),
+                resets_at: Some(primary_resets_at.to_string()),
+            }),
+            secondary: Some(RateLimitWindowSnapshot {
+                used_percent: secondary_used,
+                remaining_percent: 100 - secondary_used,
+                window_duration_mins: Some(10_080),
+                window_start: Some("2026-07-06T00:00:00Z".to_string()),
+                resets_at: Some("2026-07-13T00:00:00Z".to_string()),
+            }),
+            fetched_at: fetched_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn repeated_live_percent_updates_latest_without_growing_history() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let first = live_snapshot(
+            "2026-07-10T10:00:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        let repeated = live_snapshot(
+            "2026-07-10T10:05:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+
+        let first_stats = insert_live_rate_limit_snapshot(&conn, &first).expect("insert first");
+        let repeated_stats =
+            insert_live_rate_limit_snapshot(&conn, &repeated).expect("insert repeated");
+
+        assert_eq!(first_stats.historical_inserted, 2);
+        assert_eq!(first_stats.latest_updated, 2);
+        assert_eq!(repeated_stats.historical_inserted, 0);
+        assert_eq!(repeated_stats.latest_updated, 2);
+        let history_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| {
+                row.get(0)
+            })
+            .expect("count history");
+        let latest_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM latest_rate_limits", [], |row| {
+                row.get(0)
+            })
+            .expect("count latest");
+        assert_eq!(history_count, 2);
+        assert_eq!(latest_count, 2);
+        assert_eq!(
+            load_latest_rate_limits(&conn, Some("live"))
+                .expect("load latest")
+                .expect("latest snapshot")
+                .fetched_at,
+            repeated.fetched_at
+        );
+    }
+
+    #[test]
+    fn changed_percent_adds_one_history_point() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let first = live_snapshot(
+            "2026-07-10T10:00:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        let changed = live_snapshot(
+            "2026-07-10T10:05:00Z",
+            41,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        insert_live_rate_limit_snapshot(&conn, &first).expect("insert first");
+
+        let stats = insert_live_rate_limit_snapshot(&conn, &changed).expect("insert changed");
+
+        assert_eq!(stats.historical_inserted, 1);
+        assert_eq!(stats.latest_updated, 2);
+        let history_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| {
+                row.get(0)
+            })
+            .expect("count history");
+        assert_eq!(history_count, 3);
+    }
+
+    #[test]
+    fn new_window_keeps_previous_close_and_new_start() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let mut first = live_snapshot(
+            "2026-07-10T10:00:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        first.secondary = None;
+        let mut close = first.clone();
+        close.fetched_at = "2026-07-10T12:59:00Z".to_string();
+        let mut next = live_snapshot(
+            "2026-07-10T13:00:00Z",
+            0,
+            20,
+            "2026-07-10T13:00:00Z",
+            "2026-07-10T18:00:00Z",
+        );
+        next.secondary = None;
+        insert_live_rate_limit_snapshot(&conn, &first).expect("insert first");
+        insert_live_rate_limit_snapshot(&conn, &close).expect("observe close");
+
+        let stats = insert_live_rate_limit_snapshot(&conn, &next).expect("insert next window");
+
+        assert_eq!(stats.historical_inserted, 2);
+        let timestamps = conn
+            .prepare(
+                "SELECT sample_timestamp FROM rate_limit_samples ORDER BY sample_timestamp_ms, id",
+            )
+            .expect("prepare timestamps")
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("query timestamps")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect timestamps");
+        assert_eq!(
+            timestamps,
+            vec![
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T12:59:00Z",
+                "2026-07-10T13:00:00Z"
+            ]
+        );
+    }
+
+    #[test]
+    fn session_batch_keeps_first_change_and_last() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let mut samples = vec![
+            session_sample(
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:01:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:02:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:03:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+        ];
+        samples[2].used_percent = 26;
+        samples[2].remaining_percent = 74;
+        samples[3].used_percent = 26;
+        samples[3].remaining_percent = 74;
+
+        let stats = replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("replace session samples");
+
+        assert_eq!(stats.observed, 4);
+        assert_eq!(stats.historical_inserted, 3);
+        let timestamps = conn
+            .prepare(
+                "SELECT sample_timestamp FROM rate_limit_samples ORDER BY sample_timestamp_ms, id",
+            )
+            .expect("prepare timestamps")
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("query timestamps")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect timestamps");
+        assert_eq!(
+            timestamps,
+            vec![
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T10:02:00Z",
+                "2026-07-10T10:03:00Z"
+            ]
+        );
+    }
+
+    #[test]
+    fn repeated_session_replace_performs_zero_semantic_writes() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let samples = vec![
+            session_sample(
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:01:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+        ];
+        replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("insert session samples");
+        let changes_before = conn.total_changes();
+
+        let stats = replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("repeat session samples");
+
+        assert_eq!(stats.historical_inserted, 0);
+        assert_eq!(stats.latest_updated, 0);
+        assert_eq!(conn.total_changes(), changes_before);
+    }
+
+    #[test]
+    fn latest_quota_uses_epoch_order() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let newer = live_snapshot(
+            "2026-07-10T03:00:01Z",
+            41,
+            20,
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T07:00:00Z",
+        );
+        let older = live_snapshot(
+            "2026-07-10T10:00:00+08:00",
+            40,
+            20,
+            "2026-07-10T09:00:00+08:00",
+            "2026-07-10T14:00:00+08:00",
+        );
+        insert_live_rate_limit_snapshot(&conn, &newer).expect("insert newer");
+        insert_live_rate_limit_snapshot(&conn, &older).expect("insert older later");
+
+        let latest = load_latest_rate_limits(&conn, Some("live"))
+            .expect("load latest")
+            .expect("latest snapshot");
+
+        assert_eq!(latest.fetched_at, newer.fetched_at);
+        assert_eq!(latest.primary.map(|window| window.used_percent), Some(41));
+    }
+
+    #[test]
+    fn latest_lookup_does_not_scan_history() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let snapshot = live_snapshot(
+            "2026-07-10T10:00:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        insert_live_rate_limit_snapshot(&conn, &snapshot).expect("insert snapshot");
+        conn.execute_batch("DROP TABLE rate_limit_samples")
+            .expect("drop history table");
+
+        let latest = load_latest_rate_limits(&conn, Some("live"))
+            .expect("load latest without history")
+            .expect("latest snapshot");
+
+        assert_eq!(latest.fetched_at, snapshot.fetched_at);
+    }
+
+    #[test]
+    fn session_latest_rows_are_owned_independently() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let first = session_sample(
+            "2026-07-10T10:00:00Z",
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        let mut second = first.clone();
+        second.source_session_id = Some("session-2".to_string());
+        second.sample_timestamp = "2026-07-10T10:01:00Z".to_string();
+        append_session_rate_limit_samples(&conn, "session-1", &[first])
+            .expect("append first session");
+        append_session_rate_limit_samples(&conn, "session-2", &[second])
+            .expect("append second session");
+
+        let owner_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM latest_rate_limits WHERE source_kind = 'session' AND bucket = 'five_hour'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count owners");
+        assert_eq!(owner_count, 2);
+    }
+
+    #[test]
+    fn session_replace_plan_uses_owner_index() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+
+        let details = conn
+            .prepare(
+                "EXPLAIN QUERY PLAN DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1",
+            )
+            .expect("prepare delete plan")
+            .query_map(["session-1"], |row| row.get::<_, String>(3))
+            .expect("query delete plan")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect delete plan");
+
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("idx_rate_limit_samples_owner")),
+            "owner delete must not scan all quota history: {details:?}"
+        );
     }
 
     #[test]
@@ -283,7 +1070,9 @@ mod tests {
 
         assert!(result.is_err());
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| {
+                row.get(0)
+            })
             .expect("count quota samples");
         assert_eq!(count, 0);
     }
@@ -320,5 +1109,35 @@ mod tests {
             )
             .expect("load preserved samples");
         assert_eq!(persisted, (1, existing.sample_timestamp));
+    }
+
+    #[test]
+    fn session_replace_repairs_legacy_null_epoch_rows() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let sample = session_sample(
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T07:00:00Z",
+        );
+        replace_session_rate_limit_samples(&conn, "session-1", &[sample.clone()])
+            .expect("insert initial sample");
+        conn.execute(
+            "UPDATE rate_limit_samples SET sample_timestamp_ms = NULL, window_start_ms = NULL, resets_at_ms = NULL WHERE source_session_id = 'session-1'",
+            [],
+        )
+        .expect("simulate legacy null epochs");
+
+        replace_session_rate_limit_samples(&conn, "session-1", &[sample])
+            .expect("repair legacy session sample");
+
+        let populated: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM rate_limit_samples WHERE source_session_id = 'session-1' AND sample_timestamp_ms IS NOT NULL AND window_start_ms IS NOT NULL AND resets_at_ms IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count populated epochs");
+        assert_eq!(populated, 1);
     }
 }

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -1,14 +1,24 @@
+use std::io::{Error as IoError, ErrorKind};
+
 use rusqlite::{params, Connection};
 
 use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord};
 
-use super::now_utc_string;
+use super::{now_utc_string, parse_epoch_millis};
+
+struct ParsedRateLimitSample<'a> {
+    sample: &'a RateLimitSampleRecord,
+    sample_timestamp_ms: i64,
+    window_start_ms: i64,
+    resets_at_ms: i64,
+}
 
 pub fn replace_session_rate_limit_samples(
     conn: &Connection,
     session_id: &str,
     samples: &[RateLimitSampleRecord],
 ) -> rusqlite::Result<()> {
+    let parsed = parse_rate_limit_samples(samples)?;
     conn.execute(
         "
     DELETE FROM rate_limit_samples
@@ -16,35 +26,78 @@ pub fn replace_session_rate_limit_samples(
     ",
         params![session_id],
     )?;
-    insert_rate_limit_samples(conn, samples)
+    insert_parsed_rate_limit_samples(conn, &parsed)
 }
 
 pub fn insert_rate_limit_samples(
     conn: &Connection,
     samples: &[RateLimitSampleRecord],
 ) -> rusqlite::Result<()> {
+    let parsed = parse_rate_limit_samples(samples)?;
+    insert_parsed_rate_limit_samples(conn, &parsed)
+}
+
+fn parse_rate_limit_samples(
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<Vec<ParsedRateLimitSample<'_>>> {
+    let mut parsed = Vec::with_capacity(samples.len());
+    for sample in samples {
+        parsed.push(ParsedRateLimitSample {
+            sample,
+            sample_timestamp_ms: parse_epoch_field(
+                "sample_timestamp",
+                &sample.sample_timestamp,
+            )?,
+            window_start_ms: parse_epoch_field("window_start", &sample.window_start)?,
+            resets_at_ms: parse_epoch_field("resets_at", &sample.resets_at)?,
+        });
+    }
+    Ok(parsed)
+}
+
+fn parse_epoch_field(field_name: &str, value: &str) -> rusqlite::Result<i64> {
+    parse_epoch_millis(value).map_err(|error| {
+        rusqlite::Error::ToSqlConversionFailure(Box::new(IoError::new(
+            ErrorKind::InvalidData,
+            format!("Invalid rate limit {field_name} {value:?}: {error}"),
+        )))
+    })
+}
+
+fn insert_parsed_rate_limit_samples(
+    conn: &Connection,
+    samples: &[ParsedRateLimitSample<'_>],
+) -> rusqlite::Result<()> {
+    if samples.is_empty() {
+        return Ok(());
+    }
     let created_at = now_utc_string();
     let mut stmt = conn.prepare(
         "
     INSERT OR IGNORE INTO rate_limit_samples (
-      source_kind, source_session_id, bucket, sample_timestamp, limit_id, limit_name, plan_type,
-      window_start, resets_at, used_percent, remaining_percent, created_at
+      source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+      limit_id, limit_name, plan_type, window_start, window_start_ms,
+      resets_at, resets_at_ms, used_percent, remaining_percent, created_at
     )
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
     ",
     )?;
 
-    for sample in samples {
+    for parsed in samples {
+        let sample = parsed.sample;
         stmt.execute(params![
             sample.source_kind,
-            sample.source_session_id.clone().unwrap_or_default(),
+            sample.source_session_id.as_deref().unwrap_or_default(),
             sample.bucket,
             sample.sample_timestamp,
-            sample.limit_id.clone().unwrap_or_default(),
-            sample.limit_name.clone().unwrap_or_default(),
-            sample.plan_type.clone().unwrap_or_default(),
+            parsed.sample_timestamp_ms,
+            sample.limit_id.as_deref().unwrap_or_default(),
+            sample.limit_name.as_deref().unwrap_or_default(),
+            sample.plan_type.as_deref().unwrap_or_default(),
             sample.window_start,
+            parsed.window_start_ms,
             sample.resets_at,
+            parsed.resets_at_ms,
             sample.used_percent.clamp(0, 100),
             sample.remaining_percent.clamp(0, 100),
             created_at,
@@ -86,4 +139,186 @@ pub fn insert_live_rate_limit_snapshot(
         });
     }
     insert_rate_limit_samples(conn, &samples)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use crate::database::{init_db, parse_epoch_millis};
+    use crate::models::{
+        LiveRateLimitSnapshot, RateLimitSampleRecord, RateLimitWindowSnapshot,
+    };
+
+    use super::{
+        insert_live_rate_limit_snapshot, insert_rate_limit_samples,
+        replace_session_rate_limit_samples,
+    };
+
+    fn session_sample(
+        sample_timestamp: &str,
+        window_start: &str,
+        resets_at: &str,
+    ) -> RateLimitSampleRecord {
+        RateLimitSampleRecord {
+            source_kind: "session".to_string(),
+            source_session_id: Some("session-1".to_string()),
+            bucket: "five_hour".to_string(),
+            sample_timestamp: sample_timestamp.to_string(),
+            limit_id: Some("codex".to_string()),
+            limit_name: Some("Codex".to_string()),
+            plan_type: Some("pro".to_string()),
+            window_start: window_start.to_string(),
+            resets_at: resets_at.to_string(),
+            used_percent: 25,
+            remaining_percent: 75,
+        }
+    }
+
+    #[test]
+    fn session_quota_write_populates_all_epoch_fields() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let sample = session_sample(
+            "2026-07-10T10:00:00+08:00",
+            "2026-07-10T09:00:00+08:00",
+            "2026-07-10T14:00:00+08:00",
+        );
+
+        replace_session_rate_limit_samples(&conn, "session-1", &[sample.clone()])
+            .expect("replace session quota samples");
+
+        let epochs = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                ",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .expect("load quota epochs");
+        assert_eq!(
+            epochs,
+            (
+                parse_epoch_millis(&sample.sample_timestamp).expect("parse sample timestamp"),
+                parse_epoch_millis(&sample.window_start).expect("parse window start"),
+                parse_epoch_millis(&sample.resets_at).expect("parse resets at"),
+            )
+        );
+    }
+
+    #[test]
+    fn live_quota_write_populates_all_epoch_fields() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let snapshot = LiveRateLimitSnapshot {
+            limit_id: Some("codex".to_string()),
+            limit_name: Some("Codex".to_string()),
+            plan_type: Some("pro".to_string()),
+            primary: Some(RateLimitWindowSnapshot {
+                used_percent: 10,
+                remaining_percent: 90,
+                window_duration_mins: Some(300),
+                window_start: Some("2026-07-10T02:00:00Z".to_string()),
+                resets_at: Some("2026-07-10T07:00:00Z".to_string()),
+            }),
+            secondary: None,
+            fetched_at: "2026-07-10T10:00:00+08:00".to_string(),
+        };
+
+        insert_live_rate_limit_snapshot(&conn, &snapshot).expect("insert live quota snapshot");
+
+        let epochs = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE source_kind = 'live'
+                ",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .expect("load live quota epochs");
+        assert_eq!(
+            epochs,
+            (
+                parse_epoch_millis(&snapshot.fetched_at).expect("parse fetched at"),
+                parse_epoch_millis("2026-07-10T02:00:00Z").expect("parse window start"),
+                parse_epoch_millis("2026-07-10T07:00:00Z").expect("parse resets at"),
+            )
+        );
+    }
+
+    #[test]
+    fn malformed_quota_append_writes_nothing() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let samples = [
+            session_sample(
+                "2026-07-10T02:00:00Z",
+                "2026-07-10T02:00:00Z",
+                "2026-07-10T07:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T02:01:00Z",
+                "invalid-window-start",
+                "2026-07-10T07:01:00Z",
+            ),
+        ];
+
+        let result = insert_rate_limit_samples(&conn, &samples);
+
+        assert!(result.is_err());
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| row.get(0))
+            .expect("count quota samples");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn malformed_quota_replace_preserves_existing_session_rows() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let existing = session_sample(
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T07:00:00Z",
+        );
+        replace_session_rate_limit_samples(&conn, "session-1", &[existing.clone()])
+            .expect("insert existing sample");
+        let malformed = session_sample(
+            "invalid-sample-timestamp",
+            "2026-07-10T02:01:00Z",
+            "2026-07-10T07:01:00Z",
+        );
+
+        let result = replace_session_rate_limit_samples(&conn, "session-1", &[malformed]);
+
+        assert!(result.is_err());
+        let persisted = conn
+            .query_row(
+                "
+                SELECT COUNT(*), MIN(sample_timestamp)
+                FROM rate_limit_samples
+                WHERE source_kind = 'session' AND source_session_id = 'session-1'
+                ",
+                [],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .expect("load preserved samples");
+        assert_eq!(persisted, (1, existing.sample_timestamp));
+    }
 }

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -28,6 +28,8 @@ struct ParsedRateLimitSample {
 pub struct RateLimitWriteStats {
     pub observed: usize,
     pub historical_inserted: usize,
+    pub historical_updated: usize,
+    pub historical_deleted: usize,
     pub latest_updated: usize,
 }
 
@@ -44,13 +46,7 @@ pub fn replace_session_rate_limit_samples(
             observed: parsed.len(),
             ..RateLimitWriteStats::default()
         };
-        if load_session_history(conn, session_id)? != compacted {
-            conn.execute(
-                "DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1",
-                params![session_id],
-            )?;
-            stats.historical_inserted = insert_parsed_rate_limit_samples(conn, &compacted)?;
-        }
+        reconcile_session_history(conn, session_id, &compacted, &mut stats)?;
         let buckets = compacted
             .iter()
             .map(|sample| sample.bucket.as_str())
@@ -250,6 +246,20 @@ fn same_history_point(left: &ParsedRateLimitSample, right: &ParsedRateLimitSampl
         && same_value(left, right)
 }
 
+fn same_history_point_except_observed_at(
+    left: &ParsedRateLimitSample,
+    right: &ParsedRateLimitSample,
+) -> bool {
+    left.source_kind == right.source_kind
+        && left.source_session_id == right.source_session_id
+        && left.bucket == right.bucket
+        && left.limit_id == right.limit_id
+        && left.limit_name == right.limit_name
+        && left.plan_type == right.plan_type
+        && same_window(left, right)
+        && same_value(left, right)
+}
+
 fn grouped_sorted(samples: &[ParsedRateLimitSample]) -> Vec<Vec<ParsedRateLimitSample>> {
     let mut ordered = samples.to_vec();
     ordered.sort_by(|left, right| {
@@ -295,6 +305,12 @@ fn compact_complete_session_history(
         let mut previous = first;
         for sample in group.iter().skip(1) {
             if !same_window(previous, sample) || !same_value(previous, sample) {
+                if compacted
+                    .last()
+                    .map_or(true, |point| !same_history_point(point, previous))
+                {
+                    compacted.push(previous.clone());
+                }
                 compacted.push(sample.clone());
             }
             previous = sample;
@@ -309,6 +325,85 @@ fn compact_complete_session_history(
         }
     }
     compacted
+}
+
+#[derive(Clone, Debug)]
+struct PersistedRateLimitSample {
+    id: i64,
+    sample: ParsedRateLimitSample,
+}
+
+fn reconcile_session_history(
+    conn: &Connection,
+    session_id: &str,
+    desired: &[ParsedRateLimitSample],
+    stats: &mut RateLimitWriteStats,
+) -> rusqlite::Result<()> {
+    let existing = load_session_history(conn, session_id)?;
+    let desired_groups = grouped_sorted(desired);
+    let desired_buckets = desired_groups
+        .iter()
+        .filter_map(|group| group.first().map(|sample| sample.bucket.clone()))
+        .collect::<std::collections::HashSet<_>>();
+
+    for group in desired_groups {
+        let Some(first) = group.first() else { continue };
+        let existing_group = existing
+            .iter()
+            .filter(|persisted| persisted.sample.bucket == first.bucket)
+            .collect::<Vec<_>>();
+        let matching_prefix = existing_group
+            .iter()
+            .zip(&group)
+            .take_while(|(left, right)| same_history_point(&left.sample, right))
+            .count();
+        if matching_prefix == existing_group.len() && matching_prefix == group.len() {
+            continue;
+        }
+        if matching_prefix == existing_group.len() && existing_group.len() < group.len() {
+            stats.historical_inserted +=
+                insert_parsed_rate_limit_samples(conn, &group[matching_prefix..])?;
+            continue;
+        }
+        if existing_group.len() == group.len()
+            && !group.is_empty()
+            && matching_prefix + 1 == group.len()
+            && same_history_point_except_observed_at(
+                &existing_group.last().expect("existing last").sample,
+                group.last().expect("desired last"),
+            )
+        {
+            let last = group.last().expect("desired last");
+            stats.historical_updated += conn.execute(
+                "UPDATE rate_limit_samples SET sample_timestamp = ?1, sample_timestamp_ms = ?2, created_at = ?3 WHERE id = ?4",
+                params![
+                    last.sample_timestamp,
+                    last.sample_timestamp_ms,
+                    now_utc_string(),
+                    existing_group.last().expect("existing last").id,
+                ],
+            )?;
+            continue;
+        }
+
+        stats.historical_deleted += conn.execute(
+            "DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1 AND bucket = ?2",
+            params![session_id, first.bucket],
+        )?;
+        stats.historical_inserted += insert_parsed_rate_limit_samples(conn, &group)?;
+    }
+
+    let existing_buckets = existing
+        .iter()
+        .map(|persisted| persisted.sample.bucket.clone())
+        .collect::<std::collections::HashSet<_>>();
+    for bucket in existing_buckets.difference(&desired_buckets) {
+        stats.historical_deleted += conn.execute(
+            "DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1 AND bucket = ?2",
+            params![session_id, bucket],
+        )?;
+    }
+    Ok(())
 }
 
 fn newest_per_owner_bucket(samples: &[ParsedRateLimitSample]) -> Vec<&ParsedRateLimitSample> {
@@ -463,10 +558,10 @@ fn parsed_sample_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ParsedRat
 fn load_session_history(
     conn: &Connection,
     session_id: &str,
-) -> rusqlite::Result<Vec<ParsedRateLimitSample>> {
+) -> rusqlite::Result<Vec<PersistedRateLimitSample>> {
     let mut stmt = conn.prepare(
         "
-        SELECT source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+        SELECT id, source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
                limit_id, limit_name, plan_type, window_start, window_start_ms,
                resets_at, resets_at_ms, used_percent, remaining_percent
         FROM rate_limit_samples
@@ -475,21 +570,24 @@ fn load_session_history(
         ",
     )?;
     let rows = stmt.query_map(params![session_id], |row| {
-        Ok(ParsedRateLimitSample {
-            source_kind: row.get(0)?,
-            source_session_id: row.get(1)?,
-            bucket: row.get(2)?,
-            sample_timestamp: row.get(3)?,
-            sample_timestamp_ms: row.get::<_, Option<i64>>(4)?.unwrap_or(i64::MIN),
-            limit_id: row.get(5)?,
-            limit_name: row.get(6)?,
-            plan_type: row.get(7)?,
-            window_start: row.get(8)?,
-            window_start_ms: row.get::<_, Option<i64>>(9)?.unwrap_or(i64::MIN),
-            resets_at: row.get(10)?,
-            resets_at_ms: row.get::<_, Option<i64>>(11)?.unwrap_or(i64::MIN),
-            used_percent: row.get(12)?,
-            remaining_percent: row.get(13)?,
+        Ok(PersistedRateLimitSample {
+            id: row.get(0)?,
+            sample: ParsedRateLimitSample {
+                source_kind: row.get(1)?,
+                source_session_id: row.get(2)?,
+                bucket: row.get(3)?,
+                sample_timestamp: row.get(4)?,
+                sample_timestamp_ms: row.get::<_, Option<i64>>(5)?.unwrap_or(i64::MIN),
+                limit_id: row.get(6)?,
+                limit_name: row.get(7)?,
+                plan_type: row.get(8)?,
+                window_start: row.get(9)?,
+                window_start_ms: row.get::<_, Option<i64>>(10)?.unwrap_or(i64::MIN),
+                resets_at: row.get(11)?,
+                resets_at_ms: row.get::<_, Option<i64>>(12)?.unwrap_or(i64::MIN),
+                used_percent: row.get(13)?,
+                remaining_percent: row.get(14)?,
+            },
         })
     })?;
     rows.collect()
@@ -779,7 +877,7 @@ mod tests {
     }
 
     #[test]
-    fn session_batch_keeps_first_change_and_last() {
+    fn session_batch_keeps_change_boundaries_and_last() {
         let conn = Connection::open_in_memory().expect("open database");
         init_db(&conn).expect("initialize database");
         let mut samples = vec![
@@ -813,7 +911,7 @@ mod tests {
             .expect("replace session samples");
 
         assert_eq!(stats.observed, 4);
-        assert_eq!(stats.historical_inserted, 3);
+        assert_eq!(stats.historical_inserted, 4);
         let timestamps = conn
             .prepare(
                 "SELECT sample_timestamp FROM rate_limit_samples ORDER BY sample_timestamp_ms, id",
@@ -827,6 +925,7 @@ mod tests {
             timestamps,
             vec![
                 "2026-07-10T10:00:00Z",
+                "2026-07-10T10:01:00Z",
                 "2026-07-10T10:02:00Z",
                 "2026-07-10T10:03:00Z"
             ]
@@ -859,6 +958,108 @@ mod tests {
         assert_eq!(stats.historical_inserted, 0);
         assert_eq!(stats.latest_updated, 0);
         assert_eq!(conn.total_changes(), changes_before);
+    }
+
+    #[test]
+    fn growing_same_value_session_updates_only_last_history_point() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let mut samples = vec![
+            session_sample(
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:01:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+        ];
+        replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("insert initial session history");
+        let ids_before = history_ids(&conn, "session-1");
+        samples.push(session_sample(
+            "2026-07-10T10:02:00Z",
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        ));
+
+        let stats = replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("advance final observation");
+
+        assert_eq!(stats.historical_inserted, 0);
+        assert_eq!(stats.historical_updated, 1);
+        assert_eq!(stats.historical_deleted, 0);
+        assert_eq!(history_ids(&conn, "session-1"), ids_before);
+        let timestamps = history_timestamps(&conn, "session-1");
+        assert_eq!(
+            timestamps,
+            vec!["2026-07-10T10:00:00Z", "2026-07-10T10:02:00Z"]
+        );
+    }
+
+    #[test]
+    fn appended_percent_change_preserves_existing_history_ids() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let mut samples = vec![
+            session_sample(
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:01:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+        ];
+        replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("insert initial session history");
+        let ids_before = history_ids(&conn, "session-1");
+        let mut changed = session_sample(
+            "2026-07-10T10:02:00Z",
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        changed.used_percent = 26;
+        changed.remaining_percent = 74;
+        let mut final_sample = changed.clone();
+        final_sample.sample_timestamp = "2026-07-10T10:03:00Z".to_string();
+        samples.extend([changed, final_sample]);
+
+        let stats = replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("append changed history");
+        let ids_after = history_ids(&conn, "session-1");
+
+        assert_eq!(stats.historical_inserted, 2);
+        assert_eq!(stats.historical_updated, 0);
+        assert_eq!(stats.historical_deleted, 0);
+        assert_eq!(&ids_after[..ids_before.len()], ids_before.as_slice());
+        assert_eq!(ids_after.len(), 4);
+    }
+
+    fn history_ids(conn: &Connection, session_id: &str) -> Vec<i64> {
+        conn.prepare(
+            "SELECT id FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1 ORDER BY bucket, sample_timestamp_ms, id",
+        )
+        .expect("prepare history ids")
+        .query_map([session_id], |row| row.get(0))
+        .expect("query history ids")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("collect history ids")
+    }
+
+    fn history_timestamps(conn: &Connection, session_id: &str) -> Vec<String> {
+        conn.prepare(
+            "SELECT sample_timestamp FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1 ORDER BY bucket, sample_timestamp_ms, id",
+        )
+        .expect("prepare history timestamps")
+        .query_map([session_id], |row| row.get(0))
+        .expect("query history timestamps")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("collect history timestamps")
     }
 
     #[test]

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -1,6 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
-#[cfg(test)]
-use rusqlite::{Transaction, TransactionBehavior};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 
 use crate::models::SyncSettings;
 
@@ -428,7 +426,7 @@ pub fn save_sync_settings(
     conn: &Connection,
     settings: &SyncSettings,
 ) -> rusqlite::Result<SyncSettings> {
-    let transaction = conn.unchecked_transaction()?;
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     let current_codex_home = transaction
         .query_row(
             "SELECT codex_home FROM sync_settings WHERE singleton_id = 1",
@@ -440,14 +438,6 @@ pub fn save_sync_settings(
     let codex_home_changed = current_codex_home.as_deref() != settings.codex_home.as_deref();
     let updated_at = now_utc_string();
     let auto_scan_interval_minutes = settings.auto_scan_interval_minutes.max(1);
-    let (last_scan_started_at, last_scan_completed_at) = if codex_home_changed {
-        (None, None)
-    } else {
-        (
-            settings.last_scan_started_at.as_deref(),
-            settings.last_scan_completed_at.as_deref(),
-        )
-    };
     transaction.execute(
     "
     INSERT INTO sync_settings (
@@ -465,7 +455,7 @@ pub fn save_sync_settings(
       menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
       last_scan_started_at, last_scan_completed_at, updated_at
     )
-    VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)
+    VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, NULL, NULL, ?22)
     ON CONFLICT(singleton_id) DO UPDATE SET
       codex_home = excluded.codex_home,
       auto_scan_enabled = excluded.auto_scan_enabled,
@@ -488,8 +478,6 @@ pub fn save_sync_settings(
       menu_bar_popup_modules = excluded.menu_bar_popup_modules,
       menu_bar_popup_show_reset_timeline = excluded.menu_bar_popup_show_reset_timeline,
       menu_bar_popup_show_actions = excluded.menu_bar_popup_show_actions,
-      last_scan_started_at = excluded.last_scan_started_at,
-      last_scan_completed_at = excluded.last_scan_completed_at,
       updated_at = excluded.updated_at
     ",
     params![
@@ -514,8 +502,6 @@ pub fn save_sync_settings(
       serialize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
       bool_to_i64(settings.menu_bar_popup_show_reset_timeline),
       bool_to_i64(settings.menu_bar_popup_show_actions),
-      last_scan_started_at,
-      last_scan_completed_at,
       updated_at,
     ],
     )?;
@@ -534,7 +520,8 @@ fn clear_scan_timestamps(conn: &Connection) -> rusqlite::Result<()> {
     SET last_scan_started_at = NULL,
         last_scan_completed_at = NULL,
         last_full_scan_completed_at = NULL,
-        last_scan_codex_home = NULL
+        last_scan_codex_home = NULL,
+        scan_commit_revision = scan_commit_revision + 1
     WHERE singleton_id = 1
     ",
         [],

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -1,4 +1,6 @@
-use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use rusqlite::{params, Connection, OptionalExtension};
+#[cfg(test)]
+use rusqlite::{Transaction, TransactionBehavior};
 
 use crate::models::SyncSettings;
 
@@ -60,6 +62,19 @@ pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result
             "
       ALTER TABLE sync_settings
       ADD COLUMN sync_settings_schema_version INTEGER NOT NULL DEFAULT 1
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "scan_commit_revision")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN scan_commit_revision INTEGER NOT NULL DEFAULT 0
       ",
             [],
         )?;
@@ -289,12 +304,15 @@ pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result
         .any(|name| name == "last_full_scan_completed_at")
     {
         conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN last_full_scan_completed_at TEXT",
-      [],
-    )?;
+            "ALTER TABLE sync_settings ADD COLUMN last_full_scan_completed_at TEXT",
+            [],
+        )?;
     }
 
-    if !column_names.iter().any(|name| name == "last_scan_codex_home") {
+    if !column_names
+        .iter()
+        .any(|name| name == "last_scan_codex_home")
+    {
         let transaction = conn.unchecked_transaction()?;
         transaction.execute(
             "ALTER TABLE sync_settings ADD COLUMN last_scan_codex_home TEXT",
@@ -378,7 +396,9 @@ pub fn get_sync_settings(conn: &Connection) -> rusqlite::Result<SyncSettings> {
                 codex_home: row.get(0)?,
                 auto_scan_enabled: i64_to_bool(row.get::<_, i64>(1)?),
                 auto_scan_interval_minutes,
-                live_quota_refresh_interval_seconds: unified_refresh_interval_seconds(auto_scan_interval_minutes),
+                live_quota_refresh_interval_seconds: unified_refresh_interval_seconds(
+                    auto_scan_interval_minutes,
+                ),
                 hide_dock_icon_when_menu_bar_visible: i64_to_bool(row.get::<_, i64>(4)?),
                 show_menu_bar_logo: i64_to_bool(row.get::<_, i64>(5)?),
                 show_menu_bar_daily_api_value: i64_to_bool(row.get::<_, i64>(6)?),
@@ -529,37 +549,37 @@ pub struct ScanFreshnessStart {
     pub full_scan_required: bool,
 }
 
+#[cfg(test)]
 pub fn set_last_scan_started_for_source(
     conn: &Connection,
     timestamp: &str,
     codex_home_selector: Option<&str>,
     resolved_codex_home: &str,
 ) -> rusqlite::Result<ScanFreshnessStart> {
-    let transaction =
-        Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    let previous_freshness = transaction
-        .query_row(
-            "
-            SELECT last_scan_codex_home, last_full_scan_completed_at
-            FROM sync_settings
-            WHERE singleton_id = 1
-              AND (
-                (codex_home IS NULL AND ?1 IS NULL)
-                OR codex_home = ?1
-              )
-            ",
-            params![codex_home_selector],
-            |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
-        )
-        .optional()?;
-    let Some((previous_source, last_full_scan_completed_at)) = previous_freshness else {
-        transaction.commit()?;
-        return Ok(ScanFreshnessStart::default());
-    };
-    let source_changed = previous_source.as_deref() != Some(resolved_codex_home);
-    let full_scan_required = source_changed || last_full_scan_completed_at.is_none();
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let result = set_last_scan_started_for_source_in_transaction(
+        &transaction,
+        timestamp,
+        codex_home_selector,
+        resolved_codex_home,
+    )?;
+    transaction.commit()?;
+    Ok(result)
+}
 
-    let updated = transaction.execute(
+pub(crate) fn set_last_scan_started_for_source_in_transaction(
+    conn: &Connection,
+    timestamp: &str,
+    codex_home_selector: Option<&str>,
+    resolved_codex_home: &str,
+) -> rusqlite::Result<ScanFreshnessStart> {
+    let preview =
+        preview_scan_freshness_for_source(conn, codex_home_selector, resolved_codex_home)?;
+    if !preview.recorded {
+        return Ok(preview);
+    }
+
+    let updated = conn.execute(
         "
         UPDATE sync_settings
         SET last_scan_started_at = ?1,
@@ -581,12 +601,47 @@ pub fn set_last_scan_started_for_source(
         ",
         params![timestamp, codex_home_selector, resolved_codex_home],
     )?;
-    transaction.commit()?;
-
     Ok(ScanFreshnessStart {
         recorded: updated == 1,
-        source_changed: updated == 1 && source_changed,
-        full_scan_required: updated == 1 && full_scan_required,
+        source_changed: updated == 1 && preview.source_changed,
+        full_scan_required: updated == 1 && preview.full_scan_required,
+    })
+}
+
+pub(crate) fn preview_scan_freshness_for_source(
+    conn: &Connection,
+    codex_home_selector: Option<&str>,
+    resolved_codex_home: &str,
+) -> rusqlite::Result<ScanFreshnessStart> {
+    let previous_freshness = conn
+        .query_row(
+            "
+            SELECT last_scan_codex_home, last_full_scan_completed_at
+            FROM sync_settings
+            WHERE singleton_id = 1
+              AND (
+                (codex_home IS NULL AND ?1 IS NULL)
+                OR codex_home = ?1
+              )
+            ",
+            params![codex_home_selector],
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((previous_source, last_full_scan_completed_at)) = previous_freshness else {
+        return Ok(ScanFreshnessStart::default());
+    };
+    let source_changed = previous_source.as_deref() != Some(resolved_codex_home);
+    let full_scan_required = source_changed || last_full_scan_completed_at.is_none();
+    Ok(ScanFreshnessStart {
+        recorded: true,
+        source_changed,
+        full_scan_required,
     })
 }
 

--- a/src-tauri/src/database/usage_events.rs
+++ b/src-tauri/src/database/usage_events.rs
@@ -1,0 +1,172 @@
+use std::io::{Error as IoError, ErrorKind};
+
+use rusqlite::{params, Connection};
+
+use super::{bool_to_i64, parse_epoch_millis};
+
+pub struct NewUsageEvent<'a> {
+  pub session_id: &'a str,
+  pub model_id: String,
+  pub input_tokens: i64,
+  pub cached_input_tokens: i64,
+  pub output_tokens: i64,
+  pub reasoning_output_tokens: i64,
+  pub total_tokens: i64,
+  pub value_usd: f64,
+  pub fast_mode_auto: bool,
+  pub fast_mode_effective: bool,
+}
+
+pub fn insert_usage_events<'a, Timestamps, EventAt>(
+  conn: &Connection,
+  timestamps: Timestamps,
+  mut event_at: EventAt,
+) -> rusqlite::Result<usize>
+where
+  Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
+  EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
+{
+  let mut timestamp_epochs = Vec::with_capacity(timestamps.len());
+  for timestamp in timestamps.clone() {
+    let timestamp_ms = parse_epoch_millis(timestamp).map_err(|error| {
+      rusqlite::Error::ToSqlConversionFailure(Box::new(IoError::new(
+        ErrorKind::InvalidData,
+        format!("Invalid usage event timestamp {timestamp:?}: {error}"),
+      )))
+    })?;
+    timestamp_epochs.push(timestamp_ms);
+  }
+
+  let mut statement = conn.prepare(
+    "
+    INSERT INTO usage_events (
+      session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens,
+      output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+      fast_mode_auto, fast_mode_effective
+    )
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+    ",
+  )?;
+
+  let mut inserted = 0usize;
+  for (index, (timestamp, timestamp_ms)) in timestamps.zip(timestamp_epochs).enumerate() {
+    let Some(event) = event_at(index) else {
+      continue;
+    };
+    statement.execute(params![
+      event.session_id,
+      timestamp,
+      timestamp_ms,
+      event.model_id,
+      event.input_tokens,
+      event.cached_input_tokens,
+      event.output_tokens,
+      event.reasoning_output_tokens,
+      event.total_tokens,
+      event.value_usd,
+      bool_to_i64(event.fast_mode_auto),
+      bool_to_i64(event.fast_mode_effective),
+    ])?;
+    inserted += 1;
+  }
+
+  Ok(inserted)
+}
+
+#[cfg(test)]
+mod tests {
+  use rusqlite::Connection;
+
+  use crate::database::{init_db, parse_epoch_millis};
+
+  use super::{insert_usage_events, NewUsageEvent};
+
+  fn event<'a>(
+    session_id: &'a str,
+    model_id: &str,
+    total_tokens: i64,
+  ) -> NewUsageEvent<'a> {
+    NewUsageEvent {
+      session_id,
+      model_id: model_id.to_string(),
+      input_tokens: total_tokens,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens,
+      value_usd: 0.0,
+      fast_mode_auto: false,
+      fast_mode_effective: false,
+    }
+  }
+
+  #[test]
+  fn new_usage_event_writes_timestamp_ms() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T10:00:00+08:00"];
+
+    insert_usage_events(
+      &conn,
+      timestamps.iter().copied(),
+      |_| Some(event("session-1", "gpt-5.4", 10)),
+    )
+    .expect("insert usage event");
+
+    let persisted = conn
+      .query_row(
+        "SELECT timestamp, timestamp_ms FROM usage_events",
+        [],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+      )
+      .expect("load usage event");
+    assert_eq!(persisted.0, timestamps[0]);
+    assert_eq!(
+      persisted.1,
+      parse_epoch_millis(timestamps[0]).expect("parse expected timestamp")
+    );
+  }
+
+  #[test]
+  fn usage_event_batch_parses_mixed_offsets_by_instant() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T10:00:00+08:00", "2026-07-10T02:00:01Z"];
+
+    insert_usage_events(
+      &conn,
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("insert usage events");
+
+    let epochs = conn
+      .prepare("SELECT timestamp_ms FROM usage_events ORDER BY id")
+      .expect("prepare epoch query")
+      .query_map([], |row| row.get::<_, i64>(0))
+      .expect("query epochs")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect epochs");
+    assert_eq!(epochs.len(), 2);
+    assert_eq!(epochs[1] - epochs[0], 1_000);
+  }
+
+  #[test]
+  fn malformed_new_usage_batch_writes_nothing() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T02:00:00Z", "not-an-rfc3339-timestamp"];
+
+    let result = insert_usage_events(
+      &conn,
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    );
+
+    assert!(result.is_err());
+    let count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0))
+      .expect("count usage events");
+    assert_eq!(count, 0);
+  }
+}

--- a/src-tauri/src/database/usage_events.rs
+++ b/src-tauri/src/database/usage_events.rs
@@ -114,6 +114,29 @@ where
   }
 }
 
+pub fn append_session_usage_events<'a, Timestamps, EventAt>(
+  conn: &Connection,
+  session_id: &str,
+  timestamps: Timestamps,
+  mut event_at: EventAt,
+) -> rusqlite::Result<UsageEventWriteStats>
+where
+  Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
+  EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
+{
+  let mut prepared = prepare_usage_events(timestamps, &mut event_at)?;
+  for event in &mut prepared {
+    event.session_id = session_id.to_string();
+  }
+  let inserted = insert_prepared_usage_events(conn, &prepared)?;
+  Ok(UsageEventWriteStats {
+    observed: prepared.len(),
+    inserted,
+    deleted: 0,
+    rebuilt: false,
+  })
+}
+
 fn prepare_usage_events<'a, Timestamps, EventAt>(
   timestamps: Timestamps,
   event_at: &mut EventAt,

--- a/src-tauri/src/database/usage_events.rs
+++ b/src-tauri/src/database/usage_events.rs
@@ -17,6 +17,31 @@ pub struct NewUsageEvent<'a> {
   pub fast_mode_effective: bool,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct PreparedUsageEvent {
+  session_id: String,
+  timestamp: String,
+  timestamp_ms: i64,
+  model_id: String,
+  input_tokens: i64,
+  cached_input_tokens: i64,
+  output_tokens: i64,
+  reasoning_output_tokens: i64,
+  total_tokens: i64,
+  value_usd: f64,
+  fast_mode_auto: bool,
+  fast_mode_effective: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct UsageEventWriteStats {
+  pub observed: usize,
+  pub inserted: usize,
+  pub deleted: usize,
+  pub rebuilt: bool,
+}
+
+#[cfg(test)]
 pub fn insert_usage_events<'a, Timestamps, EventAt>(
   conn: &Connection,
   timestamps: Timestamps,
@@ -26,7 +51,78 @@ where
   Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
   EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
 {
-  let mut timestamp_epochs = Vec::with_capacity(timestamps.len());
+  let prepared = prepare_usage_events(timestamps, &mut event_at)?;
+  insert_prepared_usage_events(conn, &prepared)
+}
+
+pub fn replace_session_usage_events<'a, Timestamps, EventAt>(
+  conn: &Connection,
+  session_id: &str,
+  timestamps: Timestamps,
+  mut event_at: EventAt,
+) -> rusqlite::Result<UsageEventWriteStats>
+where
+  Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
+  EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
+{
+  let mut desired = prepare_usage_events(timestamps, &mut event_at)?;
+  for event in &mut desired {
+    event.session_id = session_id.to_string();
+  }
+  let existing = load_session_usage_events(conn, session_id)?;
+  let matching_prefix = existing
+    .iter()
+    .zip(&desired)
+    .take_while(|(left, right)| left == right)
+    .count();
+
+  conn.execute_batch("SAVEPOINT codex_pacer_usage_event_write")?;
+  let result = if matching_prefix == existing.len() {
+    insert_prepared_usage_events(conn, &desired[matching_prefix..]).map(|inserted| {
+      UsageEventWriteStats {
+        observed: desired.len(),
+        inserted,
+        deleted: 0,
+        rebuilt: false,
+      }
+    })
+  } else {
+    conn.execute(
+      "DELETE FROM usage_events WHERE session_id = ?1",
+      params![session_id],
+    )
+    .and_then(|deleted| {
+      insert_prepared_usage_events(conn, &desired).map(|inserted| UsageEventWriteStats {
+        observed: desired.len(),
+        inserted,
+        deleted,
+        rebuilt: true,
+      })
+    })
+  };
+  match result {
+    Ok(stats) => {
+      conn.execute_batch("RELEASE SAVEPOINT codex_pacer_usage_event_write")?;
+      Ok(stats)
+    }
+    Err(error) => {
+      let _ = conn.execute_batch(
+        "ROLLBACK TO SAVEPOINT codex_pacer_usage_event_write; RELEASE SAVEPOINT codex_pacer_usage_event_write",
+      );
+      Err(error)
+    }
+  }
+}
+
+fn prepare_usage_events<'a, Timestamps, EventAt>(
+  timestamps: Timestamps,
+  event_at: &mut EventAt,
+) -> rusqlite::Result<Vec<PreparedUsageEvent>>
+where
+  Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
+  EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
+{
+  let mut parsed_timestamps = Vec::with_capacity(timestamps.len());
   for timestamp in timestamps.clone() {
     let timestamp_ms = parse_epoch_millis(timestamp).map_err(|error| {
       rusqlite::Error::ToSqlConversionFailure(Box::new(IoError::new(
@@ -34,7 +130,38 @@ where
         format!("Invalid usage event timestamp {timestamp:?}: {error}"),
       )))
     })?;
-    timestamp_epochs.push(timestamp_ms);
+    parsed_timestamps.push((timestamp.to_string(), timestamp_ms));
+  }
+
+  let mut prepared = Vec::with_capacity(parsed_timestamps.len());
+  for (index, (timestamp, timestamp_ms)) in parsed_timestamps.into_iter().enumerate() {
+    let Some(event) = event_at(index) else {
+      continue;
+    };
+    prepared.push(PreparedUsageEvent {
+      session_id: event.session_id.to_string(),
+      timestamp,
+      timestamp_ms,
+      model_id: event.model_id,
+      input_tokens: event.input_tokens,
+      cached_input_tokens: event.cached_input_tokens,
+      output_tokens: event.output_tokens,
+      reasoning_output_tokens: event.reasoning_output_tokens,
+      total_tokens: event.total_tokens,
+      value_usd: event.value_usd,
+      fast_mode_auto: event.fast_mode_auto,
+      fast_mode_effective: event.fast_mode_effective,
+    });
+  }
+  Ok(prepared)
+}
+
+fn insert_prepared_usage_events(
+  conn: &Connection,
+  events: &[PreparedUsageEvent],
+) -> rusqlite::Result<usize> {
+  if events.is_empty() {
+    return Ok(0);
   }
 
   let mut statement = conn.prepare(
@@ -49,14 +176,11 @@ where
   )?;
 
   let mut inserted = 0usize;
-  for (index, (timestamp, timestamp_ms)) in timestamps.zip(timestamp_epochs).enumerate() {
-    let Some(event) = event_at(index) else {
-      continue;
-    };
+  for event in events {
     statement.execute(params![
       event.session_id,
-      timestamp,
-      timestamp_ms,
+      event.timestamp,
+      event.timestamp_ms,
       event.model_id,
       event.input_tokens,
       event.cached_input_tokens,
@@ -73,13 +197,46 @@ where
   Ok(inserted)
 }
 
+fn load_session_usage_events(
+  conn: &Connection,
+  session_id: &str,
+) -> rusqlite::Result<Vec<PreparedUsageEvent>> {
+  let mut statement = conn.prepare(
+    "
+    SELECT session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE session_id = ?1
+    ORDER BY id
+    ",
+  )?;
+  let rows = statement.query_map(params![session_id], |row| {
+    Ok(PreparedUsageEvent {
+      session_id: row.get(0)?,
+      timestamp: row.get(1)?,
+      timestamp_ms: row.get::<_, Option<i64>>(2)?.unwrap_or(i64::MIN),
+      model_id: row.get(3)?,
+      input_tokens: row.get(4)?,
+      cached_input_tokens: row.get(5)?,
+      output_tokens: row.get(6)?,
+      reasoning_output_tokens: row.get(7)?,
+      total_tokens: row.get(8)?,
+      value_usd: row.get(9)?,
+      fast_mode_auto: row.get::<_, i64>(10)? != 0,
+      fast_mode_effective: row.get::<_, i64>(11)? != 0,
+    })
+  })?;
+  rows.collect()
+}
+
 #[cfg(test)]
 mod tests {
   use rusqlite::Connection;
 
   use crate::database::{init_db, parse_epoch_millis};
 
-  use super::{insert_usage_events, NewUsageEvent};
+  use super::{insert_usage_events, replace_session_usage_events, NewUsageEvent};
 
   fn event<'a>(
     session_id: &'a str,
@@ -168,5 +325,129 @@ mod tests {
       .query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0))
       .expect("count usage events");
     assert_eq!(count, 0);
+  }
+
+  #[test]
+  fn repeated_session_usage_replace_writes_nothing_and_preserves_ids() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T02:00:00Z", "2026-07-10T02:01:00Z"];
+    replace_session_usage_events(
+      &conn,
+      "session-1",
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("insert initial usage");
+    let ids_before = usage_ids(&conn, "session-1");
+    let changes_before = conn.total_changes();
+
+    let stats = replace_session_usage_events(
+      &conn,
+      "session-1",
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("repeat usage");
+
+    assert_eq!(stats.inserted, 0);
+    assert_eq!(stats.deleted, 0);
+    assert!(!stats.rebuilt);
+    assert_eq!(usage_ids(&conn, "session-1"), ids_before);
+    assert_eq!(conn.total_changes(), changes_before);
+  }
+
+  #[test]
+  fn appended_session_usage_preserves_prefix_ids() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let initial = ["2026-07-10T02:00:00Z", "2026-07-10T02:01:00Z"];
+    replace_session_usage_events(&conn, "session-1", initial.iter().copied(), |index| {
+      Some(event("session-1", "gpt-5.4", index as i64 + 1))
+    })
+    .expect("insert initial usage");
+    let ids_before = usage_ids(&conn, "session-1");
+    let appended = [
+      "2026-07-10T02:00:00Z",
+      "2026-07-10T02:01:00Z",
+      "2026-07-10T02:02:00Z",
+    ];
+
+    let stats = replace_session_usage_events(
+      &conn,
+      "session-1",
+      appended.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("append usage");
+    let ids_after = usage_ids(&conn, "session-1");
+
+    assert_eq!(stats.inserted, 1);
+    assert_eq!(stats.deleted, 0);
+    assert!(!stats.rebuilt);
+    assert_eq!(&ids_after[..ids_before.len()], ids_before.as_slice());
+    assert_eq!(ids_after.len(), 3);
+  }
+
+  #[test]
+  fn changed_session_usage_prefix_rebuilds_safely() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T02:00:00Z", "2026-07-10T02:01:00Z"];
+    replace_session_usage_events(
+      &conn,
+      "session-1",
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("insert initial usage");
+    let ids_before = usage_ids(&conn, "session-1");
+
+    let stats = replace_session_usage_events(
+      &conn,
+      "session-1",
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 10)),
+    )
+    .expect("rebuild changed usage");
+    let ids_after = usage_ids(&conn, "session-1");
+
+    assert_eq!(stats.inserted, 2);
+    assert_eq!(stats.deleted, 2);
+    assert!(stats.rebuilt);
+    assert_ne!(ids_after, ids_before);
+  }
+
+  #[test]
+  fn malformed_session_usage_replace_preserves_existing_rows() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let initial = ["2026-07-10T02:00:00Z"];
+    replace_session_usage_events(&conn, "session-1", initial.iter().copied(), |_| {
+      Some(event("session-1", "gpt-5.4", 1))
+    })
+    .expect("insert initial usage");
+    let ids_before = usage_ids(&conn, "session-1");
+    let malformed = ["2026-07-10T02:00:00Z", "invalid-timestamp"];
+
+    let result = replace_session_usage_events(
+      &conn,
+      "session-1",
+      malformed.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    );
+
+    assert!(result.is_err());
+    assert_eq!(usage_ids(&conn, "session-1"), ids_before);
+  }
+
+  fn usage_ids(conn: &Connection, session_id: &str) -> Vec<i64> {
+    conn
+      .prepare("SELECT id FROM usage_events WHERE session_id = ?1 ORDER BY id")
+      .expect("prepare usage ids")
+      .query_map([session_id], |row| row.get(0))
+      .expect("query usage ids")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect usage ids")
   }
 }

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -11,7 +11,6 @@ use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
-use tempfile::NamedTempFile;
 use walkdir::WalkDir;
 
 use crate::database::{
@@ -24,7 +23,7 @@ use crate::pricing::{
   calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing, seed_pricing_catalog,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 struct SessionFile {
   path: PathBuf,
   bucket: String,
@@ -158,14 +157,6 @@ impl PreparedScan {
   }
 
   #[cfg(test)]
-  fn spool_path(&self) -> Option<&Path> {
-    match &self.storage {
-      PreparedStorage::Memory(_) => None,
-      PreparedStorage::Spool { file, .. } => Some(file.path()),
-    }
-  }
-
-  #[cfg(test)]
   fn parent_replay_cache_evictions(&self) -> usize {
     self.stats.parent_replay_cache_evictions
   }
@@ -227,7 +218,7 @@ struct ExistingSessionSource {
 }
 
 struct PreparedSession {
-  session_file: SessionFile,
+  session_file: PreparedSessionFile,
   parsed: ParsedSession,
   file_needs_rate_limit_repair: bool,
   file_needs_token_v2_repair: bool,
@@ -235,6 +226,25 @@ struct PreparedSession {
   replay_parent_unavailable: bool,
   related_pending_token_v2_paths: Vec<String>,
   related_pending_fork_replay_v3_paths: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PreparedSessionFile {
+  source_path: String,
+  bucket: String,
+  file_size: i64,
+  file_mtime_ms: i64,
+}
+
+impl From<SessionFile> for PreparedSessionFile {
+  fn from(session_file: SessionFile) -> Self {
+    Self {
+      source_path: session_file.path.to_string_lossy().into_owned(),
+      bucket: session_file.bucket,
+      file_size: session_file.file_size,
+      file_mtime_ms: session_file.file_mtime_ms,
+    }
+  }
 }
 
 struct PreparedParseFailure {
@@ -258,7 +268,7 @@ struct MissingSessionPlan {
 
 enum PreparedStorage {
   Memory(Vec<PreparedSession>),
-  Spool { file: NamedTempFile, records: usize },
+  Spool { file: File, records: usize },
 }
 
 enum PreparedStorageBuilder {
@@ -268,14 +278,13 @@ enum PreparedStorageBuilder {
   },
   Spool {
     writer: BufWriter<File>,
-    file: NamedTempFile,
     records: usize,
   },
 }
 
 #[derive(Serialize, Deserialize)]
 struct SpoolPreparedSession {
-  session_file: SessionFile,
+  session_file: PreparedSessionFile,
   raw_session: RawSession,
   snapshots: SpoolUsageSnapshots,
   rate_limit_samples: Vec<RateLimitSampleRecord>,
@@ -473,45 +482,50 @@ impl PreparedSession {
   fn estimated_bytes(&self) -> usize {
     let raw = &self.parsed.raw_session;
     let mut bytes = std::mem::size_of::<Self>()
-      .saturating_add(self.session_file.path.to_string_lossy().len())
-      .saturating_add(self.session_file.bucket.len())
-      .saturating_add(raw.session_id.len())
-      .saturating_add(option_string_len(&raw.parent_session_id))
-      .saturating_add(raw.root_session_id.len())
-      .saturating_add(option_string_len(&raw.title))
-      .saturating_add(raw.source_state.len())
-      .saturating_add(option_string_len(&raw.source_path))
-      .saturating_add(option_string_len(&raw.started_at))
-      .saturating_add(option_string_len(&raw.updated_at))
-      .saturating_add(option_string_len(&raw.agent_nickname))
-      .saturating_add(option_string_len(&raw.agent_role))
-      .saturating_add(raw.model_ids.iter().map(String::len).sum::<usize>())
+      .saturating_add(self.session_file.source_path.capacity())
+      .saturating_add(self.session_file.bucket.capacity())
+      .saturating_add(raw.session_id.capacity())
+      .saturating_add(option_string_capacity(&raw.parent_session_id))
+      .saturating_add(raw.root_session_id.capacity())
+      .saturating_add(option_string_capacity(&raw.title))
+      .saturating_add(raw.source_state.capacity())
+      .saturating_add(option_string_capacity(&raw.source_path))
+      .saturating_add(option_string_capacity(&raw.started_at))
+      .saturating_add(option_string_capacity(&raw.updated_at))
+      .saturating_add(option_string_capacity(&raw.agent_nickname))
+      .saturating_add(option_string_capacity(&raw.agent_role))
+      .saturating_add(estimated_string_vec_bytes(&raw.model_ids))
       .saturating_add(estimated_usage_snapshots_bytes(&self.parsed.snapshots))
-      .saturating_add(option_string_len(&self.parsed.explicit_forked_from_id))
-      .saturating_add(option_string_len(&self.parsed.latest_plan_type))
-      .saturating_add(option_string_len(&self.parsed.last_model_id));
+      .saturating_add(option_string_capacity(&self.parsed.explicit_forked_from_id))
+      .saturating_add(option_string_capacity(&self.parsed.latest_plan_type))
+      .saturating_add(option_string_capacity(&self.parsed.last_model_id))
+      .saturating_add(
+        self
+          .parsed
+          .rate_limit_samples
+          .capacity()
+          .saturating_mul(std::mem::size_of::<RateLimitSampleRecord>()),
+      );
 
     for sample in &self.parsed.rate_limit_samples {
       bytes = bytes
-        .saturating_add(std::mem::size_of::<RateLimitSampleRecord>())
-        .saturating_add(sample.source_kind.len())
-        .saturating_add(option_string_len(&sample.source_session_id))
-        .saturating_add(sample.bucket.len())
-        .saturating_add(sample.sample_timestamp.len())
-        .saturating_add(option_string_len(&sample.limit_id))
-        .saturating_add(option_string_len(&sample.limit_name))
-        .saturating_add(option_string_len(&sample.plan_type))
-        .saturating_add(sample.window_start.len())
-        .saturating_add(sample.resets_at.len());
-    }
-    for path in self
-      .related_pending_token_v2_paths
-      .iter()
-      .chain(&self.related_pending_fork_replay_v3_paths)
-    {
-      bytes = bytes.saturating_add(path.len());
+        .saturating_add(sample.source_kind.capacity())
+        .saturating_add(option_string_capacity(&sample.source_session_id))
+        .saturating_add(sample.bucket.capacity())
+        .saturating_add(sample.sample_timestamp.capacity())
+        .saturating_add(option_string_capacity(&sample.limit_id))
+        .saturating_add(option_string_capacity(&sample.limit_name))
+        .saturating_add(option_string_capacity(&sample.plan_type))
+        .saturating_add(sample.window_start.capacity())
+        .saturating_add(sample.resets_at.capacity());
     }
     bytes
+      .saturating_add(estimated_string_vec_bytes(
+        &self.related_pending_token_v2_paths,
+      ))
+      .saturating_add(estimated_string_vec_bytes(
+        &self.related_pending_fork_replay_v3_paths,
+      ))
   }
 }
 
@@ -537,49 +551,44 @@ impl PreparedStorageBuilder {
         mut entries,
         estimated_bytes,
       } => {
-        let next_bytes = estimated_bytes.saturating_add(entry.estimated_bytes());
-        if next_bytes <= PREPARED_SPOOL_THRESHOLD_BYTES {
-          entries.push(entry);
+        let previous_spare_bytes = entries
+          .capacity()
+          .saturating_sub(entries.len())
+          .saturating_mul(std::mem::size_of::<PreparedSession>());
+        let entries_bytes = estimated_bytes.saturating_sub(previous_spare_bytes);
+        let entry_bytes = entry.estimated_bytes();
+        entries.push(entry);
+        let next_spare_bytes = entries
+          .capacity()
+          .saturating_sub(entries.len())
+          .saturating_mul(std::mem::size_of::<PreparedSession>());
+        let next_bytes = entries_bytes
+          .saturating_add(entry_bytes)
+          .saturating_add(next_spare_bytes);
+        if entries.len() == 1 || next_bytes <= PREPARED_SPOOL_THRESHOLD_BYTES {
           Self::Memory {
             entries,
             estimated_bytes: next_bytes,
           }
         } else {
-          let file = tempfile::Builder::new()
-            .prefix("codex-pacer-prepared-")
-            .suffix(".jsons")
-            .tempfile()
+          let file = tempfile::tempfile()
             .map_err(|error| format!("Failed to create prepared scan spool: {error}"))?;
-          let writer_file = file
-            .reopen()
-            .map_err(|error| format!("Failed to open prepared scan spool: {error}"))?;
-          let mut writer = BufWriter::new(writer_file);
+          let mut writer = BufWriter::new(file);
           let mut records = 0usize;
           for buffered in entries {
             write_spool_record(&mut writer, buffered)?;
             records += 1;
           }
-          write_spool_record(&mut writer, entry)?;
-          records += 1;
-          Self::Spool {
-            file,
-            writer,
-            records,
-          }
+          Self::Spool { writer, records }
         }
       }
       Self::Spool {
-        file,
         mut writer,
         mut records,
       } => {
         write_spool_record(&mut writer, entry)?;
         records += 1;
-        Self::Spool {
-          file,
-          writer,
-          records,
-        }
+        Self::Spool { writer, records }
       }
     };
     Ok(())
@@ -589,14 +598,15 @@ impl PreparedStorageBuilder {
     match self {
       Self::Memory { entries, .. } => Ok(PreparedStorage::Memory(entries)),
       Self::Spool {
-        file,
         mut writer,
         records,
       } => {
         writer
           .flush()
           .map_err(|error| format!("Failed to flush prepared scan spool: {error}"))?;
-        drop(writer);
+        let file = writer
+          .into_inner()
+          .map_err(|error| format!("Failed to finish prepared scan spool: {}", error.error()))?;
         Ok(PreparedStorage::Spool { file, records })
       }
     }
@@ -628,12 +638,17 @@ impl ParentReplayCache {
   }
 
   fn insert(&mut self, session_id: String, snapshots: Option<Vec<UsageSnapshot>>) {
-    let entry_bytes = session_id.len().saturating_add(
-      snapshots
-        .as_deref()
-        .map(estimated_usage_snapshots_bytes)
-        .unwrap_or(1),
-    );
+    let insertion_order_id = session_id.clone();
+    let entry_bytes = std::mem::size_of::<ParentReplayCacheEntry>()
+      .saturating_add(std::mem::size_of::<String>().saturating_mul(2))
+      .saturating_add(session_id.capacity())
+      .saturating_add(insertion_order_id.capacity())
+      .saturating_add(
+        snapshots
+          .as_ref()
+          .map(estimated_usage_snapshots_bytes)
+          .unwrap_or(1),
+      );
     if entry_bytes > PARENT_REPLAY_CACHE_MAX_BYTES {
       self.oversized_bypasses += 1;
       return;
@@ -652,7 +667,7 @@ impl ParentReplayCache {
     }
 
     self.estimated_bytes = self.estimated_bytes.saturating_add(entry_bytes);
-    self.insertion_order.push_back(session_id.clone());
+    self.insertion_order.push_back(insertion_order_id);
     self.entries.insert(
       session_id,
       ParentReplayCacheEntry {
@@ -671,20 +686,31 @@ impl ParentReplayCache {
   }
 }
 
-fn option_string_len(value: &Option<String>) -> usize {
-  value.as_ref().map(String::len).unwrap_or_default()
+fn option_string_capacity(value: &Option<String>) -> usize {
+  value.as_ref().map(String::capacity).unwrap_or_default()
 }
 
-fn estimated_usage_snapshots_bytes(snapshots: &[UsageSnapshot]) -> usize {
-  snapshots.iter().fold(0usize, |bytes, snapshot| {
-    bytes
-      .saturating_add(std::mem::size_of::<UsageSnapshot>())
-      .saturating_add(snapshot.timestamp.len())
-      .saturating_add(snapshot.model_id.len())
-      .saturating_add(option_string_len(&snapshot.plan_type))
-      .saturating_add(option_string_len(&snapshot.limit_id))
-      .saturating_add(option_string_len(&snapshot.limit_name))
-  })
+fn estimated_string_vec_bytes(values: &Vec<String>) -> usize {
+  values
+    .capacity()
+    .saturating_mul(std::mem::size_of::<String>())
+    .saturating_add(values.iter().fold(0usize, |bytes, value| {
+      bytes.saturating_add(value.capacity())
+    }))
+}
+
+fn estimated_usage_snapshots_bytes(snapshots: &Vec<UsageSnapshot>) -> usize {
+  snapshots
+    .capacity()
+    .saturating_mul(std::mem::size_of::<UsageSnapshot>())
+    .saturating_add(snapshots.iter().fold(0usize, |bytes, snapshot| {
+      bytes
+        .saturating_add(snapshot.timestamp.capacity())
+        .saturating_add(snapshot.model_id.capacity())
+        .saturating_add(option_string_capacity(&snapshot.plan_type))
+        .saturating_add(option_string_capacity(&snapshot.limit_id))
+        .saturating_add(option_string_capacity(&snapshot.limit_name))
+    }))
 }
 
 pub fn perform_scan(
@@ -935,7 +961,7 @@ pub(crate) fn prepare_scan(
     }
 
     storage.push(PreparedSession {
-      session_file,
+      session_file: session_file.into(),
       parsed,
       file_needs_rate_limit_repair,
       file_needs_token_v2_repair,
@@ -946,6 +972,12 @@ pub(crate) fn prepare_scan(
     })?;
     updated_sessions += 1;
   }
+
+  let titles = if effective_kind == ScanKind::Full {
+    titles
+  } else {
+    HashMap::new()
+  };
 
   let parent_replay_cache_evictions = parent_snapshot_cache.evictions();
   let parent_replay_cache_oversized_bypasses = parent_snapshot_cache.oversized_bypasses();
@@ -1104,11 +1136,11 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
         commit_one_prepared_session(&tx, entry, &catalog).map_err(|error| error.to_string())?;
       }
     }
-    PreparedStorage::Spool { file, records } => {
-      let reader_file = file
-        .reopen()
-        .map_err(|error| format!("Failed to open prepared scan spool for commit: {error}"))?;
-      let reader = BufReader::new(reader_file);
+    PreparedStorage::Spool { mut file, records } => {
+      file
+        .seek(SeekFrom::Start(0))
+        .map_err(|error| format!("Failed to rewind prepared scan spool: {error}"))?;
+      let reader = BufReader::new(file);
       let mut stream =
         serde_json::Deserializer::from_reader(reader).into_iter::<SpoolPreparedSession>();
       let mut records_read = 0usize;
@@ -1120,9 +1152,6 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
         records_read += 1;
       }
       drop(stream);
-      file
-        .close()
-        .map_err(|error| format!("Failed to remove prepared scan spool: {error}"))?;
       if records_read != records {
         return Err(format!(
           "Prepared scan spool ended early: expected {records} records, read {records_read}."
@@ -1458,14 +1487,14 @@ fn commit_one_prepared_session(
     related_pending_token_v2_paths,
     related_pending_fork_replay_v3_paths,
   } = entry;
-  let source_path = session_file.path.to_string_lossy().to_string();
+  let source_path = &session_file.source_path;
 
   persist_session(conn, &session_file, &parsed, catalog)?;
   if file_needs_rate_limit_repair {
-    clear_pending_data_repair_file(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)?;
+    clear_pending_data_repair_file(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, source_path)?;
   }
   if file_needs_token_v2_repair {
-    clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)?;
+    clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, source_path)?;
     for related_source_path in related_pending_token_v2_paths {
       clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &related_source_path)?;
     }
@@ -1475,11 +1504,11 @@ fn commit_one_prepared_session(
       mark_data_repair_file_pending(
         conn,
         TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
-        &source_path,
+        source_path,
         "fork replay parent unavailable",
       )?;
     } else {
-      clear_pending_data_repair_file(conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)?;
+      clear_pending_data_repair_file(conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, source_path)?;
       for related_source_path in related_pending_fork_replay_v3_paths {
         clear_pending_data_repair_file(
           conn,
@@ -2538,7 +2567,7 @@ fn replayed_child_snapshot_cutoff(
 
 fn persist_session(
   conn: &Connection,
-  session_file: &SessionFile,
+  session_file: &PreparedSessionFile,
   parsed: &ParsedSession,
   catalog: &HashMap<String, crate::models::PricingCatalogEntry>,
 ) -> rusqlite::Result<()> {
@@ -2672,7 +2701,7 @@ fn persist_session(
       last_imported_at = excluded.last_imported_at
     ",
     params![
-      session_file.path.to_string_lossy().to_string(),
+      session_file.source_path,
       parsed.raw_session.session_id,
       session_file.bucket,
       session_file.file_size,
@@ -2686,10 +2715,7 @@ fn persist_session(
     DELETE FROM import_state
     WHERE session_id = ?1 AND source_path <> ?2
     ",
-    params![
-      parsed.raw_session.session_id,
-      session_file.path.to_string_lossy().to_string(),
-    ],
+    params![parsed.raw_session.session_id, session_file.source_path,],
   )?;
 
   Ok(())
@@ -3346,6 +3372,57 @@ mod tests {
     assert!(!right.last_completed_at.is_empty());
   }
 
+  #[cfg(unix)]
+  fn prepared_session_fixture(
+    source_path: PathBuf,
+    session_id: &str,
+    model_id_bytes: usize,
+  ) -> PreparedSession {
+    let model_id = "x".repeat(model_id_bytes.max(1));
+    let persisted_source_path = source_path.to_string_lossy().to_string();
+    PreparedSession {
+      session_file: PreparedSessionFile::from(SessionFile {
+        path: source_path,
+        bucket: "active".to_string(),
+        file_size: 1,
+        file_mtime_ms: 1,
+      }),
+      parsed: ParsedSession {
+        raw_session: RawSession {
+          session_id: session_id.to_string(),
+          root_session_id: session_id.to_string(),
+          source_state: "active".to_string(),
+          source_path: Some(persisted_source_path),
+          model_ids: vec![model_id.clone()],
+          ..Default::default()
+        },
+        snapshots: vec![UsageSnapshot {
+          timestamp: "2026-07-10T00:00:00Z".to_string(),
+          model_id,
+          usage: replay_usage((10, 0, 0, 0, 10)),
+          last_token_usage: Some(replay_usage((10, 0, 0, 0, 10))),
+          plan_type: None,
+          limit_id: None,
+          limit_name: None,
+          explicit_fast_mode: None,
+        }],
+        rate_limit_samples: Vec::new(),
+        explicit_forked_from_id: None,
+        explicit_fork_timestamp: None,
+        inherited_token_snapshot_cutoff: 0,
+        explicit_fast_mode: None,
+        latest_plan_type: None,
+        last_model_id: None,
+      },
+      file_needs_rate_limit_repair: false,
+      file_needs_token_v2_repair: false,
+      file_needs_fork_replay_v3_repair: false,
+      replay_parent_unavailable: false,
+      related_pending_token_v2_paths: Vec::new(),
+      related_pending_fork_replay_v3_paths: Vec::new(),
+    }
+  }
+
   #[test]
   fn prepare_scan_is_read_only() {
     let directory = tempdir().expect("tempdir");
@@ -3746,35 +3823,117 @@ mod tests {
     .expect("prepare incremental scan");
 
     assert!(!prepared.uses_spool());
-    assert!(prepared.spool_path().is_none());
   }
 
   #[test]
-  fn large_prepare_spills_and_drop_removes_spool() {
+  fn incremental_prepare_drops_full_title_index_after_parsing() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "67676767-6767-6767-6767-676767676767";
+    let session_path = sessions.join("title-update.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+
+    let mut title_index =
+      format!("{{\"id\":\"{session_id}\",\"thread_name\":\"Incremental title\"}}\n");
+    for index in 0..2_000 {
+      title_index.push_str(&format!(
+        "{{\"id\":\"unrelated-{index}\",\"thread_name\":\"Unused title {index}\"}}\n"
+      ));
+    }
+    std::fs::write(codex_home.join("session_index.jsonl"), title_index).expect("write title index");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental title update");
+
+    assert_eq!(prepared.effective_kind, ScanKind::Incremental);
+    assert!(prepared.titles.is_empty());
+    assert_eq!(prepared.titles.capacity(), 0);
+    let parsed_title = match &prepared.storage {
+      PreparedStorage::Memory(entries) => entries[0].parsed.raw_session.title.as_deref(),
+      PreparedStorage::Spool { .. } => panic!("small title update should stay in memory"),
+    };
+    assert_eq!(parsed_title, Some("Incremental title"));
+    commit_prepared_scan(prepared).expect("commit incremental title update");
+    let conn = open_connection(&db_path).expect("open database");
+    let title: String = conn
+      .query_row(
+        "SELECT title FROM sessions WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+      )
+      .expect("load updated title");
+    assert_eq!(title, "Incremental title");
+  }
+
+  #[test]
+  fn single_large_incremental_stays_in_memory() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions = codex_home.join("sessions");
     std::fs::create_dir_all(&sessions).expect("sessions");
     let session_id = "70707070-7070-7070-7070-707070707070";
-    let mut body = format!(
-      concat!(
-        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
-        "\"payload\":{{\"id\":\"{}\"}}}}\n",
-        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
-        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
-      ),
-      session_id
+    let session_path = sessions.join("large.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
     );
-    let mut total_tokens = 0i64;
-    while body.len() <= PREPARED_SPOOL_THRESHOLD_BYTES * 4 {
-      total_tokens += 10;
-      body.push_str(&token_count_line(TokenFixture {
-        timestamp: "2026-07-10T00:00:02Z",
-        total: (total_tokens, 0, 0, total_tokens),
-        last: (10, 0, 0, 10),
-      }));
-    }
-    std::fs::write(sessions.join("large.jsonl"), body).expect("write large session");
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+    write_large_session_file(
+      &session_path,
+      session_id,
+      PREPARED_SPOOL_THRESHOLD_BYTES * 4,
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare large scan");
+
+    assert!(!prepared.uses_spool());
+    assert!(!prepared.stats().used_spool);
+    assert_eq!(prepared.updated_sessions, 1);
+  }
+
+  #[test]
+  fn multiple_changed_sessions_spill() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    write_large_session_file(
+      &sessions.join("a-large.jsonl"),
+      "74747474-7474-7474-7474-747474747474",
+      PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+    );
+    write_session_file(
+      &sessions.join("z-second.jsonl"),
+      "75757575-7575-7575-7575-757575757575",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     let db_path = directory.path().join("usage.sqlite");
     initialize_scan_database(&db_path);
 
@@ -3783,13 +3942,129 @@ mod tests {
       Some(codex_home.to_string_lossy().to_string()),
       ScanKind::Full,
     )
-    .expect("prepare large scan");
+    .expect("prepare multiple changed sessions");
 
     assert!(prepared.uses_spool());
-    let spool_path = prepared.spool_path().expect("spool path").to_path_buf();
-    assert!(spool_path.is_file());
-    drop(prepared);
-    assert!(!spool_path.exists());
+    assert!(prepared.stats().used_spool);
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn spool_file_is_anonymous_and_unlinked() {
+    use std::os::unix::fs::MetadataExt;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    write_large_session_file(
+      &sessions.join("a-large.jsonl"),
+      "76767676-7676-7676-7676-767676767676",
+      PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+    );
+    write_session_file(
+      &sessions.join("z-second.jsonl"),
+      "77777777-7777-7777-7777-777777777777",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare anonymous spool");
+    let link_count = match &prepared.storage {
+      PreparedStorage::Memory(_) => panic!("expected spool storage"),
+      PreparedStorage::Spool { file, .. } => file.metadata().expect("spool metadata").nlink(),
+    };
+
+    assert_eq!(link_count, 0, "spool must have no directory entry");
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn non_utf8_session_path_matches_memory_and_spool_round_trip() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let session_id = "78787878-7878-7878-7878-787878787878";
+    let non_utf8_path = PathBuf::from(std::ffi::OsString::from_vec(
+      b"/synthetic/00-non-utf8-\x80.jsonl".to_vec(),
+    ));
+    let expected_path = non_utf8_path.to_string_lossy().to_string();
+    let mut memory_builder = PreparedStorageBuilder::new();
+    memory_builder
+      .push(prepared_session_fixture(
+        non_utf8_path.clone(),
+        session_id,
+        1,
+      ))
+      .expect("keep non-UTF-8 entry in memory");
+    let memory_storage = memory_builder.finish().expect("finish memory storage");
+    assert!(matches!(&memory_storage, PreparedStorage::Memory(_)));
+
+    let mut spool_builder = PreparedStorageBuilder::new();
+    spool_builder
+      .push(prepared_session_fixture(non_utf8_path, session_id, 1))
+      .expect("buffer non-UTF-8 entry");
+    spool_builder
+      .push(prepared_session_fixture(
+        PathBuf::from("/synthetic/zz-large.jsonl"),
+        "79797979-7979-7979-7979-797979797979",
+        PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+      ))
+      .expect("spill entries without serializing PathBuf directly");
+    let spool_storage = spool_builder.finish().expect("finish spool storage");
+    assert!(matches!(
+      &spool_storage,
+      PreparedStorage::Spool { records: 2, .. }
+    ));
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("Codex home");
+    let persist_and_load = |db_path: &Path, storage: PreparedStorage| {
+      initialize_scan_database(db_path);
+      let mut prepared = prepare_scan(
+        db_path,
+        Some(codex_home.to_string_lossy().to_string()),
+        ScanKind::Full,
+      )
+      .expect("prepare empty scan shell");
+      prepared.storage = storage;
+      prepared.imported_sessions = 1;
+      prepared.updated_sessions = 1;
+      commit_prepared_scan(prepared).expect("commit synthetic prepared scan");
+      let conn = open_connection(db_path).expect("open committed database");
+      conn
+        .query_row(
+          "
+          SELECT sessions.source_path, import_state.source_path,
+                 COALESCE(SUM(usage_events.total_tokens), 0)
+          FROM sessions
+          JOIN import_state USING (session_id)
+          LEFT JOIN usage_events USING (session_id)
+          WHERE sessions.session_id = ?1
+          GROUP BY sessions.source_path, import_state.source_path
+          ",
+          params![session_id],
+          |row| {
+            Ok((
+              row.get::<_, String>(0)?,
+              row.get::<_, String>(1)?,
+              row.get::<_, i64>(2)?,
+            ))
+          },
+        )
+        .expect("load persisted prepared entry")
+    };
+
+    let memory_result = persist_and_load(&directory.path().join("memory.sqlite"), memory_storage);
+    let spool_result = persist_and_load(&directory.path().join("spool.sqlite"), spool_storage);
+    assert_eq!(spool_result, memory_result);
+    assert_eq!(memory_result, (expected_path.clone(), expected_path, 10));
   }
 
   #[test]
@@ -3838,7 +4113,7 @@ mod tests {
   }
 
   #[test]
-  fn spooled_commit_preserves_last_usage_and_removes_spool() {
+  fn spooled_commit_preserves_last_usage_with_anonymous_file() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions = codex_home.join("sessions");
@@ -3867,7 +4142,12 @@ mod tests {
       }));
       snapshots += 1;
     }
-    std::fs::write(sessions.join("spooled-fork.jsonl"), body).expect("write fork session");
+    std::fs::write(sessions.join("a-spooled-fork.jsonl"), body).expect("write fork session");
+    write_session_file(
+      &sessions.join("z-spool-filler.jsonl"),
+      "72727272-7272-7272-7272-727272727273",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     let db_path = directory.path().join("usage.sqlite");
     initialize_scan_database(&db_path);
 
@@ -3878,13 +4158,33 @@ mod tests {
     )
     .expect("prepare spooled fork");
     assert!(prepared.stats().used_spool);
-    let spool_path = prepared.spool_path().expect("spool path").to_path_buf();
 
     commit_prepared_scan(prepared).expect("commit spooled fork");
 
-    assert!(!spool_path.exists());
     let conn = open_connection(&db_path).expect("open database");
     assert_eq!(session_usage_totals(&conn, session_id).3, snapshots * 10);
+  }
+
+  #[test]
+  fn prepared_estimates_include_reserved_vec_and_string_capacity() {
+    let mut model_id = String::with_capacity(4 * 1024);
+    model_id.push('x');
+    let mut snapshots = Vec::with_capacity(64);
+    snapshots.push(UsageSnapshot {
+      timestamp: "2026-07-10T00:00:00Z".to_string(),
+      model_id,
+      usage: replay_usage((10, 0, 0, 0, 10)),
+      last_token_usage: Some(replay_usage((10, 0, 0, 0, 10))),
+      plan_type: None,
+      limit_id: None,
+      limit_name: None,
+      explicit_fast_mode: None,
+    });
+
+    let estimate = estimated_usage_snapshots_bytes(&snapshots);
+
+    assert!(estimate >= snapshots.capacity() * std::mem::size_of::<UsageSnapshot>());
+    assert!(estimate >= snapshots[0].model_id.capacity());
   }
 
   #[test]
@@ -3935,6 +4235,40 @@ mod tests {
     assert_eq!(cache.evictions(), 0);
     assert_eq!(cache.oversized_bypasses(), 1);
     assert!(cache.get("oversized-parent").is_none());
+  }
+
+  #[test]
+  fn parent_replay_cache_counts_reserved_capacity_toward_its_limit() {
+    let mut reserved_key = String::with_capacity(PARENT_REPLAY_CACHE_MAX_BYTES + 1);
+    reserved_key.push('p');
+    let mut key_cache = ParentReplayCache::new();
+
+    key_cache.insert(reserved_key, None);
+
+    assert_eq!(key_cache.evictions(), 0);
+    assert_eq!(key_cache.oversized_bypasses(), 1);
+    assert!(key_cache.get("p").is_none());
+    assert!(key_cache.estimated_bytes <= PARENT_REPLAY_CACHE_MAX_BYTES);
+
+    let snapshot_capacity = PARENT_REPLAY_CACHE_MAX_BYTES
+      .checked_div(std::mem::size_of::<UsageSnapshot>())
+      .unwrap_or_default()
+      + 1;
+    let mut snapshots = Vec::with_capacity(snapshot_capacity);
+    snapshots.push(replay_snapshot(
+      "2026-07-10T00:00:00Z",
+      "gpt-5.6-sol",
+      (10, 0, 0, 10, 10),
+      Some((10, 0, 0, 10, 10)),
+    ));
+    let mut snapshot_cache = ParentReplayCache::new();
+
+    snapshot_cache.insert("reserved-snapshots".to_string(), Some(snapshots));
+
+    assert_eq!(snapshot_cache.evictions(), 0);
+    assert_eq!(snapshot_cache.oversized_bypasses(), 1);
+    assert!(snapshot_cache.get("reserved-snapshots").is_none());
+    assert!(snapshot_cache.estimated_bytes <= PARENT_REPLAY_CACHE_MAX_BYTES);
   }
 
   #[test]
@@ -7770,6 +8104,29 @@ mod tests {
       last_output,
       last_total,
     )
+  }
+
+  fn write_large_session_file(path: &Path, session_id: &str, minimum_bytes: usize) -> i64 {
+    let mut body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
+      ),
+      session_id
+    );
+    let mut total_tokens = 0i64;
+    while body.len() <= minimum_bytes {
+      total_tokens += 10;
+      body.push_str(&token_count_line(TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (total_tokens, 0, 0, total_tokens),
+        last: (10, 0, 0, 10),
+      }));
+    }
+    std::fs::write(path, body).expect("write large session");
+    total_tokens
   }
 
   fn write_session_file(path: &Path, session_id: &str, snapshots: &[(&str, i64, i64, i64, i64)]) {

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1,24 +1,30 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Timelike};
-use rusqlite::{params, Connection, OptionalExtension};
-use serde::Deserialize;
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, TransactionBehavior};
+use serde::de::{SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use tempfile::NamedTempFile;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, get_sync_settings, init_db, now_utc_string, open_connection,
-  replace_session_rate_limit_samples, set_last_scan_started_for_source, set_scan_completed_for_source,
+  bool_to_i64, init_db, now_utc_string, open_connection, preview_scan_freshness_for_source,
+  replace_session_rate_limit_samples, set_last_scan_started_for_source_in_transaction,
+  set_scan_completed_for_source,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
   calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing, seed_pricing_catalog,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct SessionFile {
   path: PathBuf,
   bucket: String,
@@ -64,40 +70,684 @@ enum TopologyMaintenance {
 }
 
 enum SessionParseError {
-  Fatal(String),
+  Fatal { message: String, bytes_read: u64 },
+}
+
+struct CountingReader<R> {
+  inner: R,
+  bytes_read: u64,
+}
+
+impl<R> CountingReader<R> {
+  fn new(inner: R) -> Self {
+    Self {
+      inner,
+      bytes_read: 0,
+    }
+  }
+}
+
+impl<R: Read> Read for CountingReader<R> {
+  fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+    let bytes_read = self.inner.read(buffer)?;
+    self.bytes_read = self.bytes_read.saturating_add(bytes_read as u64);
+    Ok(bytes_read)
+  }
 }
 
 const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
 const TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY: &str = "token_usage_fork_replay_v3";
 const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
+const PREPARED_SPOOL_THRESHOLD_BYTES: usize = 256 * 1024;
+const PARENT_REPLAY_CACHE_MAX_ENTRIES: usize = 4;
+const PARENT_REPLAY_CACHE_MAX_BYTES: usize = 256 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ScanScope {
+pub(crate) enum ScanKind {
   Full,
   Incremental,
 }
 
-pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
-  perform_scan_with_scope(db_path, codex_home_override, ScanScope::Full)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PreparedScanStats {
+  pub files_visited: usize,
+  pub source_bytes_read: u64,
+  pub full_rebuild: bool,
+  pub used_spool: bool,
+  pub parent_replay_cache_evictions: usize,
+  pub parent_replay_cache_oversized_bypasses: usize,
 }
 
-pub fn perform_incremental_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
-  perform_scan_with_scope(db_path, codex_home_override, ScanScope::Incremental)
+pub(crate) struct PreparedScan {
+  db_path: PathBuf,
+  source_identity: PreparedSourceIdentity,
+  scan_started_at: String,
+  track_scan_freshness: bool,
+  effective_kind: ScanKind,
+  freshness_full_scan_required: bool,
+  stats: PreparedScanStats,
+  imported_sessions: usize,
+  updated_sessions: usize,
+  skipped_session_files: bool,
+  storage: PreparedStorage,
+  parse_failures: Vec<PreparedParseFailure>,
+  titles: HashMap<String, String>,
+  missing_plan: MissingSourcePlan,
+  topology_dirty: bool,
+  topology_needs_repair: bool,
+  new_root_session_ids: Vec<String>,
+  needs_rate_limit_backfill: bool,
+  needs_token_usage_v2_repair_sweep: bool,
+  needs_fork_replay_v3_repair_sweep: bool,
 }
 
-fn perform_scan_with_scope(
+impl PreparedScan {
+  #[allow(dead_code)]
+  pub(crate) fn stats(&self) -> PreparedScanStats {
+    self.stats
+  }
+
+  #[allow(dead_code)]
+  pub(crate) fn source_key(&self) -> &PreparedScanSourceKey {
+    &self.source_identity.key
+  }
+
+  #[cfg(test)]
+  fn uses_spool(&self) -> bool {
+    matches!(self.storage, PreparedStorage::Spool { .. })
+  }
+
+  #[cfg(test)]
+  fn spool_path(&self) -> Option<&Path> {
+    match &self.storage {
+      PreparedStorage::Memory(_) => None,
+      PreparedStorage::Spool { file, .. } => Some(file.path()),
+    }
+  }
+
+  #[cfg(test)]
+  fn parent_replay_cache_evictions(&self) -> usize {
+    self.stats.parent_replay_cache_evictions
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedScanSourceKey {
+  selector: Option<String>,
+  resolved_home: PathBuf,
+}
+
+impl PreparedScanSourceKey {
+  #[allow(dead_code)]
+  pub(crate) fn selector(&self) -> Option<&str> {
+    self.selector.as_deref()
+  }
+
+  #[allow(dead_code)]
+  pub(crate) fn resolved_home(&self) -> &Path {
+    &self.resolved_home
+  }
+}
+
+struct PreparedSourceIdentity {
+  key: PreparedScanSourceKey,
+  scan_commit_revision: i64,
+  tracked_configured_home: Option<PathBuf>,
+  last_scan_codex_home: Option<String>,
+  last_scan_started_at: Option<String>,
+  last_scan_completed_at: Option<String>,
+  last_full_scan_completed_at: Option<String>,
+}
+
+struct PreparationDatabaseSnapshot {
+  scan_source_selector: Option<String>,
+  scan_commit_revision: i64,
+  last_scan_codex_home: Option<String>,
+  last_scan_started_at: Option<String>,
+  last_scan_completed_at: Option<String>,
+  last_full_scan_completed_at: Option<String>,
+  import_state: HashMap<String, ImportState>,
+  needs_rate_limit_backfill: bool,
+  pending_rate_limit_repair_paths: HashSet<String>,
+  needs_token_usage_v2_repair_sweep: bool,
+  pending_token_v2_repair_paths: HashSet<String>,
+  needs_fork_replay_v3_repair_sweep: bool,
+  pending_fork_replay_v3_repair_paths: HashSet<String>,
+  session_source_paths: HashMap<String, PathBuf>,
+  existing_relations: HashMap<String, ExistingSessionRelation>,
+  existing_session_sources: Vec<ExistingSessionSource>,
+  topology_needs_repair: bool,
+}
+
+struct ExistingSessionSource {
+  session_id: String,
+  source_path: String,
+  source_state: String,
+  source_bucket: Option<String>,
+}
+
+struct PreparedSession {
+  session_file: SessionFile,
+  parsed: ParsedSession,
+  file_needs_rate_limit_repair: bool,
+  file_needs_token_v2_repair: bool,
+  file_needs_fork_replay_v3_repair: bool,
+  replay_parent_unavailable: bool,
+  related_pending_token_v2_paths: Vec<String>,
+  related_pending_fork_replay_v3_paths: Vec<String>,
+}
+
+struct PreparedParseFailure {
+  source_path: String,
+  error: String,
+  mark_rate_limit_repair: bool,
+  mark_token_v2_repair: bool,
+  mark_fork_replay_v3_repair: bool,
+}
+
+#[derive(Default)]
+struct MissingSourcePlan {
+  sessions_to_mark_missing: Vec<MissingSessionPlan>,
+  import_state_paths_to_delete: Vec<String>,
+}
+
+struct MissingSessionPlan {
+  session_id: String,
+  expected_source_path: String,
+}
+
+enum PreparedStorage {
+  Memory(Vec<PreparedSession>),
+  Spool { file: NamedTempFile, records: usize },
+}
+
+enum PreparedStorageBuilder {
+  Memory {
+    entries: Vec<PreparedSession>,
+    estimated_bytes: usize,
+  },
+  Spool {
+    writer: BufWriter<File>,
+    file: NamedTempFile,
+    records: usize,
+  },
+}
+
+#[derive(Serialize, Deserialize)]
+struct SpoolPreparedSession {
+  session_file: SessionFile,
+  raw_session: RawSession,
+  snapshots: SpoolUsageSnapshots,
+  rate_limit_samples: Vec<RateLimitSampleRecord>,
+  explicit_forked_from_id: Option<String>,
+  explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
+  inherited_token_snapshot_cutoff: usize,
+  explicit_fast_mode: Option<bool>,
+  latest_plan_type: Option<String>,
+  last_model_id: Option<String>,
+  file_needs_rate_limit_repair: bool,
+  file_needs_token_v2_repair: bool,
+  file_needs_fork_replay_v3_repair: bool,
+  replay_parent_unavailable: bool,
+  related_pending_token_v2_paths: Vec<String>,
+  related_pending_fork_replay_v3_paths: Vec<String>,
+}
+
+struct SpoolUsageSnapshots(Vec<UsageSnapshot>);
+
+#[derive(Deserialize)]
+struct SpoolUsageSnapshot {
+  timestamp: String,
+  model_id: String,
+  usage: TokenUsage,
+  last_token_usage: Option<TokenUsage>,
+  plan_type: Option<String>,
+  limit_id: Option<String>,
+  limit_name: Option<String>,
+  explicit_fast_mode: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct SpoolUsageSnapshotRef<'a> {
+  timestamp: &'a str,
+  model_id: &'a str,
+  usage: &'a TokenUsage,
+  last_token_usage: Option<&'a TokenUsage>,
+  plan_type: Option<&'a str>,
+  limit_id: Option<&'a str>,
+  limit_name: Option<&'a str>,
+  explicit_fast_mode: Option<bool>,
+}
+
+struct ParentReplayCacheEntry {
+  snapshots: Option<Vec<UsageSnapshot>>,
+  estimated_bytes: usize,
+}
+
+struct ParentReplayCache {
+  entries: HashMap<String, ParentReplayCacheEntry>,
+  insertion_order: VecDeque<String>,
+  estimated_bytes: usize,
+  evictions: usize,
+  oversized_bypasses: usize,
+}
+
+impl Serialize for SpoolUsageSnapshots {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+    for snapshot in &self.0 {
+      sequence.serialize_element(&SpoolUsageSnapshotRef {
+        timestamp: &snapshot.timestamp,
+        model_id: &snapshot.model_id,
+        usage: &snapshot.usage,
+        last_token_usage: snapshot.last_token_usage.as_ref(),
+        plan_type: snapshot.plan_type.as_deref(),
+        limit_id: snapshot.limit_id.as_deref(),
+        limit_name: snapshot.limit_name.as_deref(),
+        explicit_fast_mode: snapshot.explicit_fast_mode,
+      })?;
+    }
+    sequence.end()
+  }
+}
+
+struct SpoolUsageSnapshotsVisitor;
+
+impl<'de> Visitor<'de> for SpoolUsageSnapshotsVisitor {
+  type Value = SpoolUsageSnapshots;
+
+  fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str("a sequence of prepared usage snapshots")
+  }
+
+  fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+  where
+    A: SeqAccess<'de>,
+  {
+    let mut snapshots = Vec::with_capacity(sequence.size_hint().unwrap_or_default());
+    while let Some(snapshot) = sequence.next_element::<SpoolUsageSnapshot>()? {
+      snapshots.push(snapshot.into());
+    }
+    Ok(SpoolUsageSnapshots(snapshots))
+  }
+}
+
+impl<'de> Deserialize<'de> for SpoolUsageSnapshots {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    deserializer.deserialize_seq(SpoolUsageSnapshotsVisitor)
+  }
+}
+
+impl From<SpoolUsageSnapshot> for UsageSnapshot {
+  fn from(snapshot: SpoolUsageSnapshot) -> Self {
+    Self {
+      timestamp: snapshot.timestamp,
+      model_id: snapshot.model_id,
+      usage: snapshot.usage,
+      last_token_usage: snapshot.last_token_usage,
+      plan_type: snapshot.plan_type,
+      limit_id: snapshot.limit_id,
+      limit_name: snapshot.limit_name,
+      explicit_fast_mode: snapshot.explicit_fast_mode,
+    }
+  }
+}
+
+impl From<PreparedSession> for SpoolPreparedSession {
+  fn from(entry: PreparedSession) -> Self {
+    let PreparedSession {
+      session_file,
+      parsed,
+      file_needs_rate_limit_repair,
+      file_needs_token_v2_repair,
+      file_needs_fork_replay_v3_repair,
+      replay_parent_unavailable,
+      related_pending_token_v2_paths,
+      related_pending_fork_replay_v3_paths,
+    } = entry;
+    let ParsedSession {
+      raw_session,
+      snapshots,
+      rate_limit_samples,
+      explicit_forked_from_id,
+      explicit_fork_timestamp,
+      inherited_token_snapshot_cutoff,
+      explicit_fast_mode,
+      latest_plan_type,
+      last_model_id,
+    } = parsed;
+
+    Self {
+      session_file,
+      raw_session,
+      snapshots: SpoolUsageSnapshots(snapshots),
+      rate_limit_samples,
+      explicit_forked_from_id,
+      explicit_fork_timestamp,
+      inherited_token_snapshot_cutoff,
+      explicit_fast_mode,
+      latest_plan_type,
+      last_model_id,
+      file_needs_rate_limit_repair,
+      file_needs_token_v2_repair,
+      file_needs_fork_replay_v3_repair,
+      replay_parent_unavailable,
+      related_pending_token_v2_paths,
+      related_pending_fork_replay_v3_paths,
+    }
+  }
+}
+
+impl From<SpoolPreparedSession> for PreparedSession {
+  fn from(entry: SpoolPreparedSession) -> Self {
+    Self {
+      session_file: entry.session_file,
+      parsed: ParsedSession {
+        raw_session: entry.raw_session,
+        snapshots: entry.snapshots.0,
+        rate_limit_samples: entry.rate_limit_samples,
+        explicit_forked_from_id: entry.explicit_forked_from_id,
+        explicit_fork_timestamp: entry.explicit_fork_timestamp,
+        inherited_token_snapshot_cutoff: entry.inherited_token_snapshot_cutoff,
+        explicit_fast_mode: entry.explicit_fast_mode,
+        latest_plan_type: entry.latest_plan_type,
+        last_model_id: entry.last_model_id,
+      },
+      file_needs_rate_limit_repair: entry.file_needs_rate_limit_repair,
+      file_needs_token_v2_repair: entry.file_needs_token_v2_repair,
+      file_needs_fork_replay_v3_repair: entry.file_needs_fork_replay_v3_repair,
+      replay_parent_unavailable: entry.replay_parent_unavailable,
+      related_pending_token_v2_paths: entry.related_pending_token_v2_paths,
+      related_pending_fork_replay_v3_paths: entry.related_pending_fork_replay_v3_paths,
+    }
+  }
+}
+
+impl PreparedSession {
+  fn estimated_bytes(&self) -> usize {
+    let raw = &self.parsed.raw_session;
+    let mut bytes = std::mem::size_of::<Self>()
+      .saturating_add(self.session_file.path.to_string_lossy().len())
+      .saturating_add(self.session_file.bucket.len())
+      .saturating_add(raw.session_id.len())
+      .saturating_add(option_string_len(&raw.parent_session_id))
+      .saturating_add(raw.root_session_id.len())
+      .saturating_add(option_string_len(&raw.title))
+      .saturating_add(raw.source_state.len())
+      .saturating_add(option_string_len(&raw.source_path))
+      .saturating_add(option_string_len(&raw.started_at))
+      .saturating_add(option_string_len(&raw.updated_at))
+      .saturating_add(option_string_len(&raw.agent_nickname))
+      .saturating_add(option_string_len(&raw.agent_role))
+      .saturating_add(raw.model_ids.iter().map(String::len).sum::<usize>())
+      .saturating_add(estimated_usage_snapshots_bytes(&self.parsed.snapshots))
+      .saturating_add(option_string_len(&self.parsed.explicit_forked_from_id))
+      .saturating_add(option_string_len(&self.parsed.latest_plan_type))
+      .saturating_add(option_string_len(&self.parsed.last_model_id));
+
+    for sample in &self.parsed.rate_limit_samples {
+      bytes = bytes
+        .saturating_add(std::mem::size_of::<RateLimitSampleRecord>())
+        .saturating_add(sample.source_kind.len())
+        .saturating_add(option_string_len(&sample.source_session_id))
+        .saturating_add(sample.bucket.len())
+        .saturating_add(sample.sample_timestamp.len())
+        .saturating_add(option_string_len(&sample.limit_id))
+        .saturating_add(option_string_len(&sample.limit_name))
+        .saturating_add(option_string_len(&sample.plan_type))
+        .saturating_add(sample.window_start.len())
+        .saturating_add(sample.resets_at.len());
+    }
+    for path in self
+      .related_pending_token_v2_paths
+      .iter()
+      .chain(&self.related_pending_fork_replay_v3_paths)
+    {
+      bytes = bytes.saturating_add(path.len());
+    }
+    bytes
+  }
+}
+
+impl PreparedStorageBuilder {
+  fn new() -> Self {
+    Self::Memory {
+      entries: Vec::new(),
+      estimated_bytes: 0,
+    }
+  }
+
+  fn push(&mut self, entry: PreparedSession) -> Result<(), String> {
+    let state = std::mem::replace(
+      self,
+      Self::Memory {
+        entries: Vec::new(),
+        estimated_bytes: 0,
+      },
+    );
+
+    *self = match state {
+      Self::Memory {
+        mut entries,
+        estimated_bytes,
+      } => {
+        let next_bytes = estimated_bytes.saturating_add(entry.estimated_bytes());
+        if next_bytes <= PREPARED_SPOOL_THRESHOLD_BYTES {
+          entries.push(entry);
+          Self::Memory {
+            entries,
+            estimated_bytes: next_bytes,
+          }
+        } else {
+          let file = tempfile::Builder::new()
+            .prefix("codex-pacer-prepared-")
+            .suffix(".jsons")
+            .tempfile()
+            .map_err(|error| format!("Failed to create prepared scan spool: {error}"))?;
+          let writer_file = file
+            .reopen()
+            .map_err(|error| format!("Failed to open prepared scan spool: {error}"))?;
+          let mut writer = BufWriter::new(writer_file);
+          let mut records = 0usize;
+          for buffered in entries {
+            write_spool_record(&mut writer, buffered)?;
+            records += 1;
+          }
+          write_spool_record(&mut writer, entry)?;
+          records += 1;
+          Self::Spool {
+            file,
+            writer,
+            records,
+          }
+        }
+      }
+      Self::Spool {
+        file,
+        mut writer,
+        mut records,
+      } => {
+        write_spool_record(&mut writer, entry)?;
+        records += 1;
+        Self::Spool {
+          file,
+          writer,
+          records,
+        }
+      }
+    };
+    Ok(())
+  }
+
+  fn finish(self) -> Result<PreparedStorage, String> {
+    match self {
+      Self::Memory { entries, .. } => Ok(PreparedStorage::Memory(entries)),
+      Self::Spool {
+        file,
+        mut writer,
+        records,
+      } => {
+        writer
+          .flush()
+          .map_err(|error| format!("Failed to flush prepared scan spool: {error}"))?;
+        drop(writer);
+        Ok(PreparedStorage::Spool { file, records })
+      }
+    }
+  }
+}
+
+fn write_spool_record(writer: &mut BufWriter<File>, entry: PreparedSession) -> Result<(), String> {
+  let entry = SpoolPreparedSession::from(entry);
+  serde_json::to_writer(&mut *writer, &entry)
+    .map_err(|error| format!("Failed to write prepared scan spool: {error}"))?;
+  writer
+    .write_all(b"\n")
+    .map_err(|error| format!("Failed to delimit prepared scan spool: {error}"))
+}
+
+impl ParentReplayCache {
+  fn new() -> Self {
+    Self {
+      entries: HashMap::new(),
+      insertion_order: VecDeque::new(),
+      estimated_bytes: 0,
+      evictions: 0,
+      oversized_bypasses: 0,
+    }
+  }
+
+  fn get(&self, session_id: &str) -> Option<&Option<Vec<UsageSnapshot>>> {
+    self.entries.get(session_id).map(|entry| &entry.snapshots)
+  }
+
+  fn insert(&mut self, session_id: String, snapshots: Option<Vec<UsageSnapshot>>) {
+    let entry_bytes = session_id.len().saturating_add(
+      snapshots
+        .as_deref()
+        .map(estimated_usage_snapshots_bytes)
+        .unwrap_or(1),
+    );
+    if entry_bytes > PARENT_REPLAY_CACHE_MAX_BYTES {
+      self.oversized_bypasses += 1;
+      return;
+    }
+
+    while self.entries.len() >= PARENT_REPLAY_CACHE_MAX_ENTRIES
+      || self.estimated_bytes.saturating_add(entry_bytes) > PARENT_REPLAY_CACHE_MAX_BYTES
+    {
+      let Some(oldest_session_id) = self.insertion_order.pop_front() else {
+        break;
+      };
+      if let Some(oldest) = self.entries.remove(&oldest_session_id) {
+        self.estimated_bytes = self.estimated_bytes.saturating_sub(oldest.estimated_bytes);
+        self.evictions += 1;
+      }
+    }
+
+    self.estimated_bytes = self.estimated_bytes.saturating_add(entry_bytes);
+    self.insertion_order.push_back(session_id.clone());
+    self.entries.insert(
+      session_id,
+      ParentReplayCacheEntry {
+        snapshots,
+        estimated_bytes: entry_bytes,
+      },
+    );
+  }
+
+  fn evictions(&self) -> usize {
+    self.evictions
+  }
+
+  fn oversized_bypasses(&self) -> usize {
+    self.oversized_bypasses
+  }
+}
+
+fn option_string_len(value: &Option<String>) -> usize {
+  value.as_ref().map(String::len).unwrap_or_default()
+}
+
+fn estimated_usage_snapshots_bytes(snapshots: &[UsageSnapshot]) -> usize {
+  snapshots.iter().fold(0usize, |bytes, snapshot| {
+    bytes
+      .saturating_add(std::mem::size_of::<UsageSnapshot>())
+      .saturating_add(snapshot.timestamp.len())
+      .saturating_add(snapshot.model_id.len())
+      .saturating_add(option_string_len(&snapshot.plan_type))
+      .saturating_add(option_string_len(&snapshot.limit_id))
+      .saturating_add(option_string_len(&snapshot.limit_name))
+  })
+}
+
+pub fn perform_scan(
   db_path: &Path,
   codex_home_override: Option<String>,
-  requested_scope: ScanScope,
 ) -> Result<ScanResult, String> {
-  let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  perform_scan_with_kind(db_path, codex_home_override, ScanKind::Full)
+}
+
+pub fn perform_incremental_scan(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+) -> Result<ScanResult, String> {
+  perform_scan_with_kind(db_path, codex_home_override, ScanKind::Incremental)
+}
+
+fn perform_scan_with_kind(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_kind: ScanKind,
+) -> Result<ScanResult, String> {
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
-  let scan_source_selector = get_sync_settings(&conn)
-    .map_err(|error| error.to_string())?
-    .codex_home;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
+  drop(conn);
+
+  let prepared = prepare_scan(db_path, codex_home_override, requested_kind)?;
+  commit_prepared_scan(prepared)
+}
+
+pub(crate) fn prepare_scan(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_kind: ScanKind,
+) -> Result<PreparedScan, String> {
+  let scan_started_at = now_utc_string();
+  let database_snapshot =
+    load_preparation_database_snapshot(db_path).map_err(|error| error.to_string())?;
+  let PreparationDatabaseSnapshot {
+    scan_source_selector,
+    scan_commit_revision,
+    last_scan_codex_home,
+    last_scan_started_at,
+    last_scan_completed_at,
+    last_full_scan_completed_at,
+    import_state,
+    needs_rate_limit_backfill,
+    pending_rate_limit_repair_paths,
+    needs_token_usage_v2_repair_sweep,
+    pending_token_v2_repair_paths,
+    needs_fork_replay_v3_repair_sweep,
+    pending_fork_replay_v3_repair_paths,
+    mut session_source_paths,
+    existing_relations,
+    existing_session_sources,
+    topology_needs_repair,
+  } = database_snapshot;
 
   let home_dir = dirs::home_dir();
+  let configured_home =
+    resolve_codex_home(scan_source_selector.as_deref(), None, home_dir.as_deref())
+      .and_then(|path| expand_home_prefix(path, home_dir.as_deref()))
+      .ok();
   let codex_home = validate_codex_home(
     resolve_codex_home(
       scan_source_selector.as_deref(),
@@ -112,31 +762,9 @@ fn perform_scan_with_scope(
     home_dir.as_deref(),
   );
   let resolved_codex_home = codex_home.to_string_lossy().to_string();
-  let scan_started_at = now_utc_string();
-  let scan_freshness_start = if track_scan_freshness {
-    set_last_scan_started_for_source(
-      &conn,
-      &scan_started_at,
-      scan_source_selector.as_deref(),
-      &resolved_codex_home,
-    )
-    .map_err(|error| error.to_string())?
-  } else {
-    Default::default()
-  };
-
-  let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
-  let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
-  let pending_rate_limit_repair_paths =
-    load_pending_data_repair_paths(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY).map_err(|error| error.to_string())?;
-  let needs_token_usage_v2_repair_sweep =
-    data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let pending_token_v2_repair_paths =
-    load_pending_data_repair_paths(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let needs_fork_replay_v3_repair_sweep =
-    data_repair_is_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let pending_fork_replay_v3_repair_paths =
-    load_pending_data_repair_paths(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let freshness_full_scan_required = track_scan_freshness
+    && (last_scan_codex_home.as_deref() != Some(resolved_codex_home.as_str())
+      || last_full_scan_completed_at.is_none());
   let pending_token_v2_repair_session_ids =
     pending_repair_session_ids(&import_state, &pending_token_v2_repair_paths);
   let pending_fork_replay_v3_repair_session_ids =
@@ -147,31 +775,41 @@ fn perform_scan_with_scope(
   pending_repair_session_ids.extend(pending_fork_replay_v3_repair_session_ids.iter().cloned());
   let needs_token_usage_repair_sweep =
     needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
-  let effective_scope = effective_scan_scope(
-    requested_scope,
+  let effective_kind = effective_scan_scope(
+    requested_kind,
     import_state.is_empty(),
     needs_rate_limit_backfill,
     needs_token_usage_repair_sweep,
-    scan_freshness_start.full_scan_required,
+    freshness_full_scan_required,
   );
 
-  let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
-    ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
-    ScanScope::Incremental => {
+  let (session_files, active_paths_kept_for_archive_retry) = match effective_kind {
+    ScanKind::Full => (collect_session_files(&codex_home), HashSet::new()),
+    ScanKind::Incremental => {
       collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
     }
   };
-  let session_source_paths =
-    load_session_source_paths(&conn, &import_state, &session_files).map_err(|error| error.to_string())?;
+  let stats = PreparedScanStats {
+    files_visited: session_files.len(),
+    source_bytes_read: 0,
+    full_rebuild: effective_kind == ScanKind::Full,
+    used_spool: false,
+    parent_replay_cache_evictions: 0,
+    parent_replay_cache_oversized_bypasses: 0,
+  };
+  for session_file in &session_files {
+    let Some(session_id) = fallback_session_id_from_filename(&session_file.path) else {
+      continue;
+    };
+    session_source_paths.insert(session_id, session_file.path.clone());
+  }
   let mut present_paths: HashSet<String> = session_files
     .iter()
     .map(|item| item.path.to_string_lossy().to_string())
     .collect();
   present_paths.extend(active_paths_kept_for_archive_retry);
 
-  let mut changed_sessions = 0usize;
   let mut imported_session_ids = HashSet::new();
-
   let mut changed_files = Vec::new();
   for session_file in &session_files {
     let source_path = session_file.path.to_string_lossy().to_string();
@@ -193,7 +831,7 @@ fn perform_scan_with_scope(
       || session_has_pending_token_v2_repair
       || session_has_pending_fork_replay_v3_repair
     {
-      changed_files.push(session_file);
+      changed_files.push(session_file.clone());
       continue;
     }
     if let Some(state) = import_state.get(&source_path) {
@@ -209,10 +847,10 @@ fn perform_scan_with_scope(
       }
     }
 
-    changed_files.push(session_file);
+    changed_files.push(session_file.clone());
   }
 
-  let titles = if effective_scope == ScanScope::Full || !changed_files.is_empty() {
+  let titles = if effective_kind == ScanKind::Full || !changed_files.is_empty() {
     load_session_index(&codex_home)
   } else {
     HashMap::new()
@@ -221,143 +859,293 @@ fn perform_scan_with_scope(
   let mut topology_dirty = false;
   let mut new_root_session_ids = Vec::new();
   let mut skipped_session_files = false;
-  let mut parent_snapshot_cache: HashMap<String, Option<Vec<UsageSnapshot>>> = HashMap::new();
-  if !changed_files.is_empty() {
-    let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
-    let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
+  let mut parse_failures = Vec::new();
+  let mut parent_snapshot_cache = ParentReplayCache::new();
+  let mut storage = PreparedStorageBuilder::new();
+  let mut updated_sessions = 0usize;
+  let mut source_bytes_read = 0u64;
 
-    for session_file in changed_files {
-      let source_path = session_file.path.to_string_lossy().to_string();
-      let file_needs_rate_limit_repair =
-        needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
-      let mut file_needs_token_v2_repair =
-        needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
-      let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
-        || pending_fork_replay_v3_repair_paths.contains(&source_path);
-      let mut parsed = match parse_session_file(session_file, &titles) {
-        Ok(parsed) => parsed,
-        Err(error) => {
-          skipped_session_files = true;
-          log::warn!(
-            "Skipping unreadable session file {}: {}",
-            session_file.path.display(),
-            error
-          );
-          if file_needs_token_v2_repair {
-            mark_data_repair_file_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path, &error)
-              .map_err(|error| error.to_string())?;
-          }
-          if file_needs_fork_replay_v3_repair {
-            mark_data_repair_file_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path, &error)
-              .map_err(|error| error.to_string())?;
-          }
-          if file_needs_rate_limit_repair {
-            mark_data_repair_file_pending(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path, &error)
-              .map_err(|error| error.to_string())?;
-          }
-          continue;
-        }
-      };
-      let replay_parent_unavailable = assign_inherited_token_snapshot_cutoff(
+  for session_file in changed_files {
+    let source_path = session_file.path.to_string_lossy().to_string();
+    let file_needs_rate_limit_repair =
+      needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
+    let mut file_needs_token_v2_repair =
+      needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
+    let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
+      || pending_fork_replay_v3_repair_paths.contains(&source_path);
+    let (mut parsed, bytes_read) = match parse_session_file_counted(&session_file, &titles) {
+      Ok(parsed) => parsed,
+      Err((error, bytes_read)) => {
+        source_bytes_read = source_bytes_read.saturating_add(bytes_read);
+        skipped_session_files = true;
+        log::warn!(
+          "Skipping unreadable session file {}: {}",
+          session_file.path.display(),
+          error
+        );
+        parse_failures.push(PreparedParseFailure {
+          source_path,
+          error,
+          mark_rate_limit_repair: file_needs_rate_limit_repair,
+          mark_token_v2_repair: file_needs_token_v2_repair,
+          mark_fork_replay_v3_repair: file_needs_fork_replay_v3_repair,
+        });
+        continue;
+      }
+    };
+    source_bytes_read = source_bytes_read.saturating_add(bytes_read);
+
+    let (replay_parent_unavailable, parent_replay_bytes_read) =
+      assign_inherited_token_snapshot_cutoff(
         &mut parsed,
         &session_source_paths,
         &mut parent_snapshot_cache,
       );
-      let related_pending_token_v2_paths = pending_repair_paths_for_session(
-        &import_state,
-        &pending_token_v2_repair_paths,
-        &parsed.raw_session.session_id,
-      );
-      let related_pending_fork_replay_v3_paths = pending_repair_paths_for_session(
-        &import_state,
-        &pending_fork_replay_v3_repair_paths,
-        &parsed.raw_session.session_id,
-      );
-      file_needs_token_v2_repair |= !related_pending_token_v2_paths.is_empty();
-      file_needs_fork_replay_v3_repair |=
-        replay_parent_unavailable || !related_pending_fork_replay_v3_paths.is_empty();
-      imported_session_ids.insert(parsed.raw_session.session_id.clone());
+    source_bytes_read = source_bytes_read.saturating_add(parent_replay_bytes_read);
+    let related_pending_token_v2_paths = pending_repair_paths_for_session(
+      &import_state,
+      &pending_token_v2_repair_paths,
+      &parsed.raw_session.session_id,
+    );
+    let related_pending_fork_replay_v3_paths = pending_repair_paths_for_session(
+      &import_state,
+      &pending_fork_replay_v3_repair_paths,
+      &parsed.raw_session.session_id,
+    );
+    file_needs_token_v2_repair |= !related_pending_token_v2_paths.is_empty();
+    file_needs_fork_replay_v3_repair |=
+      replay_parent_unavailable || !related_pending_fork_replay_v3_paths.is_empty();
+    imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
-      match classify_topology_maintenance(
-        existing_relations.get(&parsed.raw_session.session_id),
-        existing_relations.get(&parsed.raw_session.session_id).map(|item| item.child_count).unwrap_or_default(),
-        parsed.raw_session.parent_session_id.as_deref(),
-      ) {
-        TopologyMaintenance::None => {}
-        TopologyMaintenance::InsertRootLink => {
-          new_root_session_ids.push(parsed.raw_session.session_id.clone());
-        }
-        TopologyMaintenance::RecomputeAll => {
-          topology_dirty = true;
-        }
+    match classify_topology_maintenance(
+      existing_relations.get(&parsed.raw_session.session_id),
+      existing_relations
+        .get(&parsed.raw_session.session_id)
+        .map(|item| item.child_count)
+        .unwrap_or_default(),
+      parsed.raw_session.parent_session_id.as_deref(),
+    ) {
+      TopologyMaintenance::None => {}
+      TopologyMaintenance::InsertRootLink => {
+        new_root_session_ids.push(parsed.raw_session.session_id.clone());
       }
+      TopologyMaintenance::RecomputeAll => {
+        topology_dirty = true;
+      }
+    }
 
-      persist_session(&mut conn, session_file, &parsed, &catalog).map_err(|error| error.to_string())?;
-      if file_needs_rate_limit_repair {
-        clear_pending_data_repair_file(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)
-          .map_err(|error| error.to_string())?;
-      }
-      if file_needs_token_v2_repair {
-        clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)
-          .map_err(|error| error.to_string())?;
-        for related_source_path in related_pending_token_v2_paths {
-          clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &related_source_path)
-            .map_err(|error| error.to_string())?;
-        }
-      }
-      if file_needs_fork_replay_v3_repair {
-        if replay_parent_unavailable {
-          mark_data_repair_file_pending(
-            &conn,
-            TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
-            &source_path,
-            "fork replay parent unavailable",
-          )
-            .map_err(|error| error.to_string())?;
-        } else {
-          clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
-            .map_err(|error| error.to_string())?;
-          for related_source_path in related_pending_fork_replay_v3_paths {
-            clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &related_source_path)
-              .map_err(|error| error.to_string())?;
-          }
-        }
-      }
-      changed_sessions += 1;
+    storage.push(PreparedSession {
+      session_file,
+      parsed,
+      file_needs_rate_limit_repair,
+      file_needs_token_v2_repair,
+      file_needs_fork_replay_v3_repair,
+      replay_parent_unavailable,
+      related_pending_token_v2_paths,
+      related_pending_fork_replay_v3_paths,
+    })?;
+    updated_sessions += 1;
+  }
+
+  let parent_replay_cache_evictions = parent_snapshot_cache.evictions();
+  let parent_replay_cache_oversized_bypasses = parent_snapshot_cache.oversized_bypasses();
+  drop(parent_snapshot_cache);
+  drop(session_source_paths);
+  drop(existing_relations);
+
+  let missing_plan = prepare_missing_source_plan(
+    &existing_session_sources,
+    &import_state,
+    &present_paths,
+    effective_kind,
+    freshness_full_scan_required,
+  );
+  let storage = storage.finish()?;
+  let stats = PreparedScanStats {
+    source_bytes_read,
+    used_spool: matches!(&storage, PreparedStorage::Spool { .. }),
+    parent_replay_cache_evictions,
+    parent_replay_cache_oversized_bypasses,
+    ..stats
+  };
+
+  Ok(PreparedScan {
+    db_path: db_path.to_path_buf(),
+    source_identity: PreparedSourceIdentity {
+      key: PreparedScanSourceKey {
+        selector: scan_source_selector,
+        resolved_home: codex_home,
+      },
+      scan_commit_revision,
+      tracked_configured_home: track_scan_freshness.then_some(configured_home).flatten(),
+      last_scan_codex_home,
+      last_scan_started_at,
+      last_scan_completed_at,
+      last_full_scan_completed_at,
+    },
+    scan_started_at,
+    track_scan_freshness,
+    effective_kind,
+    freshness_full_scan_required,
+    stats,
+    imported_sessions: imported_session_ids.len(),
+    updated_sessions,
+    skipped_session_files,
+    storage,
+    parse_failures,
+    titles,
+    missing_plan,
+    topology_dirty,
+    topology_needs_repair,
+    new_root_session_ids,
+    needs_rate_limit_backfill,
+    needs_token_usage_v2_repair_sweep,
+    needs_fork_replay_v3_repair_sweep,
+  })
+}
+
+pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult, String> {
+  let PreparedScan {
+    db_path,
+    source_identity,
+    scan_started_at,
+    track_scan_freshness,
+    effective_kind,
+    freshness_full_scan_required,
+    stats,
+    imported_sessions,
+    updated_sessions,
+    skipped_session_files,
+    storage,
+    parse_failures,
+    titles,
+    missing_plan,
+    topology_dirty,
+    topology_needs_repair,
+    new_root_session_ids,
+    needs_rate_limit_backfill,
+    needs_token_usage_v2_repair_sweep,
+    needs_fork_replay_v3_repair_sweep,
+  } = prepared;
+
+  let mut conn = open_connection(&db_path).map_err(|error| error.to_string())?;
+  let tx = conn
+    .transaction_with_behavior(TransactionBehavior::Immediate)
+    .map_err(|error| error.to_string())?;
+  validate_prepared_source_identity(&tx, &source_identity)?;
+  let catalog = load_catalog_map(&tx).map_err(|error| error.to_string())?;
+  let resolved_codex_home = source_identity
+    .key
+    .resolved_home
+    .to_string_lossy()
+    .to_string();
+
+  let scan_freshness_preview = if track_scan_freshness {
+    preview_scan_freshness_for_source(
+      &tx,
+      source_identity.key.selector.as_deref(),
+      &resolved_codex_home,
+    )
+    .map_err(|error| error.to_string())?
+  } else {
+    Default::default()
+  };
+  if scan_freshness_preview.recorded
+    && scan_freshness_preview.full_scan_required != freshness_full_scan_required
+  {
+    return Err("Prepared scan freshness changed before commit.".to_string());
+  }
+
+  let scan_freshness_start = if track_scan_freshness {
+    set_last_scan_started_for_source_in_transaction(
+      &tx,
+      &scan_started_at,
+      source_identity.key.selector.as_deref(),
+      &resolved_codex_home,
+    )
+    .map_err(|error| error.to_string())?
+  } else {
+    Default::default()
+  };
+
+  for failure in parse_failures {
+    if failure.mark_token_v2_repair {
+      mark_data_repair_file_pending(
+        &tx,
+        TOKEN_USAGE_MONOTONIC_REPAIR_KEY,
+        &failure.source_path,
+        &failure.error,
+      )
+      .map_err(|error| error.to_string())?;
+    }
+    if failure.mark_fork_replay_v3_repair {
+      mark_data_repair_file_pending(
+        &tx,
+        TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+        &failure.source_path,
+        &failure.error,
+      )
+      .map_err(|error| error.to_string())?;
+    }
+    if failure.mark_rate_limit_repair {
+      mark_data_repair_file_pending(
+        &tx,
+        RATE_LIMIT_SAMPLE_BACKFILL_KEY,
+        &failure.source_path,
+        &failure.error,
+      )
+      .map_err(|error| error.to_string())?;
     }
   }
 
-  if effective_scope == ScanScope::Full {
-    refresh_session_titles(&conn, &titles).map_err(|error| error.to_string())?;
+  match storage {
+    PreparedStorage::Memory(entries) => {
+      for entry in entries {
+        commit_one_prepared_session(&tx, entry, &catalog).map_err(|error| error.to_string())?;
+      }
+    }
+    PreparedStorage::Spool { file, records } => {
+      let reader_file = file
+        .reopen()
+        .map_err(|error| format!("Failed to open prepared scan spool for commit: {error}"))?;
+      let reader = BufReader::new(reader_file);
+      let mut stream =
+        serde_json::Deserializer::from_reader(reader).into_iter::<SpoolPreparedSession>();
+      let mut records_read = 0usize;
+      while let Some(entry) = stream.next() {
+        let entry =
+          entry.map_err(|error| format!("Failed to read prepared scan spool: {error}"))?;
+        commit_one_prepared_session(&tx, PreparedSession::from(entry), &catalog)
+          .map_err(|error| error.to_string())?;
+        records_read += 1;
+      }
+      drop(stream);
+      file
+        .close()
+        .map_err(|error| format!("Failed to remove prepared scan spool: {error}"))?;
+      if records_read != records {
+        return Err(format!(
+          "Prepared scan spool ended early: expected {records} records, read {records_read}."
+        ));
+      }
+    }
   }
 
-  if effective_scope == ScanScope::Full {
-    // A full scan that is required for freshness is authoritative even on retry:
-    // paths outside the resolved source must not remain active just because they still exist.
-    let reconcile_existing_absent_sources = scan_freshness_start.full_scan_required;
-    mark_missing_sources(
-      &conn,
-      &present_paths,
-      reconcile_existing_absent_sources,
-    )
-    .map_err(|error| error.to_string())?;
-    prune_import_state(
-      &conn,
-      &present_paths,
-      reconcile_existing_absent_sources,
-    )
-    .map_err(|error| error.to_string())?;
-  } else {
-    mark_missing_active_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
+  if effective_kind == ScanKind::Full {
+    refresh_session_titles(&tx, &titles).map_err(|error| error.to_string())?;
   }
-  let topology_needs_repair = conversation_links_need_repair(&conn).map_err(|error| error.to_string())?;
+  apply_missing_source_plan(&tx, missing_plan).map_err(|error| error.to_string())?;
+
+  let topology_needs_repair = topology_needs_repair
+    || conversation_links_need_repair(&tx).map_err(|error| error.to_string())?;
   if topology_dirty || topology_needs_repair {
-    recompute_conversation_links(&conn).map_err(|error| error.to_string())?;
+    recompute_conversation_links(&tx).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
-    upsert_root_conversation_links(&conn, &new_root_session_ids).map_err(|error| error.to_string())?;
+    upsert_root_conversation_links(&tx, &new_root_session_ids)
+      .map_err(|error| error.to_string())?;
   }
 
-  let missing_sessions = conn
+  let missing_sessions = tx
     .query_row(
       "SELECT COUNT(*) FROM sessions WHERE source_state = 'missing'",
       [],
@@ -367,55 +1155,360 @@ fn perform_scan_with_scope(
 
   let completed_at = now_utc_string();
   if needs_rate_limit_backfill {
-    mark_data_repair_complete(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &completed_at)
+    mark_data_repair_complete(&tx, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
   if needs_token_usage_v2_repair_sweep {
-    mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
+    mark_data_repair_complete(&tx, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
   if needs_fork_replay_v3_repair_sweep {
-    mark_data_repair_complete(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &completed_at)
+    mark_data_repair_complete(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
   if scan_freshness_start.recorded {
     set_scan_completed_for_source(
-      &conn,
+      &tx,
       &completed_at,
-      scan_source_selector.as_deref(),
+      source_identity.key.selector.as_deref(),
       &resolved_codex_home,
-      effective_scope == ScanScope::Full && !skipped_session_files,
-      effective_scope == ScanScope::Full && skipped_session_files,
+      effective_kind == ScanKind::Full && !skipped_session_files,
+      effective_kind == ScanKind::Full && skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
 
+  let revision_updated = tx
+    .execute(
+      "
+      UPDATE sync_settings
+      SET scan_commit_revision = scan_commit_revision + 1
+      WHERE singleton_id = 1 AND scan_commit_revision = ?1
+      ",
+      params![source_identity.scan_commit_revision],
+    )
+    .map_err(|error| error.to_string())?;
+  if revision_updated != 1 {
+    return Err("Prepared scan is stale before commit.".to_string());
+  }
+
+  tx.commit().map_err(|error| error.to_string())?;
+
   Ok(ScanResult {
-    codex_home: codex_home.to_string_lossy().to_string(),
-    scanned_files: session_files.len(),
-    imported_sessions: imported_session_ids.len(),
-    updated_sessions: changed_sessions,
+    codex_home: resolved_codex_home,
+    scanned_files: stats.files_visited,
+    imported_sessions,
+    updated_sessions,
     missing_sessions,
     last_completed_at: completed_at,
   })
 }
 
+fn open_scan_snapshot(db_path: &Path) -> rusqlite::Result<Connection> {
+  let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+  conn.busy_timeout(Duration::from_secs(10))?;
+  conn.pragma_update(None, "query_only", "ON")?;
+  Ok(conn)
+}
+
+fn load_preparation_database_snapshot(
+  db_path: &Path,
+) -> rusqlite::Result<PreparationDatabaseSnapshot> {
+  let mut conn = open_scan_snapshot(db_path)?;
+  let tx = conn.transaction()?;
+  let (
+    scan_source_selector,
+    scan_commit_revision,
+    last_scan_codex_home,
+    last_scan_started_at,
+    last_scan_completed_at,
+    last_full_scan_completed_at,
+  ): (
+    Option<String>,
+    i64,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+  ) = tx.query_row(
+    "
+    SELECT codex_home, scan_commit_revision, last_scan_codex_home,
+           last_scan_started_at, last_scan_completed_at, last_full_scan_completed_at
+    FROM sync_settings
+    WHERE singleton_id = 1
+    ",
+    [],
+    |row| {
+      Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+      ))
+    },
+  )?;
+  let import_state = load_import_state(&tx)?;
+  let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&tx)?;
+  let pending_rate_limit_repair_paths =
+    load_pending_data_repair_paths(&tx, RATE_LIMIT_SAMPLE_BACKFILL_KEY)?;
+  let needs_token_usage_v2_repair_sweep =
+    data_repair_is_pending(&tx, TOKEN_USAGE_MONOTONIC_REPAIR_KEY)?;
+  let pending_token_v2_repair_paths =
+    load_pending_data_repair_paths(&tx, TOKEN_USAGE_MONOTONIC_REPAIR_KEY)?;
+  let needs_fork_replay_v3_repair_sweep =
+    data_repair_is_pending(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY)?;
+  let pending_fork_replay_v3_repair_paths =
+    load_pending_data_repair_paths(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY)?;
+  let session_source_paths = load_session_source_paths(&tx, &import_state, &[])?;
+  let existing_relations = load_existing_session_relations(&tx)?;
+  let existing_session_sources = {
+    let mut stmt = tx.prepare(
+      "
+      SELECT session_id, source_path, source_state, source_bucket
+      FROM sessions
+      WHERE source_path IS NOT NULL
+      ",
+    )?;
+    let rows = stmt
+      .query_map([], |row| {
+        Ok(ExistingSessionSource {
+          session_id: row.get(0)?,
+          source_path: row.get(1)?,
+          source_state: row.get(2)?,
+          source_bucket: row.get(3)?,
+        })
+      })?
+      .collect::<rusqlite::Result<Vec<_>>>()?;
+    rows
+  };
+  let topology_needs_repair = conversation_links_need_repair(&tx)?;
+  tx.commit()?;
+
+  Ok(PreparationDatabaseSnapshot {
+    scan_source_selector,
+    scan_commit_revision,
+    last_scan_codex_home,
+    last_scan_started_at,
+    last_scan_completed_at,
+    last_full_scan_completed_at,
+    import_state,
+    needs_rate_limit_backfill,
+    pending_rate_limit_repair_paths,
+    needs_token_usage_v2_repair_sweep,
+    pending_token_v2_repair_paths,
+    needs_fork_replay_v3_repair_sweep,
+    pending_fork_replay_v3_repair_paths,
+    session_source_paths,
+    existing_relations,
+    existing_session_sources,
+    topology_needs_repair,
+  })
+}
+
+fn validate_prepared_source_identity(
+  conn: &Connection,
+  prepared: &PreparedSourceIdentity,
+) -> Result<(), String> {
+  let (
+    selector,
+    scan_commit_revision,
+    last_scan_codex_home,
+    last_scan_started_at,
+    last_scan_completed_at,
+    last_full_scan_completed_at,
+  ): (
+    Option<String>,
+    i64,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+  ) = conn
+    .query_row(
+      "
+      SELECT codex_home, scan_commit_revision, last_scan_codex_home,
+             last_scan_started_at, last_scan_completed_at, last_full_scan_completed_at
+      FROM sync_settings
+      WHERE singleton_id = 1
+      ",
+      [],
+      |row| {
+        Ok((
+          row.get(0)?,
+          row.get(1)?,
+          row.get(2)?,
+          row.get(3)?,
+          row.get(4)?,
+          row.get(5)?,
+        ))
+      },
+    )
+    .map_err(|error| error.to_string())?;
+  let home_dir = dirs::home_dir();
+  let configured_home = resolve_codex_home(selector.as_deref(), None, home_dir.as_deref())
+    .and_then(|path| expand_home_prefix(path, home_dir.as_deref()))
+    .ok();
+
+  if selector != prepared.key.selector
+    || scan_commit_revision != prepared.scan_commit_revision
+    || prepared
+      .tracked_configured_home
+      .as_ref()
+      .is_some_and(|prepared_home| Some(prepared_home) != configured_home.as_ref())
+    || last_scan_codex_home != prepared.last_scan_codex_home
+    || last_scan_started_at != prepared.last_scan_started_at
+    || last_scan_completed_at != prepared.last_scan_completed_at
+    || last_full_scan_completed_at != prepared.last_full_scan_completed_at
+  {
+    return Err("Prepared scan source changed before commit.".to_string());
+  }
+  Ok(())
+}
+
+fn prepare_missing_source_plan(
+  existing_sources: &[ExistingSessionSource],
+  import_state: &HashMap<String, ImportState>,
+  present_paths: &HashSet<String>,
+  scan_kind: ScanKind,
+  reconcile_existing_absent_sources: bool,
+) -> MissingSourcePlan {
+  let mut plan = MissingSourcePlan::default();
+
+  match scan_kind {
+    ScanKind::Full => {
+      for source in existing_sources {
+        if !present_paths.contains(&source.source_path)
+          && (reconcile_existing_absent_sources || !Path::new(&source.source_path).exists())
+        {
+          plan.sessions_to_mark_missing.push(MissingSessionPlan {
+            session_id: source.session_id.clone(),
+            expected_source_path: source.source_path.clone(),
+          });
+        }
+      }
+      for source_path in import_state.keys() {
+        if !present_paths.contains(source_path)
+          && (reconcile_existing_absent_sources || !Path::new(source_path).exists())
+        {
+          plan.import_state_paths_to_delete.push(source_path.clone());
+        }
+      }
+    }
+    ScanKind::Incremental => {
+      for source in existing_sources {
+        if source.source_state == "active"
+          && source.source_bucket.as_deref() == Some("active")
+          && !present_paths.contains(&source.source_path)
+          && !Path::new(&source.source_path).exists()
+        {
+          plan.sessions_to_mark_missing.push(MissingSessionPlan {
+            session_id: source.session_id.clone(),
+            expected_source_path: source.source_path.clone(),
+          });
+          plan
+            .import_state_paths_to_delete
+            .push(source.source_path.clone());
+        }
+      }
+    }
+  }
+
+  plan
+}
+
+fn apply_missing_source_plan(conn: &Connection, plan: MissingSourcePlan) -> rusqlite::Result<()> {
+  let imported_at = now_utc_string();
+  for missing in plan.sessions_to_mark_missing {
+    conn.execute(
+      "
+      UPDATE sessions
+      SET source_state = 'missing', imported_at = ?1
+      WHERE session_id = ?2 AND source_path = ?3
+      ",
+      params![
+        imported_at,
+        missing.session_id,
+        missing.expected_source_path
+      ],
+    )?;
+  }
+  for source_path in plan.import_state_paths_to_delete {
+    conn.execute(
+      "DELETE FROM import_state WHERE source_path = ?1",
+      params![source_path],
+    )?;
+  }
+  Ok(())
+}
+
+fn commit_one_prepared_session(
+  conn: &Connection,
+  entry: PreparedSession,
+  catalog: &HashMap<String, crate::models::PricingCatalogEntry>,
+) -> rusqlite::Result<()> {
+  let PreparedSession {
+    session_file,
+    parsed,
+    file_needs_rate_limit_repair,
+    file_needs_token_v2_repair,
+    file_needs_fork_replay_v3_repair,
+    replay_parent_unavailable,
+    related_pending_token_v2_paths,
+    related_pending_fork_replay_v3_paths,
+  } = entry;
+  let source_path = session_file.path.to_string_lossy().to_string();
+
+  persist_session(conn, &session_file, &parsed, catalog)?;
+  if file_needs_rate_limit_repair {
+    clear_pending_data_repair_file(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)?;
+  }
+  if file_needs_token_v2_repair {
+    clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)?;
+    for related_source_path in related_pending_token_v2_paths {
+      clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &related_source_path)?;
+    }
+  }
+  if file_needs_fork_replay_v3_repair {
+    if replay_parent_unavailable {
+      mark_data_repair_file_pending(
+        conn,
+        TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+        &source_path,
+        "fork replay parent unavailable",
+      )?;
+    } else {
+      clear_pending_data_repair_file(conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)?;
+      for related_source_path in related_pending_fork_replay_v3_paths {
+        clear_pending_data_repair_file(
+          conn,
+          TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+          &related_source_path,
+        )?;
+      }
+    }
+  }
+
+  Ok(())
+}
+
 fn effective_scan_scope(
-  requested_scope: ScanScope,
+  requested_scope: ScanKind,
   import_state_is_empty: bool,
   needs_rate_limit_backfill: bool,
   needs_token_usage_repair_sweep: bool,
   resolved_source_requires_full_scan: bool,
-) -> ScanScope {
-  if requested_scope == ScanScope::Full
+) -> ScanKind {
+  if requested_scope == ScanKind::Full
     || import_state_is_empty
     || needs_rate_limit_backfill
     || needs_token_usage_repair_sweep
     || resolved_source_requires_full_scan
   {
-    ScanScope::Full
+    ScanKind::Full
   } else {
-    ScanScope::Incremental
+    ScanKind::Incremental
   }
 }
 
@@ -477,7 +1570,10 @@ fn classify_topology_maintenance(
   existing_child_count: usize,
   parent_session_id: Option<&str>,
 ) -> TopologyMaintenance {
-  match (existing_relation.filter(|item| item.exists), parent_session_id) {
+  match (
+    existing_relation.filter(|item| item.exists),
+    parent_session_id,
+  ) {
     (Some(existing_relation), next_parent_session_id) => {
       if existing_relation.parent_session_id.as_deref() == next_parent_session_id {
         TopologyMaintenance::None
@@ -600,7 +1696,10 @@ fn load_session_index(codex_home: &Path) -> HashMap<String, String> {
   titles
 }
 
-fn refresh_session_titles(conn: &Connection, titles: &HashMap<String, String>) -> rusqlite::Result<()> {
+fn refresh_session_titles(
+  conn: &Connection,
+  titles: &HashMap<String, String>,
+) -> rusqlite::Result<()> {
   for (session_id, title) in titles {
     conn.execute(
       "UPDATE sessions SET title = ?1 WHERE session_id = ?2",
@@ -634,7 +1733,10 @@ fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
   }
 
   let mut files = Vec::new();
-  for entry in WalkDir::new(sessions_root).into_iter().filter_map(Result::ok) {
+  for entry in WalkDir::new(sessions_root)
+    .into_iter()
+    .filter_map(Result::ok)
+  {
     if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), "active") {
       files.push(session_file);
     }
@@ -657,10 +1759,9 @@ fn collect_incremental_session_files(
 
   for state in import_state.values() {
     if state.source_bucket == "archived" {
-      let Some(session_file) = session_file_from_path(
-        PathBuf::from(&state.source_path),
-        "archived",
-      ) else {
+      let Some(session_file) =
+        session_file_from_path(PathBuf::from(&state.source_path), "archived")
+      else {
         continue;
       };
       let session_has_pending_repair = state
@@ -724,21 +1825,37 @@ fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
   })
 }
 
+fn parse_session_file_counted(
+  session_file: &SessionFile,
+  titles: &HashMap<String, String>,
+) -> Result<(ParsedSession, u64), (String, u64)> {
+  parse_session_file_once(session_file, titles).map_err(|error| match error {
+    SessionParseError::Fatal {
+      message,
+      bytes_read,
+    } => (message, bytes_read),
+  })
+}
+
+#[cfg(test)]
 fn parse_session_file(
   session_file: &SessionFile,
   titles: &HashMap<String, String>,
 ) -> Result<ParsedSession, String> {
-  parse_session_file_once(session_file, titles).map_err(|error| match error {
-    SessionParseError::Fatal(message) => message,
-  })
+  parse_session_file_counted(session_file, titles)
+    .map(|(parsed, _)| parsed)
+    .map_err(|(error, _)| error)
 }
 
 fn parse_session_file_once(
   session_file: &SessionFile,
   titles: &HashMap<String, String>,
-) -> Result<ParsedSession, SessionParseError> {
-  let file = File::open(&session_file.path)
-    .map_err(|error| SessionParseError::Fatal(format!("Failed to open {}: {error}", session_file.path.display())))?;
+) -> Result<(ParsedSession, u64), SessionParseError> {
+  let file = File::open(&session_file.path).map_err(|error| SessionParseError::Fatal {
+    message: format!("Failed to open {}: {error}", session_file.path.display()),
+    bytes_read: 0,
+  })?;
+  let mut reader = BufReader::new(CountingReader::new(file));
   let expected_session_id = fallback_session_id_from_filename(&session_file.path);
 
   let mut session_id = String::new();
@@ -758,10 +1875,18 @@ fn parse_session_file_once(
   let mut first_session_meta: Option<SessionMetaCandidate> = None;
   let mut matching_session_meta: Option<SessionMetaCandidate> = None;
 
-  for line_result in BufReader::new(file).lines() {
-    let line = line_result.map_err(|error| {
-      SessionParseError::Fatal(format!("Failed to read {}: {error}", session_file.path.display()))
-    })?;
+  let mut line = String::new();
+  loop {
+    line.clear();
+    let line_bytes = reader
+      .read_line(&mut line)
+      .map_err(|error| SessionParseError::Fatal {
+        message: format!("Failed to read {}: {error}", session_file.path.display()),
+        bytes_read: reader.get_ref().bytes_read,
+      })?;
+    if line_bytes == 0 {
+      break;
+    }
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
     }
@@ -791,24 +1916,26 @@ fn parse_session_file_once(
       updated_at = timestamp.clone();
     }
 
-    match value.get("type").and_then(Value::as_str).unwrap_or_default() {
+    match value
+      .get("type")
+      .and_then(Value::as_str)
+      .unwrap_or_default()
+    {
       "session_meta" => {
         let payload = value.get("payload").unwrap_or(&Value::Null);
         let candidate_explicit_forked_from_id = payload
           .get("forked_from_id")
           .and_then(Value::as_str)
           .map(ToString::to_string);
-        let parent = candidate_explicit_forked_from_id
-          .clone()
-          .or_else(|| {
-            payload
-              .get("source")
-              .and_then(|source| source.get("subagent"))
-              .and_then(|subagent| subagent.get("thread_spawn"))
-              .and_then(|thread_spawn| thread_spawn.get("parent_thread_id"))
-              .and_then(Value::as_str)
-              .map(ToString::to_string)
-          });
+        let parent = candidate_explicit_forked_from_id.clone().or_else(|| {
+          payload
+            .get("source")
+            .and_then(|source| source.get("subagent"))
+            .and_then(|subagent| subagent.get("thread_spawn"))
+            .and_then(|thread_spawn| thread_spawn.get("parent_thread_id"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+        });
         let candidate_explicit_fork_timestamp = candidate_explicit_forked_from_id
           .as_ref()
           .and_then(|_| timestamp.as_deref())
@@ -918,7 +2045,9 @@ fn parse_session_file_once(
         let sample_timestamp = timestamp.unwrap_or_else(now_utc_string);
         rate_limit_samples.extend(extract_rate_limit_samples(&sample_timestamp, payload));
 
-        let model_id = current_model.clone().unwrap_or_else(|| "unknown".to_string());
+        let model_id = current_model
+          .clone()
+          .unwrap_or_else(|| "unknown".to_string());
         seen_models.insert(model_id.clone());
 
         snapshots.push(UsageSnapshot {
@@ -936,6 +2065,7 @@ fn parse_session_file_once(
     }
   }
 
+  let bytes_read = reader.get_ref().bytes_read;
   if let Some(candidate) = matching_session_meta.or(first_session_meta) {
     session_id = candidate.session_id;
     parent_session_id = candidate.parent_session_id.or(parent_session_id);
@@ -952,10 +2082,13 @@ fn parse_session_file_once(
   }
 
   if session_id.is_empty() {
-    return Err(SessionParseError::Fatal(format!(
-      "Could not determine session id for {}",
-      session_file.path.display()
-    )));
+    return Err(SessionParseError::Fatal {
+      message: format!(
+        "Could not determine session id for {}",
+        session_file.path.display()
+      ),
+      bytes_read,
+    });
   }
 
   let title = titles.get(&session_id).cloned();
@@ -965,30 +2098,33 @@ fn parse_session_file_once(
     sample.source_session_id = Some(session_id.clone());
   }
 
-  Ok(ParsedSession {
-    raw_session: RawSession {
-      session_id: session_id.clone(),
-      parent_session_id,
-      root_session_id: session_id,
-      title,
-      source_state: session_file.bucket.clone(),
-      source_path: Some(session_file.path.to_string_lossy().to_string()),
-      started_at,
-      updated_at,
-      model_ids: seen_models.into_iter().collect(),
-      contains_subagents: false,
-      agent_nickname,
-      agent_role,
+  Ok((
+    ParsedSession {
+      raw_session: RawSession {
+        session_id: session_id.clone(),
+        parent_session_id,
+        root_session_id: session_id,
+        title,
+        source_state: session_file.bucket.clone(),
+        source_path: Some(session_file.path.to_string_lossy().to_string()),
+        started_at,
+        updated_at,
+        model_ids: seen_models.into_iter().collect(),
+        contains_subagents: false,
+        agent_nickname,
+        agent_role,
+      },
+      snapshots,
+      rate_limit_samples,
+      explicit_forked_from_id,
+      explicit_fork_timestamp,
+      inherited_token_snapshot_cutoff: 0,
+      explicit_fast_mode,
+      latest_plan_type,
+      last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
     },
-    snapshots,
-    rate_limit_samples,
-    explicit_forked_from_id,
-    explicit_fork_timestamp,
-    inherited_token_snapshot_cutoff: 0,
-    explicit_fast_mode,
-    latest_plan_type,
-    last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
-  })
+    bytes_read,
+  ))
 }
 
 fn fallback_session_id_from_filename(path: &Path) -> Option<String> {
@@ -1017,7 +2153,10 @@ fn looks_like_session_id(value: &str) -> bool {
     .iter()
     .zip(expected_lengths.iter())
     .all(|(segment, expected_len)| {
-      segment.len() == *expected_len && segment.chars().all(|character| character.is_ascii_hexdigit())
+      segment.len() == *expected_len
+        && segment
+          .chars()
+          .all(|character| character.is_ascii_hexdigit())
     })
 }
 
@@ -1027,9 +2166,8 @@ fn load_session_source_paths(
   session_files: &[SessionFile],
 ) -> rusqlite::Result<HashMap<String, PathBuf>> {
   let mut source_paths = HashMap::new();
-  let mut stmt = conn.prepare(
-    "SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL",
-  )?;
+  let mut stmt =
+    conn.prepare("SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL")?;
   let rows = stmt.query_map([], |row| {
     Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
   })?;
@@ -1060,90 +2198,110 @@ fn load_session_source_paths(
 fn assign_inherited_token_snapshot_cutoff(
   parsed: &mut ParsedSession,
   session_source_paths: &HashMap<String, PathBuf>,
-  parent_snapshot_cache: &mut HashMap<String, Option<Vec<UsageSnapshot>>>,
-) -> bool {
+  parent_snapshot_cache: &mut ParentReplayCache,
+) -> (bool, u64) {
   let Some(parent_session_id) = parsed
     .explicit_forked_from_id
     .as_deref()
     .filter(|session_id| !session_id.trim().is_empty())
+    .map(ToString::to_string)
   else {
-    return false;
+    return (false, 0);
   };
   let Some(fork_timestamp) = parsed.explicit_fork_timestamp else {
-    return false;
+    return (false, 0);
   };
 
-  if !parent_snapshot_cache.contains_key(parent_session_id) {
-    let parent_snapshots = match session_source_paths.get(parent_session_id) {
-      Some(source_path) => match read_parent_replay_snapshots(source_path, parent_session_id) {
-        Ok(snapshots) => Some(snapshots),
-        Err(()) => {
+  if let Some(cached) = parent_snapshot_cache.get(&parent_session_id) {
+    let Some(parent_snapshots) = cached.as_deref() else {
+      return (true, 0);
+    };
+    parsed.inherited_token_snapshot_cutoff =
+      replayed_child_snapshot_cutoff(parent_snapshots, &parsed.snapshots, Some(fork_timestamp));
+    return (false, 0);
+  }
+
+  let (parent_snapshots, bytes_read) = match session_source_paths.get(&parent_session_id) {
+    Some(source_path) => {
+      match read_parent_replay_snapshots_counted(source_path, &parent_session_id) {
+        Ok((snapshots, bytes_read)) => (Some(snapshots), bytes_read),
+        Err(bytes_read) => {
           log::warn!(
             "Replay parent unavailable: child_id={}, parent_id={}, source_path={}",
             parsed.raw_session.session_id,
             parent_session_id,
             source_path.display()
           );
-          None
+          (None, bytes_read)
         }
-      },
-      None => {
-        log::warn!(
-          "Replay parent unavailable: child_id={}, parent_id={}",
-          parsed.raw_session.session_id,
-          parent_session_id
-        );
-        None
       }
-    };
-    parent_snapshot_cache.insert(parent_session_id.to_string(), parent_snapshots);
-  }
-
-  let Some(parent_snapshots) = parent_snapshot_cache
-    .get(parent_session_id)
-    .and_then(Option::as_deref)
-  else {
-    return true;
+    }
+    None => {
+      log::warn!(
+        "Replay parent unavailable: child_id={}, parent_id={}",
+        parsed.raw_session.session_id,
+        parent_session_id
+      );
+      (None, 0)
+    }
   };
-
-  parsed.inherited_token_snapshot_cutoff = replayed_child_snapshot_cutoff(
-    parent_snapshots,
-    &parsed.snapshots,
-    Some(fork_timestamp),
-  );
-  false
+  let replay_parent_unavailable = parent_snapshots.is_none();
+  if let Some(parent_snapshots) = parent_snapshots.as_deref() {
+    parsed.inherited_token_snapshot_cutoff =
+      replayed_child_snapshot_cutoff(parent_snapshots, &parsed.snapshots, Some(fork_timestamp));
+  }
+  parent_snapshot_cache.insert(parent_session_id, parent_snapshots);
+  (replay_parent_unavailable, bytes_read)
 }
 
+#[cfg(test)]
 fn read_parent_replay_snapshots(
   source_path: &Path,
   requested_parent_id: &str,
 ) -> Result<Vec<UsageSnapshot>, ()> {
+  read_parent_replay_snapshots_counted(source_path, requested_parent_id)
+    .map(|(snapshots, _)| snapshots)
+    .map_err(|_| ())
+}
+
+fn read_parent_replay_snapshots_counted(
+  source_path: &Path,
+  requested_parent_id: &str,
+) -> Result<(Vec<UsageSnapshot>, u64), u64> {
   let filename_session_id = fallback_session_id_from_filename(source_path);
   if filename_session_id
     .as_deref()
     .is_some_and(|session_id| session_id != requested_parent_id)
   {
-    return Err(());
+    return Err(0);
   }
 
-  let file = File::open(source_path).map_err(|_| ())?;
+  let file = File::open(source_path).map_err(|_| 0u64)?;
+  let mut reader = BufReader::new(CountingReader::new(file));
   let mut first_session_meta_id: Option<String> = None;
   let mut snapshots = Vec::new();
+  let mut line = String::new();
 
-  for line_result in BufReader::new(file).lines() {
-    let line = line_result.map_err(|_| ())?;
+  loop {
+    line.clear();
+    match reader.read_line(&mut line) {
+      Ok(0) => break,
+      Ok(_) => {}
+      Err(_) => return Err(reader.get_ref().bytes_read),
+    }
     if !line.contains("\"session_meta\"") && !line.contains("\"token_count\"") {
       continue;
     }
 
-    let envelope = serde_json::from_str::<ReplayParentLineEnvelope<'_>>(&line).map_err(|_| ())?;
+    let envelope = serde_json::from_str::<ReplayParentLineEnvelope<'_>>(&line)
+      .map_err(|_| reader.get_ref().bytes_read)?;
     match envelope.record_type {
       Some("session_meta") if first_session_meta_id.is_none() => {
         let Some(session_id) = envelope.payload.as_ref().and_then(|payload| payload.id) else {
           continue;
         };
         if filename_session_id.is_none() && session_id != requested_parent_id {
-          return Err(());
+          return Err(reader.get_ref().bytes_read);
         }
         first_session_meta_id = Some(session_id.to_string());
       }
@@ -1154,8 +2312,9 @@ fn read_parent_replay_snapshots(
           .and_then(|payload| payload.record_type)
           == Some("token_count") =>
       {
-        let timestamp = envelope.timestamp.ok_or(())?;
-        let details = serde_json::from_str::<ReplayParentTokenDetails>(&line).map_err(|_| ())?;
+        let timestamp = envelope.timestamp.ok_or(reader.get_ref().bytes_read)?;
+        let details = serde_json::from_str::<ReplayParentTokenDetails>(&line)
+          .map_err(|_| reader.get_ref().bytes_read)?;
 
         snapshots.push(UsageSnapshot {
           timestamp: timestamp.to_string(),
@@ -1176,14 +2335,15 @@ fn read_parent_replay_snapshots(
     }
   }
 
+  let bytes_read = reader.get_ref().bytes_read;
   if filename_session_id.is_none() && first_session_meta_id.is_none() {
-    return Err(());
+    return Err(bytes_read);
   }
   if snapshots.is_empty() {
-    return Err(());
+    return Err(bytes_read);
   }
 
-  Ok(snapshots)
+  Ok((snapshots, bytes_read))
 }
 
 #[derive(Deserialize)]
@@ -1280,7 +2440,10 @@ fn canonical_replay_snapshots(snapshots: &[UsageSnapshot]) -> Vec<CanonicalRepla
     }
 
     high_water = Some(snapshot.usage.total_tokens);
-    canonical.push(CanonicalReplaySnapshot { raw_index, snapshot });
+    canonical.push(CanonicalReplaySnapshot {
+      raw_index,
+      snapshot,
+    });
   }
 
   canonical
@@ -1328,7 +2491,11 @@ fn replayed_child_snapshot_cutoff(
         .is_ok_and(|timestamp| timestamp <= explicit_fork_timestamp)
     })
     .count();
-  let minimum_match_length = if eligible_parent_snapshot_count == 1 { 1 } else { 2 };
+  let minimum_match_length = if eligible_parent_snapshot_count == 1 {
+    1
+  } else {
+    2
+  };
   if child_pattern.len() < minimum_match_length {
     return 0;
   }
@@ -1370,17 +2537,16 @@ fn replayed_child_snapshot_cutoff(
 }
 
 fn persist_session(
-  conn: &mut Connection,
+  conn: &Connection,
   session_file: &SessionFile,
   parsed: &ParsedSession,
   catalog: &HashMap<String, crate::models::PricingCatalogEntry>,
 ) -> rusqlite::Result<()> {
-  let tx = conn.transaction()?;
   let created_at = now_utc_string();
   let imported_at = created_at.clone();
   let fast_mode_default = false;
 
-  tx.execute(
+  conn.execute(
     "
     INSERT INTO sessions (
       session_id, root_session_id, parent_session_id, title, source_state, source_path,
@@ -1426,11 +2592,15 @@ fn persist_session(
     ],
   )?;
 
-  tx.execute(
+  conn.execute(
     "DELETE FROM usage_events WHERE session_id = ?1",
     params![parsed.raw_session.session_id],
   )?;
-  replace_session_rate_limit_samples(&tx, &parsed.raw_session.session_id, &parsed.rate_limit_samples)?;
+  replace_session_rate_limit_samples(
+    conn,
+    &parsed.raw_session.session_id,
+    &parsed.rate_limit_samples,
+  )?;
 
   let snapshot_cutoff = parsed.inherited_token_snapshot_cutoff;
   let mut previous_usage = snapshot_cutoff
@@ -1466,7 +2636,7 @@ fn persist_session(
     let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
     let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
 
-    tx.execute(
+    conn.execute(
       "
       INSERT INTO usage_events (
         session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
@@ -1490,7 +2660,7 @@ fn persist_session(
     )?;
   }
 
-  tx.execute(
+  conn.execute(
     "
     INSERT INTO import_state (source_path, session_id, source_bucket, file_size, file_mtime_ms, last_imported_at)
     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
@@ -1511,7 +2681,7 @@ fn persist_session(
     ],
   )?;
 
-  tx.execute(
+  conn.execute(
     "
     DELETE FROM import_state
     WHERE session_id = ?1 AND source_path <> ?2
@@ -1522,7 +2692,7 @@ fn persist_session(
     ],
   )?;
 
-  tx.commit()
+  Ok(())
 }
 
 fn diff_usage(previous: &TokenUsage, current: &TokenUsage) -> TokenUsage {
@@ -1532,9 +2702,15 @@ fn diff_usage(previous: &TokenUsage, current: &TokenUsage) -> TokenUsage {
 
   TokenUsage {
     input_tokens: non_negative_delta(current.input_tokens, previous.input_tokens),
-    cached_input_tokens: non_negative_delta(current.cached_input_tokens, previous.cached_input_tokens),
+    cached_input_tokens: non_negative_delta(
+      current.cached_input_tokens,
+      previous.cached_input_tokens,
+    ),
     output_tokens: non_negative_delta(current.output_tokens, previous.output_tokens),
-    reasoning_output_tokens: non_negative_delta(current.reasoning_output_tokens, previous.reasoning_output_tokens),
+    reasoning_output_tokens: non_negative_delta(
+      current.reasoning_output_tokens,
+      previous.reasoning_output_tokens,
+    ),
     total_tokens: current.total_tokens - previous.total_tokens,
   }
 }
@@ -1587,7 +2763,9 @@ fn extract_rate_limit_samples(timestamp: &str, payload: &Value) -> Vec<RateLimit
     let Some(resets_at) = unix_seconds_to_rfc3339_local(resets_at_seconds) else {
       continue;
     };
-    let Some(window_start) = unix_seconds_to_rfc3339_local(resets_at_seconds - window_duration_mins * 60) else {
+    let Some(window_start) =
+      unix_seconds_to_rfc3339_local(resets_at_seconds - window_duration_mins * 60)
+    else {
       continue;
     };
 
@@ -1669,7 +2847,11 @@ fn data_repair_is_pending(conn: &Connection, repair_key: &str) -> rusqlite::Resu
   Ok(completed.is_none())
 }
 
-fn mark_data_repair_complete(conn: &Connection, repair_key: &str, completed_at: &str) -> rusqlite::Result<()> {
+fn mark_data_repair_complete(
+  conn: &Connection,
+  repair_key: &str,
+  completed_at: &str,
+) -> rusqlite::Result<()> {
   conn.execute(
     "
     INSERT INTO data_repairs (repair_key, completed_at)
@@ -1681,7 +2863,10 @@ fn mark_data_repair_complete(conn: &Connection, repair_key: &str, completed_at: 
   Ok(())
 }
 
-fn load_pending_data_repair_paths(conn: &Connection, repair_key: &str) -> rusqlite::Result<HashSet<String>> {
+fn load_pending_data_repair_paths(
+  conn: &Connection,
+  repair_key: &str,
+) -> rusqlite::Result<HashSet<String>> {
   let mut stmt = conn.prepare(
     "
     SELECT source_path
@@ -1711,7 +2896,8 @@ fn pending_repair_paths_for_session(
         .and_then(|state| state.session_id.as_deref());
       import_state_session_id == Some(session_id)
         || (import_state_session_id.is_none()
-          && fallback_session_id_from_filename(Path::new(source_path)).as_deref() == Some(session_id))
+          && fallback_session_id_from_filename(Path::new(source_path)).as_deref()
+            == Some(session_id))
     })
     .cloned()
     .collect()
@@ -1751,7 +2937,11 @@ fn mark_data_repair_file_pending(
   Ok(())
 }
 
-fn clear_pending_data_repair_file(conn: &Connection, repair_key: &str, source_path: &str) -> rusqlite::Result<()> {
+fn clear_pending_data_repair_file(
+  conn: &Connection,
+  repair_key: &str,
+  source_path: &str,
+) -> rusqlite::Result<()> {
   conn.execute(
     "
     DELETE FROM data_repair_pending_files
@@ -1762,7 +2952,9 @@ fn clear_pending_data_repair_file(conn: &Connection, repair_key: &str, source_pa
   Ok(())
 }
 
-fn load_existing_session_relations(conn: &Connection) -> rusqlite::Result<HashMap<String, ExistingSessionRelation>> {
+fn load_existing_session_relations(
+  conn: &Connection,
+) -> rusqlite::Result<HashMap<String, ExistingSessionRelation>> {
   let mut stmt = conn.prepare("SELECT session_id, parent_session_id FROM sessions")?;
   let rows = stmt.query_map([], |row| {
     Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
@@ -1782,7 +2974,10 @@ fn load_existing_session_relations(conn: &Connection) -> rusqlite::Result<HashMa
   Ok(relations)
 }
 
-fn upsert_root_conversation_links(conn: &Connection, session_ids: &[String]) -> rusqlite::Result<()> {
+fn upsert_root_conversation_links(
+  conn: &Connection,
+  session_ids: &[String],
+) -> rusqlite::Result<()> {
   for session_id in session_ids {
     conn.execute(
       "
@@ -1816,84 +3011,6 @@ fn conversation_links_need_repair(conn: &Connection) -> rusqlite::Result<bool> {
   )
 }
 
-fn mark_missing_sources(
-  conn: &Connection,
-  present_paths: &HashSet<String>,
-  reconcile_existing_absent_sources: bool,
-) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare("SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL")?;
-  let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
-
-  for row in rows {
-    let (session_id, source_path) = row?;
-    if !present_paths.contains(&source_path)
-      && (reconcile_existing_absent_sources || !Path::new(&source_path).exists())
-    {
-      conn.execute(
-        "
-        UPDATE sessions
-        SET source_state = 'missing', imported_at = ?1
-        WHERE session_id = ?2
-        ",
-        params![now_utc_string(), session_id],
-      )?;
-    }
-  }
-  Ok(())
-}
-
-fn mark_missing_active_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT session_id, source_path
-    FROM sessions
-    WHERE source_state = 'active' AND source_bucket = 'active' AND source_path IS NOT NULL
-    ",
-  )?;
-  let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
-
-  for row in rows {
-    let (session_id, source_path) = row?;
-    if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
-      let now = now_utc_string();
-      conn.execute(
-        "
-        UPDATE sessions
-        SET source_state = 'missing', imported_at = ?1
-        WHERE session_id = ?2
-        ",
-        params![now, session_id],
-      )?;
-      conn.execute(
-        "DELETE FROM import_state WHERE source_path = ?1",
-        params![source_path],
-      )?;
-    }
-  }
-  Ok(())
-}
-
-fn prune_import_state(
-  conn: &Connection,
-  present_paths: &HashSet<String>,
-  reconcile_existing_absent_sources: bool,
-) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare("SELECT source_path FROM import_state")?;
-  let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-  for row in rows {
-    let source_path = row?;
-    if !present_paths.contains(&source_path)
-      && (reconcile_existing_absent_sources || !Path::new(&source_path).exists())
-    {
-      conn.execute(
-        "DELETE FROM import_state WHERE source_path = ?1",
-        params![source_path],
-      )?;
-    }
-  }
-  Ok(())
-}
-
 fn recompute_conversation_links(conn: &Connection) -> rusqlite::Result<()> {
   let mut stmt = conn.prepare("SELECT session_id, parent_session_id FROM sessions")?;
   let rows = stmt.query_map([], |row| {
@@ -1922,7 +3039,12 @@ fn recompute_conversation_links(conn: &Connection) -> rusqlite::Result<()> {
         parent_session_id = excluded.parent_session_id,
         depth = excluded.depth
       ",
-      params![session_id, root_session_id, parents.get(session_id).cloned().flatten(), depth as i64],
+      params![
+        session_id,
+        root_session_id,
+        parents.get(session_id).cloned().flatten(),
+        depth as i64
+      ],
     )?;
 
     conn.execute(
@@ -1977,15 +3099,18 @@ fn read_i64(value: &Value, key: &str) -> i64 {
 }
 
 fn read_total_tokens(value: &Value) -> i64 {
-  value.get("total_tokens").and_then(Value::as_i64).unwrap_or_else(|| {
-    read_i64(value, "input_tokens") + read_i64(value, "output_tokens")
-  })
+  value
+    .get("total_tokens")
+    .and_then(Value::as_i64)
+    .unwrap_or_else(|| read_i64(value, "input_tokens") + read_i64(value, "output_tokens"))
 }
 
 fn read_percent(value: &Value, key: &str) -> Option<i64> {
-  value
-    .get(key)
-    .and_then(|field| field.as_i64().or_else(|| field.as_f64().map(|number| number.round() as i64)))
+  value.get(key).and_then(|field| {
+    field
+      .as_i64()
+      .or_else(|| field.as_f64().map(|number| number.round() as i64))
+  })
 }
 
 #[derive(Debug, Clone)]
@@ -2001,7 +3126,8 @@ struct ImportState {
 mod tests {
   use super::*;
   use crate::database::{
-    get_last_full_scan_completed, init_db, now_utc_string, open_connection, save_sync_settings,
+    get_last_full_scan_completed, get_sync_settings, init_db, now_utc_string, open_connection,
+    save_sync_settings,
   };
   use rusqlite::OptionalExtension;
   use std::ffi::OsString;
@@ -2064,6 +3190,850 @@ mod tests {
     chrono::DateTime::parse_from_rfc3339(timestamp).expect("valid fork instant")
   }
 
+  #[derive(Debug, PartialEq, Eq)]
+  struct DatabaseMutationFingerprint {
+    sessions: i64,
+    conversation_links: i64,
+    usage_events: i64,
+    import_state: i64,
+    data_repairs: i64,
+    pending_repairs: i64,
+    rate_limit_samples: i64,
+    freshness: (
+      Option<String>,
+      Option<String>,
+      Option<String>,
+      Option<String>,
+      Option<String>,
+      String,
+      i64,
+    ),
+  }
+
+  fn database_mutation_fingerprint(conn: &Connection) -> DatabaseMutationFingerprint {
+    let count = |table: &str| {
+      conn
+        .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+          row.get(0)
+        })
+        .expect("count table")
+    };
+    let freshness = conn
+      .query_row(
+        "
+        SELECT codex_home, last_scan_codex_home, last_scan_started_at,
+               last_scan_completed_at, last_full_scan_completed_at, updated_at,
+               scan_commit_revision
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| {
+          Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+            row.get(5)?,
+            row.get(6)?,
+          ))
+        },
+      )
+      .expect("load freshness fingerprint");
+
+    DatabaseMutationFingerprint {
+      sessions: count("sessions"),
+      conversation_links: count("conversation_links"),
+      usage_events: count("usage_events"),
+      import_state: count("import_state"),
+      data_repairs: count("data_repairs"),
+      pending_repairs: count("data_repair_pending_files"),
+      rate_limit_samples: count("rate_limit_samples"),
+      freshness,
+    }
+  }
+
+  fn initialize_scan_database(db_path: &Path) {
+    let conn = open_connection(db_path).expect("open database");
+    init_db(&conn).expect("init database");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+  }
+
+  fn configure_codex_home(db_path: &Path, codex_home: &Path) {
+    let conn = open_connection(db_path).expect("open database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.codex_home = Some(codex_home.to_string_lossy().to_string());
+    save_sync_settings(&conn, &settings).expect("save source");
+  }
+
+  fn write_session_with_rate_limit_sample(path: &Path, session_id: &str, total_tokens: i64) {
+    let body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:02Z\",\"type\":\"event_msg\",\"payload\":{{",
+        "\"type\":\"token_count\",\"info\":{{\"total_token_usage\":{{",
+        "\"input_tokens\":{},\"cached_input_tokens\":0,\"output_tokens\":0,",
+        "\"reasoning_output_tokens\":0,\"total_tokens\":{}}}}},",
+        "\"rate_limits\":{{\"plan_type\":\"pro\",\"primary\":{{",
+        "\"used_percent\":25,\"window_duration_mins\":300,\"resets_at\":1783648800",
+        "}}}}}}}}\n"
+      ),
+      session_id, total_tokens, total_tokens,
+    );
+    std::fs::write(path, body).expect("write session with rate limit sample");
+  }
+
+  fn write_replay_cache_pair(
+    sessions: &Path,
+    prefix: usize,
+    parent_session_id: &str,
+    child_session_id: &str,
+  ) {
+    let timestamp = "2026-07-10T00:00:00Z";
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      timestamp, parent_session_id, timestamp,
+    );
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      timestamp, child_session_id, parent_session_id, timestamp,
+    );
+    for total in [10, 20, 30] {
+      let line = token_count_line(TokenFixture {
+        timestamp,
+        total: (total, 0, 0, total),
+        last: (10, 0, 0, 10),
+      });
+      parent_body.push_str(&line);
+      child_body.push_str(&line);
+    }
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp,
+      total: (40, 0, 0, 40),
+      last: (10, 0, 0, 10),
+    }));
+
+    std::fs::write(
+      sessions.join(format!("{prefix:02}-parent-{parent_session_id}.jsonl")),
+      parent_body,
+    )
+    .expect("write replay parent");
+    std::fs::write(
+      sessions.join(format!("{prefix:02}-child-{child_session_id}.jsonl")),
+      child_body,
+    )
+    .expect("write replay child");
+  }
+
+  fn assert_scan_results_equivalent(left: &ScanResult, right: &ScanResult) {
+    assert_eq!(left.codex_home, right.codex_home);
+    assert_eq!(left.scanned_files, right.scanned_files);
+    assert_eq!(left.imported_sessions, right.imported_sessions);
+    assert_eq!(left.updated_sessions, right.updated_sessions);
+    assert_eq!(left.missing_sessions, right.missing_sessions);
+    assert!(!left.last_completed_at.is_empty());
+    assert!(!right.last_completed_at.is_empty());
+  }
+
+  #[test]
+  fn prepare_scan_is_read_only() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    write_session_file(
+      &sessions.join("read-only.jsonl"),
+      "10101010-1010-1010-1010-101010101010",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+
+    let conn = open_connection(&db_path).expect("open database");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare scan");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+    drop(prepared);
+
+    let read_only = open_scan_snapshot(&db_path).expect("open read-only snapshot");
+    let error = read_only
+      .execute(
+        "UPDATE sync_settings SET updated_at = 'forbidden' WHERE singleton_id = 1",
+        [],
+      )
+      .expect_err("read-only snapshot must reject writes");
+    assert!(matches!(
+      error,
+      rusqlite::Error::SqliteFailure(ref sqlite_error, _)
+        if sqlite_error.code == rusqlite::ErrorCode::ReadOnly
+    ));
+  }
+
+  #[test]
+  fn prepared_scan_exposes_read_only_runtime_metadata_and_is_send() {
+    fn assert_send_static<T: Send + 'static>() {}
+    assert_send_static::<PreparedScan>();
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    write_session_file(
+      &sessions.join("metadata.jsonl"),
+      "11111111-1111-1111-1111-111111111111",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+
+    let prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare scan");
+    let stats = prepared.stats();
+    assert_eq!(stats.files_visited, 1);
+    assert!(stats.source_bytes_read > 0);
+    assert!(stats.full_rebuild);
+    assert!(!stats.used_spool);
+    assert_eq!(
+      prepared.source_key().selector(),
+      Some(codex_home.to_string_lossy().as_ref())
+    );
+    assert_eq!(prepared.source_key().resolved_home(), codex_home.as_path());
+  }
+
+  #[test]
+  fn prepared_scan_stays_uncommitted_until_commit() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "20202020-2020-2020-2020-202020202020";
+    let session_path = sessions.join("prepared.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare scan");
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(database_mutation_fingerprint(&conn).sessions, 0);
+    drop(conn);
+
+    std::fs::remove_file(&session_path).expect("remove parsed source");
+    let result =
+      commit_prepared_scan(prepared).expect("commit prepared scan without source reread");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, session_id).3, 110);
+  }
+
+  #[test]
+  fn commit_prepared_scan_is_atomic() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let first_session_id = "30303030-3030-3030-3030-303030303030";
+    let failed_session_id = "40404040-4040-4040-4040-404040404040";
+    write_session_with_rate_limit_sample(&sessions.join("a-first.jsonl"), first_session_id, 110);
+    write_session_file(
+      &sessions.join("b-fails.jsonl"),
+      failed_session_id,
+      &[("2026-07-10T00:01:00Z", 200, 40, 20, 220)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+    let prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    conn
+      .execute_batch(&format!(
+        "
+        CREATE TRIGGER fail_second_prepared_session
+        BEFORE INSERT ON sessions
+        WHEN NEW.session_id = '{failed_session_id}'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced mid-commit failure');
+        END;
+        "
+      ))
+      .expect("install failure trigger");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let error = commit_prepared_scan(prepared).expect_err("commit must fail");
+    assert!(error.contains("forced mid-commit failure"));
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+  }
+
+  #[test]
+  fn commit_checks_full_scan_guard_before_freshness_write() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("Codex home");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+    let mut prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare scan");
+    prepared.freshness_full_scan_required = !prepared.freshness_full_scan_required;
+
+    let conn = open_connection(&db_path).expect("open database");
+    conn
+      .execute_batch(
+        "
+        CREATE TRIGGER reject_freshness_write
+        BEFORE UPDATE ON sync_settings
+        BEGIN
+          SELECT RAISE(ABORT, 'freshness write happened before guard');
+        END;
+        ",
+      )
+      .expect("install freshness trigger");
+    drop(conn);
+
+    let error = commit_prepared_scan(prepared).expect_err("reject mismatched freshness plan");
+    assert!(
+      error.contains("freshness changed"),
+      "unexpected error: {error}"
+    );
+    assert!(!error.contains("freshness write happened"));
+  }
+
+  #[test]
+  fn commit_rejects_changed_source_without_prepared_writes() {
+    let directory = tempdir().expect("tempdir");
+    let first_codex_home = directory.path().join("codex-home-a");
+    let second_codex_home = directory.path().join("codex-home-b");
+    let sessions = first_codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&second_codex_home).expect("second source");
+    write_session_file(
+      &sessions.join("stale.jsonl"),
+      "50505050-5050-5050-5050-505050505050",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &first_codex_home);
+    let prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare first source");
+
+    configure_codex_home(&db_path, &second_codex_home);
+    let conn = open_connection(&db_path).expect("open database");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let error = commit_prepared_scan(prepared).expect_err("reject stale prepared source");
+    assert!(error.contains("source changed"));
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+  }
+
+  #[test]
+  fn override_commit_ignores_unrelated_default_source_change() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let first_default_home = directory.path().join("default-a");
+    let second_default_home = directory.path().join("default-b");
+    let scanned_home = directory.path().join("explicit-override");
+    let sessions = scanned_home.join("sessions");
+    std::fs::create_dir_all(&first_default_home).expect("first default source");
+    std::fs::create_dir_all(&second_default_home).expect("second default source");
+    std::fs::create_dir_all(&sessions).expect("override sessions");
+    let session_id = "53535353-5353-5353-5353-535353535353";
+    write_session_file(
+      &sessions.join("override.jsonl"),
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    let _environment = CodexHomeEnvGuard::set(&first_default_home);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(scanned_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare override scan");
+    std::env::set_var("CODEX_HOME", &second_default_home);
+
+    commit_prepared_scan(prepared).expect("commit override scan");
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(session_usage_totals(&conn, session_id).3, 110);
+  }
+
+  #[test]
+  fn same_source_scan_commit_after_prepare_is_rejected_without_writes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "51515151-5151-5151-5151-515151515151";
+    let session_path = sessions.join("same-source.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+    commit_prepared_scan(prepare_scan(&db_path, None, ScanKind::Full).expect("prepare full"))
+      .expect("commit full");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+
+    let stale = prepare_scan(&db_path, None, ScanKind::Incremental).expect("prepare stale scan");
+    let winner = prepare_scan(&db_path, None, ScanKind::Incremental).expect("prepare winning scan");
+    commit_prepared_scan(winner).expect("commit winning scan");
+    let conn = open_connection(&db_path).expect("open database");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let error = commit_prepared_scan(stale).expect_err("reject stale same-source scan");
+    assert!(error.contains("source changed") || error.contains("stale"));
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+  }
+
+  #[test]
+  fn untracked_override_rejects_same_source_commit_after_prepare() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let default_home = directory.path().join("default-home");
+    let scanned_home = directory.path().join("explicit-override");
+    let sessions = scanned_home.join("sessions");
+    std::fs::create_dir_all(&default_home).expect("default source");
+    std::fs::create_dir_all(&sessions).expect("override sessions");
+    let _environment = CodexHomeEnvGuard::set(&default_home);
+    let session_id = "54545454-5454-5454-5454-545454545454";
+    let session_path = sessions.join("untracked-override.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    let source_override = Some(scanned_home.to_string_lossy().to_string());
+    commit_prepared_scan(
+      prepare_scan(&db_path, source_override.clone(), ScanKind::Full)
+        .expect("prepare initial scan"),
+    )
+    .expect("commit initial scan");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+
+    let stale = prepare_scan(&db_path, source_override.clone(), ScanKind::Incremental)
+      .expect("prepare stale override scan");
+    let winner = prepare_scan(&db_path, source_override, ScanKind::Incremental)
+      .expect("prepare winning override scan");
+    commit_prepared_scan(winner).expect("commit winning override scan");
+    let conn = open_connection(&db_path).expect("open database");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let error = commit_prepared_scan(stale).expect_err("reject stale override scan");
+    assert!(error.contains("source changed") || error.contains("stale"));
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+  }
+
+  #[test]
+  fn prepare_stats_count_only_bytes_consumed_before_parse_failure() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_path = sessions.join("partial-read.jsonl");
+    let mut file = File::create(&session_path).expect("session file");
+    writeln!(
+      file,
+      "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"52525252-5252-5252-5252-525252525252\"}}}}"
+    )
+    .expect("write metadata");
+    file.write_all(&[0xff, b'\n']).expect("write invalid utf8");
+    file
+      .write_all(&vec![b' '; 32 * 1024])
+      .expect("write unread tail");
+    drop(file);
+    let file_size = std::fs::metadata(&session_path).expect("metadata").len();
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare scan with unreadable file");
+
+    assert!(prepared.stats().source_bytes_read > 0);
+    assert!(prepared.stats().source_bytes_read < file_size);
+  }
+
+  #[test]
+  fn small_incremental_prepare_stays_in_memory() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "60606060-6060-6060-6060-606060606060";
+    let session_path = sessions.join("small.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental scan");
+
+    assert!(!prepared.uses_spool());
+    assert!(prepared.spool_path().is_none());
+  }
+
+  #[test]
+  fn large_prepare_spills_and_drop_removes_spool() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "70707070-7070-7070-7070-707070707070";
+    let mut body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
+      ),
+      session_id
+    );
+    let mut total_tokens = 0i64;
+    while body.len() <= PREPARED_SPOOL_THRESHOLD_BYTES * 4 {
+      total_tokens += 10;
+      body.push_str(&token_count_line(TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (total_tokens, 0, 0, total_tokens),
+        last: (10, 0, 0, 10),
+      }));
+    }
+    std::fs::write(sessions.join("large.jsonl"), body).expect("write large session");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare large scan");
+
+    assert!(prepared.uses_spool());
+    let spool_path = prepared.spool_path().expect("spool path").to_path_buf();
+    assert!(spool_path.is_file());
+    drop(prepared);
+    assert!(!spool_path.exists());
+  }
+
+  #[test]
+  fn prepared_scan_started_at_includes_parse_time() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "73737373-7373-7373-7373-737373737373";
+    let mut body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
+      ),
+      session_id
+    );
+    let mut total_tokens = 0i64;
+    while body.len() <= PREPARED_SPOOL_THRESHOLD_BYTES * 32 {
+      total_tokens += 10;
+      body.push_str(&token_count_line(TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (total_tokens, 0, 0, total_tokens),
+        last: (10, 0, 0, 10),
+      }));
+    }
+    std::fs::write(sessions.join("timed.jsonl"), body).expect("write timed session");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare timed scan");
+    let scan_started_at =
+      chrono::DateTime::parse_from_rfc3339(&prepared.scan_started_at).expect("parse scan start");
+    let elapsed = chrono::Utc::now().signed_duration_since(scan_started_at);
+
+    assert!(
+      elapsed >= chrono::Duration::milliseconds(10),
+      "scan start should precede parsing, elapsed={elapsed:?}"
+    );
+  }
+
+  #[test]
+  fn spooled_commit_preserves_last_usage_and_removes_spool() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "71717171-7171-7171-7171-717171717171";
+    let missing_parent_id = "72727272-7272-7272-7272-727272727272";
+    let mut body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
+      ),
+      session_id, missing_parent_id,
+    );
+    let mut snapshots = 0i64;
+    let mut total_tokens = 1_000i64;
+    while body.len() <= PREPARED_SPOOL_THRESHOLD_BYTES * 3 {
+      if snapshots > 0 {
+        total_tokens += 10;
+      }
+      body.push_str(&token_count_line(TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (total_tokens, 0, 0, total_tokens),
+        last: (10, 0, 0, 10),
+      }));
+      snapshots += 1;
+    }
+    std::fs::write(sessions.join("spooled-fork.jsonl"), body).expect("write fork session");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare spooled fork");
+    assert!(prepared.stats().used_spool);
+    let spool_path = prepared.spool_path().expect("spool path").to_path_buf();
+
+    commit_prepared_scan(prepared).expect("commit spooled fork");
+
+    assert!(!spool_path.exists());
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(session_usage_totals(&conn, session_id).3, snapshots * 10);
+  }
+
+  #[test]
+  fn bounded_parent_replay_cache_evicts_without_changing_fork_results() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let pair_count = PARENT_REPLAY_CACHE_MAX_ENTRIES + 1;
+    let mut child_session_ids = Vec::new();
+    for index in 0..pair_count {
+      let parent_session_id = format!("90000000-0000-0000-0000-{index:012x}");
+      let child_session_id = format!("a0000000-0000-0000-0000-{index:012x}");
+      write_replay_cache_pair(&sessions, index, &parent_session_id, &child_session_id);
+      child_session_ids.push(child_session_id);
+    }
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare replay pairs");
+
+    assert!(prepared.parent_replay_cache_evictions() > 0);
+    commit_prepared_scan(prepared).expect("commit replay pairs");
+    let conn = open_connection(&db_path).expect("open database");
+    for child_session_id in child_session_ids {
+      assert_eq!(session_usage_totals(&conn, &child_session_id).3, 10);
+    }
+  }
+
+  #[test]
+  fn oversized_parent_replay_cache_entry_is_bypassed_not_evicted() {
+    let oversized_model_id = "x".repeat(PARENT_REPLAY_CACHE_MAX_BYTES);
+    let snapshots = vec![replay_snapshot(
+      "2026-07-10T00:00:00Z",
+      &oversized_model_id,
+      (10, 0, 0, 10, 10),
+      Some((10, 0, 0, 10, 10)),
+    )];
+    let mut cache = ParentReplayCache::new();
+
+    cache.insert("oversized-parent".to_string(), Some(snapshots));
+
+    assert_eq!(cache.evictions(), 0);
+    assert_eq!(cache.oversized_bypasses(), 1);
+    assert!(cache.get("oversized-parent").is_none());
+  }
+
+  #[test]
+  fn prepared_stats_include_parent_replay_bytes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let parent_session_id = "91919191-9191-9191-9191-919191919191";
+    let child_session_id = "92929292-9292-9292-9292-929292929292";
+    write_replay_cache_pair(&sessions, 0, parent_session_id, child_session_id);
+    let main_scan_bytes = std::fs::read_dir(&sessions)
+      .expect("read sessions")
+      .map(|entry| {
+        entry
+          .expect("session entry")
+          .metadata()
+          .expect("metadata")
+          .len()
+      })
+      .sum::<u64>();
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare replay pair");
+
+    assert!(prepared.stats().source_bytes_read > main_scan_bytes);
+  }
+
+  #[test]
+  fn full_and_incremental_wrappers_match_prepared_scan_results() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "80808080-8080-8080-8080-808080808080";
+    let session_path = sessions.join("compatibility.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let direct_db_path = directory.path().join("direct.sqlite");
+    let wrapper_db_path = directory.path().join("wrapper.sqlite");
+    initialize_scan_database(&direct_db_path);
+
+    let direct_full = commit_prepared_scan(
+      prepare_scan(
+        &direct_db_path,
+        Some(codex_home.to_string_lossy().to_string()),
+        ScanKind::Full,
+      )
+      .expect("prepare direct full scan"),
+    )
+    .expect("commit direct full scan");
+    let wrapper_full = perform_scan(
+      &wrapper_db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+    )
+    .expect("wrapper full scan");
+    assert_scan_results_equivalent(&direct_full, &wrapper_full);
+
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+    let direct_incremental = commit_prepared_scan(
+      prepare_scan(
+        &direct_db_path,
+        Some(codex_home.to_string_lossy().to_string()),
+        ScanKind::Incremental,
+      )
+      .expect("prepare direct incremental scan"),
+    )
+    .expect("commit direct incremental scan");
+    let wrapper_incremental = perform_incremental_scan(
+      &wrapper_db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+    )
+    .expect("wrapper incremental scan");
+    assert_scan_results_equivalent(&direct_incremental, &wrapper_incremental);
+
+    let direct_conn = open_connection(&direct_db_path).expect("open direct database");
+    let wrapper_conn = open_connection(&wrapper_db_path).expect("open wrapper database");
+    assert_eq!(
+      session_usage_totals(&direct_conn, session_id),
+      session_usage_totals(&wrapper_conn, session_id)
+    );
+  }
+
   #[test]
   fn parent_replay_reader_rejects_malformed_token_candidate_between_snapshots() {
     let directory = tempdir().expect("tempdir");
@@ -2104,13 +4074,11 @@ mod tests {
       total: (100, 0, 0, 100),
       last: (100, 0, 0, 100),
     });
-    body.push_str(
-      concat!(
-        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{",
-        "\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":0,",
-        "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":180}}}}\n"
-      ),
-    );
+    body.push_str(concat!(
+      "{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{",
+      "\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":0,",
+      "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":180}}}}\n"
+    ));
     std::fs::write(&parent_path, body).expect("write replay parent without timestamp");
 
     assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
@@ -2128,14 +4096,12 @@ mod tests {
       total: (100, 0, 0, 100),
       last: (100, 0, 0, 100),
     });
-    body.push_str(
-      concat!(
-        "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",",
-        "\"payload\":{\"type\":\"token_count\",\"info\":{",
-        "\"last_token_usage\":{\"input_tokens\":80,\"cached_input_tokens\":0,",
-        "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":80}}}}\n"
-      ),
-    );
+    body.push_str(concat!(
+      "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",",
+      "\"payload\":{\"type\":\"token_count\",\"info\":{",
+      "\"last_token_usage\":{\"input_tokens\":80,\"cached_input_tokens\":0,",
+      "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":80}}}}\n"
+    ));
     std::fs::write(&parent_path, body).expect("write replay parent without total usage");
 
     assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
@@ -2171,15 +4137,13 @@ mod tests {
       total: (100, 0, 0, 100),
       last: (100, 0, 0, 100),
     });
-    body.push_str(
-      concat!(
-        "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"response_item\",",
-        "\"payload\":{\"message\":{\"type\":\"event_msg\",\"payload\":{",
-        "\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
-        "\"input_tokens\":900,\"cached_input_tokens\":0,\"output_tokens\":0,",
-        "\"reasoning_output_tokens\":0,\"total_tokens\":900}}}}}}\n"
-      ),
-    );
+    body.push_str(concat!(
+      "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"response_item\",",
+      "\"payload\":{\"message\":{\"type\":\"event_msg\",\"payload\":{",
+      "\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
+      "\"input_tokens\":900,\"cached_input_tokens\":0,\"output_tokens\":0,",
+      "\"reasoning_output_tokens\":0,\"total_tokens\":900}}}}}}\n"
+    ));
     std::fs::write(&parent_path, body).expect("write replay parent with nested token types");
 
     let snapshots = read_parent_replay_snapshots(&parent_path, parent_session_id)
@@ -2232,11 +4196,7 @@ mod tests {
     ];
 
     assert_eq!(
-      replayed_child_snapshot_cutoff(
-        &parent,
-        &child,
-        Some(fork_instant("2026-03-24T00:05:00Z")),
-      ),
+      replayed_child_snapshot_cutoff(&parent, &child, Some(fork_instant("2026-03-24T00:05:00Z")),),
       3
     );
   }
@@ -2271,11 +4231,7 @@ mod tests {
     let child = vec![first, second, third];
 
     assert_eq!(
-      replayed_child_snapshot_cutoff(
-        &parent,
-        &child,
-        Some(fork_instant("2026-03-24T00:04:00Z")),
-      ),
+      replayed_child_snapshot_cutoff(&parent, &child, Some(fork_instant("2026-03-24T00:04:00Z")),),
       3
     );
   }
@@ -2319,12 +4275,8 @@ mod tests {
       (180, 20, 35, 2, 217),
       Some((80, 10, 15, 1, 96)),
     );
-    let child_second = replay_snapshot(
-      "2026-03-24T00:01:00Z",
-      "model",
-      (180, 20, 35, 2, 217),
-      None,
-    );
+    let child_second =
+      replay_snapshot("2026-03-24T00:01:00Z", "model", (180, 20, 35, 2, 217), None);
 
     assert_eq!(
       replayed_child_snapshot_cutoff(
@@ -2445,11 +4397,7 @@ mod tests {
     );
 
     assert_eq!(
-      replayed_child_snapshot_cutoff(
-        &[first.clone(), second.clone()],
-        &[first, second],
-        None,
-      ),
+      replayed_child_snapshot_cutoff(&[first.clone(), second.clone()], &[first, second], None,),
       0
     );
   }
@@ -2504,7 +4452,10 @@ mod tests {
       Some(fork_instant("2026-03-24T08:30:00+08:00"))
     );
     let serialized = serde_json::to_value(&parsed.snapshots[0]).expect("serialize snapshot");
-    assert!(!serialized.as_object().expect("snapshot object").contains_key("lastTokenUsage"));
+    assert!(!serialized
+      .as_object()
+      .expect("snapshot object")
+      .contains_key("lastTokenUsage"));
   }
 
   #[test]
@@ -2539,7 +4490,10 @@ mod tests {
     )
     .expect("parse thread-spawn session");
 
-    assert_eq!(parsed.raw_session.parent_session_id.as_deref(), Some(parent_id));
+    assert_eq!(
+      parsed.raw_session.parent_session_id.as_deref(),
+      Some(parent_id)
+    );
     assert!(parsed.explicit_forked_from_id.is_none());
     assert!(parsed.explicit_fork_timestamp.is_none());
   }
@@ -2679,9 +4633,8 @@ mod tests {
       )
       .expect("query usage");
 
-    let standard = (75.0 / 1_000_000.0) * 5.0
-      + (25.0 / 1_000_000.0) * 0.5
-      + (40.0 / 1_000_000.0) * 30.0;
+    let standard =
+      (75.0 / 1_000_000.0) * 5.0 + (25.0 / 1_000_000.0) * 0.5 + (40.0 / 1_000_000.0) * 30.0;
     assert!((value_usd - standard).abs() < 1e-9);
     assert_eq!(fast_mode_auto, 0);
     assert_eq!(fast_mode_effective, 0);
@@ -2710,8 +4663,13 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    let (input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd):
-      (i64, i64, i64, i64, f64) = conn
+    let (input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd): (
+      i64,
+      i64,
+      i64,
+      i64,
+      f64,
+    ) = conn
       .query_row(
         "
         SELECT input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd
@@ -2735,9 +4693,8 @@ mod tests {
     assert_eq!(cached_input_tokens, 25);
     assert_eq!(output_tokens, 40);
     assert_eq!(total_tokens, 140);
-    let standard = (75.0 / 1_000_000.0) * 5.0
-      + (25.0 / 1_000_000.0) * 0.5
-      + (40.0 / 1_000_000.0) * 30.0;
+    let standard =
+      (75.0 / 1_000_000.0) * 5.0 + (25.0 / 1_000_000.0) * 0.5 + (40.0 / 1_000_000.0) * 30.0;
     assert!((value_usd - standard).abs() < 1e-9);
   }
 
@@ -2750,7 +4707,9 @@ mod tests {
 
     let child_session_id = "019d4f72-a2ee-77a0-bd4a-76f43b7b299b";
     let wrong_session_id = "019d4d7c-457e-7020-8b5f-7940eb5e3716";
-    let session_path = sessions_dir.join(format!("rollout-2026-04-03T02-26-46-{child_session_id}.jsonl"));
+    let session_path = sessions_dir.join(format!(
+      "rollout-2026-04-03T02-26-46-{child_session_id}.jsonl"
+    ));
     write_session_file_with_parent(
       &session_path,
       child_session_id,
@@ -2799,7 +4758,10 @@ mod tests {
       .optional()
       .expect("query repaired import state");
     assert_eq!(repaired_session_id.as_deref(), Some(child_session_id));
-    assert_eq!(session_usage_totals(&conn, child_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(
+      session_usage_totals(&conn, child_session_id),
+      (100, 20, 25, 125, 1)
+    );
   }
 
   #[test]
@@ -2828,7 +4790,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.parent_session_id.as_deref(), Some("root-parent"));
+    assert_eq!(
+      parsed.raw_session.parent_session_id.as_deref(),
+      Some("root-parent")
+    );
     assert_eq!(parsed.raw_session.agent_nickname.as_deref(), Some("Hume"));
     assert_eq!(parsed.snapshots.len(), 2);
     assert_eq!(parsed.latest_plan_type.as_deref(), Some("pro"));
@@ -2837,10 +4802,9 @@ mod tests {
   #[test]
   fn parser_prefers_file_matching_session_meta_when_fork_file_replays_parent_meta() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
-        .path()
-        .join("rollout-2026-03-24T00-00-00-55555555-5555-5555-5555-555555555555.jsonl");
+    let session_path = directory
+      .path()
+      .join("rollout-2026-03-24T00-00-00-55555555-5555-5555-5555-555555555555.jsonl");
     std::fs::write(
       &session_path,
       concat!(
@@ -2863,7 +4827,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "55555555-5555-5555-5555-555555555555");
+    assert_eq!(
+      parsed.raw_session.session_id,
+      "55555555-5555-5555-5555-555555555555"
+    );
     assert_eq!(
       parsed.raw_session.parent_session_id.as_deref(),
       Some("44444444-4444-4444-4444-444444444444")
@@ -2930,10 +4897,9 @@ mod tests {
   #[test]
   fn parser_supports_legacy_top_level_id_format() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
-        .path()
-        .join("rollout-2025-09-09T16-29-03-0df0be29-d74d-468f-8dda-0630fc6e989e.jsonl");
+    let session_path = directory
+      .path()
+      .join("rollout-2025-09-09T16-29-03-0df0be29-d74d-468f-8dda-0630fc6e989e.jsonl");
     std::fs::write(
       &session_path,
       concat!(
@@ -2955,17 +4921,22 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "0df0be29-d74d-468f-8dda-0630fc6e989e");
-    assert_eq!(parsed.raw_session.started_at.as_deref(), Some("2025-09-09T08:29:03.118Z"));
+    assert_eq!(
+      parsed.raw_session.session_id,
+      "0df0be29-d74d-468f-8dda-0630fc6e989e"
+    );
+    assert_eq!(
+      parsed.raw_session.started_at.as_deref(),
+      Some("2025-09-09T08:29:03.118Z")
+    );
   }
 
   #[test]
   fn parser_falls_back_to_session_id_from_filename() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
-        .path()
-        .join("rollout-2026-03-17T18-00-21-019cfb3d-415c-7623-aab0-22e73abcec2e.jsonl");
+    let session_path = directory
+      .path()
+      .join("rollout-2026-03-17T18-00-21-019cfb3d-415c-7623-aab0-22e73abcec2e.jsonl");
     std::fs::write(
       &session_path,
       concat!(
@@ -2986,7 +4957,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "019cfb3d-415c-7623-aab0-22e73abcec2e");
+    assert_eq!(
+      parsed.raw_session.session_id,
+      "019cfb3d-415c-7623-aab0-22e73abcec2e"
+    );
   }
 
   #[test]
@@ -2997,11 +4971,19 @@ mod tests {
       child_count: 0,
     };
     assert_eq!(
-      classify_topology_maintenance(Some(&existing_child), existing_child.child_count, Some("root-parent")),
+      classify_topology_maintenance(
+        Some(&existing_child),
+        existing_child.child_count,
+        Some("root-parent")
+      ),
       TopologyMaintenance::None
     );
     assert_eq!(
-      classify_topology_maintenance(Some(&existing_child), existing_child.child_count, Some("other-parent")),
+      classify_topology_maintenance(
+        Some(&existing_child),
+        existing_child.child_count,
+        Some("other-parent")
+      ),
       TopologyMaintenance::RecomputeAll
     );
 
@@ -3011,7 +4993,11 @@ mod tests {
       child_count: 2,
     };
     assert_eq!(
-      classify_topology_maintenance(Some(&missing_parent_placeholder), missing_parent_placeholder.child_count, None),
+      classify_topology_maintenance(
+        Some(&missing_parent_placeholder),
+        missing_parent_placeholder.child_count,
+        None
+      ),
       TopologyMaintenance::RecomputeAll
     );
     assert_eq!(
@@ -3033,7 +5019,11 @@ mod tests {
 
     let parent_session_id = "44444444-4444-4444-4444-444444444444";
     let child_session_id = "55555555-5555-5555-5555-555555555555";
-    write_session_file(&sessions_dir.join("parent.jsonl"), parent_session_id, &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)]);
+    write_session_file(
+      &sessions_dir.join("parent.jsonl"),
+      parent_session_id,
+      &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)],
+    );
     write_session_file_with_parent(
       &sessions_dir.join("child.jsonl"),
       child_session_id,
@@ -3066,7 +5056,11 @@ mod tests {
     );
     assert_eq!(
       conversation_link(&conn, child_session_id),
-      Some((parent_session_id.to_string(), Some(parent_session_id.to_string()), 1))
+      Some((
+        parent_session_id.to_string(),
+        Some(parent_session_id.to_string()),
+        1
+      ))
     );
   }
 
@@ -3107,7 +5101,11 @@ mod tests {
     );
     assert_eq!(
       conversation_link(&conn, child_session_id),
-      Some((parent_session_id.to_string(), Some(parent_session_id.to_string()), 1))
+      Some((
+        parent_session_id.to_string(),
+        Some(parent_session_id.to_string()),
+        1
+      ))
     );
   }
 
@@ -3125,24 +5123,34 @@ mod tests {
     write_session_file(
       &active_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("active".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("active".to_string())
+    );
 
     let archived_path = archived_dir.join("sample.jsonl");
     std::fs::rename(&active_path, &archived_path).expect("move to archived");
 
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("archived".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("archived".to_string())
+    );
   }
 
   #[test]
@@ -3173,13 +5181,19 @@ mod tests {
       ],
     );
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 0);
-    assert_eq!(session_usage_totals(&conn, active_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, archived_session_id), (0, 0, 0, 0, 0));
+    assert_eq!(
+      session_usage_totals(&conn, active_session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, archived_session_id),
+      (0, 0, 0, 0, 0)
+    );
   }
 
   #[test]
@@ -3212,13 +5226,19 @@ mod tests {
       &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
     );
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+    assert_eq!(
+      session_usage_totals(&conn, existing_session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, new_session_id),
+      (180, 40, 45, 225, 1)
+    );
   }
 
   #[test]
@@ -3247,13 +5267,19 @@ mod tests {
       &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
     );
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+    assert_eq!(
+      session_usage_totals(&conn, existing_session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, new_session_id),
+      (180, 40, 45, 225, 1)
+    );
   }
 
   #[test]
@@ -3275,13 +5301,19 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
     std::fs::remove_file(&session_path).expect("remove active session");
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 0);
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("missing".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("missing".to_string())
+    );
   }
 
   #[test]
@@ -3310,13 +5342,19 @@ mod tests {
       &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
     );
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, recovered_session_id), (180, 40, 45, 225, 1));
+    assert_eq!(
+      session_usage_totals(&conn, existing_session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, recovered_session_id),
+      (180, 40, 45, 225, 1)
+    );
     let pending_count: i64 = conn
       .query_row(
         "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
@@ -3339,9 +5377,7 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 150, 30, 40, 190),
-      ],
+      &[("2026-03-24T00:00:01Z", 150, 30, 40, 190)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
@@ -3350,8 +5386,14 @@ mod tests {
 
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (150, 30, 40, 190, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("missing".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (150, 30, 40, 190, 1)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("missing".to_string())
+    );
   }
 
   #[test]
@@ -3366,9 +5408,7 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
@@ -3387,8 +5427,14 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("third scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
-    assert_eq!(session_source_state(&conn, session_id), Some("active".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("active".to_string())
+    );
   }
 
   #[test]
@@ -3415,7 +5461,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (960, 120, 120, 1200, 3));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (960, 120, 120, 1200, 3)
+    );
   }
 
   #[test]
@@ -3492,18 +5541,31 @@ mod tests {
           )
           VALUES (?1, '2026-05-18T14:42:50Z', 'gpt-5.4', ?2, ?3, ?4, 0, ?5, 0.0, 0, 0)
           ",
-          params![session_id, input_tokens, cached_input_tokens, output_tokens, total_tokens],
+          params![
+            session_id,
+            input_tokens,
+            cached_input_tokens,
+            output_tokens,
+            total_tokens
+          ],
         )
         .expect("insert stale usage event");
     }
-    assert_eq!(session_usage_totals(&conn, session_id), (1840, 230, 230, 2300, 4));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (1840, 230, 230, 2300, 4)
+    );
     drop(conn);
 
-    let result = perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+    let result =
+      perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, session_id), (960, 120, 120, 1200, 3));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (960, 120, 120, 1200, 3)
+    );
     let repair_completed: Option<String> = conn
       .query_row(
         "SELECT completed_at FROM data_repairs WHERE repair_key = ?1",
@@ -3572,10 +5634,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, child_created_at,
     );
     for (index, fixture) in parent_fixtures.iter().copied().enumerate() {
       let timestamp = match index {
@@ -3725,8 +5784,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_session_id,
-      parent_session_id,
+      child_session_id, parent_session_id,
     );
     child_body.push_str(&token_count_line(inherited));
     child_body.push_str(&token_count_line(TokenFixture {
@@ -3887,7 +5945,8 @@ mod tests {
         ("2026-05-18T14:42:50Z", 960, 120, 120, 1200),
       ],
     );
-    std::fs::write(sessions_dir.join("unparseable.jsonl"), "not json\n").expect("write bad session");
+    std::fs::write(sessions_dir.join("unparseable.jsonl"), "not json\n")
+      .expect("write bad session");
 
     let db_path = directory.path().join("usage.sqlite");
     let conn = open_connection(&db_path).expect("open db");
@@ -3932,7 +5991,13 @@ mod tests {
           )
           VALUES (?1, '2026-05-18T14:42:50Z', 'gpt-5.4', ?2, ?3, ?4, 0, ?5, 0.0, 0, 0)
           ",
-          params![session_id, input_tokens, cached_input_tokens, output_tokens, total_tokens],
+          params![
+            session_id,
+            input_tokens,
+            cached_input_tokens,
+            output_tokens,
+            total_tokens
+          ],
         )
         .expect("insert stale usage event");
     }
@@ -3941,7 +6006,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (960, 120, 120, 1200, 3));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (960, 120, 120, 1200, 3)
+    );
     let repair_completed: Option<String> = conn
       .query_row(
         "SELECT completed_at FROM data_repairs WHERE repair_key = ?1",
@@ -3961,7 +6029,12 @@ mod tests {
       .expect("query pending repair file");
     assert_eq!(
       pending_path.as_deref(),
-      Some(sessions_dir.join("unparseable.jsonl").to_string_lossy().as_ref())
+      Some(
+        sessions_dir
+          .join("unparseable.jsonl")
+          .to_string_lossy()
+          .as_ref()
+      )
     );
     let session_rate_sample_count: i64 = conn
       .query_row(
@@ -3973,7 +6046,8 @@ mod tests {
     assert!(session_rate_sample_count > 0);
     drop(conn);
 
-    let result = perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("rescan");
+    let result =
+      perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("rescan");
     assert_eq!(result.updated_sessions, 0);
   }
 
@@ -4060,16 +6134,17 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
     let conn = open_connection(&db_path).expect("open db after first scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
     drop(conn);
 
     write_session_file(
@@ -4083,7 +6158,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after second scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
   }
 
   #[test]
@@ -4098,16 +6176,17 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
     let conn = open_connection(&db_path).expect("open db after first scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
     drop(conn);
 
     std::fs::write(
@@ -4124,7 +6203,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after incomplete rescan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
     drop(conn);
 
     write_session_file(
@@ -4138,7 +6220,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("third scan");
 
     let conn = open_connection(&db_path).expect("open db after third scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
   }
 
   #[test]
@@ -4174,7 +6259,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after second scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
   }
 
   #[test]
@@ -4186,10 +6274,12 @@ mod tests {
 
     let parent_session_id = "77777777-7777-7777-7777-777777777777";
     let child_session_id = "88888888-8888-8888-8888-888888888888";
-    let parent_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"));
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-05-00-{child_session_id}.jsonl"));
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-05-00-{child_session_id}.jsonl"
+    ));
 
     write_session_file(
       &parent_path,
@@ -4214,8 +6304,14 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, parent_session_id), (260, 60, 65, 325, 3));
-    assert_eq!(session_usage_totals(&conn, child_session_id), (140, 20, 25, 165, 2));
+    assert_eq!(
+      session_usage_totals(&conn, parent_session_id),
+      (260, 60, 65, 325, 3)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, child_session_id),
+      (140, 20, 25, 165, 2)
+    );
     assert_eq!(
       session_root_and_subagents(&conn, parent_session_id),
       Some((parent_session_id.to_string(), true))
@@ -4243,10 +6339,12 @@ mod tests {
 
     let parent_session_id = "99999999-9999-9999-9999-999999999999";
     let child_session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-    let parent_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"));
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"));
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
     let parent_fixtures = [
       TokenFixture {
         timestamp: "2026-03-24T00:00:01Z",
@@ -4287,10 +6385,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, child_created_at,
     );
     for fixture in parent_fixtures.iter().copied() {
       child_body.push_str(&token_count_line(TokenFixture {
@@ -4357,10 +6452,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, child_created_at,
     );
     child_body.push_str(&token_count_line(TokenFixture {
       timestamp: "2026-03-24T00:30:01Z",
@@ -4445,10 +6537,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, child_created_at,
     );
     for (index, fixture) in parent_fixtures.iter().copied().enumerate() {
       let timestamp = match index {
@@ -4558,8 +6647,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_session_id,
-      root_session_id,
+      child_session_id, root_session_id,
     );
     for fixture in child_fixtures.iter().copied() {
       child_body.push_str(&token_count_line(fixture));
@@ -4573,8 +6661,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      grandchild_session_id,
-      child_session_id,
+      grandchild_session_id, child_session_id,
     );
     for (index, fixture) in child_fixtures.iter().copied().enumerate() {
       let timestamp = match index {
@@ -4596,7 +6683,8 @@ mod tests {
     std::fs::write(&grandchild_path, grandchild_body).expect("write grandchild session");
 
     let db_path = directory.path().join("usage.sqlite");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full family scan");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("full family scan");
 
     let conn = open_connection(&db_path).expect("open db");
     let root_total = session_usage_totals(&conn, root_session_id).3;
@@ -4676,11 +6764,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, parent_session_id, child_created_at,
     );
     for fixture in [
       TokenFixture {
@@ -4717,8 +6801,9 @@ mod tests {
 
     let parent_session_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
     let child_session_id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T01-00-00-{child_session_id}.jsonl"));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T01-00-00-{child_session_id}.jsonl"
+    ));
     let mut child_body = format!(
       concat!(
         "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"session_meta\",",
@@ -4726,8 +6811,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_session_id,
-      parent_session_id,
+      child_session_id, parent_session_id,
     );
     child_body.push_str(&token_count_line(TokenFixture {
       timestamp: "2026-03-24T01:00:00Z",
@@ -4752,8 +6836,9 @@ mod tests {
 
     let parent_session_id = "dddddddd-dddd-dddd-dddd-dddddddddddd";
     let child_session_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T02-00-00-{child_session_id}.jsonl"));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T02-00-00-{child_session_id}.jsonl"
+    ));
     let mut child_body = format!(
       concat!(
         "{{\"timestamp\":\"2026-03-24T02:00:00Z\",\"type\":\"session_meta\",\"payload\":{{",
@@ -4762,8 +6847,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T02:00:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_session_id,
-      parent_session_id,
+      child_session_id, parent_session_id,
     );
     child_body.push_str(&token_count_line(TokenFixture {
       timestamp: "2026-03-24T02:00:00Z",
@@ -4846,11 +6930,8 @@ mod tests {
       .expect("create source switch trigger");
     drop(conn);
 
-    perform_scan(
-      &db_path,
-      Some(old_codex_home.to_string_lossy().to_string()),
-    )
-    .expect("scan old source");
+    perform_scan(&db_path, Some(old_codex_home.to_string_lossy().to_string()))
+      .expect("scan old source");
 
     let conn = open_connection(&db_path).expect("reopen database");
     let (codex_home, started, completed, full_completed): (
@@ -4898,18 +6979,19 @@ mod tests {
       .expect("scan matching source");
 
     let conn = open_connection(&db_path).expect("reopen database");
-    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) = conn
-      .query_row(
-        "
+    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) =
+      conn
+        .query_row(
+          "
         SELECT last_scan_started_at, last_scan_completed_at,
                last_full_scan_completed_at
         FROM sync_settings
         WHERE singleton_id = 1
         ",
-        [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-      )
-      .expect("load scan freshness");
+          [],
+          |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("load scan freshness");
 
     assert!(started.is_some());
     assert!(completed.is_some());
@@ -4932,25 +7014,23 @@ mod tests {
     save_sync_settings(&conn, &settings).expect("save new source");
     drop(conn);
 
-    perform_scan(
-      &db_path,
-      Some(old_codex_home.to_string_lossy().to_string()),
-    )
-    .expect("scan previous source");
+    perform_scan(&db_path, Some(old_codex_home.to_string_lossy().to_string()))
+      .expect("scan previous source");
 
     let conn = open_connection(&db_path).expect("reopen database");
-    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) = conn
-      .query_row(
-        "
+    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) =
+      conn
+        .query_row(
+          "
         SELECT last_scan_started_at, last_scan_completed_at,
                last_full_scan_completed_at
         FROM sync_settings
         WHERE singleton_id = 1
         ",
-        [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-      )
-      .expect("load scan freshness");
+          [],
+          |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("load scan freshness");
 
     assert_eq!(started, None);
     assert_eq!(completed, None);
@@ -4960,8 +7040,8 @@ mod tests {
   #[test]
   fn changed_resolved_default_source_forces_full_scan() {
     assert_eq!(
-      effective_scan_scope(ScanScope::Incremental, false, false, false, true),
-      ScanScope::Full
+      effective_scan_scope(ScanKind::Incremental, false, false, false, true),
+      ScanKind::Full
     );
   }
 
@@ -5010,17 +7090,26 @@ mod tests {
       .expect("load scan source identity");
 
     assert_eq!(selector, None);
-    assert_eq!(resolved_source.as_deref(), Some(second_codex_home.to_string_lossy().as_ref()));
+    assert_eq!(
+      resolved_source.as_deref(),
+      Some(second_codex_home.to_string_lossy().as_ref())
+    );
     assert_eq!(result.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
     assert_eq!(session_usage_totals(&conn, first_session_id).3, 110);
-    assert_eq!(session_source_state(&conn, first_session_id), Some("missing".to_string()));
-    assert_eq!(import_state_session_id(&conn, &first_sessions.join("first.jsonl")), None);
+    assert_eq!(
+      session_source_state(&conn, first_session_id),
+      Some("missing".to_string())
+    );
+    assert_eq!(
+      import_state_session_id(&conn, &first_sessions.join("first.jsonl")),
+      None
+    );
     assert!(first_sessions.join("first.jsonl").is_file());
   }
 
   #[test]
-  fn full_scan_retry_reconciles_previous_source_after_the_first_attempt_fails() {
+  fn failed_full_scan_rolls_back_freshness_and_retry_reconciles_previous_source() {
     let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
     let directory = tempdir().expect("tempdir");
     let first_codex_home = directory.path().join("codex-home-a");
@@ -5049,6 +7138,9 @@ mod tests {
     perform_scan(&db_path, None).expect("scan first default source");
 
     let conn = open_connection(&db_path).expect("open database");
+    let previous_full_scan_completed_at =
+      get_last_full_scan_completed(&conn).expect("load previous full freshness");
+    assert!(previous_full_scan_completed_at.is_some());
     conn
       .execute_batch(&format!(
         "
@@ -5064,11 +7156,15 @@ mod tests {
     drop(conn);
 
     std::env::set_var("CODEX_HOME", &second_codex_home);
-    let error = perform_incremental_scan(&db_path, None).expect_err("first moved-source scan should fail");
+    let error =
+      perform_incremental_scan(&db_path, None).expect_err("first moved-source scan should fail");
     assert!(error.contains("forced source reconciliation failure"));
 
     let conn = open_connection(&db_path).expect("reopen failed database");
-    assert_eq!(get_last_full_scan_completed(&conn).expect("load full freshness"), None);
+    assert_eq!(
+      get_last_full_scan_completed(&conn).expect("load rolled-back freshness"),
+      previous_full_scan_completed_at
+    );
     conn
       .execute_batch("DROP TRIGGER fail_previous_source_reconciliation;")
       .expect("drop reconciliation trigger");
@@ -5079,7 +7175,10 @@ mod tests {
     let conn = open_connection(&db_path).expect("open retried database");
     assert_eq!(retry.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
-    assert_eq!(session_source_state(&conn, first_session_id), Some("missing".to_string()));
+    assert_eq!(
+      session_source_state(&conn, first_session_id),
+      Some("missing".to_string())
+    );
     assert_eq!(import_state_session_id(&conn, &first_session_path), None);
     assert!(first_session_path.is_file());
   }
@@ -5105,7 +7204,9 @@ mod tests {
     perform_scan(&db_path, None).expect("initial full scan");
 
     let conn = open_connection(&db_path).expect("open initial database");
-    assert!(get_last_full_scan_completed(&conn).expect("load initial freshness").is_some());
+    assert!(get_last_full_scan_completed(&conn)
+      .expect("load initial freshness")
+      .is_some());
     conn
       .execute(
         "DELETE FROM data_repairs WHERE repair_key = ?1",
@@ -5135,7 +7236,10 @@ mod tests {
       )
       .optional()
       .expect("load pending rate-limit repair");
-    assert_eq!(pending_rate_limit_path.as_deref(), Some(session_path.to_string_lossy().as_ref()));
+    assert_eq!(
+      pending_rate_limit_path.as_deref(),
+      Some(session_path.to_string_lossy().as_ref())
+    );
     drop(conn);
 
     write_session_file(
@@ -5151,7 +7255,9 @@ mod tests {
     let conn = open_connection(&db_path).expect("open repaired database");
     assert_eq!(retry.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, session_id).3, 220);
-    assert!(get_last_full_scan_completed(&conn).expect("load repaired freshness").is_some());
+    assert!(get_last_full_scan_completed(&conn)
+      .expect("load repaired freshness")
+      .is_some());
     let pending_rate_limit_count: i64 = conn
       .query_row(
         "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
@@ -5170,9 +7276,8 @@ mod tests {
     std::fs::create_dir_all(&archived_sessions).expect("archived sessions");
 
     let session_id = "69696969-6969-4969-8969-696969696969";
-    let session_path = archived_sessions.join(format!(
-      "rollout-2026-07-10T00-00-00-{session_id}.jsonl"
-    ));
+    let session_path =
+      archived_sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
     write_session_file(
       &session_path,
       session_id,
@@ -5245,11 +7350,15 @@ mod tests {
     perform_scan(&db_path, None).expect("scan first default source");
 
     std::env::set_var("CODEX_HOME", &second_codex_home);
-    let partial = perform_incremental_scan(&db_path, None).expect("scan moved source with skipped archive");
+    let partial =
+      perform_incremental_scan(&db_path, None).expect("scan moved source with skipped archive");
     assert_eq!(partial.scanned_files, 2);
 
     let conn = open_connection(&db_path).expect("open partial database");
-    assert_eq!(get_last_full_scan_completed(&conn).expect("load full freshness"), None);
+    assert_eq!(
+      get_last_full_scan_completed(&conn).expect("load full freshness"),
+      None
+    );
     drop(conn);
 
     write_session_file(
@@ -5275,7 +7384,8 @@ mod tests {
       directory.path()
     );
     assert_eq!(
-      validate_codex_home(PathBuf::from("~/codex-home"), Some(directory.path())).expect("tilde prefix"),
+      validate_codex_home(PathBuf::from("~/codex-home"), Some(directory.path()))
+        .expect("tilde prefix"),
       nested
     );
   }
@@ -5291,7 +7401,11 @@ mod tests {
     let session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
     let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
     let archived_path = archived.join(active_path.file_name().expect("filename"));
-    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    write_session_file(
+      &active_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
@@ -5309,7 +7423,10 @@ mod tests {
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(session_usage_totals(&conn, session_id).3, 200);
-    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+    assert_eq!(
+      session_source_state(&conn, session_id).as_deref(),
+      Some("archived")
+    );
   }
 
   #[test]
@@ -5325,7 +7442,11 @@ mod tests {
     let session_id = "a0a0a0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0";
     let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
     let archived_path = archived.join(active_path.file_name().expect("filename"));
-    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    write_session_file(
+      &active_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
@@ -5346,11 +7467,15 @@ mod tests {
     drop(file);
     std::fs::rename(&active_path, &archived_path).expect("archive session");
 
-    let first_result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
-      .expect("import complete prefix from archive");
+    let first_result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("import complete prefix from archive");
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(first_result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 10, 110, 1));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 10, 110, 1)
+    );
     let archived_state: i64 = conn
       .query_row(
         "SELECT COUNT(*) FROM import_state WHERE source_path = ?1 AND source_bucket = 'archived'",
@@ -5380,8 +7505,14 @@ mod tests {
       .expect("reimport finished archive");
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 20, 200, 2));
-    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 20, 200, 2)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id).as_deref(),
+      Some("archived")
+    );
   }
 
   #[test]
@@ -5397,7 +7528,11 @@ mod tests {
     let session_id = "a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1";
     let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
     let archived_path = archived.join(active_path.file_name().expect("filename"));
-    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    write_session_file(
+      &active_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     write_session_file(
       &sessions.join("other.jsonl"),
       "a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2",
@@ -5442,7 +7577,10 @@ mod tests {
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(session_usage_totals(&conn, session_id).3, 200);
-    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+    assert_eq!(
+      session_source_state(&conn, session_id).as_deref(),
+      Some("archived")
+    );
   }
 
   #[test]
@@ -5458,12 +7596,18 @@ mod tests {
       &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
     );
     let index_path = codex_home.join("session_index.jsonl");
-    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"A\"}}\n"))
-      .expect("title A");
+    std::fs::write(
+      &index_path,
+      format!("{{\"id\":\"{session_id}\",\"thread_name\":\"A\"}}\n"),
+    )
+    .expect("title A");
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
-    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"B\"}}\n"))
-      .expect("title B");
+    std::fs::write(
+      &index_path,
+      format!("{{\"id\":\"{session_id}\",\"thread_name\":\"B\"}}\n"),
+    )
+    .expect("title B");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db");
@@ -5502,7 +7646,8 @@ mod tests {
     drop(file);
 
     let db_path = directory.path().join("usage.sqlite");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan skips bad file");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("scan skips bad file");
     let conn = open_connection(&db_path).expect("open db");
     let sessions_count: i64 = conn
       .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
@@ -5537,14 +7682,20 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
     let conn = open_connection(&db_path).expect("open db");
     conn
-      .execute("DELETE FROM conversation_links WHERE session_id = ?1", params![child])
+      .execute(
+        "DELETE FROM conversation_links WHERE session_id = ?1",
+        params![child],
+      )
       .expect("remove link");
     drop(conn);
 
     perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
       .expect("repair scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(conversation_link(&conn, child).expect("child link").0, parent);
+    assert_eq!(
+      conversation_link(&conn, child).expect("child link").0,
+      parent
+    );
   }
 
   #[test]
@@ -5581,7 +7732,10 @@ mod tests {
       .expect("repair scan");
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(
-      conversation_link(&conn, child).expect("child link").1.as_deref(),
+      conversation_link(&conn, child)
+        .expect("child link")
+        .1
+        .as_deref(),
       Some(parent)
     );
   }
@@ -5659,11 +7813,7 @@ mod tests {
           "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
           "}}}}\n"
         ),
-        timestamp,
-        input_tokens,
-        cached_input_tokens,
-        output_tokens,
-        total_tokens
+        timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens
       ));
     }
 
@@ -5676,7 +7826,10 @@ mod tests {
     parent_session_id: &str,
     snapshots: &[(&str, i64, i64, i64, i64)],
   ) {
-    let first_timestamp = snapshots.first().map(|item| item.0).unwrap_or("2026-03-24T00:00:00Z");
+    let first_timestamp = snapshots
+      .first()
+      .map(|item| item.0)
+      .unwrap_or("2026-03-24T00:00:00Z");
     let mut body = format!(
       concat!(
         "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
@@ -5708,11 +7861,7 @@ mod tests {
           "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
           "}}}}\n"
         ),
-        timestamp,
-        input_tokens,
-        cached_input_tokens,
-        output_tokens,
-        total_tokens
+        timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens
       ));
     }
 
@@ -5730,7 +7879,10 @@ mod tests {
       .expect("query root and subagents")
   }
 
-  fn conversation_link(conn: &Connection, session_id: &str) -> Option<(String, Option<String>, i64)> {
+  fn conversation_link(
+    conn: &Connection,
+    session_id: &str,
+  ) -> Option<(String, Option<String>, i64)> {
     conn
       .query_row(
         "
@@ -5759,7 +7911,15 @@ mod tests {
         WHERE session_id = ?1
         ",
         params![session_id],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        |row| {
+          Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+          ))
+        },
       )
       .expect("query usage totals")
   }

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -126,6 +126,31 @@ const PARSER_PREFIX_SIGNATURE_BYTES: u64 = 128;
 const PARENT_REPLAY_CACHE_MAX_ENTRIES: usize = 4;
 const PARENT_REPLAY_CACHE_MAX_BYTES: usize = 256 * 1024;
 
+struct RefreshMemoryRelief;
+
+impl Drop for RefreshMemoryRelief {
+  fn drop(&mut self) {
+    release_unused_process_memory();
+  }
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+  fn malloc_zone_pressure_relief(zone: *mut std::ffi::c_void, goal: usize) -> usize;
+}
+
+#[cfg(target_os = "macos")]
+fn release_unused_process_memory() {
+  // SAFETY: A null zone asks the macOS allocator to visit every registered zone.
+  // The call only releases pages currently unused by those zones.
+  unsafe {
+    malloc_zone_pressure_relief(std::ptr::null_mut(), 0);
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn release_unused_process_memory() {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScanKind {
   Full,
@@ -1105,6 +1130,7 @@ pub(crate) fn prepare_scan(
 }
 
 pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult, String> {
+  let _memory_relief = RefreshMemoryRelief;
   let PreparedScan {
     db_path,
     source_identity,

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -14,9 +14,9 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, now_utc_string, open_connection, preview_scan_freshness_for_source,
-  replace_session_rate_limit_samples, set_last_scan_started_for_source_in_transaction,
-  set_scan_completed_for_source,
+  bool_to_i64, insert_usage_events, now_utc_string, open_connection,
+  preview_scan_freshness_for_source, replace_session_rate_limit_samples,
+  set_last_scan_started_for_source_in_transaction, set_scan_completed_for_source, NewUsageEvent,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
@@ -2642,57 +2642,54 @@ fn persist_session(
     .and_then(|index| parsed.snapshots.get(index))
     .map(|snapshot| snapshot.usage.clone());
 
-  for snapshot in parsed.snapshots.iter().skip(snapshot_cutoff) {
-    if previous_usage.as_ref() == Some(&snapshot.usage) {
-      continue;
-    }
-
-    let delta = if let Some(previous) = previous_usage.as_ref() {
-      if snapshot.usage.total_tokens <= previous.total_tokens {
-        continue;
+  insert_usage_events(
+    conn,
+    parsed
+      .snapshots
+      .iter()
+      .skip(snapshot_cutoff)
+      .map(|snapshot| snapshot.timestamp.as_str()),
+    |index| {
+      let snapshot = &parsed.snapshots[snapshot_cutoff + index];
+      if previous_usage.as_ref() == Some(&snapshot.usage) {
+        return None;
       }
-      diff_usage(previous, &snapshot.usage)
-    } else if parsed.explicit_forked_from_id.is_some() {
-      snapshot
-        .last_token_usage
-        .clone()
-        .unwrap_or_else(|| snapshot.usage.clone())
-    } else {
-      snapshot.usage.clone()
-    };
 
-    previous_usage = Some(snapshot.usage.clone());
+      let delta = if let Some(previous) = previous_usage.as_ref() {
+        if snapshot.usage.total_tokens <= previous.total_tokens {
+          return None;
+        }
+        diff_usage(previous, &snapshot.usage)
+      } else if parsed.explicit_forked_from_id.is_some() {
+        snapshot
+          .last_token_usage
+          .clone()
+          .unwrap_or_else(|| snapshot.usage.clone())
+      } else {
+        snapshot.usage.clone()
+      };
 
-    if is_zero_delta(&delta) {
-      continue;
-    }
+      previous_usage = Some(snapshot.usage.clone());
+      if is_zero_delta(&delta) {
+        return None;
+      }
 
-    let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
-    let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
-
-    conn.execute(
-      "
-      INSERT INTO usage_events (
-        session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
-        reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective
-      )
-      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
-      ",
-      params![
-        parsed.raw_session.session_id,
-        snapshot.timestamp,
-        normalize_model_id(&snapshot.model_id),
-        delta.input_tokens,
-        delta.cached_input_tokens,
-        delta.output_tokens,
-        delta.reasoning_output_tokens,
-        delta.total_tokens,
+      let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
+      let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
+      Some(NewUsageEvent {
+        session_id: &parsed.raw_session.session_id,
+        model_id: normalize_model_id(&snapshot.model_id),
+        input_tokens: delta.input_tokens,
+        cached_input_tokens: delta.cached_input_tokens,
+        output_tokens: delta.output_tokens,
+        reasoning_output_tokens: delta.reasoning_output_tokens,
+        total_tokens: delta.total_tokens,
         value_usd,
-        0,
-        0,
-      ],
-    )?;
-  }
+        fast_mode_auto: false,
+        fast_mode_effective: false,
+      })
+    },
+  )?;
 
   conn.execute(
     "
@@ -5231,6 +5228,58 @@ mod tests {
     assert_eq!(samples.2, "seven_day".to_string());
     assert_eq!(samples.3, 79);
     assert_eq!(samples.4, 88);
+  }
+
+  #[test]
+  fn scan_persists_usage_event_epoch_timestamp() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_path = sessions_dir.join("usage-epoch.jsonl");
+    std::fs::write(
+      &session_path,
+      concat!(
+        "{\"timestamp\":\"2026-07-10T10:00:00+08:00\",\"type\":\"session_meta\",\"payload\":{\"id\":\"98989898-9898-4898-8898-989898989898\"}}\n",
+        "{\"timestamp\":\"2026-07-10T10:00:01+08:00\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n",
+        "{\"timestamp\":\"2026-07-10T10:00:02+08:00\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":25,\"reasoning_output_tokens\":0,\"total_tokens\":125}}}}\n"
+      ),
+    )
+    .expect("write session");
+    let db_path = directory.path().join("usage.sqlite");
+
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    let persisted = conn
+      .query_row(
+        "SELECT timestamp, timestamp_ms FROM usage_events",
+        [],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+      )
+      .expect("load usage epoch");
+    assert_eq!(persisted.0, "2026-07-10T10:00:02+08:00");
+    assert_eq!(
+      persisted.1,
+      Some(
+        crate::database::parse_epoch_millis(&persisted.0).expect("parse expected usage epoch")
+      )
+    );
+  }
+
+  #[test]
+  fn persist_session_delegates_usage_inserts_to_database_writer() {
+    let source = include_str!("importer.rs");
+    let persist_session_source = source
+      .split("fn persist_session(")
+      .nth(1)
+      .expect("persist_session source")
+      .split("fn diff_usage(")
+      .next()
+      .expect("persist_session body");
+
+    assert!(persist_session_source.contains("insert_usage_events("));
+    assert!(!persist_session_source.contains("INSERT INTO usage_events"));
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2033,9 +2033,18 @@ fn try_parse_session_tail_counted(
         reader.get_ref().bytes_read,
       )
     })?;
-    if line_bytes == 0 || !line.ends_with('\n') {
+    if line_bytes == 0 {
       break;
     }
+    let has_trailing_newline = line.ends_with('\n');
+    let value = match serde_json::from_str::<Value>(&line) {
+      Ok(value) => value,
+      Err(_) if !has_trailing_newline => break,
+      Err(_) => {
+        completed_offset = completed_offset.saturating_add(line_bytes as u64);
+        continue;
+      }
+    };
     completed_offset = completed_offset.saturating_add(line_bytes as u64);
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
@@ -2043,9 +2052,6 @@ fn try_parse_session_tail_counted(
     if line.contains("\"fast_mode\":false") || line.contains("\"quick_mode\":false") {
       explicit_fast_mode = Some(false);
     }
-    let Ok(value) = serde_json::from_str::<Value>(&line) else {
-      continue;
-    };
     let timestamp = value
       .get("timestamp")
       .and_then(Value::as_str)
@@ -2236,9 +2242,15 @@ fn parse_session_file_once(
     if line_bytes == 0 {
       break;
     }
-    if !line.ends_with('\n') {
-      break;
-    }
+    let has_trailing_newline = line.ends_with('\n');
+    let value = match serde_json::from_str::<Value>(&line) {
+      Ok(value) => value,
+      Err(_) if !has_trailing_newline => break,
+      Err(_) => {
+        completed_offset = completed_offset.saturating_add(line_bytes as u64);
+        continue;
+      }
+    };
     completed_offset = completed_offset.saturating_add(line_bytes as u64);
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
@@ -2246,10 +2258,6 @@ fn parse_session_file_once(
     if line.contains("\"fast_mode\":false") || line.contains("\"quick_mode\":false") {
       explicit_fast_mode = Some(false);
     }
-
-    let Ok(value) = serde_json::from_str::<Value>(&line) else {
-      continue;
-    };
 
     if session_id.is_empty() {
       if let Some(id) = value.get("id").and_then(Value::as_str) {
@@ -7282,7 +7290,7 @@ mod tests {
   }
 
   #[test]
-  fn incomplete_trailing_token_line_is_ignored_until_next_rescan() {
+  fn complete_trailing_token_line_without_newline_is_imported_once() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions_dir = codex_home.join("sessions");
@@ -7312,31 +7320,24 @@ mod tests {
         "{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"55555555-5555-5555-5555-555555555555\"}}\n",
         "{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n",
         "{\"timestamp\":\"2026-03-24T00:00:01Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":25,\"reasoning_output_tokens\":0,\"total_tokens\":125}},\"rate_limits\":{\"plan_type\":\"pro\"}}}\n",
-        "{\"timestamp\":\"2026-03-24T00:00:10Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":40,\"output_tokens\":45,\"reasoning_output_tokens\":0,\"total_tokens\":225}},\"rate_limits\":{\"plan_type\":\"pro\"}}"
+        "{\"timestamp\":\"2026-03-24T00:00:10Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":40,\"output_tokens\":45,\"reasoning_output_tokens\":0,\"total_tokens\":225}},\"rate_limits\":{\"plan_type\":\"pro\"}}}"
       ),
     )
-    .expect("write incomplete session");
+    .expect("write complete session without trailing newline");
 
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
-    let conn = open_connection(&db_path).expect("open db after incomplete rescan");
+    let conn = open_connection(&db_path).expect("open db after no-newline rescan");
     assert_eq!(
       session_usage_totals(&conn, session_id),
-      (100, 20, 25, 125, 1)
+      (180, 40, 45, 225, 2)
     );
     drop(conn);
 
-    write_session_file(
-      &session_path,
-      session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-        ("2026-03-24T00:00:10Z", 180, 40, 45, 225),
-      ],
-    );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("third scan");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("unchanged third scan");
 
-    let conn = open_connection(&db_path).expect("open db after third scan");
+    let conn = open_connection(&db_path).expect("open db after unchanged scan");
     assert_eq!(
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -14,9 +14,10 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, insert_usage_events, now_utc_string, open_connection,
+  bool_to_i64, now_utc_string, open_connection,
   preview_scan_freshness_for_source, replace_session_rate_limit_samples,
-  set_last_scan_started_for_source_in_transaction, set_scan_completed_for_source, NewUsageEvent,
+  replace_session_usage_events, set_last_scan_started_for_source_in_transaction,
+  set_scan_completed_for_source, NewUsageEvent,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
@@ -2626,10 +2627,6 @@ fn persist_session(
     ],
   )?;
 
-  conn.execute(
-    "DELETE FROM usage_events WHERE session_id = ?1",
-    params![parsed.raw_session.session_id],
-  )?;
   replace_session_rate_limit_samples(
     conn,
     &parsed.raw_session.session_id,
@@ -2669,8 +2666,9 @@ fn persist_session(
     usage_event_plan.push((snapshot_index, delta));
   }
 
-  insert_usage_events(
+  replace_session_usage_events(
     conn,
+    &parsed.raw_session.session_id,
     usage_event_plan
       .iter()
       .map(|(snapshot_index, _)| parsed.snapshots[*snapshot_index].timestamp.as_str()),
@@ -5431,7 +5429,7 @@ mod tests {
       .next()
       .expect("persist_session body");
 
-    assert!(persist_session_source.contains("insert_usage_events("));
+    assert!(persist_session_source.contains("replace_session_usage_events("));
     assert!(!persist_session_source.contains("INSERT INTO usage_events"));
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2642,38 +2642,41 @@ fn persist_session(
     .and_then(|index| parsed.snapshots.get(index))
     .map(|snapshot| snapshot.usage.clone());
 
+  let mut usage_event_plan = Vec::new();
+  for (snapshot_index, snapshot) in parsed.snapshots.iter().enumerate().skip(snapshot_cutoff) {
+    if previous_usage.as_ref() == Some(&snapshot.usage) {
+      continue;
+    }
+
+    let delta = if let Some(previous) = previous_usage.as_ref() {
+      if snapshot.usage.total_tokens <= previous.total_tokens {
+        continue;
+      }
+      diff_usage(previous, &snapshot.usage)
+    } else if parsed.explicit_forked_from_id.is_some() {
+      snapshot
+        .last_token_usage
+        .clone()
+        .unwrap_or_else(|| snapshot.usage.clone())
+    } else {
+      snapshot.usage.clone()
+    };
+
+    previous_usage = Some(snapshot.usage.clone());
+    if is_zero_delta(&delta) {
+      continue;
+    }
+    usage_event_plan.push((snapshot_index, delta));
+  }
+
   insert_usage_events(
     conn,
-    parsed
-      .snapshots
+    usage_event_plan
       .iter()
-      .skip(snapshot_cutoff)
-      .map(|snapshot| snapshot.timestamp.as_str()),
+      .map(|(snapshot_index, _)| parsed.snapshots[*snapshot_index].timestamp.as_str()),
     |index| {
-      let snapshot = &parsed.snapshots[snapshot_cutoff + index];
-      if previous_usage.as_ref() == Some(&snapshot.usage) {
-        return None;
-      }
-
-      let delta = if let Some(previous) = previous_usage.as_ref() {
-        if snapshot.usage.total_tokens <= previous.total_tokens {
-          return None;
-        }
-        diff_usage(previous, &snapshot.usage)
-      } else if parsed.explicit_forked_from_id.is_some() {
-        snapshot
-          .last_token_usage
-          .clone()
-          .unwrap_or_else(|| snapshot.usage.clone())
-      } else {
-        snapshot.usage.clone()
-      };
-
-      previous_usage = Some(snapshot.usage.clone());
-      if is_zero_delta(&delta) {
-        return None;
-      }
-
+      let (snapshot_index, delta) = &usage_event_plan[index];
+      let snapshot = &parsed.snapshots[*snapshot_index];
       let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
       let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
       Some(NewUsageEvent {
@@ -5265,6 +5268,156 @@ mod tests {
         crate::database::parse_epoch_millis(&persisted.0).expect("parse expected usage epoch")
       )
     );
+  }
+
+  #[test]
+  fn scan_ignores_malformed_timestamps_on_skipped_usage_snapshots() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_path = sessions_dir.join("skipped-usage-timestamps.jsonl");
+    let mut body = concat!(
+      "{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"97979797-9797-4797-8797-979797979797\"}}\n",
+      "{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n"
+    )
+    .to_string();
+    for fixture in [
+      TokenFixture {
+        timestamp: "invalid-zero-delta",
+        total: (0, 0, 0, 0),
+        last: (0, 0, 0, 0),
+      },
+      TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "invalid-duplicate",
+        total: (100, 0, 0, 100),
+        last: (0, 0, 0, 0),
+      },
+      TokenFixture {
+        timestamp: "invalid-non-monotonic",
+        total: (90, 0, 0, 90),
+        last: (0, 0, 0, 0),
+      },
+    ] {
+      body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&session_path, body).expect("write session");
+    let db_path = directory.path().join("usage.sqlite");
+
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    let persisted = conn
+      .query_row(
+        "
+        SELECT COUNT(*), MIN(timestamp), MIN(timestamp_ms), SUM(total_tokens)
+        FROM usage_events
+        ",
+        [],
+        |row| {
+          Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, i64>(3)?,
+          ))
+        },
+      )
+      .expect("load persisted usage");
+    assert_eq!(persisted.0, 1);
+    assert_eq!(persisted.1, "2026-07-10T00:00:02Z");
+    assert_eq!(
+      persisted.2,
+      crate::database::parse_epoch_millis(&persisted.1).expect("parse persisted timestamp")
+    );
+    assert_eq!(persisted.3, 100);
+  }
+
+  #[test]
+  fn malformed_timestamp_on_written_usage_event_rolls_back_batch_and_freshness() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_path = sessions_dir.join("written-usage-timestamps.jsonl");
+    let mut body = concat!(
+      "{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"96969696-9696-4696-8696-969696969696\"}}\n",
+      "{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n"
+    )
+    .to_string();
+    for fixture in [
+      TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "invalid-written-event",
+        total: (200, 0, 0, 200),
+        last: (100, 0, 0, 100),
+      },
+    ] {
+      body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&session_path, body).expect("write session");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+    let conn = open_connection(&db_path).expect("open database");
+    let freshness_before = conn
+      .query_row(
+        "
+        SELECT last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at, scan_commit_revision
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| {
+          Ok((
+            row.get::<_, Option<String>>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, i64>(3)?,
+          ))
+        },
+      )
+      .expect("load initial freshness");
+    drop(conn);
+
+    let error = perform_scan(&db_path, None).expect_err("reject malformed written event");
+
+    assert!(error.contains("Invalid usage event timestamp"));
+    let conn = open_connection(&db_path).expect("reopen database");
+    let usage_count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0))
+      .expect("count usage events");
+    let freshness_after = conn
+      .query_row(
+        "
+        SELECT last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at, scan_commit_revision
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| {
+          Ok((
+            row.get::<_, Option<String>>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, i64>(3)?,
+          ))
+        },
+      )
+      .expect("load rolled back freshness");
+    assert_eq!(usage_count, 0);
+    assert_eq!(freshness_after, freshness_before);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Timelike};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, TransactionBehavior};
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
@@ -280,7 +281,7 @@ enum PreparedStorageBuilder {
     estimated_bytes: usize,
   },
   Spool {
-    writer: BufWriter<File>,
+    writer: GzEncoder<BufWriter<File>>,
     records: usize,
   },
 }
@@ -576,7 +577,7 @@ impl PreparedStorageBuilder {
         } else {
           let file = tempfile::tempfile()
             .map_err(|error| format!("Failed to create prepared scan spool: {error}"))?;
-          let mut writer = BufWriter::new(file);
+          let mut writer = GzEncoder::new(BufWriter::new(file), Compression::fast());
           let mut records = 0usize;
           for buffered in entries {
             write_spool_record(&mut writer, buffered)?;
@@ -601,13 +602,12 @@ impl PreparedStorageBuilder {
     match self {
       Self::Memory { entries, .. } => Ok(PreparedStorage::Memory(entries)),
       Self::Spool {
-        mut writer,
+        writer,
         records,
       } => {
-        writer
-          .flush()
-          .map_err(|error| format!("Failed to flush prepared scan spool: {error}"))?;
         let file = writer
+          .finish()
+          .map_err(|error| format!("Failed to compress prepared scan spool: {error}"))?
           .into_inner()
           .map_err(|error| format!("Failed to finish prepared scan spool: {}", error.error()))?;
         Ok(PreparedStorage::Spool { file, records })
@@ -616,7 +616,10 @@ impl PreparedStorageBuilder {
   }
 }
 
-fn write_spool_record(writer: &mut BufWriter<File>, entry: PreparedSession) -> Result<(), String> {
+fn write_spool_record(
+  writer: &mut GzEncoder<BufWriter<File>>,
+  entry: PreparedSession,
+) -> Result<(), String> {
   let entry = SpoolPreparedSession::from(entry);
   serde_json::to_writer(&mut *writer, &entry)
     .map_err(|error| format!("Failed to write prepared scan spool: {error}"))?;
@@ -1146,7 +1149,7 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
       file
         .seek(SeekFrom::Start(0))
         .map_err(|error| format!("Failed to rewind prepared scan spool: {error}"))?;
-      let reader = BufReader::new(file);
+      let reader = GzDecoder::new(BufReader::new(file));
       let mut stream =
         serde_json::Deserializer::from_reader(reader).into_iter::<SpoolPreparedSession>();
       let mut records_read = 0usize;
@@ -3985,6 +3988,40 @@ mod tests {
     };
 
     assert_eq!(link_count, 0, "spool must have no directory entry");
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn spool_compresses_repetitive_prepared_records() {
+    let mut builder = PreparedStorageBuilder::new();
+    builder
+      .push(prepared_session_fixture(
+        PathBuf::from("/synthetic/a-large.jsonl"),
+        "80808080-8080-8080-8080-808080808080",
+        PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+      ))
+      .expect("buffer first large record");
+    builder
+      .push(prepared_session_fixture(
+        PathBuf::from("/synthetic/b-large.jsonl"),
+        "81818181-8181-8181-8181-818181818181",
+        PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+      ))
+      .expect("spill second large record");
+
+    let storage = builder.finish().expect("finish compressed spool");
+    let bytes = match storage {
+      PreparedStorage::Memory(_) => panic!("expected spool storage"),
+      PreparedStorage::Spool { file, records } => {
+        assert_eq!(records, 2);
+        file.metadata().expect("spool metadata").len()
+      }
+    };
+
+    assert!(
+      bytes < 64 * 1024,
+      "repetitive prepared records should compress below 64 KiB, got {bytes}"
+    );
   }
 
   #[cfg(unix)]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -15,8 +15,8 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, now_utc_string, open_connection,
-  preview_scan_freshness_for_source, replace_session_rate_limit_samples,
+  append_session_rate_limit_samples, append_session_usage_events, bool_to_i64, now_utc_string,
+  open_connection, preview_scan_freshness_for_source, replace_session_rate_limit_samples,
   replace_session_usage_events, set_last_scan_started_for_source_in_transaction,
   set_scan_completed_for_source, NewUsageEvent,
 };
@@ -46,6 +46,26 @@ struct ParsedSession {
   explicit_fast_mode: Option<bool>,
   latest_plan_type: Option<String>,
   last_model_id: Option<String>,
+  mode: ParsedSessionMode,
+  checkpoint: ParserCheckpoint,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum ParsedSessionMode {
+  Full,
+  Tail {
+    previous_usage: Option<TokenUsage>,
+  },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ParserCheckpoint {
+  completed_offset: u64,
+  prefix_signature: Vec<u8>,
+  last_usage: Option<TokenUsage>,
+  current_model: Option<String>,
+  explicit_fast_mode: Option<bool>,
+  latest_plan_type: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +122,7 @@ const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
 const TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY: &str = "token_usage_fork_replay_v3";
 const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
 const PREPARED_SPOOL_THRESHOLD_BYTES: usize = 256 * 1024;
+const PARSER_PREFIX_SIGNATURE_BYTES: u64 = 128;
 const PARENT_REPLAY_CACHE_MAX_ENTRIES: usize = 4;
 const PARENT_REPLAY_CACHE_MAX_BYTES: usize = 256 * 1024;
 
@@ -298,6 +319,8 @@ struct SpoolPreparedSession {
   explicit_fast_mode: Option<bool>,
   latest_plan_type: Option<String>,
   last_model_id: Option<String>,
+  mode: ParsedSessionMode,
+  checkpoint: ParserCheckpoint,
   file_needs_rate_limit_repair: bool,
   file_needs_token_v2_repair: bool,
   file_needs_fork_replay_v3_repair: bool,
@@ -434,6 +457,8 @@ impl From<PreparedSession> for SpoolPreparedSession {
       explicit_fast_mode,
       latest_plan_type,
       last_model_id,
+      mode,
+      checkpoint,
     } = parsed;
 
     Self {
@@ -447,6 +472,8 @@ impl From<PreparedSession> for SpoolPreparedSession {
       explicit_fast_mode,
       latest_plan_type,
       last_model_id,
+      mode,
+      checkpoint,
       file_needs_rate_limit_repair,
       file_needs_token_v2_repair,
       file_needs_fork_replay_v3_repair,
@@ -471,6 +498,8 @@ impl From<SpoolPreparedSession> for PreparedSession {
         explicit_fast_mode: entry.explicit_fast_mode,
         latest_plan_type: entry.latest_plan_type,
         last_model_id: entry.last_model_id,
+        mode: entry.mode,
+        checkpoint: entry.checkpoint,
       },
       file_needs_rate_limit_repair: entry.file_needs_rate_limit_repair,
       file_needs_token_v2_repair: entry.file_needs_token_v2_repair,
@@ -908,7 +937,33 @@ pub(crate) fn prepare_scan(
       needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
     let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
       || pending_fork_replay_v3_repair_paths.contains(&source_path);
-    let (mut parsed, bytes_read) = match parse_session_file_counted(&session_file, &titles) {
+    let tail_candidate = if effective_kind == ScanKind::Incremental
+      && !file_needs_rate_limit_repair
+      && !file_needs_token_v2_repair
+      && !file_needs_fork_replay_v3_repair
+    {
+      if let Some(state) = import_state.get(&source_path) {
+        try_parse_session_tail_counted(
+          &session_file,
+          state,
+          &titles,
+          state
+            .session_id
+            .as_ref()
+            .and_then(|session_id| existing_relations.get(session_id)),
+        )
+      } else {
+        Ok(None)
+      }
+    } else {
+      Ok(None)
+    };
+    let parsed_result = match tail_candidate {
+      Ok(Some(result)) => Ok(result),
+      Ok(None) => parse_session_file_counted(&session_file, &titles),
+      Err(error) => Err(error),
+    };
+    let (mut parsed, bytes_read) = match parsed_result {
       Ok(parsed) => parsed,
       Err((error, bytes_read)) => {
         source_bytes_read = source_bytes_read.saturating_add(bytes_read);
@@ -931,11 +986,15 @@ pub(crate) fn prepare_scan(
     source_bytes_read = source_bytes_read.saturating_add(bytes_read);
 
     let (replay_parent_unavailable, parent_replay_bytes_read) =
-      assign_inherited_token_snapshot_cutoff(
-        &mut parsed,
-        &session_source_paths,
-        &mut parent_snapshot_cache,
-      );
+      if matches!(parsed.mode, ParsedSessionMode::Full) {
+        assign_inherited_token_snapshot_cutoff(
+          &mut parsed,
+          &session_source_paths,
+          &mut parent_snapshot_cache,
+        )
+      } else {
+        (false, 0)
+      };
     source_bytes_read = source_bytes_read.saturating_add(parent_replay_bytes_read);
     let related_pending_token_v2_paths = pending_repair_paths_for_session(
       &import_state,
@@ -1875,6 +1934,231 @@ fn parse_session_file_counted(
   })
 }
 
+fn try_parse_session_tail_counted(
+  session_file: &SessionFile,
+  state: &ImportState,
+  titles: &HashMap<String, String>,
+  existing_relation: Option<&ExistingSessionRelation>,
+) -> Result<Option<(ParsedSession, u64)>, (String, u64)> {
+  let Some(session_id) = state.session_id.as_ref() else {
+    return Ok(None);
+  };
+  let Some(checkpoint) = state.parser_checkpoint.as_ref() else {
+    return Ok(None);
+  };
+  if state.source_bucket != "active"
+    || session_file.bucket != "active"
+    || session_file.file_size <= state.file_size
+    || checkpoint.completed_offset > session_file.file_size.max(0) as u64
+    || import_state_session_id_mismatch(state, session_file)
+  {
+    return Ok(None);
+  }
+  let current_signature = read_prefix_signature(&session_file.path, checkpoint.completed_offset)
+    .map_err(|error| {
+      (
+        format!(
+          "Failed to validate parser checkpoint for {}: {error}",
+          session_file.path.display()
+        ),
+        0,
+      )
+    })?;
+  if current_signature != checkpoint.prefix_signature {
+    return Ok(None);
+  }
+
+  let mut file = File::open(&session_file.path).map_err(|error| {
+    (
+      format!("Failed to open {}: {error}", session_file.path.display()),
+      0,
+    )
+  })?;
+  file
+    .seek(SeekFrom::Start(checkpoint.completed_offset))
+    .map_err(|error| {
+      (
+        format!(
+          "Failed to seek {} to parser checkpoint: {error}",
+          session_file.path.display()
+        ),
+        0,
+      )
+    })?;
+  let mut reader = BufReader::new(CountingReader::new(file));
+  let mut completed_offset = checkpoint.completed_offset;
+  let mut current_model = checkpoint.current_model.clone();
+  let mut explicit_fast_mode = checkpoint.explicit_fast_mode;
+  let mut latest_plan_type = checkpoint.latest_plan_type.clone();
+  let mut updated_at = None;
+  let mut snapshots = Vec::new();
+  let mut rate_limit_samples = Vec::new();
+  let mut seen_models = HashSet::new();
+  if let Some(model) = current_model.as_ref() {
+    seen_models.insert(model.clone());
+  }
+
+  let mut line = String::new();
+  loop {
+    line.clear();
+    let line_bytes = reader.read_line(&mut line).map_err(|error| {
+      (
+        format!("Failed to read {}: {error}", session_file.path.display()),
+        reader.get_ref().bytes_read,
+      )
+    })?;
+    if line_bytes == 0 || !line.ends_with('\n') {
+      break;
+    }
+    completed_offset = completed_offset.saturating_add(line_bytes as u64);
+    if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
+      explicit_fast_mode = Some(true);
+    }
+    if line.contains("\"fast_mode\":false") || line.contains("\"quick_mode\":false") {
+      explicit_fast_mode = Some(false);
+    }
+    let Ok(value) = serde_json::from_str::<Value>(&line) else {
+      continue;
+    };
+    let timestamp = value
+      .get("timestamp")
+      .and_then(Value::as_str)
+      .map(ToString::to_string);
+    if timestamp.is_some() {
+      updated_at = timestamp.clone();
+    }
+    match value
+      .get("type")
+      .and_then(Value::as_str)
+      .unwrap_or_default()
+    {
+      "session_meta" => return Ok(None),
+      "turn_context" => {
+        if let Some(model) = value
+          .get("payload")
+          .and_then(|payload| payload.get("model"))
+          .and_then(Value::as_str)
+        {
+          let model = normalize_model_id(model);
+          seen_models.insert(model.clone());
+          current_model = Some(model);
+        }
+      }
+      "event_msg" => {
+        let payload = value.get("payload").unwrap_or(&Value::Null);
+        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
+          continue;
+        }
+        let info = payload.get("info").unwrap_or(&Value::Null);
+        let total_usage = info.get("total_token_usage").unwrap_or(&Value::Null);
+        if total_usage.is_null() {
+          continue;
+        }
+        let usage = TokenUsage {
+          input_tokens: read_i64(total_usage, "input_tokens"),
+          cached_input_tokens: read_i64(total_usage, "cached_input_tokens"),
+          output_tokens: read_i64(total_usage, "output_tokens"),
+          reasoning_output_tokens: read_i64(total_usage, "reasoning_output_tokens"),
+          total_tokens: read_total_tokens(total_usage),
+        };
+        let last_token_usage = info
+          .get("last_token_usage")
+          .filter(|last_usage| !last_usage.is_null())
+          .map(|last_usage| TokenUsage {
+            input_tokens: read_i64(last_usage, "input_tokens"),
+            cached_input_tokens: read_i64(last_usage, "cached_input_tokens"),
+            output_tokens: read_i64(last_usage, "output_tokens"),
+            reasoning_output_tokens: read_i64(last_usage, "reasoning_output_tokens"),
+            total_tokens: read_total_tokens(last_usage),
+          });
+        let plan_type = payload
+          .get("rate_limits")
+          .and_then(|rate_limits| rate_limits.get("plan_type"))
+          .and_then(Value::as_str)
+          .map(ToString::to_string);
+        if plan_type.is_some() {
+          latest_plan_type = plan_type.clone();
+        }
+        let limit_id = nested_str(payload, &["rate_limits", "limit_id"])
+          .or_else(|| nested_str(payload, &["rate_limits", "primary", "limit_id"]));
+        let limit_name = nested_str(payload, &["rate_limits", "limit_name"])
+          .or_else(|| nested_str(payload, &["rate_limits", "primary", "limit_name"]));
+        let sample_timestamp = timestamp.unwrap_or_else(now_utc_string);
+        rate_limit_samples.extend(extract_rate_limit_samples(&sample_timestamp, payload));
+        let model_id = current_model
+          .clone()
+          .unwrap_or_else(|| "unknown".to_string());
+        seen_models.insert(model_id.clone());
+        snapshots.push(UsageSnapshot {
+          timestamp: sample_timestamp,
+          model_id,
+          usage,
+          last_token_usage,
+          plan_type,
+          limit_id,
+          limit_name,
+          explicit_fast_mode,
+        });
+      }
+      _ => {}
+    }
+  }
+  let bytes_read = reader.get_ref().bytes_read;
+  for sample in &mut rate_limit_samples {
+    sample.source_session_id = Some(session_id.clone());
+  }
+  let new_checkpoint = ParserCheckpoint {
+    completed_offset,
+    prefix_signature: read_prefix_signature(&session_file.path, completed_offset).map_err(
+      |error| {
+        (
+          format!(
+            "Failed to checkpoint {}: {error}",
+            session_file.path.display()
+          ),
+          bytes_read,
+        )
+      },
+    )?,
+    last_usage: monotonic_usage_high_water(checkpoint.last_usage.clone(), &snapshots),
+    current_model: current_model.clone(),
+    explicit_fast_mode,
+    latest_plan_type: latest_plan_type.clone(),
+  };
+  let parent_session_id = existing_relation.and_then(|relation| relation.parent_session_id.clone());
+  Ok(Some((
+    ParsedSession {
+      raw_session: RawSession {
+        session_id: session_id.clone(),
+        parent_session_id,
+        root_session_id: session_id.clone(),
+        title: titles.get(session_id).cloned(),
+        source_state: session_file.bucket.clone(),
+        source_path: Some(session_file.path.to_string_lossy().to_string()),
+        started_at: None,
+        updated_at,
+        model_ids: seen_models.into_iter().collect(),
+        contains_subagents: false,
+        agent_nickname: None,
+        agent_role: None,
+      },
+      snapshots,
+      rate_limit_samples,
+      explicit_forked_from_id: None,
+      explicit_fork_timestamp: None,
+      inherited_token_snapshot_cutoff: 0,
+      explicit_fast_mode,
+      latest_plan_type,
+      last_model_id: current_model.or_else(|| Some("unknown".to_string())),
+      mode: ParsedSessionMode::Tail {
+        previous_usage: checkpoint.last_usage.clone(),
+      },
+      checkpoint: new_checkpoint,
+    },
+    bytes_read,
+  )))
+}
+
 #[cfg(test)]
 fn parse_session_file(
   session_file: &SessionFile,
@@ -1912,6 +2196,7 @@ fn parse_session_file_once(
   let mut seen_models = HashSet::new();
   let mut first_session_meta: Option<SessionMetaCandidate> = None;
   let mut matching_session_meta: Option<SessionMetaCandidate> = None;
+  let mut completed_offset = 0u64;
 
   let mut line = String::new();
   loop {
@@ -1925,6 +2210,10 @@ fn parse_session_file_once(
     if line_bytes == 0 {
       break;
     }
+    if !line.ends_with('\n') {
+      break;
+    }
+    completed_offset = completed_offset.saturating_add(line_bytes as u64);
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
     }
@@ -2131,6 +2420,22 @@ fn parse_session_file_once(
 
   let title = titles.get(&session_id).cloned();
   let last_model_id = current_model.clone();
+  let checkpoint = ParserCheckpoint {
+    completed_offset,
+    prefix_signature: read_prefix_signature(&session_file.path, completed_offset).map_err(|error| {
+      SessionParseError::Fatal {
+        message: format!(
+          "Failed to checkpoint {}: {error}",
+          session_file.path.display()
+        ),
+        bytes_read,
+      }
+    })?,
+    last_usage: monotonic_usage_high_water(None, &snapshots),
+    current_model: current_model.clone(),
+    explicit_fast_mode,
+    latest_plan_type: latest_plan_type.clone(),
+  };
   let mut rate_limit_samples = rate_limit_samples;
   for sample in &mut rate_limit_samples {
     sample.source_session_id = Some(session_id.clone());
@@ -2160,9 +2465,36 @@ fn parse_session_file_once(
       explicit_fast_mode,
       latest_plan_type,
       last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
+      mode: ParsedSessionMode::Full,
+      checkpoint,
     },
     bytes_read,
   ))
+}
+
+fn read_prefix_signature(path: &Path, completed_offset: u64) -> std::io::Result<Vec<u8>> {
+  let signature_start = completed_offset.saturating_sub(PARSER_PREFIX_SIGNATURE_BYTES);
+  let signature_len = completed_offset.saturating_sub(signature_start) as usize;
+  let mut file = File::open(path)?;
+  file.seek(SeekFrom::Start(signature_start))?;
+  let mut signature = vec![0u8; signature_len];
+  file.read_exact(&mut signature)?;
+  Ok(signature)
+}
+
+fn monotonic_usage_high_water(
+  mut high_water: Option<TokenUsage>,
+  snapshots: &[UsageSnapshot],
+) -> Option<TokenUsage> {
+  for snapshot in snapshots {
+    if high_water
+      .as_ref()
+      .is_none_or(|previous| snapshot.usage.total_tokens > previous.total_tokens)
+    {
+      high_water = Some(snapshot.usage.clone());
+    }
+  }
+  high_water
 }
 
 fn fallback_session_id_from_filename(path: &Path) -> Option<String> {
@@ -2600,7 +2932,7 @@ fn persist_session(
       source_path = excluded.source_path,
       source_bucket = excluded.source_bucket,
       started_at = COALESCE(sessions.started_at, excluded.started_at),
-      updated_at = excluded.updated_at,
+      updated_at = COALESCE(excluded.updated_at, sessions.updated_at),
       agent_nickname = COALESCE(excluded.agent_nickname, sessions.agent_nickname),
       agent_role = COALESCE(excluded.agent_role, sessions.agent_role),
       explicit_fast_mode = excluded.explicit_fast_mode,
@@ -2630,17 +2962,30 @@ fn persist_session(
     ],
   )?;
 
-  replace_session_rate_limit_samples(
-    conn,
-    &parsed.raw_session.session_id,
-    &parsed.rate_limit_samples,
-  )?;
+  match &parsed.mode {
+    ParsedSessionMode::Full => replace_session_rate_limit_samples(
+      conn,
+      &parsed.raw_session.session_id,
+      &parsed.rate_limit_samples,
+    )?,
+    ParsedSessionMode::Tail { .. } => append_session_rate_limit_samples(
+      conn,
+      &parsed.raw_session.session_id,
+      &parsed.rate_limit_samples,
+    )?,
+  };
 
-  let snapshot_cutoff = parsed.inherited_token_snapshot_cutoff;
-  let mut previous_usage = snapshot_cutoff
-    .checked_sub(1)
-    .and_then(|index| parsed.snapshots.get(index))
-    .map(|snapshot| snapshot.usage.clone());
+  let (snapshot_cutoff, mut previous_usage) = match &parsed.mode {
+    ParsedSessionMode::Full => {
+      let snapshot_cutoff = parsed.inherited_token_snapshot_cutoff;
+      let previous_usage = snapshot_cutoff
+        .checked_sub(1)
+        .and_then(|index| parsed.snapshots.get(index))
+        .map(|snapshot| snapshot.usage.clone());
+      (snapshot_cutoff, previous_usage)
+    }
+    ParsedSessionMode::Tail { previous_usage } => (0, previous_usage.clone()),
+  };
 
   let mut usage_event_plan = Vec::new();
   for (snapshot_index, snapshot) in parsed.snapshots.iter().enumerate().skip(snapshot_cutoff) {
@@ -2669,17 +3014,14 @@ fn persist_session(
     usage_event_plan.push((snapshot_index, delta));
   }
 
-  replace_session_usage_events(
-    conn,
-    &parsed.raw_session.session_id,
-    usage_event_plan
-      .iter()
-      .map(|(snapshot_index, _)| parsed.snapshots[*snapshot_index].timestamp.as_str()),
-    |index| {
+  let timestamps = usage_event_plan
+    .iter()
+    .map(|(snapshot_index, _)| parsed.snapshots[*snapshot_index].timestamp.as_str());
+  let event_at = |index: usize| {
       let (snapshot_index, delta) = &usage_event_plan[index];
       let snapshot = &parsed.snapshots[*snapshot_index];
       let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
-      let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
+      let value_usd = calculate_value_usd(delta, resolved_pricing.as_ref());
       Some(NewUsageEvent {
         session_id: &parsed.raw_session.session_id,
         model_id: normalize_model_id(&snapshot.model_id),
@@ -2692,18 +3034,38 @@ fn persist_session(
         fast_mode_auto: false,
         fast_mode_effective: false,
       })
-    },
-  )?;
+    };
+  match &parsed.mode {
+    ParsedSessionMode::Full => replace_session_usage_events(
+      conn,
+      &parsed.raw_session.session_id,
+      timestamps,
+      event_at,
+    )?,
+    ParsedSessionMode::Tail { .. } => append_session_usage_events(
+      conn,
+      &parsed.raw_session.session_id,
+      timestamps,
+      event_at,
+    )?,
+  };
+
+  let parser_checkpoint = serde_json::to_string(&parsed.checkpoint)
+    .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?;
 
   conn.execute(
     "
-    INSERT INTO import_state (source_path, session_id, source_bucket, file_size, file_mtime_ms, last_imported_at)
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+    INSERT INTO import_state (
+      source_path, session_id, source_bucket, file_size, file_mtime_ms,
+      parser_checkpoint, last_imported_at
+    )
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
     ON CONFLICT(source_path) DO UPDATE SET
       session_id = excluded.session_id,
       source_bucket = excluded.source_bucket,
       file_size = excluded.file_size,
       file_mtime_ms = excluded.file_mtime_ms,
+      parser_checkpoint = excluded.parser_checkpoint,
       last_imported_at = excluded.last_imported_at
     ",
     params![
@@ -2712,6 +3074,7 @@ fn persist_session(
       session_file.bucket,
       session_file.file_size,
       session_file.file_mtime_ms,
+      parser_checkpoint,
       now_utc_string(),
     ],
   )?;
@@ -2841,7 +3204,7 @@ fn normalize_local_timestamp(timestamp: chrono::DateTime<Local>) -> chrono::Date
 fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, ImportState>> {
   let mut stmt = conn.prepare(
     "
-    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms, parser_checkpoint
     FROM import_state
     ",
   )?;
@@ -2853,6 +3216,9 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
       source_bucket: row.get(2)?,
       file_size: row.get(3)?,
       file_mtime_ms: row.get(4)?,
+      parser_checkpoint: row
+        .get::<_, Option<String>>(5)?
+        .and_then(|checkpoint| serde_json::from_str(&checkpoint).ok()),
     })
   })?;
 
@@ -3152,6 +3518,7 @@ struct ImportState {
   source_bucket: String,
   file_size: i64,
   file_mtime_ms: i64,
+  parser_checkpoint: Option<ParserCheckpoint>,
 }
 
 #[cfg(test)]
@@ -3419,6 +3786,8 @@ mod tests {
         explicit_fast_mode: None,
         latest_plan_type: None,
         last_model_id: None,
+        mode: ParsedSessionMode::Full,
+        checkpoint: ParserCheckpoint::default(),
       },
       file_needs_rate_limit_repair: false,
       file_needs_token_v2_repair: false,
@@ -6737,6 +7106,152 @@ mod tests {
     assert_eq!(
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn growing_active_session_reads_only_completed_tail_after_checkpoint() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "45454545-4545-4545-4545-454545454545";
+    let session_path = sessions_dir.join("growing.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let filler = "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"ignored\",\"payload\":{}}\n";
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open initial session for append");
+    for _ in 0..4_096 {
+      file.write_all(filler.as_bytes()).expect("append filler");
+    }
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial full scan");
+
+    let appended = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (180, 40, 45, 225),
+      last: (80, 20, 20, 100),
+    });
+    std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open growing session")
+      .write_all(appended.as_bytes())
+      .expect("append completed token line");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental tail");
+    assert!(
+      prepared.stats().source_bytes_read < appended.len() as u64 * 4,
+      "incremental parse should avoid rereading the historical prefix; read {} bytes",
+      prepared.stats().source_bytes_read
+    );
+    commit_prepared_scan(prepared).expect("commit incremental tail");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn changed_checkpoint_suffix_falls_back_to_full_session_parse() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_id = "46464646-4646-4646-4646-464646464646";
+    let session_path = sessions_dir.join("rewritten.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial scan");
+
+    let mut body = std::fs::read_to_string(&session_path).expect("read initial session");
+    let suffix_index = body.rfind('\n').expect("session ends with newline");
+    body.insert(suffix_index, ' ');
+    body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (180, 40, 45, 225),
+      last: (80, 20, 20, 100),
+    }));
+    std::fs::write(&session_path, body).expect("rewrite checkpoint suffix and append");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare safe fallback");
+    assert!(
+      prepared.stats().source_bytes_read > 500,
+      "signature mismatch must re-read the complete session"
+    );
+    commit_prepared_scan(prepared).expect("commit fallback scan");
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn tail_checkpoint_keeps_monotonic_usage_high_water() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_id = "47474747-4747-4747-4747-474747474747";
+    let session_path = sessions_dir.join("rollback.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-03-24T00:00:01Z", 100, 0, 0, 100),
+        ("2026-03-24T00:00:02Z", 80, 0, 0, 80),
+      ],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial scan with rollback");
+
+    let appended = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (150, 0, 0, 150),
+      last: (50, 0, 0, 50),
+    });
+    std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open session")
+      .write_all(appended.as_bytes())
+      .expect("append recovery after rollback");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental tail scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (150, 0, 0, 150, 2)
     );
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -140,7 +140,7 @@ unsafe extern "C" {
 }
 
 #[cfg(target_os = "macos")]
-fn release_unused_process_memory() {
+pub(crate) fn release_unused_process_memory() {
   // SAFETY: A null zone asks the macOS allocator to visit every registered zone.
   // The call only releases pages currently unused by those zones.
   unsafe {
@@ -149,7 +149,7 @@ fn release_unused_process_memory() {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn release_unused_process_memory() {}
+pub(crate) fn release_unused_process_memory() {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScanKind {

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -14,14 +14,16 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, init_db, now_utc_string, open_connection, preview_scan_freshness_for_source,
+  bool_to_i64, now_utc_string, open_connection, preview_scan_freshness_for_source,
   replace_session_rate_limit_samples, set_last_scan_started_for_source_in_transaction,
   set_scan_completed_for_source,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
-  calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing, seed_pricing_catalog,
+  calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing,
 };
+#[cfg(test)]
+use crate::{database::init_db, pricing::seed_pricing_catalog};
 
 #[derive(Debug, Clone)]
 struct SessionFile {
@@ -713,6 +715,7 @@ fn estimated_usage_snapshots_bytes(snapshots: &Vec<UsageSnapshot>) -> usize {
     }))
 }
 
+#[cfg(test)]
 pub fn perform_scan(
   db_path: &Path,
   codex_home_override: Option<String>,
@@ -720,6 +723,7 @@ pub fn perform_scan(
   perform_scan_with_kind(db_path, codex_home_override, ScanKind::Full)
 }
 
+#[cfg(test)]
 pub fn perform_incremental_scan(
   db_path: &Path,
   codex_home_override: Option<String>,
@@ -727,6 +731,7 @@ pub fn perform_incremental_scan(
   perform_scan_with_kind(db_path, codex_home_override, ScanKind::Incremental)
 }
 
+#[cfg(test)]
 fn perform_scan_with_kind(
   db_path: &Path,
   codex_home_override: Option<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,9 @@ mod queries;
 mod rate_limits;
 mod refresh;
 
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,7 +20,8 @@ use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
 use rusqlite::params;
 use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
-  insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
+  insert_live_rate_limit_snapshot, load_latest_rate_limits, open_connection,
+  save_subscription_profile, save_sync_settings,
 };
 use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
 use models::{
@@ -157,7 +158,9 @@ struct AppLiveQuotaPersister {
 impl refresh::LiveQuotaPersister for AppLiveQuotaPersister {
   fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
     let conn = open_connection(&self.db_path).map_err(|error| error.to_string())?;
-    insert_live_rate_limit_snapshot(&conn, snapshot).map_err(|error| error.to_string())
+    insert_live_rate_limit_snapshot(&conn, snapshot)
+      .map(|_| ())
+      .map_err(|error| error.to_string())
   }
 }
 
@@ -1361,6 +1364,9 @@ fn load_persisted_live_rate_limits_from_connection(
   conn: &rusqlite::Connection,
   source_kind: Option<&str>,
 ) -> Option<LiveRateLimitSnapshot> {
+  if let Ok(Some(snapshot)) = load_latest_rate_limits(conn, source_kind) {
+    return Some(snapshot);
+  }
   let mut primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
     .ok()
     .flatten();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,7 +60,6 @@ const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 const SCHEDULER_MAX_SLEEP_SECONDS: u64 = 5;
-const FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS: u64 = 5;
 const PRICING_VALUE_RESOLUTION_REPAIR_KEY: &str = "pricing_value_resolution_v2";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,12 +68,6 @@ enum BackgroundRefreshDecision {
   Wait(Duration),
   Incremental,
   Full,
-}
-
-#[derive(Clone)]
-struct CachedRateLimitSnapshot {
-  fetched_at: Instant,
-  snapshot: LiveRateLimitSnapshot,
 }
 
 #[derive(Clone)]
@@ -92,7 +85,7 @@ struct AppState {
   live_refresh_in_progress: Arc<AtomicBool>,
   menu_bar_refresh_in_progress: Arc<AtomicBool>,
   daily_value_tray: Option<TrayIcon>,
-  live_rate_limits: Arc<Mutex<Option<CachedRateLimitSnapshot>>>,
+  live_rate_limits: refresh::LiveQuotaCache,
   menu_bar_popup_anchor: Arc<Mutex<Option<MenuBarPopupAnchor>>>,
 }
 
@@ -1052,74 +1045,86 @@ fn get_live_rate_limits_cached(state: &AppState) -> Result<LiveRateLimitSnapshot
 }
 
 fn get_live_rate_limits(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_with_fallback(
-    state,
-    force_refresh,
-    true,
-    live_rate_limit_foreground_query_timeout(),
-  )
+  get_live_rate_limits_with_fallback(state, force_refresh, live_rate_limit_foreground_query_timeout())
 }
 
 fn get_live_rate_limits_background(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  let ttl = live_rate_limit_cache_ttl(state);
-  get_live_rate_limits_with_fallback(
-    state,
-    force_refresh,
-    false,
-    live_rate_limit_background_query_timeout_for_interval(ttl),
-  )
+  get_live_rate_limits_with_fallback(state, force_refresh, live_rate_limit_background_query_timeout())
 }
 
 fn get_live_rate_limits_with_fallback(
   state: &AppState,
   force_refresh: bool,
-  refresh_history_on_failure: bool,
   query_timeout: Duration,
 ) -> Result<LiveRateLimitSnapshot, String> {
-  let ttl = live_rate_limit_cache_ttl(state);
-
-  if !force_refresh {
-    let cache = state
-      .live_rate_limits
-      .lock()
-      .map_err(|_| "Live rate-limit cache is unavailable.".to_string())?;
-    if let Some(snapshot) = cache.as_ref() {
-      if snapshot.fetched_at.elapsed() <= ttl {
-        return Ok(snapshot.snapshot.clone());
-      }
-    }
+  if let Some(snapshot) =
+    get_fresh_cached_live_rate_limits(state, force_refresh, || live_rate_limit_cache_ttl(state))
+  {
+    return Ok(snapshot);
   }
 
+  state.live_rate_limits.set_refreshing(true);
   let query_result = {
     let _activity = begin_scheduler_activity();
     query_live_rate_limits(query_timeout)
   };
   match query_result {
-    Ok(snapshot) => {
-      {
+    Ok(snapshot) => Ok(publish_live_rate_limits_and_persist(
+      state,
+      snapshot,
+      |snapshot| {
         let _activity = begin_scheduler_activity();
         let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-        insert_live_rate_limit_snapshot(&conn, &snapshot).map_err(|error| error.to_string())?;
-      }
-      store_live_rate_limits_cache(state, &snapshot)?;
-      Ok(snapshot)
-    }
+        insert_live_rate_limit_snapshot(&conn, snapshot).map_err(|error| error.to_string())
+      },
+    )),
     Err(error) => {
       log::warn!("Failed to refresh live rate limits from Codex app-server: {error}");
-      let fallback = if refresh_history_on_failure {
-        get_live_rate_limits_history_fallback(state)
-      } else {
-        get_live_rate_limits_stored_fallback(state)
-      };
-      if let Some(snapshot) = fallback {
-        if let Err(cache_error) = store_live_rate_limits_cache(state, &snapshot) {
-          log::warn!("Failed to cache fallback live rate limits: {cache_error}");
+      if let Some(fallback) = get_live_rate_limits_stored_fallback(state) {
+        state.live_rate_limits.publish_fallback(
+          Arc::new(fallback),
+          Instant::now(),
+          Utc::now(),
+        );
+        if let Some(effective) = get_cached_live_rate_limits(state) {
+          return Ok(effective);
         }
-        return Ok(snapshot);
       }
+      state.live_rate_limits.set_refreshing(false);
       Err(error)
     }
   }
+}
+
+fn get_fresh_cached_live_rate_limits(
+  state: &AppState,
+  force_refresh: bool,
+  load_ttl: impl FnOnce() -> Duration,
+) -> Option<LiveRateLimitSnapshot> {
+  if force_refresh {
+    return None;
+  }
+  let ttl = load_ttl();
+  if state.live_rate_limits.needs_live_refresh(ttl, Instant::now()) {
+    None
+  } else {
+    get_cached_live_rate_limits(state)
+  }
+}
+
+fn publish_live_rate_limits_and_persist(
+  state: &AppState,
+  snapshot: LiveRateLimitSnapshot,
+  persist: impl FnOnce(&LiveRateLimitSnapshot) -> Result<(), String>,
+) -> LiveRateLimitSnapshot {
+  let snapshot = Arc::new(snapshot);
+  state
+    .live_rate_limits
+    .publish_live(Arc::clone(&snapshot), Instant::now(), Utc::now());
+  if let Err(error) = persist(&snapshot) {
+    log::warn!("Failed to persist live rate-limit snapshot: {error}");
+  }
+  snapshot.as_ref().clone()
 }
 
 #[derive(Clone)]
@@ -1196,19 +1201,24 @@ fn load_latest_persisted_rate_limit_window(
   }))
 }
 
+#[cfg(test)]
 fn load_persisted_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
   load_persisted_live_rate_limits_for_source(state, None)
 }
 
-fn load_history_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  load_persisted_live_rate_limits_for_source(state, Some("session"))
-}
-
+#[cfg(test)]
 fn load_persisted_live_rate_limits_for_source(
   state: &AppState,
   source_kind: Option<&str>,
 ) -> Option<LiveRateLimitSnapshot> {
   let conn = open_connection(&state.db_path).ok()?;
+  load_persisted_live_rate_limits_from_connection(&conn, source_kind)
+}
+
+fn load_persisted_live_rate_limits_from_connection(
+  conn: &rusqlite::Connection,
+  source_kind: Option<&str>,
+) -> Option<LiveRateLimitSnapshot> {
   let mut primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
     .ok()
     .flatten();
@@ -1258,47 +1268,67 @@ fn load_persisted_live_rate_limits_for_source(
 }
 
 fn get_live_rate_limits_local(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  get_cached_live_rate_limits(state).or_else(|| load_persisted_live_rate_limits(state))
+  if let Some(cached) = get_cached_live_rate_limits(state) {
+    return Some(cached);
+  }
+  let fallback = get_live_rate_limits_stored_fallback(state)?;
+  state.live_rate_limits.publish_fallback(
+    Arc::new(fallback),
+    Instant::now(),
+    Utc::now(),
+  );
+  get_cached_live_rate_limits(state)
 }
 
 fn get_live_rate_limits_stored_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  load_persisted_live_rate_limits(state)
-    .or_else(|| load_history_live_rate_limits(state))
-    .or_else(|| get_cached_live_rate_limits(state))
-}
-
-fn get_live_rate_limits_history_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  refresh_rate_limit_history_if_idle(state);
-  get_live_rate_limits_stored_fallback(state)
-}
-
-fn refresh_rate_limit_history_if_idle(state: &AppState) {
-  if let Err(error) = run_background_incremental_scan_if_idle(state.clone(), None) {
-    if error == "A scan is already running." {
-      return;
-    }
-    log::warn!("Failed to refresh Codex history rate-limit samples: {error}");
-  }
+  let memory = get_cached_live_rate_limits(state);
+  let Ok(conn) = open_connection(&state.db_path) else {
+    return memory;
+  };
+  let persisted = load_persisted_live_rate_limits_from_connection(&conn, None);
+  let session_only = if persisted.is_none() {
+    load_persisted_live_rate_limits_from_connection(&conn, Some("session"))
+  } else {
+    None
+  };
+  newest_live_rate_limit_snapshot([memory, persisted, session_only])
 }
 
 fn get_cached_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
   state
     .live_rate_limits
-    .lock()
-    .ok()
-    .and_then(|cache| cache.as_ref().map(|snapshot| snapshot.snapshot.clone()))
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone())
 }
 
-fn store_live_rate_limits_cache(state: &AppState, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
-  let mut cache = state
-    .live_rate_limits
-    .lock()
-    .map_err(|_| "Live rate-limit cache is unavailable.".to_string())?;
-  *cache = Some(CachedRateLimitSnapshot {
-    fetched_at: Instant::now(),
-    snapshot: snapshot.clone(),
-  });
-  Ok(())
+fn newest_live_rate_limit_snapshot(
+  snapshots: impl IntoIterator<Item = Option<LiveRateLimitSnapshot>>,
+) -> Option<LiveRateLimitSnapshot> {
+  snapshots.into_iter().flatten().fold(None, |newest, candidate| {
+    let Some(current) = newest else {
+      return Some(candidate);
+    };
+    if live_snapshot_is_newer(&candidate, &current) {
+      Some(candidate)
+    } else {
+      Some(current)
+    }
+  })
+}
+
+fn live_snapshot_is_newer(
+  candidate: &LiveRateLimitSnapshot,
+  current: &LiveRateLimitSnapshot,
+) -> bool {
+  match (
+    DateTime::parse_from_rfc3339(&candidate.fetched_at).ok(),
+    DateTime::parse_from_rfc3339(&current.fetched_at).ok(),
+  ) {
+    (Some(candidate), Some(current)) => candidate > current,
+    (Some(_), None) => true,
+    (None, Some(_)) => false,
+    (None, None) => candidate.fetched_at > current.fetched_at,
+  }
 }
 
 fn best_effort_live_rate_limits(state: &AppState, force_refresh: bool) -> Option<LiveRateLimitSnapshot> {
@@ -1462,13 +1492,11 @@ fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
 }
 
 fn live_rate_limit_foreground_query_timeout() -> Duration {
-  Duration::from_secs(FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS)
+  refresh::LIVE_QUERY_TIMEOUT
 }
 
-fn live_rate_limit_background_query_timeout_for_interval(interval: Duration) -> Duration {
-  interval
-    .checked_sub(Duration::from_secs(FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS))
-    .unwrap_or_else(|| Duration::from_secs(1))
+fn live_rate_limit_background_query_timeout() -> Duration {
+  refresh::LIVE_QUERY_TIMEOUT
 }
 
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
@@ -2109,7 +2137,7 @@ pub fn run() {
         live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         daily_value_tray,
-        live_rate_limits: Arc::new(Mutex::new(None)),
+        live_rate_limits: refresh::LiveQuotaCache::new(),
         menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
       };
       app.manage(state.clone());
@@ -2263,20 +2291,81 @@ mod tests {
   }
 
   #[test]
-  fn live_rate_limit_query_timeout_finishes_before_next_refresh() {
+  fn live_rate_limit_background_query_timeout_is_fixed() {
     assert_eq!(
-      live_rate_limit_background_query_timeout_for_interval(Duration::from_secs(60)),
-      Duration::from_secs(55)
-    );
-    assert_eq!(
-      live_rate_limit_background_query_timeout_for_interval(Duration::from_secs(180)),
-      Duration::from_secs(175)
+      live_rate_limit_background_query_timeout(),
+      Duration::from_secs(10)
     );
   }
 
   #[test]
   fn live_rate_limit_foreground_query_timeout_stays_short() {
-    assert_eq!(live_rate_limit_foreground_query_timeout(), Duration::from_secs(5));
+    assert_eq!(live_rate_limit_foreground_query_timeout(), Duration::from_secs(10));
+  }
+
+  #[test]
+  fn legacy_live_publication_survives_persistence_failure() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: refresh::LiveQuotaCache::new(),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+    let snapshot = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: None,
+      fetched_at: "2026-07-11T00:00:00Z".to_string(),
+    };
+
+    let returned = publish_live_rate_limits_and_persist(&state, snapshot, |_| {
+      Err("intentional persistence failure".to_string())
+    });
+
+    assert_eq!(returned.fetched_at, "2026-07-11T00:00:00Z");
+    assert_eq!(
+      get_cached_live_rate_limits(&state)
+        .expect("fresh cache survives persistence failure")
+        .fetched_at,
+      "2026-07-11T00:00:00Z"
+    );
+  }
+
+  #[test]
+  fn forced_live_refresh_does_not_read_cache_ttl() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: refresh::LiveQuotaCache::new(),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+    let ttl_reads = std::cell::Cell::new(0_u32);
+
+    let cached = get_fresh_cached_live_rate_limits(&state, true, || {
+      ttl_reads.set(ttl_reads.get() + 1);
+      Duration::from_secs(300)
+    });
+
+    assert!(cached.is_none());
+    assert_eq!(ttl_reads.get(), 0);
   }
 
   #[test]
@@ -2441,7 +2530,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 
@@ -3021,7 +3110,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
     let (scan_loaded_sender, scan_loaded_receiver) = std::sync::mpsc::channel();
@@ -3081,54 +3170,6 @@ mod tests {
   }
 
   #[test]
-  fn history_fallback_scan_waits_for_usage_mutation_lock() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    let codex_home = directory.path().join("codex-home");
-    std::fs::create_dir_all(&codex_home).expect("create Codex home");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let conn = open_connection(&db_path).expect("open database");
-    let settings = SyncSettings {
-      codex_home: Some(codex_home.to_string_lossy().to_string()),
-      ..get_sync_settings(&conn).expect("load settings")
-    };
-    save_sync_settings(&conn, &settings).expect("save settings");
-    drop(conn);
-
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-    let mutation_guard = lock_usage_mutations(&state);
-    let (completed_sender, completed_receiver) = std::sync::mpsc::channel();
-    let scan_state = state.clone();
-    let scan_thread = std::thread::spawn(move || {
-      refresh_rate_limit_history_if_idle(&scan_state);
-      completed_sender.send(()).expect("report completion");
-    });
-
-    let completed_while_locked = completed_receiver
-      .recv_timeout(Duration::from_millis(100))
-      .is_ok();
-    drop(mutation_guard);
-    if !completed_while_locked {
-      completed_receiver
-        .recv_timeout(Duration::from_secs(2))
-        .expect("history scan should complete after unlock");
-    }
-    scan_thread.join().expect("join history scan");
-
-    assert!(!completed_while_locked, "history scan bypassed the shared usage mutation lock");
-  }
-
-  #[test]
   fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
@@ -3169,7 +3210,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 
@@ -3179,6 +3220,10 @@ mod tests {
 
     assert_eq!(api_value_title, None);
     assert_eq!(live_metric_title.as_deref(), Some("88%"));
+    assert!(state.live_rate_limits.state().is_fallback);
+    assert!(state
+      .live_rate_limits
+      .needs_live_refresh(Duration::from_secs(300), Instant::now()));
   }
 
   #[test]
@@ -3232,7 +3277,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 
@@ -3242,6 +3287,31 @@ mod tests {
     assert_eq!(
       snapshot.primary.as_ref().map(|window| window.remaining_percent),
       Some(88)
+    );
+
+    state.live_rate_limits.publish_live(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 23,
+          remaining_percent: 77,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-03-27T05:10:00+08:00".to_string()),
+          window_start: Some("2026-03-27T00:10:00+08:00".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-03-27T00:10:00+08:00".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+    let memory = get_live_rate_limits_stored_fallback(&state).expect("prefer newer memory");
+    assert_eq!(memory.fetched_at, "2026-03-27T00:10:00+08:00");
+    assert_eq!(
+      memory.primary.as_ref().map(|window| window.remaining_percent),
+      Some(77)
     );
   }
 
@@ -3296,7 +3366,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 
@@ -3366,7 +3436,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ mod refresh;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{
-  atomic::{AtomicBool, Ordering},
+  atomic::{AtomicBool, AtomicU8, Ordering},
   Arc, Mutex,
 };
 use std::time::{Duration, Instant};
@@ -20,7 +20,7 @@ use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
   insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
 };
-use importer::{perform_incremental_scan, perform_scan, recalculate_all_session_values};
+use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
 use models::{
   ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
@@ -35,7 +35,6 @@ use queries::{
   get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
 };
 use rate_limits::query_live_rate_limits;
-use refresh::begin_scheduler_activity;
 use tauri::{
   Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
   WebviewWindowBuilder,
@@ -59,16 +58,10 @@ const MENU_BAR_POPUP_OFFSET_Y: i32 = 8;
 const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
-const SCHEDULER_MAX_SLEEP_SECONDS: u64 = 5;
 const PRICING_VALUE_RESOLUTION_REPAIR_KEY: &str = "pricing_value_resolution_v2";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BackgroundRefreshDecision {
-  Disabled(Duration),
-  Wait(Duration),
-  Incremental,
-  Full,
-}
+const MENU_RENDER_IDLE: u8 = 0;
+const MENU_RENDER_RUNNING: u8 = 1;
+const MENU_RENDER_PENDING: u8 = 2;
 
 #[derive(Clone)]
 struct MenuBarPopupAnchor {
@@ -80,61 +73,198 @@ struct MenuBarPopupAnchor {
 struct AppState {
   app_handle: Option<AppHandle>,
   db_path: PathBuf,
-  scan_in_progress: Arc<AtomicBool>,
-  usage_mutation_lock: Arc<Mutex<()>>,
-  live_refresh_in_progress: Arc<AtomicBool>,
-  menu_bar_refresh_in_progress: Arc<AtomicBool>,
+  refresh: AppRefreshHandle,
+  usage_mutations: refresh::UsageMutationCoordinator,
+  menu_bar_render_state: Arc<AtomicU8>,
   daily_value_tray: Option<TrayIcon>,
   live_rate_limits: refresh::LiveQuotaCache,
+  menu_bar_popup_visible: Arc<AtomicBool>,
   menu_bar_popup_anchor: Arc<Mutex<Option<MenuBarPopupAnchor>>>,
 }
 
-struct AtomicFlagGuard {
-  flag: Arc<AtomicBool>,
+#[cfg(not(test))]
+type AppRefreshHandle = refresh::RefreshCoordinatorHandle;
+#[cfg(test)]
+type AppRefreshHandle = Option<refresh::RefreshCoordinatorHandle>;
+
+#[cfg(not(test))]
+fn installed_refresh_handle(handle: refresh::RefreshCoordinatorHandle) -> AppRefreshHandle {
+  handle
 }
 
-impl Drop for AtomicFlagGuard {
-  fn drop(&mut self) {
-    self.flag.store(false, Ordering::SeqCst);
+#[cfg(test)]
+fn installed_refresh_handle(handle: refresh::RefreshCoordinatorHandle) -> AppRefreshHandle {
+  Some(handle)
+}
+
+#[derive(Clone)]
+struct AppTokenRefreshExecutor {
+  db_path: PathBuf,
+}
+
+impl refresh::TokenRefreshExecutor for AppTokenRefreshExecutor {
+  fn parse(
+    &self,
+    request: refresh::TokenExecutionRequest,
+  ) -> Result<refresh::PreparedTokenRefresh, String> {
+    let started_at = Utc::now();
+    let scan_kind = effective_token_scan_kind(
+      &self.db_path,
+      request.request.kind,
+      started_at,
+    )?;
+    let prepared_scan = prepare_scan(
+      &self.db_path,
+      request.request.codex_home,
+      scan_kind,
+    )?;
+    Ok(refresh::PreparedTokenRefresh::new(
+      request.generation,
+      request.source_generation,
+      started_at,
+      prepared_scan,
+    ))
+  }
+
+  fn commit(&self, prepared: refresh::PreparedTokenRefresh) -> Result<ScanResult, String> {
+    commit_prepared_scan(prepared.prepared_scan)
   }
 }
 
-fn try_acquire_flag(flag: &Arc<AtomicBool>, busy_message: &str) -> Result<AtomicFlagGuard, String> {
-  if flag
-    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-    .is_err()
-  {
-    return Err(busy_message.to_string());
-  }
-
-  Ok(AtomicFlagGuard {
-    flag: Arc::clone(flag),
-  })
+#[derive(Clone)]
+struct AppLiveQuotaFetcher {
+  db_path: PathBuf,
+  live_cache: refresh::LiveQuotaCache,
 }
 
-fn lock_usage_mutations(state: &AppState) -> std::sync::MutexGuard<'_, ()> {
+impl refresh::LiveQuotaFetcher for AppLiveQuotaFetcher {
+  fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+    query_live_rate_limits(timeout)
+  }
+
+  fn fallback(&self) -> Option<LiveRateLimitSnapshot> {
+    load_display_live_rate_limit_fallback(&self.db_path, &self.live_cache)
+  }
+}
+
+#[derive(Clone)]
+struct AppLiveQuotaPersister {
+  db_path: PathBuf,
+}
+
+impl refresh::LiveQuotaPersister for AppLiveQuotaPersister {
+  fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
+    let conn = open_connection(&self.db_path).map_err(|error| error.to_string())?;
+    insert_live_rate_limit_snapshot(&conn, snapshot).map_err(|error| error.to_string())
+  }
+}
+
+#[derive(Clone)]
+struct TauriRefreshEventSink {
+  app_handle: AppHandle,
+}
+
+impl refresh::RefreshEventSink for TauriRefreshEventSink {
+  fn publish_invalidation(&self, _: refresh::DisplayInvalidation) {
+    let Some(state) = self.app_handle.try_state::<AppState>() else {
+      return;
+    };
+    let popup_visible = state.menu_bar_popup_visible.load(Ordering::Acquire);
+    refresh_daily_value_menu_bar(state.inner());
+    if popup_visible {
+      if let Some(window) = self.app_handle.get_webview_window(MENU_BAR_POPUP_WINDOW_LABEL) {
+        let _ = window.emit(MENU_BAR_POPUP_REFRESH_EVENT, ());
+      }
+    }
+  }
+
+  fn publish_completion(&self, value: refresh::RefreshCompletedEvent) {
+    if let Err(error) = self
+      .app_handle
+      .emit("codex-counter://refresh-completed", value)
+    {
+      log::warn!("Failed to emit refresh completion: {error}");
+    }
+  }
+}
+
+#[cfg(not(test))]
+fn refresh_handle(state: &AppState) -> Result<&refresh::RefreshCoordinatorHandle, String> {
+  Ok(&state.refresh)
+}
+
+#[cfg(test)]
+fn refresh_handle(state: &AppState) -> Result<&refresh::RefreshCoordinatorHandle, String> {
   state
-    .usage_mutation_lock
-    .lock()
-    .unwrap_or_else(std::sync::PoisonError::into_inner)
+    .refresh
+    .as_ref()
+    .ok_or_else(|| "Refresh coordinator is unavailable.".to_string())
+}
+
+fn refresh_error_message(error: refresh::RefreshError) -> String {
+  format!("{error:?}")
+}
+
+fn run_manual_scan_with_coordinator(
+  refresh: &refresh::RefreshCoordinatorHandle,
+  codex_home: Option<String>,
+) -> Result<ScanResult, String> {
+  let ticket = refresh
+    .request_manual_token(codex_home)
+    .map_err(refresh_error_message)?;
+  ticket
+    .wait()
+    .map(|result| result.as_ref().clone())
+    .map_err(refresh_error_message)
+}
+
+fn get_passive_live_rate_limits(
+  cache: &refresh::LiveQuotaCache,
+) -> Result<LiveRateLimitSnapshot, String> {
+  cache
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone())
+    .ok_or_else(|| "Live rate limits are unavailable.".to_string())
 }
 
 #[allow(non_snake_case)]
 #[tauri::command(rename_all = "camelCase")]
-fn scanCodexUsage(state: State<'_, AppState>, codex_home: Option<String>) -> Result<ScanResult, String> {
-  run_scan_if_idle(state.inner().clone(), codex_home)
+async fn scanCodexUsage(
+  state: State<'_, AppState>,
+  codex_home: Option<String>,
+) -> Result<ScanResult, String> {
+  let refresh = refresh_handle(state.inner())?.clone();
+  tauri::async_runtime::spawn_blocking(move || {
+    run_manual_scan_with_coordinator(&refresh, codex_home)
+  })
+  .await
+  .map_err(|error| format!("Failed to join manual refresh: {error}"))?
 }
 
 #[allow(non_snake_case)]
 #[tauri::command]
 fn getScanInProgress(state: State<'_, AppState>) -> bool {
-  state.inner().scan_in_progress.load(Ordering::SeqCst)
+  refresh_handle(state.inner())
+    .map(|refresh| {
+      let status = refresh.status();
+      status.token.running || status.token.pending
+    })
+    .unwrap_or(false)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+fn getRefreshStatus(state: State<'_, AppState>) -> Result<refresh::RefreshStatus, String> {
+  Ok(refresh_handle(state.inner())?.status())
 }
 
 #[allow(non_snake_case)]
 #[tauri::command]
 fn refreshBackgroundData(state: State<'_, AppState>) -> Result<Option<ScanResult>, String> {
-  run_due_background_refresh(state.inner().clone(), Utc::now())
+  match refresh_handle(state.inner())?.wake() {
+    Ok(()) | Err(refresh::RefreshError::Busy) => Ok(None),
+    Err(error) => Err(refresh_error_message(error)),
+  }
 }
 
 #[allow(non_snake_case)]
@@ -158,9 +288,26 @@ fn refresh_pricing_catalog_for_state(
   state: &AppState,
   official_entries: Option<&[PricingCatalogEntry]>,
 ) -> Result<Vec<PricingCatalogEntry>, String> {
-  let _mutation_guard = lock_usage_mutations(state);
-  let mut conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  refresh_pricing_catalog_atomically(&mut conn, official_entries)
+  refresh_pricing_catalog_with_runner(
+    &state.db_path,
+    official_entries,
+    |priority, mutation| state.usage_mutations.run(priority, mutation).value,
+  )
+}
+
+fn refresh_pricing_catalog_with_runner(
+  db_path: &Path,
+  official_entries: Option<&[PricingCatalogEntry]>,
+  run: impl FnOnce(
+    refresh::MutationPriority,
+    &mut dyn FnMut() -> Result<Vec<PricingCatalogEntry>, String>,
+  ) -> Result<Vec<PricingCatalogEntry>, String>,
+) -> Result<Vec<PricingCatalogEntry>, String> {
+  let mut mutation = || {
+    let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
+    refresh_pricing_catalog_atomically(&mut conn, official_entries)
+  };
+  run(refresh::MutationPriority::Pricing, &mut mutation)
 }
 
 fn refresh_pricing_catalog_atomically(
@@ -218,16 +365,24 @@ fn listConversations(
 #[allow(non_snake_case)]
 #[tauri::command]
 fn getLiveRateLimits(state: State<'_, AppState>) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_cached(state.inner())
+  get_passive_live_rate_limits(&state.live_rate_limits)
 }
 
 #[allow(non_snake_case)]
 #[tauri::command(rename_all = "camelCase")]
-fn getMenuBarPopupSnapshot(
+async fn getMenuBarPopupSnapshot(
   state: State<'_, AppState>,
   force_refresh: Option<bool>,
 ) -> Result<MenuBarPopupSnapshot, String> {
-  build_due_menu_bar_popup_snapshot(state.inner(), force_refresh.unwrap_or(false), Utc::now())
+  let state = state.inner().clone();
+  tauri::async_runtime::spawn_blocking(move || {
+    if force_refresh.unwrap_or(false) {
+      refresh_popup_data(&state)?;
+    }
+    build_passive_menu_bar_popup_snapshot(&state.db_path, &state.live_rate_limits)
+  })
+  .await
+  .map_err(|error| format!("Failed to join popup refresh: {error}"))?
 }
 
 #[allow(non_snake_case)]
@@ -306,7 +461,7 @@ fn getConversationDetail(
 
 #[allow(non_snake_case)]
 #[tauri::command(rename_all = "camelCase")]
-fn handleMenuBarPopupAction(
+async fn handleMenuBarPopupAction(
   app: AppHandle,
   state: State<'_, AppState>,
   action: String,
@@ -330,7 +485,10 @@ fn handleMenuBarPopupAction(
       Ok(true)
     }
     "refresh" => {
-      let _ = build_due_menu_bar_popup_snapshot(state.inner(), true, Utc::now())?;
+      let refresh_state = state.inner().clone();
+      tauri::async_runtime::spawn_blocking(move || refresh_popup_data(&refresh_state))
+        .await
+        .map_err(|error| format!("Failed to join popup refresh: {error}"))??;
       refresh_daily_value_menu_bar(state.inner());
       Ok(true)
     }
@@ -349,7 +507,6 @@ fn save_normalized_sync_settings(
   conn: &rusqlite::Connection,
   payload: SyncSettings,
 ) -> rusqlite::Result<SyncSettings> {
-  let current = get_sync_settings(conn)?;
   let auto_scan_interval_minutes = payload.auto_scan_interval_minutes.max(1);
   let updated = SyncSettings {
     codex_home: payload.codex_home,
@@ -373,11 +530,41 @@ fn save_normalized_sync_settings(
     menu_bar_popup_modules: normalize_menu_bar_popup_modules(&payload.menu_bar_popup_modules),
     menu_bar_popup_show_reset_timeline: payload.menu_bar_popup_show_reset_timeline,
     menu_bar_popup_show_actions: payload.menu_bar_popup_show_actions,
-    last_scan_started_at: current.last_scan_started_at,
-    last_scan_completed_at: current.last_scan_completed_at,
-    updated_at: current.updated_at,
+    last_scan_started_at: payload.last_scan_started_at,
+    last_scan_completed_at: payload.last_scan_completed_at,
+    updated_at: payload.updated_at,
   };
   save_sync_settings(conn, &updated)
+}
+
+fn refresh_config_from_saved_settings(
+  settings: &SyncSettings,
+  live_last_success_at: Option<&str>,
+) -> refresh::RefreshConfig {
+  refresh::RefreshConfig {
+    auto_scan_enabled: settings.auto_scan_enabled,
+    interval: Duration::from_secs(
+      unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
+    ),
+    codex_home: settings.codex_home.clone(),
+    token_last_success_wall: refresh::parse_persisted_success_wall(
+      settings.last_scan_completed_at.as_deref(),
+    ),
+    live_last_success_wall: refresh::parse_persisted_success_wall(live_last_success_at),
+  }
+}
+
+fn update_coordinator_from_saved_settings(
+  coordinator: &refresh::RefreshCoordinatorHandle,
+  settings: &SyncSettings,
+) -> Result<(), String> {
+  let live_last_success_at = coordinator.status().live.last_success_at;
+  coordinator
+    .update_settings(refresh_config_from_saved_settings(
+      settings,
+      live_last_success_at.as_deref(),
+    ))
+    .map_err(refresh_error_message)
 }
 
 #[allow(non_snake_case)]
@@ -389,6 +576,8 @@ fn updateSyncSettings(
 ) -> Result<SyncSettings, String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let saved = save_normalized_sync_settings(&conn, payload).map_err(|error| error.to_string())?;
+  drop(conn);
+  update_coordinator_from_saved_settings(refresh_handle(state.inner())?, &saved)?;
   refresh_daily_value_menu_bar(state.inner());
   apply_dock_icon_visibility(&app, &saved, state.daily_value_tray.is_some());
   Ok(saved)
@@ -416,80 +605,6 @@ fn updateSubscriptionProfile(
     updated_at: payload.updated_at,
   };
   save_subscription_profile(&conn, &updated).map_err(|error| error.to_string())
-}
-
-fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
-  run_scan_if_idle_with_live_refresh(state, codex_home, true, perform_scan)
-}
-
-fn run_background_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
-  run_scan_if_idle_with_live_refresh(state, codex_home, false, perform_scan)
-}
-
-fn run_background_incremental_scan_if_idle(
-  state: AppState,
-  codex_home: Option<String>,
-) -> Result<ScanResult, String> {
-  run_scan_if_idle_with_live_refresh(state, codex_home, false, perform_incremental_scan)
-}
-
-fn run_scan_if_idle_with_live_refresh<F>(
-  state: AppState,
-  codex_home: Option<String>,
-  allow_menu_bar_live_refresh: bool,
-  scan: F,
-) -> Result<ScanResult, String>
-where
-  F: FnOnce(&Path, Option<String>) -> Result<ScanResult, String>,
-{
-  let guard = try_acquire_flag(&state.scan_in_progress, "A scan is already running.")?;
-  let mutation_guard = lock_usage_mutations(&state);
-
-  let result = {
-    let _activity = begin_scheduler_activity();
-    scan(&state.db_path, codex_home)
-  };
-  drop(mutation_guard);
-  drop(guard);
-  refresh_daily_value_menu_bar_with_live_refresh(&state, allow_menu_bar_live_refresh);
-  result
-}
-
-fn run_due_background_refresh(
-  state: AppState,
-  now: chrono::DateTime<chrono::Utc>,
-) -> Result<Option<ScanResult>, String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
-  let last_full_scan_completed = get_last_full_scan_completed(&conn).map_err(|error| error.to_string())?;
-  let decision = background_refresh_decision(&settings, last_full_scan_completed.as_deref(), now);
-  drop(conn);
-
-  match decision {
-    BackgroundRefreshDecision::Full => {
-      let result = if state.scan_in_progress.load(Ordering::SeqCst) {
-        Ok(None)
-      } else {
-        run_background_scan_if_idle(state.clone(), settings.codex_home.clone()).map(Some)
-      };
-      if background_live_rate_limits_enabled(&settings) {
-        spawn_live_rate_limits_refresh_if_idle(state, true);
-      }
-      result
-    }
-    BackgroundRefreshDecision::Incremental => {
-      let result = if state.scan_in_progress.load(Ordering::SeqCst) {
-        Ok(None)
-      } else {
-        run_background_incremental_scan_if_idle(state.clone(), settings.codex_home.clone()).map(Some)
-      };
-      if background_live_rate_limits_enabled(&settings) {
-        spawn_live_rate_limits_refresh_if_idle(state, true);
-      }
-      result
-    }
-    BackgroundRefreshDecision::Disabled(_) | BackgroundRefreshDecision::Wait(_) => Ok(None),
-  }
 }
 
 fn prepare_app_database(db_path: &Path) -> Result<(), String> {
@@ -566,55 +681,116 @@ fn load_pricing_value_signature(conn: &rusqlite::Connection) -> rusqlite::Result
   rows.collect()
 }
 
-fn refresh_daily_value_menu_bar(state: &AppState) {
-  refresh_daily_value_menu_bar_with_live_refresh(state, true);
+fn claim_menu_bar_render(state: &AtomicU8) -> bool {
+  claim_menu_bar_render_with_hook(state, |_| {})
 }
 
-fn refresh_daily_value_menu_bar_with_live_refresh(state: &AppState, allow_live_refresh: bool) {
+fn claim_menu_bar_render_with_hook(
+  state: &AtomicU8,
+  mut before_transition: impl FnMut(u8),
+) -> bool {
+  loop {
+    let current = state.load(Ordering::Acquire);
+    before_transition(current);
+    match current {
+      MENU_RENDER_IDLE => {
+        if state
+          .compare_exchange(
+            MENU_RENDER_IDLE,
+            MENU_RENDER_RUNNING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+          )
+          .is_ok()
+        {
+          return true;
+        }
+      }
+      MENU_RENDER_RUNNING => {
+        if state
+          .compare_exchange(
+            MENU_RENDER_RUNNING,
+            MENU_RENDER_PENDING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+          )
+          .is_ok()
+        {
+          return false;
+        }
+      }
+      MENU_RENDER_PENDING => return false,
+      _ => {
+        state.store(MENU_RENDER_PENDING, Ordering::Release);
+        return false;
+      }
+    }
+  }
+}
+
+fn complete_menu_bar_render(state: &AtomicU8) -> bool {
+  state.swap(MENU_RENDER_IDLE, Ordering::AcqRel) == MENU_RENDER_PENDING
+}
+
+fn refresh_daily_value_menu_bar(state: &AppState) {
   let Some(app_handle) = state.app_handle.as_ref().cloned() else {
-    if let Err(error) = update_daily_value_menu_bar(state, allow_live_refresh) {
+    if let Err(error) = update_daily_value_menu_bar(state) {
       log::warn!("Failed to update menu bar display: {error}");
     }
     return;
   };
 
-  let Ok(guard) = try_acquire_flag(
-    &state.menu_bar_refresh_in_progress,
-    "A menu bar refresh is already running.",
-  ) else {
+  if !claim_menu_bar_render(&state.menu_bar_render_state) {
     return;
-  };
+  }
   let state = state.clone();
+  let scheduled_state = state.clone();
   if let Err(error) = app_handle.run_on_main_thread(move || {
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-      update_daily_value_menu_bar(&state, allow_live_refresh)
-    }));
-    drop(guard);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| update_daily_value_menu_bar(&state)));
+    let pending = complete_menu_bar_render(&state.menu_bar_render_state);
     match result {
       Ok(Ok(())) => {}
       Ok(Err(error)) => log::warn!("Failed to update menu bar display: {error}"),
       Err(_) => log::warn!("Menu bar display update panicked."),
     }
+    if pending {
+      refresh_daily_value_menu_bar(&state);
+    }
   }) {
+    let pending = complete_menu_bar_render(&scheduled_state.menu_bar_render_state);
     log::warn!("Failed to schedule menu bar display update: {error}");
+    if pending {
+      refresh_daily_value_menu_bar(&scheduled_state);
+    }
   }
 }
 
-fn update_daily_value_menu_bar(state: &AppState, allow_live_refresh: bool) -> Result<(), String> {
+fn update_daily_value_menu_bar(state: &AppState) -> Result<(), String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+  render_daily_value_menu_bar(state, &settings)
+}
+
+fn render_daily_value_menu_bar(
+  state: &AppState,
+  settings: &SyncSettings,
+) -> Result<(), String> {
   let Some(tray) = state.daily_value_tray.as_ref() else {
     return Ok(());
   };
 
-  if !menu_bar_has_visible_content(&settings) {
+  if !menu_bar_has_visible_content(settings) {
     tray.set_visible(false).map_err(|error| error.to_string())?;
     return Ok(());
   }
 
   apply_menu_bar_icon(tray, settings.show_menu_bar_logo)?;
-  let (api_value_title, live_metric_title) =
-    current_menu_bar_title_parts_with_live_refresh(state, &settings, allow_live_refresh)?;
+  let live_rate_limits = state.live_rate_limits.rate_limits();
+  let (api_value_title, live_metric_title) = current_menu_bar_title_parts(
+    state,
+    settings,
+    live_rate_limits.as_deref(),
+  )?;
   match menu_bar_title(api_value_title.as_deref(), live_metric_title.as_deref()) {
     Some(title) => tray.set_title(Some(&title)).map_err(|error| error.to_string())?,
     None => tray
@@ -622,11 +798,10 @@ fn update_daily_value_menu_bar(state: &AppState, allow_live_refresh: bool) -> Re
       .map_err(|error| error.to_string())?,
   }
   tray
-    .set_tooltip(Some(menu_bar_tooltip_with_live_refresh(
-      &settings,
+    .set_tooltip(Some(menu_bar_tooltip(
+      settings,
       api_value_title.as_deref(),
-      state,
-      allow_live_refresh,
+      live_rate_limits.as_deref(),
     )?))
     .map_err(|error| error.to_string())?;
   tray.set_visible(true).map_err(|error| error.to_string())?;
@@ -637,13 +812,6 @@ fn menu_bar_has_visible_content(settings: &SyncSettings) -> bool {
   settings.show_menu_bar_logo
     || settings.show_menu_bar_daily_api_value
     || settings.show_menu_bar_live_quota_percent
-}
-
-fn background_live_rate_limits_enabled(settings: &SyncSettings) -> bool {
-  let menu_bar_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
-  settings.show_menu_bar_live_quota_percent
-    || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&menu_bar_bucket))
-    || settings.menu_bar_popup_enabled
 }
 
 fn should_hide_dock_icon(settings: &SyncSettings) -> bool {
@@ -681,17 +849,17 @@ fn apply_menu_bar_icon(tray: &TrayIcon, show_logo: bool) -> Result<(), String> {
   Ok(())
 }
 
-fn current_menu_bar_title_parts_with_live_refresh(
+fn current_menu_bar_title_parts(
   state: &AppState,
   settings: &SyncSettings,
-  allow_live_refresh: bool,
+  cached_live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<(Option<String>, Option<String>), String> {
   let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let anchor = Local::now().format("%Y-%m-%d").to_string();
   let live_rate_limits = if settings.show_menu_bar_live_quota_percent
     || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&bucket))
   {
-    maybe_live_rate_limits_for_bucket_with_live_refresh(state, Some(&bucket), None, allow_live_refresh)?
+    cached_live_rate_limits
   } else {
     None
   };
@@ -702,7 +870,7 @@ fn current_menu_bar_title_parts_with_live_refresh(
       if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
       None,
       None,
-      live_rate_limits.clone(),
+      live_rate_limits.cloned(),
       None,
     )?;
     Some(format!("${:.1}", api_value_usd))
@@ -711,13 +879,11 @@ fn current_menu_bar_title_parts_with_live_refresh(
   };
   let live_metric_title = if settings.show_menu_bar_live_quota_percent {
     menu_bar_live_quota_snapshot(
-      state,
       settings,
       &settings.menu_bar_live_quota_bucket,
       &settings.menu_bar_live_quota_metric,
       live_rate_limits,
       Local::now(),
-      allow_live_refresh,
     )?
   } else {
     None
@@ -792,11 +958,10 @@ fn normalize_menu_bar_popup_modules(modules: &[String]) -> Vec<String> {
   normalized
 }
 
-fn menu_bar_tooltip_with_live_refresh(
+fn menu_bar_tooltip(
   settings: &SyncSettings,
   api_value_title: Option<&str>,
-  state: &AppState,
-  allow_live_refresh: bool,
+  cached_live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<String, String> {
   let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let mut fragments = Vec::new();
@@ -804,14 +969,9 @@ fn menu_bar_tooltip_with_live_refresh(
     fragments.push(format!("{}累计 API 价值：{title}", menu_bar_bucket_label(&bucket)));
   }
   if settings.show_menu_bar_live_quota_percent {
-    let snapshot = if allow_live_refresh {
-      Some(get_live_rate_limits_cached(state)?)
-    } else {
-      get_live_rate_limits_local(state)
-    };
-    if let Some(snapshot) = snapshot {
+    if let Some(snapshot) = cached_live_rate_limits {
       if let Some(fragment) = menu_bar_live_quota_tooltip(
-        &snapshot,
+        snapshot,
         settings,
         &settings.menu_bar_live_quota_bucket,
         &settings.menu_bar_live_quota_metric,
@@ -850,25 +1010,16 @@ fn bucket_uses_anchor(bucket: &str) -> bool {
 }
 
 fn menu_bar_live_quota_snapshot(
-  state: &AppState,
   settings: &SyncSettings,
   bucket: &str,
   metric: &str,
-  existing_snapshot: Option<LiveRateLimitSnapshot>,
+  existing_snapshot: Option<&LiveRateLimitSnapshot>,
   now: DateTime<Local>,
-  allow_live_refresh: bool,
 ) -> Result<Option<String>, String> {
-  let snapshot = match existing_snapshot {
-    Some(snapshot) => snapshot,
-    None if allow_live_refresh => get_live_rate_limits_cached(state)?,
-    None => {
-      let Some(snapshot) = get_live_rate_limits_local(state) else {
-        return Ok(None);
-      };
-      snapshot
-    }
+  let Some(snapshot) = existing_snapshot else {
+    return Ok(None);
   };
-  Ok(menu_bar_live_quota_title(&snapshot, settings, bucket, metric, now))
+  Ok(menu_bar_live_quota_title(snapshot, settings, bucket, metric, now))
 }
 
 fn selected_menu_bar_live_quota_window<'a>(
@@ -1015,15 +1166,6 @@ fn maybe_live_rate_limits_for_bucket(
   bucket: Option<&str>,
   live_window_offset: Option<i64>,
 ) -> Result<Option<LiveRateLimitSnapshot>, String> {
-  maybe_live_rate_limits_for_bucket_with_live_refresh(state, bucket, live_window_offset, true)
-}
-
-fn maybe_live_rate_limits_for_bucket_with_live_refresh(
-  state: &AppState,
-  bucket: Option<&str>,
-  live_window_offset: Option<i64>,
-  allow_live_refresh: bool,
-) -> Result<Option<LiveRateLimitSnapshot>, String> {
   let Some(bucket) = bucket else {
     return Ok(None);
   };
@@ -1033,102 +1175,17 @@ fn maybe_live_rate_limits_for_bucket_with_live_refresh(
   if live_window_offset.unwrap_or(0) > 0 {
     return Ok(None);
   }
-  if allow_live_refresh {
-    Ok(Some(get_live_rate_limits_cached(state)?))
-  } else {
-    Ok(get_live_rate_limits_local(state))
-  }
-}
-
-fn get_live_rate_limits_cached(state: &AppState) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits(state, false)
-}
-
-fn get_live_rate_limits(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_with_fallback(state, force_refresh, live_rate_limit_foreground_query_timeout())
-}
-
-fn get_live_rate_limits_background(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_with_fallback(state, force_refresh, live_rate_limit_background_query_timeout())
-}
-
-fn get_live_rate_limits_with_fallback(
-  state: &AppState,
-  force_refresh: bool,
-  query_timeout: Duration,
-) -> Result<LiveRateLimitSnapshot, String> {
-  if let Some(snapshot) =
-    get_fresh_cached_live_rate_limits(state, force_refresh, || live_rate_limit_cache_ttl(state))
-  {
-    return Ok(snapshot);
-  }
-
-  state.live_rate_limits.set_refreshing(true);
-  let query_result = {
-    let _activity = begin_scheduler_activity();
-    query_live_rate_limits(query_timeout)
-  };
-  match query_result {
-    Ok(snapshot) => Ok(publish_live_rate_limits_and_persist(
-      state,
-      snapshot,
-      |snapshot| {
-        let _activity = begin_scheduler_activity();
-        let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-        insert_live_rate_limit_snapshot(&conn, snapshot).map_err(|error| error.to_string())
-      },
-    )),
-    Err(error) => {
-      log::warn!("Failed to refresh live rate limits from Codex app-server: {error}");
-      if let Some(fallback) = get_live_rate_limits_stored_fallback(state) {
-        state.live_rate_limits.publish_fallback(
-          Arc::new(fallback),
-          Instant::now(),
-          Utc::now(),
-        );
-        if let Some(effective) = get_cached_live_rate_limits(state) {
-          return Ok(effective);
-        }
-      }
-      state.live_rate_limits.set_refreshing(false);
-      Err(error)
-    }
-  }
-}
-
-fn get_fresh_cached_live_rate_limits(
-  state: &AppState,
-  force_refresh: bool,
-  load_ttl: impl FnOnce() -> Duration,
-) -> Option<LiveRateLimitSnapshot> {
-  if force_refresh {
-    return None;
-  }
-  let ttl = load_ttl();
-  if state.live_rate_limits.needs_live_refresh(ttl, Instant::now()) {
-    None
-  } else {
-    get_cached_live_rate_limits(state)
-  }
-}
-
-fn publish_live_rate_limits_and_persist(
-  state: &AppState,
-  snapshot: LiveRateLimitSnapshot,
-  persist: impl FnOnce(&LiveRateLimitSnapshot) -> Result<(), String>,
-) -> LiveRateLimitSnapshot {
-  let snapshot = Arc::new(snapshot);
-  state
+  Ok(state
     .live_rate_limits
-    .publish_live(Arc::clone(&snapshot), Instant::now(), Utc::now());
-  if let Err(error) = persist(&snapshot) {
-    log::warn!("Failed to persist live rate-limit snapshot: {error}");
-  }
-  snapshot.as_ref().clone()
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone()))
 }
 
 #[derive(Clone)]
 struct PersistedRateLimitWindow {
+  row_id: i64,
+  source_kind: String,
+  source_session_id: String,
   snapshot: RateLimitWindowSnapshot,
   fetched_at: String,
   limit_id: Option<String>,
@@ -1144,7 +1201,8 @@ fn load_latest_persisted_rate_limit_window(
   let mut stmt = conn
     .prepare(
       "
-      SELECT sample_timestamp, limit_id, limit_name, plan_type, window_start, resets_at, used_percent, remaining_percent
+      SELECT id, source_kind, source_session_id, sample_timestamp, limit_id, limit_name, plan_type,
+             window_start, resets_at, used_percent, remaining_percent
       FROM rate_limit_samples
       WHERE bucket = ?1 AND (?2 IS NULL OR source_kind = ?2)
       ORDER BY julianday(sample_timestamp) DESC, id DESC
@@ -1160,23 +1218,26 @@ fn load_latest_persisted_rate_limit_window(
     return Ok(None);
   };
 
-  let sample_timestamp = row.get::<_, String>(0).map_err(|error| error.to_string())?;
+  let row_id = row.get::<_, i64>(0).map_err(|error| error.to_string())?;
+  let source_kind = row.get::<_, String>(1).map_err(|error| error.to_string())?;
+  let source_session_id = row.get::<_, String>(2).map_err(|error| error.to_string())?;
+  let sample_timestamp = row.get::<_, String>(3).map_err(|error| error.to_string())?;
   let limit_id = row
-    .get::<_, String>(1)
+    .get::<_, String>(4)
     .ok()
     .and_then(|value| (!value.is_empty()).then_some(value));
   let limit_name = row
-    .get::<_, String>(2)
+    .get::<_, String>(5)
     .ok()
     .and_then(|value| (!value.is_empty()).then_some(value));
   let plan_type = row
-    .get::<_, String>(3)
+    .get::<_, String>(6)
     .ok()
     .and_then(|value| (!value.is_empty()).then_some(value));
-  let window_start = row.get::<_, String>(4).map_err(|error| error.to_string())?;
-  let resets_at = row.get::<_, String>(5).map_err(|error| error.to_string())?;
-  let used_percent = row.get::<_, i64>(6).map_err(|error| error.to_string())?;
-  let remaining_percent = row.get::<_, i64>(7).map_err(|error| error.to_string())?;
+  let window_start = row.get::<_, String>(7).map_err(|error| error.to_string())?;
+  let resets_at = row.get::<_, String>(8).map_err(|error| error.to_string())?;
+  let used_percent = row.get::<_, i64>(9).map_err(|error| error.to_string())?;
+  let remaining_percent = row.get::<_, i64>(10).map_err(|error| error.to_string())?;
 
   let window_duration_mins = match (
     parse_rfc3339_local(&window_start),
@@ -1187,6 +1248,9 @@ fn load_latest_persisted_rate_limit_window(
   };
 
   Ok(Some(PersistedRateLimitWindow {
+    row_id,
+    source_kind,
+    source_session_id,
     snapshot: RateLimitWindowSnapshot {
       used_percent,
       remaining_percent,
@@ -1201,20 +1265,6 @@ fn load_latest_persisted_rate_limit_window(
   }))
 }
 
-#[cfg(test)]
-fn load_persisted_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  load_persisted_live_rate_limits_for_source(state, None)
-}
-
-#[cfg(test)]
-fn load_persisted_live_rate_limits_for_source(
-  state: &AppState,
-  source_kind: Option<&str>,
-) -> Option<LiveRateLimitSnapshot> {
-  let conn = open_connection(&state.db_path).ok()?;
-  load_persisted_live_rate_limits_from_connection(&conn, source_kind)
-}
-
 fn load_persisted_live_rate_limits_from_connection(
   conn: &rusqlite::Connection,
   source_kind: Option<&str>,
@@ -1225,21 +1275,25 @@ fn load_persisted_live_rate_limits_from_connection(
   let mut secondary = load_latest_persisted_rate_limit_window(&conn, "seven_day", source_kind)
     .ok()
     .flatten();
-  let primary_instant = primary
+  let newest = match (primary.as_ref(), secondary.as_ref()) {
+    (Some(primary), Some(secondary)) => {
+      if persisted_window_is_newer(secondary, primary) { secondary } else { primary }
+    }
+    (Some(primary), None) => primary,
+    (None, Some(secondary)) => secondary,
+    (None, None) => return None,
+  };
+  let keep_primary = primary
     .as_ref()
-    .and_then(|window| DateTime::parse_from_rfc3339(&window.fetched_at).ok());
-  let secondary_instant = secondary
+    .is_some_and(|window| same_persisted_sample(window, newest));
+  let keep_secondary = secondary
     .as_ref()
-    .and_then(|window| DateTime::parse_from_rfc3339(&window.fetched_at).ok());
-  let newest_instant = [primary_instant.as_ref(), secondary_instant.as_ref()]
-    .into_iter()
-    .flatten()
-    .max()?;
+    .is_some_and(|window| same_persisted_sample(window, newest));
 
-  if primary_instant.as_ref() != Some(newest_instant) {
+  if !keep_primary {
     primary = None;
   }
-  if secondary_instant.as_ref() != Some(newest_instant) {
+  if !keep_secondary {
     secondary = None;
   }
 
@@ -1267,22 +1321,47 @@ fn load_persisted_live_rate_limits_from_connection(
   })
 }
 
-fn get_live_rate_limits_local(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  if let Some(cached) = get_cached_live_rate_limits(state) {
-    return Some(cached);
+fn persisted_window_is_newer(
+  candidate: &PersistedRateLimitWindow,
+  current: &PersistedRateLimitWindow,
+) -> bool {
+  match (
+    DateTime::parse_from_rfc3339(&candidate.fetched_at).ok(),
+    DateTime::parse_from_rfc3339(&current.fetched_at).ok(),
+  ) {
+    (Some(candidate_time), Some(current_time)) if candidate_time != current_time => {
+      candidate_time > current_time
+    }
+    (Some(_), Some(_)) => candidate.row_id > current.row_id,
+    (Some(_), None) => true,
+    (None, Some(_)) => false,
+    (None, None) if candidate.fetched_at != current.fetched_at => {
+      candidate.fetched_at > current.fetched_at
+    }
+    (None, None) => candidate.row_id > current.row_id,
   }
-  let fallback = get_live_rate_limits_stored_fallback(state)?;
-  state.live_rate_limits.publish_fallback(
-    Arc::new(fallback),
-    Instant::now(),
-    Utc::now(),
-  );
-  get_cached_live_rate_limits(state)
 }
 
-fn get_live_rate_limits_stored_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  let memory = get_cached_live_rate_limits(state);
-  let Ok(conn) = open_connection(&state.db_path) else {
+fn same_persisted_sample(
+  left: &PersistedRateLimitWindow,
+  right: &PersistedRateLimitWindow,
+) -> bool {
+  left.source_kind == right.source_kind
+    && left.source_session_id == right.source_session_id
+    && left.fetched_at == right.fetched_at
+    && left.limit_id == right.limit_id
+    && left.limit_name == right.limit_name
+    && left.plan_type == right.plan_type
+}
+
+fn load_display_live_rate_limit_fallback(
+  db_path: &Path,
+  live_cache: &refresh::LiveQuotaCache,
+) -> Option<LiveRateLimitSnapshot> {
+  let memory = live_cache
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone());
+  let Ok(conn) = open_connection(db_path) else {
     return memory;
   };
   let persisted = load_persisted_live_rate_limits_from_connection(&conn, None);
@@ -1292,13 +1371,6 @@ fn get_live_rate_limits_stored_fallback(state: &AppState) -> Option<LiveRateLimi
     None
   };
   newest_live_rate_limit_snapshot([memory, persisted, session_only])
-}
-
-fn get_cached_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  state
-    .live_rate_limits
-    .rate_limits()
-    .map(|snapshot| snapshot.as_ref().clone())
 }
 
 fn newest_live_rate_limit_snapshot(
@@ -1331,31 +1403,20 @@ fn live_snapshot_is_newer(
   }
 }
 
-fn best_effort_live_rate_limits(state: &AppState, force_refresh: bool) -> Option<LiveRateLimitSnapshot> {
-  match get_live_rate_limits(state, force_refresh) {
-    Ok(snapshot) => Some(snapshot),
-    Err(error) => {
-      log::warn!("Failed to refresh live rate limits for popup: {error}");
-      get_live_rate_limits_local(state)
-    }
-  }
-}
-
-fn build_menu_bar_popup_snapshot(
-  state: &AppState,
-  force_refresh: bool,
+fn build_passive_menu_bar_popup_snapshot(
+  db_path: &Path,
+  live_cache: &refresh::LiveQuotaCache,
 ) -> Result<MenuBarPopupSnapshot, String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
-  let live_rate_limits = if force_refresh {
-    best_effort_live_rate_limits(state, true)
-  } else {
-    get_live_rate_limits_local(state)
-  };
+  drop(conn);
+  let live_rate_limits = live_cache
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone());
   let selected_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let anchor = bucket_uses_anchor(&selected_bucket).then(|| Local::now().format("%Y-%m-%d").to_string());
   let overview = get_overview(
-    &state.db_path,
+    db_path,
     Some(selected_bucket.clone()),
     anchor,
     None,
@@ -1374,7 +1435,7 @@ fn build_menu_bar_popup_snapshot(
       .map(|value| value.quota_trend.clone())
       .unwrap_or_default()
   } else {
-    get_quota_trend(&state.db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
+    get_quota_trend(db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
   };
 
   Ok(MenuBarPopupSnapshot {
@@ -1409,15 +1470,21 @@ fn build_menu_bar_popup_snapshot(
   })
 }
 
-fn build_due_menu_bar_popup_snapshot(
-  state: &AppState,
-  force_refresh: bool,
-  now: chrono::DateTime<chrono::Utc>,
-) -> Result<MenuBarPopupSnapshot, String> {
-  if let Err(error) = run_due_background_refresh(state.clone(), now) {
-    log::warn!("Failed to run due background refresh before menu bar snapshot: {error}");
+fn refresh_popup_data(state: &AppState) -> Result<(), String> {
+  let coordinator = refresh_handle(state)?;
+  let token_ticket = coordinator.request_manual_token(None);
+  let live_ticket = coordinator.request_manual_live();
+
+  let token_result = token_ticket.and_then(|ticket| ticket.wait());
+  let live_result = live_ticket.and_then(|ticket| ticket.wait());
+  match (token_result, live_result) {
+    (Ok(_), Ok(_)) => Ok(()),
+    (token, live) => Err(format!(
+      "Popup refresh failed (token: {:?}, live: {:?})",
+      token.err(),
+      live.err()
+    )),
   }
-  build_menu_bar_popup_snapshot(state, force_refresh)
 }
 
 fn menu_bar_popup_quota_snapshot(window: &RateLimitWindowSnapshot) -> MenuBarPopupQuotaSnapshot {
@@ -1481,24 +1548,6 @@ fn usage_velocity_status(percent: f64, fast_threshold: f64, slow_threshold: f64)
   }
 }
 
-fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
-  open_connection(&state.db_path)
-    .ok()
-    .and_then(|conn| get_sync_settings(&conn).ok())
-    .map(|settings| {
-      Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64)
-    })
-    .unwrap_or(Duration::from_secs(300))
-}
-
-fn live_rate_limit_foreground_query_timeout() -> Duration {
-  refresh::LIVE_QUERY_TIMEOUT
-}
-
-fn live_rate_limit_background_query_timeout() -> Duration {
-  refresh::LIVE_QUERY_TIMEOUT
-}
-
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
   auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
@@ -1526,7 +1575,15 @@ fn build_menu_bar_popup_window(app: &AppHandle) -> Result<WebviewWindow, String>
 
 fn hide_menu_bar_popup(app: &AppHandle) {
   if let Some(window) = app.get_webview_window(MENU_BAR_POPUP_WINDOW_LABEL) {
-    let _ = window.hide();
+    if window.hide().is_ok() {
+      set_menu_bar_popup_visibility(app, false);
+    }
+  }
+}
+
+fn set_menu_bar_popup_visibility(app: &AppHandle, visible: bool) {
+  if let Some(state) = app.try_state::<AppState>() {
+    state.menu_bar_popup_visible.store(visible, Ordering::Release);
   }
 }
 
@@ -1538,8 +1595,10 @@ fn toggle_menu_bar_popup(
   let state = app.state::<AppState>();
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+  drop(conn);
   if !settings.menu_bar_popup_enabled {
     clear_menu_bar_popup_anchor(state.inner());
+    hide_menu_bar_popup(app);
     show_main_window(app);
     return Ok(());
   }
@@ -1548,12 +1607,14 @@ fn toggle_menu_bar_popup(
   if window.is_visible().map_err(|error| error.to_string())? {
     clear_menu_bar_popup_anchor(state.inner());
     window.hide().map_err(|error| error.to_string())?;
+    state.menu_bar_popup_visible.store(false, Ordering::Release);
     return Ok(());
   }
 
   store_menu_bar_popup_anchor(state.inner(), rect, click_position);
   position_menu_bar_popup(&window, rect, click_position)?;
   window.show().map_err(|error| error.to_string())?;
+  state.menu_bar_popup_visible.store(true, Ordering::Release);
   window.set_focus().map_err(|error| error.to_string())?;
   window
     .emit(MENU_BAR_POPUP_REFRESH_EVENT, ())
@@ -1845,9 +1906,7 @@ fn tray_rect_size_to_physical(size: tauri::Size, scale_factor: f64) -> tauri::Ph
   }
 }
 
-fn build_daily_value_menu_bar(app: &AppHandle, db_path: &PathBuf) -> Result<TrayIcon, String> {
-  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+fn build_daily_value_menu_bar(app: &AppHandle, settings: &SyncSettings) -> Result<TrayIcon, String> {
   let initial_title = String::new();
 
   let show_window = MenuItem::with_id(
@@ -1917,136 +1976,6 @@ fn show_main_window(app: &AppHandle) {
   }
 }
 
-fn spawn_initial_scan(state: AppState) {
-  std::thread::Builder::new()
-    .name("codex-pacer-initial-scan".to_string())
-    .spawn(move || {
-      let _ = run_background_incremental_scan_if_idle(state, None);
-    })
-    .expect("failed to spawn initial scan thread");
-}
-
-fn spawn_live_rate_limits_refresh_if_idle(state: AppState, force_refresh: bool) {
-  let Ok(guard) = try_acquire_flag(&state.live_refresh_in_progress, "A live quota refresh is already running.") else {
-    return;
-  };
-
-  if let Err(error) = std::thread::Builder::new()
-    .name("codex-pacer-live-quota-refresh".to_string())
-    .spawn(move || {
-      let result = get_live_rate_limits_background(&state, force_refresh);
-      drop(guard);
-      if let Err(error) = result {
-        log::warn!("Failed to refresh live quota in background: {error}");
-      }
-      refresh_daily_value_menu_bar_with_live_refresh(&state, false);
-    })
-  {
-    log::warn!("Failed to spawn live quota refresh thread: {error}");
-  }
-}
-
-fn spawn_scheduler(state: AppState) {
-  std::thread::Builder::new()
-    .name("codex-pacer-scheduler".to_string())
-    .spawn(move || {
-      loop {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_scheduler_tick(&state)));
-        let delay = match result {
-          Ok(delay) => delay,
-          Err(_) => {
-            log::warn!("Background scheduler tick panicked; continuing on the next interval.");
-            Duration::from_secs(60)
-          }
-        };
-        std::thread::sleep(scheduler_sleep_duration(delay));
-      }
-    })
-    .expect("failed to spawn background scheduler thread");
-}
-
-fn scheduler_sleep_duration(delay: Duration) -> Duration {
-  let max_sleep = Duration::from_secs(SCHEDULER_MAX_SLEEP_SECONDS);
-  if delay > max_sleep { max_sleep } else { delay }
-}
-
-fn run_scheduler_tick(state: &AppState) -> Duration {
-  let Ok(conn) = open_connection(&state.db_path) else {
-    return Duration::from_secs(60);
-  };
-  let Ok(settings) = get_sync_settings(&conn) else {
-    return Duration::from_secs(60);
-  };
-  let now = Utc::now();
-  let last_full_scan_completed = get_last_full_scan_completed(&conn).unwrap_or(None);
-  let decision = background_refresh_decision(&settings, last_full_scan_completed.as_deref(), now);
-  drop(conn);
-
-  match decision {
-    BackgroundRefreshDecision::Disabled(delay) | BackgroundRefreshDecision::Wait(delay) => delay,
-    BackgroundRefreshDecision::Full | BackgroundRefreshDecision::Incremental => {
-      if !state.scan_in_progress.load(Ordering::SeqCst) {
-        let result = match decision {
-          BackgroundRefreshDecision::Full => run_background_scan_if_idle(state.clone(), settings.codex_home.clone()),
-          BackgroundRefreshDecision::Incremental => {
-            run_background_incremental_scan_if_idle(state.clone(), settings.codex_home.clone())
-          }
-          BackgroundRefreshDecision::Disabled(_) | BackgroundRefreshDecision::Wait(_) => unreachable!(),
-        };
-        if let Err(error) = result {
-          log::warn!("Failed to run background Codex scan: {error}");
-        }
-      }
-      if background_live_rate_limits_enabled(&settings) {
-        spawn_live_rate_limits_refresh_if_idle(state.clone(), true);
-      }
-      Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64)
-    }
-  }
-}
-
-fn background_refresh_decision(
-  settings: &SyncSettings,
-  last_full_scan_completed_at: Option<&str>,
-  now: chrono::DateTime<chrono::Utc>,
-) -> BackgroundRefreshDecision {
-  let interval = Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64);
-  if !settings.auto_scan_enabled {
-    return BackgroundRefreshDecision::Disabled(interval);
-  }
-
-  let delay = scheduler_delay_until_next_refresh(settings, now);
-  if !delay.is_zero() {
-    return BackgroundRefreshDecision::Wait(delay);
-  }
-
-  if full_maintenance_due(last_full_scan_completed_at, now) {
-    BackgroundRefreshDecision::Full
-  } else {
-    BackgroundRefreshDecision::Incremental
-  }
-}
-
-fn scheduler_delay_until_next_refresh(settings: &SyncSettings, now: chrono::DateTime<chrono::Utc>) -> Duration {
-  let interval_seconds = unified_refresh_interval_seconds(settings.auto_scan_interval_minutes);
-  if !settings.auto_scan_enabled {
-    return Duration::from_secs(interval_seconds as u64);
-  }
-
-  let Some(last_completed_at) = settings.last_scan_completed_at.as_deref() else {
-    return Duration::ZERO;
-  };
-  let Some(last_completed_at) = chrono::DateTime::parse_from_rfc3339(last_completed_at).ok() else {
-    return Duration::ZERO;
-  };
-  let elapsed_seconds = now
-    .signed_duration_since(last_completed_at.with_timezone(&chrono::Utc))
-    .num_seconds()
-    .max(0);
-  let remaining_seconds = interval_seconds.saturating_sub(elapsed_seconds);
-  Duration::from_secs(remaining_seconds as u64)
-}
-
 fn full_maintenance_due(last_completed_at: Option<&str>, now: chrono::DateTime<chrono::Utc>) -> bool {
   let Some(last_completed_at) = last_completed_at else {
     return true;
@@ -2060,9 +1989,28 @@ fn full_maintenance_due(last_completed_at: Option<&str>, now: chrono::DateTime<c
     >= FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS
 }
 
+fn effective_token_scan_kind(
+  db_path: &Path,
+  requested: refresh::TokenScanKind,
+  now: DateTime<Utc>,
+) -> Result<ScanKind, String> {
+  if requested == refresh::TokenScanKind::Full {
+    return Ok(ScanKind::Full);
+  }
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  let last_full = get_last_full_scan_completed(&conn).map_err(|error| error.to_string())?;
+  Ok(if full_maintenance_due(last_full.as_deref(), now) {
+    ScanKind::Full
+  } else {
+    ScanKind::Incremental
+  })
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
+  let runtime_owner = Arc::new(Mutex::new(None::<refresh::RefreshRuntime>));
+  let setup_runtime_owner = Arc::clone(&runtime_owner);
+  let app = tauri::Builder::default()
     .plugin(
       tauri_plugin_log::Builder::default()
         .level(if cfg!(debug_assertions) {
@@ -2077,10 +2025,14 @@ pub fn run() {
         match event {
           tauri::WindowEvent::CloseRequested { api, .. } => {
             api.prevent_close();
-            let _ = window.hide();
+            if window.hide().is_ok() {
+              set_menu_bar_popup_visibility(window.app_handle(), false);
+            }
           }
           tauri::WindowEvent::Focused(false) => {
-            let _ = window.hide();
+            if window.hide().is_ok() {
+              set_menu_bar_popup_visibility(window.app_handle(), false);
+            }
           }
           _ => {}
         }
@@ -2109,7 +2061,7 @@ pub fn run() {
         let _ = window.hide();
       }
     })
-    .setup(|app| {
+    .setup(move |app| {
       let app_data_dir = app
         .path()
         .app_data_dir()
@@ -2120,9 +2072,50 @@ pub fn run() {
 
       prepare_app_database(&db_path)?;
       let conn = open_connection(&db_path).map_err(|error| error.to_string())?;
+      let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+      let display_fallback = load_persisted_live_rate_limits_from_connection(&conn, None)
+        .or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")));
+      let live_last_success_at = load_persisted_live_rate_limits_from_connection(&conn, Some("live"))
+        .map(|snapshot| snapshot.fetched_at);
+      drop(conn);
+
+      let live_rate_limits = refresh::LiveQuotaCache::new();
+      if let Some(fallback) = display_fallback {
+        live_rate_limits.publish_fallback(
+          Arc::new(fallback),
+          Instant::now(),
+          Utc::now(),
+        );
+      }
 
       let app_handle = app.app_handle();
-      let daily_value_tray = match build_daily_value_menu_bar(&app_handle, &db_path) {
+      let usage_mutations = refresh::UsageMutationCoordinator::new();
+      let runtime = refresh::RefreshRuntime::start(
+        refresh::RefreshRuntimeDependencies::with_system_defaults(
+          refresh_config_from_saved_settings(&settings, live_last_success_at.as_deref()),
+          Arc::new(AppTokenRefreshExecutor {
+            db_path: db_path.clone(),
+          }),
+          Arc::new(AppLiveQuotaFetcher {
+            db_path: db_path.clone(),
+            live_cache: live_rate_limits.clone(),
+          }),
+          Arc::new(AppLiveQuotaPersister {
+            db_path: db_path.clone(),
+          }),
+          live_rate_limits.clone(),
+          Arc::new(TauriRefreshEventSink {
+            app_handle: app_handle.clone(),
+          }),
+          usage_mutations.clone(),
+        ),
+      )?;
+      let refresh = runtime.handle();
+      *setup_runtime_owner
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(runtime);
+
+      let daily_value_tray = match build_daily_value_menu_bar(&app_handle, &settings) {
         Ok(tray) => Some(tray),
         Err(error) => {
           log::warn!("Failed to set up menu bar API value: {error}");
@@ -2132,36 +2125,29 @@ pub fn run() {
       let state = AppState {
         app_handle: Some(app_handle.clone()),
         db_path,
-        scan_in_progress: Arc::new(AtomicBool::new(false)),
-        usage_mutation_lock: Arc::new(Mutex::new(())),
-        live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-        menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+        refresh: installed_refresh_handle(refresh),
+        usage_mutations,
+        menu_bar_render_state: Arc::new(AtomicU8::new(MENU_RENDER_IDLE)),
         daily_value_tray,
-        live_rate_limits: refresh::LiveQuotaCache::new(),
+        live_rate_limits,
+        menu_bar_popup_visible: Arc::new(AtomicBool::new(false)),
         menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
       };
       app.manage(state.clone());
-      let should_refresh_live_on_startup = if let Ok(settings) = get_sync_settings(&conn) {
-        apply_dock_icon_visibility(&app_handle, &settings, state.daily_value_tray.is_some());
-        background_live_rate_limits_enabled(&settings)
-      } else {
-        false
-      };
+      apply_dock_icon_visibility(&app_handle, &settings, state.daily_value_tray.is_some());
       if let Err(error) = build_menu_bar_popup_window(&app_handle) {
         log::warn!("Failed to set up menu bar popup window: {error}");
       }
-      refresh_daily_value_menu_bar_with_live_refresh(&state, false);
-      if should_refresh_live_on_startup {
-        spawn_live_rate_limits_refresh_if_idle(state.clone(), true);
+      if let Err(error) = render_daily_value_menu_bar(&state, &settings) {
+        log::warn!("Failed to render initial menu bar display: {error}");
       }
-      spawn_initial_scan(state.clone());
-      spawn_scheduler(state);
 
       Ok(())
     })
     .invoke_handler(tauri::generate_handler![
       scanCodexUsage,
       getScanInProgress,
+      getRefreshStatus,
       refreshBackgroundData,
       refreshPricing,
       getOverview,
@@ -2177,14 +2163,220 @@ pub fn run() {
       getSubscriptionProfile,
       updateSubscriptionProfile,
     ])
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    .build(tauri::generate_context!())
+    .expect("error while building tauri application");
+
+  app.run(move |app_handle, event| match event {
+    tauri::RunEvent::Resumed => {
+      if let Some(state) = app_handle.try_state::<AppState>() {
+        match refresh_handle(state.inner()) {
+          Ok(refresh) => match refresh.try_wake() {
+            Ok(()) | Err(refresh::RefreshError::Busy) => {}
+            Err(error) => log::warn!("Failed to wake refresh coordinator after resume: {error:?}"),
+          },
+          Err(error) => log::warn!("Failed to wake refresh coordinator after resume: {error}"),
+        }
+      }
+    }
+    tauri::RunEvent::Exit => {
+      let runtime = runtime_owner
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take();
+      if let Some(runtime) = runtime {
+        if let Err(error) = runtime.shutdown_and_join() {
+          log::warn!("Failed to shut down refresh runtime: {error:?}");
+        }
+      }
+    }
+    _ => {}
+  });
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::sync::mpsc::{self, Receiver, Sender};
+  use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
   use tempfile::tempdir;
+
+  struct RecordingTokenExecutor {
+    requests: Sender<refresh::TokenExecutionRequest>,
+  }
+
+  impl refresh::TokenRefreshExecutor for RecordingTokenExecutor {
+    fn parse(
+      &self,
+      request: refresh::TokenExecutionRequest,
+    ) -> Result<refresh::PreparedTokenRefresh, String> {
+      self
+        .requests
+        .send(request)
+        .map_err(|error| error.to_string())?;
+      Err("recording token executor stops after parse intake".to_string())
+    }
+
+    fn commit(&self, _: refresh::PreparedTokenRefresh) -> Result<ScanResult, String> {
+      Err("recording token executor does not commit".to_string())
+    }
+  }
+
+  struct RecordingAppTokenExecutor {
+    inner: AppTokenRefreshExecutor,
+    parsed: Sender<(u64, u64, refresh::TokenScanKind)>,
+    committed: Sender<u64>,
+  }
+
+  impl refresh::TokenRefreshExecutor for RecordingAppTokenExecutor {
+    fn parse(
+      &self,
+      request: refresh::TokenExecutionRequest,
+    ) -> Result<refresh::PreparedTokenRefresh, String> {
+      self
+        .parsed
+        .send((
+          request.generation,
+          request.source_generation,
+          request.request.kind,
+        ))
+        .map_err(|error| error.to_string())?;
+      self.inner.parse(request)
+    }
+
+    fn commit(
+      &self,
+      prepared: refresh::PreparedTokenRefresh,
+    ) -> Result<ScanResult, String> {
+      self
+        .committed
+        .send(prepared.generation)
+        .map_err(|error| error.to_string())?;
+      self.inner.commit(prepared)
+    }
+  }
+
+  struct CountingLiveFetcher {
+    calls: Arc<AtomicUsize>,
+  }
+
+  impl refresh::LiveQuotaFetcher for CountingLiveFetcher {
+    fn fetch(&self, _: Duration) -> Result<LiveRateLimitSnapshot, String> {
+      self.calls.fetch_add(1, AtomicOrdering::AcqRel);
+      Err("counting live fetcher should not run".to_string())
+    }
+  }
+
+  struct NoopLivePersister;
+
+  impl refresh::LiveQuotaPersister for NoopLivePersister {
+    fn persist(&self, _: &LiveRateLimitSnapshot) -> Result<(), String> {
+      Ok(())
+    }
+  }
+
+  struct NoopRefreshEvents;
+
+  impl refresh::RefreshEventSink for NoopRefreshEvents {
+    fn publish_invalidation(&self, _: refresh::DisplayInvalidation) {}
+
+    fn publish_completion(&self, _: refresh::RefreshCompletedEvent) {}
+  }
+
+  struct GatedFailingTokenExecutor {
+    entered: Sender<()>,
+    release: Mutex<Receiver<()>>,
+  }
+
+  impl refresh::TokenRefreshExecutor for GatedFailingTokenExecutor {
+    fn parse(
+      &self,
+      _: refresh::TokenExecutionRequest,
+    ) -> Result<refresh::PreparedTokenRefresh, String> {
+      self.entered.send(()).map_err(|error| error.to_string())?;
+      self
+        .release
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .recv()
+        .map_err(|error| error.to_string())?;
+      Err("injected popup token failure".to_string())
+    }
+
+    fn commit(&self, _: refresh::PreparedTokenRefresh) -> Result<ScanResult, String> {
+      Err("injected popup token commit failure".to_string())
+    }
+  }
+
+  struct GatedFailingLiveFetcher {
+    entered: Sender<()>,
+    release: Mutex<Receiver<()>>,
+  }
+
+  impl refresh::LiveQuotaFetcher for GatedFailingLiveFetcher {
+    fn fetch(&self, _: Duration) -> Result<LiveRateLimitSnapshot, String> {
+      self.entered.send(()).map_err(|error| error.to_string())?;
+      self
+        .release
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .recv()
+        .map_err(|error| error.to_string())?;
+      Err("injected popup live failure".to_string())
+    }
+  }
+
+  fn start_recording_runtime(
+    config: refresh::RefreshConfig,
+  ) -> (
+    refresh::RefreshRuntime,
+    Receiver<refresh::TokenExecutionRequest>,
+    Arc<AtomicUsize>,
+  ) {
+    let (requests, received) = mpsc::channel();
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let dependencies = refresh::RefreshRuntimeDependencies::with_system_defaults(
+      config,
+      Arc::new(RecordingTokenExecutor { requests }),
+      Arc::new(CountingLiveFetcher {
+        calls: Arc::clone(&live_calls),
+      }),
+      Arc::new(NoopLivePersister),
+      refresh::LiveQuotaCache::new(),
+      Arc::new(NoopRefreshEvents),
+      refresh::UsageMutationCoordinator::new(),
+    );
+    let runtime = refresh::RefreshRuntime::start(dependencies).expect("start recording runtime");
+    (runtime, received, live_calls)
+  }
+
+  fn disabled_refresh_config(codex_home: Option<String>) -> refresh::RefreshConfig {
+    refresh::RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(3600),
+      codex_home,
+      token_last_success_wall: None,
+      live_last_success_wall: None,
+    }
+  }
+
+  fn test_app_state(
+    db_path: PathBuf,
+    refresh: refresh::RefreshCoordinatorHandle,
+    usage_mutations: refresh::UsageMutationCoordinator,
+    live_rate_limits: refresh::LiveQuotaCache,
+  ) -> AppState {
+    AppState {
+      app_handle: None,
+      db_path,
+      refresh: Some(refresh),
+      usage_mutations,
+      menu_bar_render_state: Arc::new(AtomicU8::new(MENU_RENDER_IDLE)),
+      daily_value_tray: None,
+      live_rate_limits,
+      menu_bar_popup_visible: Arc::new(AtomicBool::new(false)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    }
+  }
 
   fn speed_test_settings() -> SyncSettings {
     SyncSettings {
@@ -2211,22 +2403,335 @@ mod tests {
       .with_timezone(&chrono::Utc)
   }
 
+  #[test]
+  fn settings_change_wakes_coordinator_immediately() {
+    let initial = refresh::RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(3600),
+      codex_home: None,
+      token_last_success_wall: None,
+      live_last_success_wall: None,
+    };
+    let (runtime, token_requests, _) = start_recording_runtime(initial);
+    let handle = runtime.handle();
+    let saved = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 60,
+      ..SyncSettings::default()
+    };
+
+    update_coordinator_from_saved_settings(&handle, &saved).expect("deliver settings update");
+
+    assert!(handle.status().auto_scan_enabled);
+    token_requests
+      .recv_timeout(Duration::from_secs(2))
+      .expect("enabled overdue settings wake token lane");
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn codex_home_change_requests_full_scan() {
+    let initial = refresh::RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(3600),
+      codex_home: Some("/tmp/codex-home-before".to_string()),
+      token_last_success_wall: None,
+      live_last_success_wall: None,
+    };
+    let (runtime, token_requests, _) = start_recording_runtime(initial);
+    let handle = runtime.handle();
+    let source_generation_before = handle.status().source_generation;
+    let saved = SyncSettings {
+      codex_home: Some("/tmp/codex-home-after".to_string()),
+      auto_scan_enabled: false,
+      auto_scan_interval_minutes: 60,
+      ..SyncSettings::default()
+    };
+
+    update_coordinator_from_saved_settings(&handle, &saved).expect("deliver source change");
+
+    let request = token_requests
+      .recv_timeout(Duration::from_secs(2))
+      .expect("source change starts protected token refresh");
+    assert_eq!(request.request.kind, refresh::TokenScanKind::Full);
+    assert!(request
+      .request
+      .reasons
+      .contains(refresh::RefreshReason::SettingsChanged));
+    assert_eq!(
+      request.request.codex_home.as_deref(),
+      Some("/tmp/codex-home-after")
+    );
+    assert_eq!(handle.status().source_generation, source_generation_before + 1);
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn passive_live_getter_does_not_start_fetch() {
+    let (runtime, token_requests, live_calls) =
+      start_recording_runtime(disabled_refresh_config(None));
+    let status_before = runtime.handle().status();
+    let cache = refresh::LiveQuotaCache::new();
+    cache.publish_fallback(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: None,
+        secondary: None,
+        fetched_at: "2026-07-11T00:00:00Z".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+
+    let snapshot = get_passive_live_rate_limits(&cache).expect("read cached quota");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-11T00:00:00Z");
+    assert!(cache.needs_live_refresh(Duration::from_secs(3600), Instant::now()));
+    assert!(matches!(token_requests.try_recv(), Err(mpsc::TryRecvError::Empty)));
+    assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
+    let status_after = runtime.handle().status();
+    assert_eq!(status_after.source_generation, status_before.source_generation);
+    assert!(!status_after.token.running && !status_after.token.pending);
+    assert!(!status_after.live.running && !status_after.live.pending);
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn popup_snapshot_read_does_not_start_scan() {
+    let (runtime, token_requests, live_calls) =
+      start_recording_runtime(disabled_refresh_config(None));
+    let status_before = runtime.handle().status();
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let cache = refresh::LiveQuotaCache::new();
+
+    let snapshot = build_passive_menu_bar_popup_snapshot(&db_path, &cache)
+      .expect("build passive popup snapshot");
+
+    assert_eq!(snapshot.total_tokens_selected_bucket, 0);
+    let conn = open_connection(&db_path).expect("open database");
+    let event_count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0))
+      .expect("count usage events");
+    assert_eq!(event_count, 0);
+    assert!(matches!(token_requests.try_recv(), Err(mpsc::TryRecvError::Empty)));
+    assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
+    let status_after = runtime.handle().status();
+    assert_eq!(status_after.source_generation, status_before.source_generation);
+    assert!(!status_after.token.running && !status_after.token.pending);
+    assert!(!status_after.live.running && !status_after.live.pending);
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn forced_popup_requests_token_and_live_before_waiting() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let live_cache = refresh::LiveQuotaCache::new();
+    live_cache.publish_fallback(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("cached".to_string()),
+        limit_name: None,
+        plan_type: None,
+        primary: None,
+        secondary: None,
+        fetched_at: "2026-07-11T00:00:00Z".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+    let mutation = refresh::UsageMutationCoordinator::new();
+    let (token_entered_tx, token_entered_rx) = mpsc::channel();
+    let (token_release_tx, token_release_rx) = mpsc::channel();
+    let (live_entered_tx, live_entered_rx) = mpsc::channel();
+    let (live_release_tx, live_release_rx) = mpsc::channel();
+    let runtime = refresh::RefreshRuntime::start(
+      refresh::RefreshRuntimeDependencies::with_system_defaults(
+        disabled_refresh_config(None),
+        Arc::new(GatedFailingTokenExecutor {
+          entered: token_entered_tx,
+          release: Mutex::new(token_release_rx),
+        }),
+        Arc::new(GatedFailingLiveFetcher {
+          entered: live_entered_tx,
+          release: Mutex::new(live_release_rx),
+        }),
+        Arc::new(NoopLivePersister),
+        live_cache.clone(),
+        Arc::new(NoopRefreshEvents),
+        mutation.clone(),
+      ),
+    )
+    .expect("start popup runtime");
+    let state = test_app_state(
+      db_path,
+      runtime.handle(),
+      mutation,
+      live_cache.clone(),
+    );
+    let refresh_thread = std::thread::spawn(move || refresh_popup_data(&state));
+
+    token_entered_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("token lane starts");
+    live_entered_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("live lane starts before token wait completes");
+    token_release_tx.send(()).expect("release token lane");
+    live_release_tx.send(()).expect("release live lane");
+    assert!(refresh_thread
+      .join()
+      .expect("join forced popup refresh")
+      .is_err());
+    assert_eq!(
+      live_cache
+        .rate_limits()
+        .expect("old fallback remains cached")
+        .fetched_at,
+      "2026-07-11T00:00:00Z"
+    );
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn manual_scan_uses_coordinator_generation() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("create Codex home");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let (parsed_tx, parsed_rx) = mpsc::channel();
+    let (committed_tx, committed_rx) = mpsc::channel();
+    let token_executor = RecordingAppTokenExecutor {
+      inner: AppTokenRefreshExecutor {
+        db_path: db_path.clone(),
+      },
+      parsed: parsed_tx,
+      committed: committed_tx,
+    };
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let dependencies = refresh::RefreshRuntimeDependencies::with_system_defaults(
+      disabled_refresh_config(Some(codex_home.to_string_lossy().to_string())),
+      Arc::new(token_executor),
+      Arc::new(CountingLiveFetcher {
+        calls: Arc::clone(&live_calls),
+      }),
+      Arc::new(NoopLivePersister),
+      refresh::LiveQuotaCache::new(),
+      Arc::new(NoopRefreshEvents),
+      refresh::UsageMutationCoordinator::new(),
+    );
+    let runtime = refresh::RefreshRuntime::start(dependencies).expect("start runtime");
+    let handle = runtime.handle();
+
+    let result = run_manual_scan_with_coordinator(
+      &handle,
+      Some(codex_home.to_string_lossy().to_string()),
+    )
+    .expect("manual scan succeeds through coordinator");
+
+    let (parsed_generation, source_generation, kind) = parsed_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("manual scan reaches production adapter");
+    let committed_generation = committed_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("prepared generation reaches commit");
+    assert!(parsed_generation > 0);
+    assert_eq!(parsed_generation, committed_generation);
+    assert_eq!(source_generation, handle.status().source_generation);
+    assert_eq!(kind, refresh::TokenScanKind::Full);
+    assert_eq!(result.codex_home, codex_home.to_string_lossy());
+    assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn pricing_recalculation_uses_lower_priority_mutation_ticket() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let coordinator = refresh::UsageMutationCoordinator::new();
+    let blocker = coordinator.clone();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let blocker_thread = std::thread::spawn(move || {
+      blocker.run(refresh::MutationPriority::Refresh, || {
+        entered_tx.send(()).expect("report refresh slot");
+        release_rx.recv().expect("release refresh slot");
+      });
+    });
+    entered_rx.recv().expect("refresh mutation enters first");
+
+    let pricing_coordinator = coordinator.clone();
+    let (result_tx, result_rx) = mpsc::channel();
+    let pricing_thread = std::thread::spawn(move || {
+      let result = refresh_pricing_catalog_with_runner(
+        &db_path,
+        None,
+        |priority, mutation| pricing_coordinator.run(priority, mutation).value,
+      );
+      result_tx.send(result).expect("send pricing result");
+    });
+
+    assert!(matches!(
+      result_rx.recv_timeout(Duration::from_millis(50)),
+      Err(mpsc::RecvTimeoutError::Timeout)
+    ));
+    release_tx.send(()).expect("release refresh mutation");
+    result_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("pricing runs after refresh slot")
+      .expect("pricing refresh succeeds");
+    blocker_thread.join().expect("join refresh blocker");
+    pricing_thread.join().expect("join pricing refresh");
+  }
+
+  #[test]
+  fn menu_render_coalescer_retries_failed_running_transition() {
+    let state = AtomicU8::new(MENU_RENDER_RUNNING);
+    let transitioned = std::cell::Cell::new(false);
+
+    let claimed = claim_menu_bar_render_with_hook(&state, |observed| {
+      if observed == MENU_RENDER_RUNNING && !transitioned.replace(true) {
+        state.store(MENU_RENDER_IDLE, Ordering::Release);
+      }
+    });
+
+    assert!(claimed, "failed RUNNING to PENDING CAS must retry from IDLE");
+    assert_eq!(state.load(Ordering::Acquire), MENU_RENDER_RUNNING);
+    assert!(!claim_menu_bar_render(&state));
+    assert_eq!(state.load(Ordering::Acquire), MENU_RENDER_PENDING);
+    assert!(complete_menu_bar_render(&state));
+    assert_eq!(state.load(Ordering::Acquire), MENU_RENDER_IDLE);
+  }
+
   fn seed_scan_freshness(conn: &rusqlite::Connection, codex_home: &str) -> SyncSettings {
     let initial = SyncSettings {
       codex_home: Some(codex_home.to_string()),
       ..get_sync_settings(conn).expect("load settings")
     };
     save_sync_settings(conn, &initial).expect("save initial source");
-
-    let settings = SyncSettings {
-      last_scan_started_at: Some("2026-07-10T08:00:00Z".to_string()),
-      last_scan_completed_at: Some("2026-07-10T08:01:00Z".to_string()),
-      ..get_sync_settings(conn).expect("reload initial source")
-    };
-    let saved = save_sync_settings(conn, &settings).expect("save scan freshness");
-    database::set_last_full_scan_completed(conn, "2026-07-10T08:01:00Z")
-      .expect("set full scan");
-    saved
+    database::set_last_scan_started_for_source(
+      conn,
+      "2026-07-10T08:00:00Z",
+      Some(codex_home),
+      codex_home,
+    )
+    .expect("set scan start");
+    assert!(database::set_scan_completed_for_source(
+      conn,
+      "2026-07-10T08:01:00Z",
+      Some(codex_home),
+      codex_home,
+      true,
+      false,
+    )
+    .expect("set full scan completion"));
+    get_sync_settings(conn).expect("reload scan freshness")
   }
 
   #[test]
@@ -2267,296 +2772,6 @@ mod tests {
   }
 
   #[test]
-  fn scheduler_uses_auto_scan_interval_when_disabled() {
-    let settings = SyncSettings {
-      auto_scan_enabled: false,
-      auto_scan_interval_minutes: 7,
-      last_scan_completed_at: None,
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
-      Duration::from_secs(420)
-    );
-  }
-
-  #[test]
-  fn scheduler_caps_actual_sleep_duration() {
-    assert_eq!(
-      scheduler_sleep_duration(Duration::from_secs(60)),
-      Duration::from_secs(SCHEDULER_MAX_SLEEP_SECONDS)
-    );
-    assert_eq!(scheduler_sleep_duration(Duration::from_secs(2)), Duration::from_secs(2));
-  }
-
-  #[test]
-  fn live_rate_limit_background_query_timeout_is_fixed() {
-    assert_eq!(
-      live_rate_limit_background_query_timeout(),
-      Duration::from_secs(10)
-    );
-  }
-
-  #[test]
-  fn live_rate_limit_foreground_query_timeout_stays_short() {
-    assert_eq!(live_rate_limit_foreground_query_timeout(), Duration::from_secs(10));
-  }
-
-  #[test]
-  fn legacy_live_publication_survives_persistence_failure() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-    let snapshot = LiveRateLimitSnapshot {
-      limit_id: Some("codex".to_string()),
-      limit_name: Some("Codex".to_string()),
-      plan_type: Some("pro".to_string()),
-      primary: None,
-      secondary: None,
-      fetched_at: "2026-07-11T00:00:00Z".to_string(),
-    };
-
-    let returned = publish_live_rate_limits_and_persist(&state, snapshot, |_| {
-      Err("intentional persistence failure".to_string())
-    });
-
-    assert_eq!(returned.fetched_at, "2026-07-11T00:00:00Z");
-    assert_eq!(
-      get_cached_live_rate_limits(&state)
-        .expect("fresh cache survives persistence failure")
-        .fetched_at,
-      "2026-07-11T00:00:00Z"
-    );
-  }
-
-  #[test]
-  fn forced_live_refresh_does_not_read_cache_ttl() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-    let ttl_reads = std::cell::Cell::new(0_u32);
-
-    let cached = get_fresh_cached_live_rate_limits(&state, true, || {
-      ttl_reads.set(ttl_reads.get() + 1);
-      Duration::from_secs(300)
-    });
-
-    assert!(cached.is_none());
-    assert_eq!(ttl_reads.get(), 0);
-  }
-
-  #[test]
-  fn default_menu_bar_popup_requires_background_live_rate_limits() {
-    assert!(background_live_rate_limits_enabled(&SyncSettings::default()));
-  }
-
-  #[test]
-  fn scheduler_runs_immediately_without_previous_scan() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 7,
-      last_scan_completed_at: None,
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
-      Duration::ZERO
-    );
-  }
-
-  #[test]
-  fn scheduler_waits_remaining_auto_scan_interval() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 7,
-      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:03:00Z")),
-      Duration::from_secs(240)
-    );
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:07:00Z")),
-      Duration::ZERO
-    );
-  }
-
-  #[test]
-  fn scheduler_honors_auto_scan_intervals_above_one_hour() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 180,
-      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T01:00:00Z")),
-      Duration::from_secs(7200)
-    );
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T03:00:00Z")),
-      Duration::ZERO
-    );
-  }
-
-  #[test]
-  fn background_refresh_decision_skips_when_auto_scan_is_disabled() {
-    let settings = SyncSettings {
-      auto_scan_enabled: false,
-      auto_scan_interval_minutes: 7,
-      last_scan_completed_at: None,
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      background_refresh_decision(&settings, None, utc_time("2026-03-27T00:00:00Z")),
-      BackgroundRefreshDecision::Disabled(Duration::from_secs(420))
-    );
-  }
-
-  #[test]
-  fn background_refresh_decision_runs_incremental_when_interval_is_due() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 5,
-      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      background_refresh_decision(
-        &settings,
-        Some("2026-03-27T00:00:00Z"),
-        utc_time("2026-03-27T00:05:00Z")
-      ),
-      BackgroundRefreshDecision::Incremental
-    );
-  }
-
-  #[test]
-  fn background_refresh_decision_runs_full_when_daily_maintenance_is_due() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 5,
-      last_scan_completed_at: Some("2026-03-27T23:55:00Z".to_string()),
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      background_refresh_decision(
-        &settings,
-        Some("2026-03-27T00:00:00Z"),
-        utc_time("2026-03-28T00:00:00Z")
-      ),
-      BackgroundRefreshDecision::Full
-    );
-  }
-
-  #[test]
-  fn menu_bar_popup_snapshot_runs_due_background_refresh() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    let codex_home = directory.path().join("codex-home");
-    let sessions_dir = codex_home
-      .join("sessions")
-      .join(Local::now().format("%Y").to_string())
-      .join(Local::now().format("%m").to_string())
-      .join(Local::now().format("%d").to_string());
-    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
-    let session_id = "abcdefab-1234-5678-90ab-abcdefabcdef";
-    std::fs::write(
-      sessions_dir.join("new.jsonl"),
-      format!(
-        concat!(
-          "{{\"timestamp\":\"2026-03-27T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\"}}}}\n",
-          "{{\"timestamp\":\"2026-03-27T00:00:00Z\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n",
-          "{{\"timestamp\":\"2026-03-27T00:00:01Z\",\"type\":\"event_msg\",\"payload\":{{",
-          "\"type\":\"token_count\",",
-          "\"info\":{{\"total_token_usage\":{{",
-          "\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":25,",
-          "\"reasoning_output_tokens\":0,\"total_tokens\":125",
-          "}}}},",
-          "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
-          "}}}}\n"
-        ),
-        session_id
-      ),
-    )
-    .expect("write session");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let conn = open_connection(&db_path).expect("open database");
-    let settings = SyncSettings {
-      codex_home: Some(codex_home.to_string_lossy().to_string()),
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 1,
-      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
-      ..get_sync_settings(&conn).expect("load settings")
-    };
-    save_sync_settings(&conn, &settings).expect("save settings");
-    database::set_last_full_scan_completed(&conn, "2026-03-27T00:00:30Z").expect("set full scan");
-    drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path: db_path.clone(),
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-
-    let snapshot = build_due_menu_bar_popup_snapshot(
-      &state,
-      false,
-      utc_time("2026-03-27T00:01:00Z"),
-    )
-    .expect("load snapshot");
-
-    let conn = open_connection(&db_path).expect("reopen database");
-    let event_count: i64 = conn
-      .query_row(
-        "SELECT COUNT(*) FROM usage_events WHERE session_id = ?1",
-        params![session_id],
-        |row| row.get(0),
-      )
-      .expect("count events");
-    assert_eq!(event_count, 1);
-    assert_ne!(
-      snapshot.last_scan_completed_at.as_deref(),
-      Some("2026-03-27T00:00:00Z")
-    );
-  }
-
-  #[test]
   fn full_maintenance_is_due_without_previous_full_scan() {
     assert!(full_maintenance_due(None, utc_time("2026-03-27T00:00:00Z")));
   }
@@ -2571,6 +2786,36 @@ mod tests {
       Some("2026-03-27T00:00:00Z"),
       utc_time("2026-03-28T00:00:00Z")
     ));
+  }
+
+  #[test]
+  fn automatic_incremental_request_upgrades_to_full_after_daily_maintenance() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    database::set_last_full_scan_completed(&conn, "2026-07-10T00:00:00Z")
+      .expect("seed full scan freshness");
+    drop(conn);
+
+    assert_eq!(
+      effective_token_scan_kind(
+        &db_path,
+        refresh::TokenScanKind::Incremental,
+        utc_time("2026-07-11T00:00:00Z"),
+      )
+      .expect("select scan kind"),
+      ScanKind::Full
+    );
+    assert_eq!(
+      effective_token_scan_kind(
+        &db_path,
+        refresh::TokenScanKind::Incremental,
+        utc_time("2026-07-10T23:59:59Z"),
+      )
+      .expect("select recent scan kind"),
+      ScanKind::Incremental
+    );
   }
 
   #[test]
@@ -3057,176 +3302,6 @@ mod tests {
   }
 
   #[test]
-  fn pricing_refresh_waits_for_active_scan_before_recalculating() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let conn = open_connection(&db_path).expect("open database");
-    let created_at = database::now_utc_string();
-    conn
-      .execute(
-        "
-        INSERT INTO sessions (
-          session_id, root_session_id, parent_session_id, title, source_state, source_path,
-          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
-          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
-        )
-        VALUES ('refresh-race', 'refresh-race', NULL, NULL, 'active', NULL, 'active',
-          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?1, ?1)
-        ",
-        params![created_at],
-      )
-      .expect("insert session");
-    conn
-      .execute(
-        "
-        INSERT INTO usage_events (
-          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
-          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
-          fast_mode_auto, fast_mode_effective
-        )
-        VALUES ('refresh-race', '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
-          0, 0, 1000000, 0, 1000000, 30.0, 0, 0)
-        ",
-        [],
-      )
-      .expect("insert usage event");
-    let mut official_sol = load_catalog(&conn)
-      .expect("load catalog")
-      .into_iter()
-      .find(|entry| entry.model_id == "gpt-5.6-sol")
-      .expect("load GPT-5.6 Sol");
-    official_sol.output_price_per_million = 42.0;
-    official_sol.is_official = true;
-    official_sol.note = Some("serialized refresh test".to_string());
-    official_sol.updated_at = "serialized-refresh-test".to_string();
-    drop(conn);
-
-    let state = AppState {
-      app_handle: None,
-      db_path: db_path.clone(),
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-    let (scan_loaded_sender, scan_loaded_receiver) = std::sync::mpsc::channel();
-    let (release_scan_sender, release_scan_receiver) = std::sync::mpsc::channel();
-    let scan_state = state.clone();
-    let scan_thread = std::thread::spawn(move || {
-      run_scan_if_idle_with_live_refresh(scan_state, None, false, |db_path, _| {
-        let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-        let stale_output_price: f64 = conn
-          .query_row(
-            "SELECT output_price_per_million FROM pricing_catalog WHERE model_id = 'gpt-5.6-sol'",
-            [],
-            |row| row.get(0),
-          )
-          .map_err(|error| error.to_string())?;
-        scan_loaded_sender.send(()).map_err(|error| error.to_string())?;
-        release_scan_receiver.recv().map_err(|error| error.to_string())?;
-        conn
-          .execute(
-            "UPDATE usage_events SET value_usd = ?1 WHERE session_id = 'refresh-race'",
-            params![stale_output_price],
-          )
-          .map_err(|error| error.to_string())?;
-        Ok(ScanResult {
-          codex_home: "test".to_string(),
-          scanned_files: 1,
-          imported_sessions: 1,
-          updated_sessions: 1,
-          missing_sessions: 0,
-          last_completed_at: database::now_utc_string(),
-        })
-      })
-    });
-    scan_loaded_receiver.recv().expect("scan loaded stale pricing");
-    let release_thread = std::thread::spawn(move || {
-      std::thread::sleep(Duration::from_millis(100));
-      release_scan_sender.send(()).expect("release scan");
-    });
-
-    refresh_pricing_catalog_for_state(&state, Some(&[official_sol]))
-      .expect("refresh pricing after scan");
-    release_thread.join().expect("join release thread");
-    scan_thread
-      .join()
-      .expect("join scan thread")
-      .expect("complete scan");
-
-    let conn = open_connection(&db_path).expect("reopen database");
-    let value_usd: f64 = conn
-      .query_row(
-        "SELECT value_usd FROM usage_events WHERE session_id = 'refresh-race'",
-        [],
-        |row| row.get(0),
-      )
-      .expect("load final value");
-    assert_eq!(value_usd, 42.0);
-  }
-
-  #[test]
-  fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let conn = open_connection(&db_path).expect("open database");
-    let settings = SyncSettings {
-      show_menu_bar_daily_api_value: false,
-      show_menu_bar_live_quota_percent: true,
-      menu_bar_live_quota_metric: "remaining_percent".to_string(),
-      menu_bar_live_quota_bucket: "five_hour".to_string(),
-      ..get_sync_settings(&conn).expect("load settings")
-    };
-    save_sync_settings(&conn, &settings).expect("save settings");
-    insert_live_rate_limit_snapshot(
-      &conn,
-      &LiveRateLimitSnapshot {
-        limit_id: Some("codex".to_string()),
-        limit_name: Some("Codex".to_string()),
-        plan_type: Some("pro".to_string()),
-        primary: Some(RateLimitWindowSnapshot {
-          used_percent: 12,
-          remaining_percent: 88,
-          window_duration_mins: Some(300),
-          resets_at: Some("2026-03-27T05:00:00+08:00".to_string()),
-          window_start: Some("2026-03-27T00:00:00+08:00".to_string()),
-        }),
-        secondary: None,
-        fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
-      },
-    )
-    .expect("insert live limits");
-    drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-
-    let (api_value_title, live_metric_title) =
-      current_menu_bar_title_parts_with_live_refresh(&state, &settings, false)
-        .expect("build title");
-
-    assert_eq!(api_value_title, None);
-    assert_eq!(live_metric_title.as_deref(), Some("88%"));
-    assert!(state.live_rate_limits.state().is_fallback);
-    assert!(state
-      .live_rate_limits
-      .needs_live_refresh(Duration::from_secs(300), Instant::now()));
-  }
-
-  #[test]
   fn background_live_rate_limit_fallback_prefers_newest_persisted_sample() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
@@ -3269,19 +3344,10 @@ mod tests {
     )
     .expect("insert live sample");
     drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
+    let live_cache = refresh::LiveQuotaCache::new();
 
-    let snapshot = get_live_rate_limits_stored_fallback(&state).expect("load fallback");
+    let snapshot = load_display_live_rate_limit_fallback(&db_path, &live_cache)
+      .expect("load fallback");
 
     assert_eq!(snapshot.fetched_at, "2026-03-27T00:05:00+08:00");
     assert_eq!(
@@ -3289,7 +3355,7 @@ mod tests {
       Some(88)
     );
 
-    state.live_rate_limits.publish_live(
+    live_cache.publish_live(
       Arc::new(LiveRateLimitSnapshot {
         limit_id: Some("codex".to_string()),
         limit_name: Some("Codex".to_string()),
@@ -3307,7 +3373,8 @@ mod tests {
       Instant::now(),
       Utc::now(),
     );
-    let memory = get_live_rate_limits_stored_fallback(&state).expect("prefer newer memory");
+    let memory = load_display_live_rate_limit_fallback(&db_path, &live_cache)
+      .expect("prefer newer memory");
     assert_eq!(memory.fetched_at, "2026-03-27T00:10:00+08:00");
     assert_eq!(
       memory.primary.as_ref().map(|window| window.remaining_percent),
@@ -3357,20 +3424,9 @@ mod tests {
       },
     )
     .expect("insert later UTC sample");
-    drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
 
-    let snapshot = load_persisted_live_rate_limits(&state).expect("load persisted sample");
+    let snapshot = load_persisted_live_rate_limits_from_connection(&conn, None)
+      .expect("load persisted sample");
 
     assert_eq!(snapshot.fetched_at, "2026-07-10T02:00:00Z");
     assert_eq!(
@@ -3385,30 +3441,39 @@ mod tests {
     let db_path = directory.path().join("usage.sqlite");
     prepare_app_database(&db_path).expect("prepare app database");
     let conn = open_connection(&db_path).expect("open database");
-    insert_live_rate_limit_snapshot(
+    database::replace_session_rate_limit_samples(
       &conn,
-      &LiveRateLimitSnapshot {
-        limit_id: Some("codex".to_string()),
-        limit_name: Some("Codex".to_string()),
-        plan_type: Some("pro".to_string()),
-        primary: Some(RateLimitWindowSnapshot {
+      "session-same-instant",
+      &[
+        crate::models::RateLimitSampleRecord {
+          source_kind: "session".to_string(),
+          source_session_id: Some("session-same-instant".to_string()),
+          bucket: "five_hour".to_string(),
+          sample_timestamp: "2026-07-10T10:00:00+08:00".to_string(),
+          limit_id: Some("codex".to_string()),
+          limit_name: Some("Codex".to_string()),
+          plan_type: Some("pro".to_string()),
+          window_start: "2026-07-10T10:00:00+08:00".to_string(),
+          resets_at: "2026-07-10T15:00:00+08:00".to_string(),
           used_percent: 30,
           remaining_percent: 70,
-          window_duration_mins: Some(300),
-          resets_at: Some("2026-07-10T06:00:00Z".to_string()),
-          window_start: Some("2026-07-10T01:00:00Z".to_string()),
-        }),
-        secondary: Some(RateLimitWindowSnapshot {
+        },
+        crate::models::RateLimitSampleRecord {
+          source_kind: "session".to_string(),
+          source_session_id: Some("session-same-instant".to_string()),
+          bucket: "seven_day".to_string(),
+          sample_timestamp: "2026-07-10T10:00:00+08:00".to_string(),
+          limit_id: Some("codex".to_string()),
+          limit_name: Some("Codex".to_string()),
+          plan_type: Some("pro".to_string()),
+          window_start: "2026-07-10T10:00:00+08:00".to_string(),
+          resets_at: "2026-07-17T10:00:00+08:00".to_string(),
           used_percent: 40,
           remaining_percent: 60,
-          window_duration_mins: Some(10_080),
-          resets_at: Some("2026-07-17T01:00:00Z".to_string()),
-          window_start: Some("2026-07-10T01:00:00Z".to_string()),
-        }),
-        fetched_at: "2026-07-10T01:00:00Z".to_string(),
-      },
+        },
+      ],
     )
-    .expect("insert older complete sample");
+    .expect("insert complete session sample");
     insert_live_rate_limit_snapshot(
       &conn,
       &LiveRateLimitSnapshot {
@@ -3426,21 +3491,10 @@ mod tests {
         fetched_at: "2026-07-10T02:00:00Z".to_string(),
       },
     )
-    .expect("insert newer primary-only sample");
-    drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
+    .expect("insert later primary-only row at the same instant");
 
-    let snapshot = load_persisted_live_rate_limits(&state).expect("load persisted sample");
+    let snapshot = load_persisted_live_rate_limits_from_connection(&conn, None)
+      .expect("load persisted sample");
 
     assert_eq!(snapshot.fetched_at, "2026-07-10T02:00:00Z");
     assert_eq!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,8 @@ use std::sync::{
   atomic::{AtomicBool, AtomicU8, Ordering},
   Arc, Mutex,
 };
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
@@ -159,9 +161,36 @@ impl refresh::LiveQuotaPersister for AppLiveQuotaPersister {
   }
 }
 
-#[derive(Clone)]
 struct AppEpochMaintenanceExecutor {
   db_path: PathBuf,
+  connection: Mutex<Option<rusqlite::Connection>>,
+  #[cfg(test)]
+  open_count: AtomicUsize,
+}
+
+impl AppEpochMaintenanceExecutor {
+  fn new(db_path: PathBuf) -> Self {
+    Self {
+      db_path,
+      connection: Mutex::new(None),
+      #[cfg(test)]
+      open_count: AtomicUsize::new(0),
+    }
+  }
+
+  #[cfg(test)]
+  fn open_count_for_test(&self) -> usize {
+    self.open_count.load(Ordering::Acquire)
+  }
+
+  #[cfg(test)]
+  fn connection_is_open_for_test(&self) -> bool {
+    self
+      .connection
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner)
+      .is_some()
+  }
 }
 
 impl refresh::EpochMaintenanceExecutor for AppEpochMaintenanceExecutor {
@@ -170,21 +199,41 @@ impl refresh::EpochMaintenanceExecutor for AppEpochMaintenanceExecutor {
     limit: usize,
     cancellation: Arc<AtomicBool>,
   ) -> Result<refresh::EpochMaintenanceBatch, String> {
-    let conn = database::open_epoch_maintenance_connection(&self.db_path)
-      .map_err(|error| error.to_string())?;
+    if cancellation.load(Ordering::Acquire) {
+      return Ok(refresh::EpochMaintenanceBatch::Cancelled);
+    }
+    let mut connection = self
+      .connection
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if connection.is_none() {
+      let opened = database::open_epoch_maintenance_connection(&self.db_path)
+        .map_err(|error| error.to_string())?;
+      #[cfg(test)]
+      self.open_count.fetch_add(1, Ordering::AcqRel);
+      *connection = Some(opened);
+    }
     let progress = database::backfill_epoch_batch_cancellable(
-      &conn,
+      connection
+        .as_ref()
+        .expect("epoch maintenance connection was initialized"),
       limit,
       cancellation.as_ref(),
     )
     .map_err(|error| error.to_string())?;
     Ok(match progress {
-      Some(progress) => refresh::EpochMaintenanceBatch::Progress {
-        processed_rows: progress
-          .usage_rows_updated
-          .saturating_add(progress.quota_rows_updated),
-        complete: progress.complete,
-      },
+      Some(progress) => {
+        let result = refresh::EpochMaintenanceBatch::Progress {
+          processed_rows: progress
+            .usage_rows_updated
+            .saturating_add(progress.quota_rows_updated),
+          complete: progress.complete,
+        };
+        if progress.complete {
+          *connection = None;
+        }
+        result
+      }
       None => refresh::EpochMaintenanceBatch::Cancelled,
     })
   }
@@ -196,7 +245,7 @@ fn configure_epoch_maintenance(
   pending: bool,
 ) -> refresh::RefreshRuntimeDependencies {
   if pending {
-    dependencies.with_epoch_maintenance(Arc::new(AppEpochMaintenanceExecutor { db_path }))
+    dependencies.with_epoch_maintenance(Arc::new(AppEpochMaintenanceExecutor::new(db_path)))
   } else {
     dependencies
   }
@@ -2342,7 +2391,7 @@ mod tests {
       WITH RECURSIVE rows(value) AS (
         SELECT 1
         UNION ALL
-        SELECT value + 1 FROM rows WHERE value < 1501
+        SELECT value + 1 FROM rows WHERE value < 2501
       )
       INSERT INTO usage_events (
         session_id, timestamp, timestamp_ms, model_id,
@@ -2360,9 +2409,7 @@ mod tests {
     assert!(database::epoch_backfill_pending(&conn).expect("read repair marker"));
     drop(conn);
 
-    let first_adapter = AppEpochMaintenanceExecutor {
-      db_path: db_path.clone(),
-    };
+    let first_adapter = AppEpochMaintenanceExecutor::new(db_path.clone());
     let first = refresh::EpochMaintenanceExecutor::run_batch(
       &first_adapter,
       1_000,
@@ -2376,6 +2423,29 @@ mod tests {
         complete: false,
       }
     );
+    assert_eq!(first_adapter.open_count_for_test(), 1);
+    assert!(first_adapter.connection_is_open_for_test());
+
+    let second = refresh::EpochMaintenanceExecutor::run_batch(
+      &first_adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect("run second production slice on the same adapter");
+    assert_eq!(
+      second,
+      refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: 1_000,
+        complete: false,
+      }
+    );
+    assert_eq!(
+      first_adapter.open_count_for_test(),
+      1,
+      "incomplete slices reuse one WAL connection"
+    );
+    assert!(first_adapter.connection_is_open_for_test());
+
     let reopened = open_connection(&db_path).expect("reopen after first slice");
     let cursor: i64 = reopened
       .query_row(
@@ -2384,10 +2454,11 @@ mod tests {
         |row| row.get(0),
       )
       .expect("load persisted cursor");
-    assert_eq!(cursor, 1_000);
+    assert_eq!(cursor, 2_000);
     drop(reopened);
+    drop(first_adapter);
 
-    let resumed_adapter = AppEpochMaintenanceExecutor { db_path };
+    let resumed_adapter = AppEpochMaintenanceExecutor::new(db_path);
     let resumed = refresh::EpochMaintenanceExecutor::run_batch(
       &resumed_adapter,
       1_000,
@@ -2401,6 +2472,92 @@ mod tests {
         complete: true,
       }
     );
+    assert_eq!(resumed_adapter.open_count_for_test(), 1);
+    assert!(
+      !resumed_adapter.connection_is_open_for_test(),
+      "completed repair releases its WAL connection"
+    );
+  }
+
+  #[test]
+  fn pre_cancelled_epoch_maintenance_adapter_does_not_open_database() {
+    let directory = tempdir().expect("create cancelled adapter directory");
+    let adapter = AppEpochMaintenanceExecutor::new(
+      directory.path().join("pre-cancelled.sqlite3"),
+    );
+
+    let result = refresh::EpochMaintenanceExecutor::run_batch(
+      &adapter,
+      1_000,
+      Arc::new(AtomicBool::new(true)),
+    )
+    .expect("observe pre-cancelled adapter call");
+
+    assert_eq!(result, refresh::EpochMaintenanceBatch::Cancelled);
+    assert_eq!(adapter.open_count_for_test(), 0);
+    assert!(!adapter.connection_is_open_for_test());
+  }
+
+  #[test]
+  fn failed_epoch_maintenance_slice_keeps_connection_for_retry() {
+    let directory = tempdir().expect("create retry adapter directory");
+    let db_path = directory.path().join("retry.sqlite3");
+    let conn = open_connection(&db_path).expect("open retry database");
+    init_db(&conn).expect("initialize retry database");
+    conn.execute_batch(
+      "
+      INSERT INTO usage_events (
+        session_id, timestamp, timestamp_ms, model_id,
+        input_tokens, cached_input_tokens, output_tokens,
+        reasoning_output_tokens, total_tokens, value_usd,
+        fast_mode_auto, fast_mode_effective
+      )
+      VALUES (
+        'legacy', '2026-07-10T03:00:00Z', NULL, 'gpt-5',
+        1, 0, 1, 0, 2, 0.01, 0, 0
+      );
+      CREATE TRIGGER fail_epoch_retry
+      BEFORE UPDATE OF timestamp_ms ON usage_events
+      BEGIN
+        SELECT RAISE(ABORT, 'injected epoch retry failure');
+      END;
+      ",
+    )
+    .expect("seed retry failure");
+    drop(conn);
+    let adapter = AppEpochMaintenanceExecutor::new(db_path.clone());
+
+    let error = refresh::EpochMaintenanceExecutor::run_batch(
+      &adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect_err("inject first slice failure");
+    assert!(error.contains("injected epoch retry failure"));
+    assert_eq!(adapter.open_count_for_test(), 1);
+    assert!(adapter.connection_is_open_for_test());
+
+    let repair = open_connection(&db_path).expect("open trigger repair connection");
+    repair
+      .execute_batch("DROP TRIGGER fail_epoch_retry;")
+      .expect("remove injected failure");
+    drop(repair);
+    let retried = refresh::EpochMaintenanceExecutor::run_batch(
+      &adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect("retry with retained connection");
+
+    assert_eq!(
+      retried,
+      refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: 1,
+        complete: true,
+      }
+    );
+    assert_eq!(adapter.open_count_for_test(), 1);
+    assert!(!adapter.connection_is_open_for_test());
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,13 +15,6 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
-#[cfg(target_os = "macos")]
-use objc2::{
-  rc::Retained,
-  runtime::{NSObjectProtocol, ProtocolObject},
-};
-#[cfg(target_os = "macos")]
-use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
 use rusqlite::params;
 use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
@@ -42,6 +35,7 @@ use queries::{
   get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
 };
 use rate_limits::query_live_rate_limits;
+use refresh::begin_scheduler_activity;
 use tauri::{
   Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
   WebviewWindowBuilder,
@@ -130,38 +124,6 @@ fn lock_usage_mutations(state: &AppState) -> std::sync::MutexGuard<'_, ()> {
     .usage_mutation_lock
     .lock()
     .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-#[cfg(target_os = "macos")]
-struct SchedulerActivity {
-  activity: Retained<ProtocolObject<dyn NSObjectProtocol>>,
-}
-
-#[cfg(target_os = "macos")]
-impl Drop for SchedulerActivity {
-  fn drop(&mut self) {
-    unsafe {
-      NSProcessInfo::processInfo().endActivity(&self.activity);
-    }
-  }
-}
-
-#[cfg(target_os = "macos")]
-fn begin_scheduler_activity() -> Option<SchedulerActivity> {
-  let reason = NSString::from_str("Codex Pacer background refresh");
-  let activity = NSProcessInfo::processInfo().beginActivityWithOptions_reason(
-    NSActivityOptions::UserInitiatedAllowingIdleSystemSleep,
-    &reason,
-  );
-  Some(SchedulerActivity { activity })
-}
-
-#[cfg(not(target_os = "macos"))]
-struct SchedulerActivity;
-
-#[cfg(not(target_os = "macos"))]
-fn begin_scheduler_activity() -> Option<SchedulerActivity> {
-  None
 }
 
 #[allow(non_snake_case)]
@@ -490,7 +452,10 @@ where
   let guard = try_acquire_flag(&state.scan_in_progress, "A scan is already running.")?;
   let mutation_guard = lock_usage_mutations(&state);
 
-  let result = scan(&state.db_path, codex_home);
+  let result = {
+    let _activity = begin_scheduler_activity();
+    scan(&state.db_path, codex_home)
+  };
   drop(mutation_guard);
   drop(guard);
   refresh_daily_value_menu_bar_with_live_refresh(&state, allow_menu_bar_live_refresh);
@@ -1125,10 +1090,17 @@ fn get_live_rate_limits_with_fallback(
     }
   }
 
-  match query_live_rate_limits(query_timeout) {
+  let query_result = {
+    let _activity = begin_scheduler_activity();
+    query_live_rate_limits(query_timeout)
+  };
+  match query_result {
     Ok(snapshot) => {
-      let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-      insert_live_rate_limit_snapshot(&conn, &snapshot).map_err(|error| error.to_string())?;
+      {
+        let _activity = begin_scheduler_activity();
+        let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+        insert_live_rate_limit_snapshot(&conn, &snapshot).map_err(|error| error.to_string())?;
+      }
       store_live_rate_limits_cache(state, &snapshot)?;
       Ok(snapshot)
     }
@@ -1950,7 +1922,6 @@ fn spawn_scheduler(state: AppState) {
   std::thread::Builder::new()
     .name("codex-pacer-scheduler".to_string())
     .spawn(move || {
-      let _scheduler_activity = begin_scheduler_activity();
       loop {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_scheduler_tick(&state)));
         let delay = match result {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -861,9 +861,13 @@ fn refresh_daily_value_menu_bar(state: &AppState) {
 }
 
 fn update_daily_value_menu_bar(state: &AppState) -> Result<(), String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
-  render_daily_value_menu_bar(state, &settings)
+  let result = (|| {
+    let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+    let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+    render_daily_value_menu_bar(state, &settings)
+  })();
+  importer::release_unused_process_memory();
+  result
 }
 
 fn render_daily_value_menu_bar(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod models;
 mod pricing;
 mod queries;
 mod rate_limits;
+mod refresh;
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,6 +160,49 @@ impl refresh::LiveQuotaPersister for AppLiveQuotaPersister {
 }
 
 #[derive(Clone)]
+struct AppEpochMaintenanceExecutor {
+  db_path: PathBuf,
+}
+
+impl refresh::EpochMaintenanceExecutor for AppEpochMaintenanceExecutor {
+  fn run_batch(
+    &self,
+    limit: usize,
+    cancellation: Arc<AtomicBool>,
+  ) -> Result<refresh::EpochMaintenanceBatch, String> {
+    let conn = database::open_epoch_maintenance_connection(&self.db_path)
+      .map_err(|error| error.to_string())?;
+    let progress = database::backfill_epoch_batch_cancellable(
+      &conn,
+      limit,
+      cancellation.as_ref(),
+    )
+    .map_err(|error| error.to_string())?;
+    Ok(match progress {
+      Some(progress) => refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: progress
+          .usage_rows_updated
+          .saturating_add(progress.quota_rows_updated),
+        complete: progress.complete,
+      },
+      None => refresh::EpochMaintenanceBatch::Cancelled,
+    })
+  }
+}
+
+fn configure_epoch_maintenance(
+  dependencies: refresh::RefreshRuntimeDependencies,
+  db_path: PathBuf,
+  pending: bool,
+) -> refresh::RefreshRuntimeDependencies {
+  if pending {
+    dependencies.with_epoch_maintenance(Arc::new(AppEpochMaintenanceExecutor { db_path }))
+  } else {
+    dependencies
+  }
+}
+
+#[derive(Clone)]
 struct TauriRefreshEventSink {
   app_handle: AppHandle,
 }
@@ -2077,6 +2120,8 @@ pub fn run() {
         .or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")));
       let live_last_success_at = load_persisted_live_rate_limits_from_connection(&conn, Some("live"))
         .map(|snapshot| snapshot.fetched_at);
+      let epoch_backfill_is_pending =
+        database::epoch_backfill_pending(&conn).map_err(|error| error.to_string())?;
       drop(conn);
 
       let live_rate_limits = refresh::LiveQuotaCache::new();
@@ -2090,8 +2135,7 @@ pub fn run() {
 
       let app_handle = app.app_handle();
       let usage_mutations = refresh::UsageMutationCoordinator::new();
-      let runtime = refresh::RefreshRuntime::start(
-        refresh::RefreshRuntimeDependencies::with_system_defaults(
+      let runtime_dependencies = refresh::RefreshRuntimeDependencies::with_system_defaults(
           refresh_config_from_saved_settings(&settings, live_last_success_at.as_deref()),
           Arc::new(AppTokenRefreshExecutor {
             db_path: db_path.clone(),
@@ -2108,8 +2152,13 @@ pub fn run() {
             app_handle: app_handle.clone(),
           }),
           usage_mutations.clone(),
-        ),
-      )?;
+        );
+      let runtime_dependencies = configure_epoch_maintenance(
+        runtime_dependencies,
+        db_path.clone(),
+        epoch_backfill_is_pending,
+      );
+      let runtime = refresh::RefreshRuntime::start(runtime_dependencies)?;
       let refresh = runtime.handle();
       *setup_runtime_owner
         .lock()
@@ -2197,7 +2246,7 @@ pub fn run() {
 mod tests {
   use super::*;
   use std::sync::mpsc::{self, Receiver, Sender};
-  use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+  use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
   use tempfile::tempdir;
 
   struct RecordingTokenExecutor {
@@ -2280,6 +2329,116 @@ mod tests {
     fn publish_invalidation(&self, _: refresh::DisplayInvalidation) {}
 
     fn publish_completion(&self, _: refresh::RefreshCompletedEvent) {}
+  }
+
+  #[test]
+  fn production_epoch_maintenance_adapter_is_bounded_and_resumes_from_cursor() {
+    let directory = tempdir().expect("create adapter test directory");
+    let db_path = directory.path().join("epoch-maintenance.sqlite3");
+    let conn = open_connection(&db_path).expect("open adapter database");
+    init_db(&conn).expect("initialize adapter database");
+    conn.execute_batch(
+      "
+      WITH RECURSIVE rows(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM rows WHERE value < 1501
+      )
+      INSERT INTO usage_events (
+        session_id, timestamp, timestamp_ms, model_id,
+        input_tokens, cached_input_tokens, output_tokens,
+        reasoning_output_tokens, total_tokens, value_usd,
+        fast_mode_auto, fast_mode_effective
+      )
+      SELECT
+        'legacy-' || value, '2026-07-10T03:00:00Z', NULL, 'gpt-5',
+        1, 0, 1, 0, 2, 0.01, 0, 0
+      FROM rows;
+      ",
+    )
+    .expect("seed legacy epoch rows");
+    assert!(database::epoch_backfill_pending(&conn).expect("read repair marker"));
+    drop(conn);
+
+    let first_adapter = AppEpochMaintenanceExecutor {
+      db_path: db_path.clone(),
+    };
+    let first = refresh::EpochMaintenanceExecutor::run_batch(
+      &first_adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect("run first production slice");
+    assert_eq!(
+      first,
+      refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: 1_000,
+        complete: false,
+      }
+    );
+    let reopened = open_connection(&db_path).expect("reopen after first slice");
+    let cursor: i64 = reopened
+      .query_row(
+        "SELECT progress_value FROM data_repair_progress WHERE repair_key = 'epoch_timestamp_backfill_v1' AND stream_key = 'usage_events'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load persisted cursor");
+    assert_eq!(cursor, 1_000);
+    drop(reopened);
+
+    let resumed_adapter = AppEpochMaintenanceExecutor { db_path };
+    let resumed = refresh::EpochMaintenanceExecutor::run_batch(
+      &resumed_adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect("resume production slice");
+    assert_eq!(
+      resumed,
+      refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: 501,
+        complete: true,
+      }
+    );
+  }
+
+  #[test]
+  fn completed_epoch_repair_does_not_inject_a_runtime_worker() {
+    let directory = tempdir().expect("create completed repair directory");
+    let db_path = directory.path().join("completed.sqlite3");
+    let conn = open_connection(&db_path).expect("open completed database");
+    init_db(&conn).expect("initialize completed database");
+    conn.execute(
+      "INSERT INTO data_repairs (repair_key, completed_at) VALUES ('epoch_timestamp_backfill_v1', '2026-07-11T00:00:00Z')",
+      [],
+    )
+    .expect("mark epoch repair complete");
+    let pending = database::epoch_backfill_pending(&conn).expect("check completion marker");
+    drop(conn);
+    let (requests, _) = mpsc::channel();
+    let dependencies = refresh::RefreshRuntimeDependencies::with_system_defaults(
+      refresh::RefreshConfig {
+        auto_scan_enabled: false,
+        interval: Duration::from_secs(60),
+        codex_home: None,
+        token_last_success_wall: None,
+        live_last_success_wall: None,
+      },
+      Arc::new(RecordingTokenExecutor { requests }),
+      Arc::new(CountingLiveFetcher {
+        calls: Arc::new(AtomicUsize::new(0)),
+      }),
+      Arc::new(NoopLivePersister),
+      refresh::LiveQuotaCache::new(),
+      Arc::new(NoopRefreshEvents),
+      refresh::UsageMutationCoordinator::new(),
+    );
+
+    let dependencies = configure_epoch_maintenance(dependencies, db_path, pending);
+
+    assert!(!pending);
+    assert!(dependencies.epoch_maintenance_executor.is_none());
   }
 
   struct GatedFailingTokenExecutor {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -223,6 +223,17 @@ pub struct LiveRateLimitSnapshot {
   pub fetched_at: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveQuotaState {
+  pub rate_limits: Option<LiveRateLimitSnapshot>,
+  pub source_fetched_at: Option<String>,
+  pub cached_at: String,
+  pub is_fallback: bool,
+  pub last_live_success_at: Option<String>,
+  pub refreshing: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MenuBarPopupQuotaSnapshot {

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -176,7 +176,6 @@ pub fn get_window_api_value(
     return sum_all_api_value(&conn).map_err(|error| error.to_string());
   }
 
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let resolved_window = resolve_window(
     &conn,
@@ -184,12 +183,12 @@ pub fn get_window_api_value(
     anchor,
     custom_start,
     custom_end,
-    &events,
+    &[],
     profile.billing_anchor_day,
     live_rate_limits.as_ref(),
     live_window_offset,
   )?;
-  Ok(sum_window_api_value(&events, &resolved_window.window))
+  sum_window_api_value_sql(&conn, &resolved_window.window).map_err(|error| error.to_string())
 }
 
 pub fn list_conversations(
@@ -1198,12 +1197,28 @@ fn sum_all_api_value(conn: &Connection) -> rusqlite::Result<f64> {
   })
 }
 
-fn sum_window_api_value(events: &[EventRow], window: &Window) -> f64 {
-  events
-    .iter()
-    .filter(|event| event_in_window(event, window))
-    .map(|event| event.value_usd)
-    .sum()
+fn sum_window_api_value_sql(conn: &Connection, window: &Window) -> rusqlite::Result<f64> {
+  let start_ms = window.start.timestamp_millis();
+  let end_ms = window.end.timestamp_millis();
+  conn.query_row(
+    "
+    SELECT
+      COALESCE((
+        SELECT SUM(value_usd)
+        FROM usage_events
+        WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
+      ), 0.0)
+      + COALESCE((
+        SELECT SUM(value_usd)
+        FROM usage_events
+        WHERE timestamp_ms IS NULL
+          AND unixepoch(timestamp) * 1000 >= ?1
+          AND unixepoch(timestamp) * 1000 < ?2
+      ), 0.0)
+    ",
+    rusqlite::params![start_ms, end_ms],
+    |row| row.get(0),
+  )
 }
 
 fn resolve_window(

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -3,6 +3,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use chrono::{Local, LocalResult, TimeZone, Timelike};
@@ -50,28 +51,63 @@ struct AppServerCommandSpec {
   hide_window: bool,
 }
 
+struct AppServerSession {
+  child: Child,
+  stdout_reader: Option<JoinHandle<()>>,
+}
+
+impl Drop for AppServerSession {
+  fn drop(&mut self) {
+    let _ = self.child.stdin.take();
+
+    if !matches!(self.child.try_wait(), Ok(Some(_))) {
+      let _ = self.child.kill();
+    }
+    let _ = self.child.wait();
+
+    if let Some(stdout_reader) = self.stdout_reader.take() {
+      let _ = stdout_reader.join();
+    }
+  }
+}
+
 pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
   let started_at = Instant::now();
   let codex_binary = resolve_codex_binary();
   let command_spec = app_server_command_spec(&codex_binary);
+  query_live_rate_limits_with_command(started_at, timeout, command_spec, &codex_binary)
+}
+
+fn query_live_rate_limits_with_command(
+  started_at: Instant,
+  timeout: Duration,
+  command_spec: AppServerCommandSpec,
+  command_path: &Path,
+) -> Result<LiveRateLimitSnapshot, String> {
   let mut command = app_server_command(&command_spec);
-  let mut child = command
+  let child = command
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
     .stderr(Stdio::null())
     .spawn()
-    .map_err(|error| format!("Failed to launch codex app-server from {}: {error}", codex_binary.display()))?;
+    .map_err(|error| {
+      format!(
+        "Failed to launch codex app-server from {}: {error}",
+        command_path.display()
+      )
+    })?;
+  let mut session = AppServerSession {
+    child,
+    stdout_reader: None,
+  };
 
-  let stdout = match child.stdout.take() {
+  let stdout = match session.child.stdout.take() {
     Some(stdout) => stdout,
-    None => {
-      stop_app_server(&mut child);
-      return Err("Failed to capture codex app-server stdout.".to_string());
-    }
+    None => return Err("Failed to capture codex app-server stdout.".to_string()),
   };
   let (sender, receiver) = mpsc::channel();
 
-  std::thread::spawn(move || {
+  session.stdout_reader = Some(std::thread::spawn(move || {
     let mut init_ok = false;
     for line in BufReader::new(stdout).lines().map_while(Result::ok) {
       let parsed: Value = match serde_json::from_str(&line) {
@@ -134,10 +170,10 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
     }
 
     let _ = sender.send(AppServerMessage::Closed);
-  });
+  }));
 
   if let Err(error) = send_app_server_request(
-    &mut child,
+    &mut session.child,
     json!({
       "id": INIT_REQUEST_ID,
       "method": "initialize",
@@ -154,49 +190,31 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
     "Failed to initialize codex app-server",
     "Failed to flush codex app-server init request",
   ) {
-    stop_app_server(&mut child);
     return Err(error);
   }
 
   let init_timeout = match remaining_app_server_timeout(started_at, timeout) {
     Some(timeout) => timeout,
-    None => {
-      stop_app_server(&mut child);
-      return Err("Timed out while initializing Codex app-server.".to_string());
-    }
+    None => return Err("Timed out while initializing Codex app-server.".to_string()),
   };
   let init_response = match receiver.recv_timeout(init_timeout) {
     Ok(message) => message,
-    Err(_) => {
-      stop_app_server(&mut child);
-      return Err("Timed out while initializing Codex app-server.".to_string());
-    }
+    Err(_) => return Err("Timed out while initializing Codex app-server.".to_string()),
   };
 
   match init_response {
     AppServerMessage::Initialized(Ok(())) => {}
-    AppServerMessage::Initialized(Err(error)) => {
-      stop_app_server(&mut child);
-      return Err(error);
-    }
-    AppServerMessage::RateLimits(result) => {
-      stop_app_server(&mut child);
-      return result;
-    }
+    AppServerMessage::Initialized(Err(error)) => return Err(error),
+    AppServerMessage::RateLimits(result) => return result,
     AppServerMessage::Closed => {
-      stop_app_server(&mut child);
-      return Err("Codex app-server closed before initialization completed.".to_string());
+      return Err("Codex app-server closed before initialization completed.".to_string())
     }
   }
 
   for (message, write_context, flush_context) in post_initialize_messages() {
-    if let Err(error) = send_app_server_request(
-      &mut child,
-      message,
-      write_context,
-      flush_context,
-    ) {
-      stop_app_server(&mut child);
+    if let Err(error) =
+      send_app_server_request(&mut session.child, message, write_context, flush_context)
+    {
       return Err(error);
     }
   }
@@ -204,17 +222,11 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
   let response = loop {
     let timeout = match remaining_app_server_timeout(started_at, timeout) {
       Some(timeout) => timeout,
-      None => {
-        stop_app_server(&mut child);
-        return Err("Timed out while querying live rate limits from Codex.".to_string());
-      }
+      None => return Err("Timed out while querying live rate limits from Codex.".to_string()),
     };
     let message = match receiver.recv_timeout(timeout) {
       Ok(message) => message,
-      Err(_) => {
-        stop_app_server(&mut child);
-        return Err("Timed out while querying live rate limits from Codex.".to_string());
-      }
+      Err(_) => return Err("Timed out while querying live rate limits from Codex.".to_string()),
     };
 
     match message {
@@ -227,7 +239,6 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
     }
   };
 
-  stop_app_server(&mut child);
   response
 }
 
@@ -348,12 +359,6 @@ fn send_app_server_request(
   stdin
     .flush()
     .map_err(|error| format!("{flush_context}: {error}"))
-}
-
-fn stop_app_server(child: &mut Child) {
-  let _ = child.stdin.take();
-  let _ = child.kill();
-  let _ = child.wait();
 }
 
 fn convert_live_rate_limits(snapshot: AppServerRateLimitSnapshot) -> LiveRateLimitSnapshot {
@@ -500,10 +505,106 @@ mod tests {
   #[cfg(windows)]
   use std::ffi::OsString;
   use std::path::{Path, PathBuf};
+  #[cfg(unix)]
+  use std::time::{Duration, Instant};
 
   fn existing_paths(paths: &[&str]) -> impl Fn(&Path) -> bool {
     let paths: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
     move |candidate| paths.iter().any(|path| path == candidate)
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn live_timeout_terminates_and_reaps_child() {
+    fn assert_not_running_or_waitable(pid: i32) {
+      const ESRCH: i32 = 3;
+      const ECHILD: i32 = 10;
+      const SIGKILL: i32 = 9;
+      const WNOHANG: i32 = 1;
+
+      extern "C" {
+        fn kill(pid: i32, signal: i32) -> i32;
+        fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
+      }
+
+      let kill_result = unsafe { kill(pid, 0) };
+      let kill_error = (kill_result == -1).then(std::io::Error::last_os_error);
+
+      let mut status = 0;
+      let wait_result = unsafe { waitpid(pid, &mut status, WNOHANG) };
+      let wait_error = (wait_result == -1).then(std::io::Error::last_os_error);
+
+      if wait_result == 0 {
+        let _ = unsafe { kill(pid, SIGKILL) };
+        let _ = unsafe { waitpid(pid, &mut status, 0) };
+      }
+
+      assert_eq!(
+        kill_result, -1,
+        "app-server fixture PID {pid} is still alive or a zombie"
+      );
+      assert_eq!(
+        kill_error.and_then(|error| error.raw_os_error()),
+        Some(ESRCH),
+        "unexpected kill probe result for PID {pid}"
+      );
+      assert_eq!(
+        wait_result, -1,
+        "app-server fixture PID {pid} was not reaped"
+      );
+      assert_eq!(
+        wait_error.and_then(|error| error.raw_os_error()),
+        Some(ECHILD),
+        "unexpected waitpid result for PID {pid}"
+      );
+    }
+
+    let fixtures = [
+      (
+        "echo $$ > \"$1\"; while IFS= read -r _line; do :; done",
+        "Timed out while initializing Codex app-server.",
+      ),
+      (
+        concat!(
+          "echo $$ > \"$1\"; ",
+          "IFS= read -r _line; ",
+          "printf '%s\\n' '{\"id\":\"codex-counter.init\",\"result\":{}}'; ",
+          "while IFS= read -r _line; do :; done"
+        ),
+        "Timed out while querying live rate limits from Codex.",
+      ),
+    ];
+
+    for (index, (script, expected_error)) in fixtures.into_iter().enumerate() {
+      let temp_dir = tempfile::tempdir().expect("create app-server fixture directory");
+      let pid_path = temp_dir.path().join(format!("fixture-{index}.pid"));
+      let command_spec = super::AppServerCommandSpec {
+        program: "/bin/sh".into(),
+        args: vec![
+          "-c".into(),
+          script.into(),
+          "codex-pacer-app-server-fixture".into(),
+          pid_path.as_os_str().to_owned(),
+        ],
+        hide_window: false,
+      };
+
+      let error = super::query_live_rate_limits_with_command(
+        Instant::now(),
+        Duration::from_millis(100),
+        command_spec,
+        Path::new("local app-server fixture"),
+      )
+      .expect_err("fixture should force a timeout");
+      assert_eq!(error, expected_error);
+
+      let pid = std::fs::read_to_string(&pid_path)
+        .expect("fixture should record its PID")
+        .trim()
+        .parse::<i32>()
+        .expect("fixture PID should be numeric");
+      assert_not_running_or_waitable(pid);
+    }
   }
 
   #[test]

--- a/src-tauri/src/refresh/live_cache.rs
+++ b/src-tauri/src/refresh/live_cache.rs
@@ -1,0 +1,550 @@
+use crate::models::{LiveQuotaState, LiveRateLimitSnapshot};
+use chrono::{DateTime, Utc};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+const PERSISTENCE_RETRY_SECONDS: [u64; 6] = [5, 15, 30, 60, 120, 300];
+const MAX_PERSISTENCE_RETRY: Duration = Duration::from_secs(300);
+const MIN_PERSISTENCE_RETRY: Duration = Duration::from_secs(1);
+
+#[derive(Clone)]
+pub(crate) struct LiveQuotaCache {
+  inner: Arc<Mutex<LiveQuotaCacheInner>>,
+}
+
+struct LiveQuotaCacheInner {
+  rate_limits: Option<Arc<LiveRateLimitSnapshot>>,
+  source_fetched_at: Option<String>,
+  cached_at: String,
+  is_fallback: bool,
+  last_live_success_at: Option<String>,
+  refreshing: bool,
+  fresh_at: Option<Instant>,
+}
+
+impl Default for LiveQuotaCache {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl LiveQuotaCache {
+  pub(crate) fn new() -> Self {
+    Self {
+      inner: Arc::new(Mutex::new(LiveQuotaCacheInner {
+        rate_limits: None,
+        source_fetched_at: None,
+        cached_at: "1970-01-01T00:00:00+00:00".to_string(),
+        is_fallback: false,
+        last_live_success_at: None,
+        refreshing: false,
+        fresh_at: None,
+      })),
+    }
+  }
+
+  pub(crate) fn state(&self) -> LiveQuotaState {
+    state_from_inner(&lock(&self.inner))
+  }
+
+  pub(crate) fn rate_limits(&self) -> Option<Arc<LiveRateLimitSnapshot>> {
+    lock(&self.inner).rate_limits.as_ref().map(Arc::clone)
+  }
+
+  pub(crate) fn publish_live(
+    &self,
+    snapshot: Arc<LiveRateLimitSnapshot>,
+    monotonic_now: Instant,
+    wall_now: DateTime<Utc>,
+  ) -> LiveQuotaState {
+    let mut inner = lock(&self.inner);
+    inner.source_fetched_at = Some(snapshot.fetched_at.clone());
+    inner.rate_limits = Some(snapshot);
+    inner.cached_at = wall_now.to_rfc3339();
+    inner.is_fallback = false;
+    inner.last_live_success_at = Some(wall_now.to_rfc3339());
+    inner.refreshing = false;
+    inner.fresh_at = Some(monotonic_now);
+    state_from_inner(&inner)
+  }
+
+  pub(crate) fn publish_fallback(
+    &self,
+    fallback: Arc<LiveRateLimitSnapshot>,
+    _monotonic_now: Instant,
+    wall_now: DateTime<Utc>,
+  ) -> LiveQuotaState {
+    let mut inner = lock(&self.inner);
+    let replace = inner.rate_limits.as_ref().map_or(true, |current| {
+      snapshot_is_strictly_newer(&fallback, current)
+    });
+    if replace {
+      inner.source_fetched_at = Some(fallback.fetched_at.clone());
+      inner.rate_limits = Some(fallback);
+      inner.cached_at = wall_now.to_rfc3339();
+    }
+    inner.is_fallback = true;
+    inner.refreshing = false;
+    inner.fresh_at = None;
+    state_from_inner(&inner)
+  }
+
+  pub(crate) fn set_refreshing(&self, refreshing: bool) -> LiveQuotaState {
+    let mut inner = lock(&self.inner);
+    inner.refreshing = refreshing;
+    state_from_inner(&inner)
+  }
+
+  pub(crate) fn mark_current_as_fallback(&self) -> LiveQuotaState {
+    let mut inner = lock(&self.inner);
+    inner.refreshing = false;
+    if inner.rate_limits.is_some() {
+      inner.is_fallback = true;
+      inner.fresh_at = None;
+    }
+    state_from_inner(&inner)
+  }
+
+  pub(crate) fn needs_live_refresh(&self, ttl: Duration, monotonic_now: Instant) -> bool {
+    let inner = lock(&self.inner);
+    inner.rate_limits.is_none()
+      || inner.is_fallback
+      || inner.fresh_at.map_or(true, |fresh_at| {
+        monotonic_now.saturating_duration_since(fresh_at) > ttl
+      })
+  }
+}
+
+fn state_from_inner(inner: &LiveQuotaCacheInner) -> LiveQuotaState {
+  LiveQuotaState {
+    rate_limits: inner
+      .rate_limits
+      .as_ref()
+      .map(|value| value.as_ref().clone()),
+    source_fetched_at: inner.source_fetched_at.clone(),
+    cached_at: inner.cached_at.clone(),
+    is_fallback: inner.is_fallback,
+    last_live_success_at: inner.last_live_success_at.clone(),
+    refreshing: inner.refreshing,
+  }
+}
+
+fn snapshot_is_strictly_newer(
+  candidate: &LiveRateLimitSnapshot,
+  current: &LiveRateLimitSnapshot,
+) -> bool {
+  match (
+    parse_source_instant(&candidate.fetched_at),
+    parse_source_instant(&current.fetched_at),
+  ) {
+    (Some(candidate), Some(current)) => candidate > current,
+    (Some(_), None) => true,
+    (None, Some(_)) => false,
+    (None, None) => candidate.fetched_at > current.fetched_at,
+  }
+}
+
+fn parse_source_instant(value: &str) -> Option<DateTime<Utc>> {
+  DateTime::parse_from_rfc3339(value)
+    .ok()
+    .map(|value| value.with_timezone(&Utc))
+}
+
+fn lock<T>(value: &Mutex<T>) -> MutexGuard<'_, T> {
+  value
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[derive(Clone)]
+struct PersistenceItem {
+  identity: u64,
+  source_generation: u64,
+  snapshot: Arc<LiveRateLimitSnapshot>,
+}
+
+#[derive(Clone)]
+pub(crate) struct LivePersistenceWork {
+  item: PersistenceItem,
+}
+
+impl LivePersistenceWork {
+  pub(crate) fn identity(&self) -> u64 {
+    self.item.identity
+  }
+
+  pub(crate) fn source_generation(&self) -> u64 {
+    self.item.source_generation
+  }
+
+  pub(crate) fn snapshot(&self) -> &Arc<LiveRateLimitSnapshot> {
+    &self.item.snapshot
+  }
+}
+
+pub(crate) struct LivePersistenceRetryState {
+  source_generation: Option<u64>,
+  in_flight: Option<PersistenceItem>,
+  latest_pending: Option<PersistenceItem>,
+  failure_streak: u32,
+  retry_at: Option<Instant>,
+  next_identity: u64,
+}
+
+impl Default for LivePersistenceRetryState {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl LivePersistenceRetryState {
+  pub(crate) fn new() -> Self {
+    Self {
+      source_generation: None,
+      in_flight: None,
+      latest_pending: None,
+      failure_streak: 0,
+      retry_at: None,
+      next_identity: 0,
+    }
+  }
+
+  pub(crate) fn publish(
+    &mut self,
+    snapshot: Arc<LiveRateLimitSnapshot>,
+    source_generation: u64,
+    _now: Instant,
+  ) {
+    if self.source_generation != Some(source_generation) {
+      self.reset_source(source_generation);
+    }
+    self.next_identity = self.next_identity.saturating_add(1);
+    self.latest_pending = Some(PersistenceItem {
+      identity: self.next_identity,
+      source_generation,
+      snapshot,
+    });
+    self.failure_streak = 0;
+    self.retry_at = None;
+  }
+
+  pub(crate) fn take_ready(
+    &mut self,
+    now: Instant,
+    live_fetch_running: bool,
+  ) -> Option<LivePersistenceWork> {
+    if live_fetch_running || self.in_flight.is_some() {
+      return None;
+    }
+    if self.retry_at.is_some_and(|deadline| deadline > now) {
+      return None;
+    }
+    let item = self.latest_pending.take()?;
+    self.retry_at = None;
+    self.in_flight = Some(item.clone());
+    Some(LivePersistenceWork { item })
+  }
+
+  pub(crate) fn finish(
+    &mut self,
+    work: &LivePersistenceWork,
+    result: Result<(), String>,
+    now: Instant,
+    interval: Duration,
+  ) -> bool {
+    let matches = self
+      .in_flight
+      .as_ref()
+      .is_some_and(|running| persistence_item_matches(running, &work.item));
+    if !matches {
+      return false;
+    }
+    self.in_flight = None;
+    if self.source_generation != Some(work.item.source_generation) {
+      if self.latest_pending.is_some() {
+        self.retry_at = None;
+      }
+      return true;
+    }
+    match result {
+      Ok(()) => {
+        self.failure_streak = 0;
+        self.retry_at = None;
+      }
+      Err(_) if self.latest_pending.is_some() => {
+        self.retry_at = None;
+      }
+      Err(_) => {
+        self.failure_streak = self.failure_streak.saturating_add(1);
+        self.latest_pending = Some(work.item.clone());
+        self.retry_at = Some(
+          now
+            .checked_add(persistence_retry_delay(self.failure_streak, interval))
+            .unwrap_or(now),
+        );
+      }
+    }
+    true
+  }
+
+  pub(crate) fn abandon(&mut self, work: &LivePersistenceWork) -> bool {
+    let matches = self
+      .in_flight
+      .as_ref()
+      .is_some_and(|running| persistence_item_matches(running, &work.item));
+    if !matches {
+      return false;
+    }
+    self.in_flight = None;
+    if self.latest_pending.is_some() {
+      self.retry_at = None;
+    }
+    true
+  }
+
+  pub(crate) fn reset_source(&mut self, source_generation: u64) {
+    if self.source_generation == Some(source_generation) {
+      return;
+    }
+    self.source_generation = Some(source_generation);
+    self.latest_pending = None;
+    self.failure_streak = 0;
+    self.retry_at = None;
+  }
+
+  pub(crate) fn cancel_pending(&mut self) {
+    self.latest_pending = None;
+    self.retry_at = None;
+  }
+
+  pub(crate) fn retry_deadline(&self) -> Option<Instant> {
+    self.retry_at
+  }
+
+  pub(crate) fn has_in_flight(&self) -> bool {
+    self.in_flight.is_some()
+  }
+
+  pub(crate) fn next_wait(&self, now: Instant, live_fetch_running: bool) -> Option<Duration> {
+    if live_fetch_running || self.in_flight.is_some() || self.latest_pending.is_none() {
+      return None;
+    }
+    Some(self.retry_at.map_or(Duration::ZERO, |deadline| {
+      deadline.saturating_duration_since(now)
+    }))
+  }
+
+  pub(crate) fn failure_streak(&self) -> u32 {
+    self.failure_streak
+  }
+}
+
+fn persistence_item_matches(left: &PersistenceItem, right: &PersistenceItem) -> bool {
+  left.identity == right.identity
+    && left.source_generation == right.source_generation
+    && Arc::ptr_eq(&left.snapshot, &right.snapshot)
+}
+
+fn persistence_retry_delay(failure_streak: u32, interval: Duration) -> Duration {
+  let index = failure_streak
+    .saturating_sub(1)
+    .min(PERSISTENCE_RETRY_SECONDS.len().saturating_sub(1) as u32) as usize;
+  let base = Duration::from_secs(PERSISTENCE_RETRY_SECONDS[index]);
+  let cap = interval
+    .min(MAX_PERSISTENCE_RETRY)
+    .max(MIN_PERSISTENCE_RETRY);
+  base.min(cap).max(MIN_PERSISTENCE_RETRY)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{LivePersistenceRetryState, LiveQuotaCache};
+  use crate::models::LiveRateLimitSnapshot;
+  use chrono::{DateTime, Utc};
+  use std::sync::Arc;
+  use std::time::{Duration, Instant};
+
+  fn utc(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+      .expect("valid test timestamp")
+      .with_timezone(&Utc)
+  }
+
+  fn snapshot(fetched_at: &str) -> Arc<LiveRateLimitSnapshot> {
+    Arc::new(LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: None,
+      fetched_at: fetched_at.to_string(),
+    })
+  }
+
+  #[test]
+  fn fallback_never_becomes_fresh_for_ttl() {
+    let cache = LiveQuotaCache::new();
+    let monotonic = Instant::now();
+    let state = cache.publish_fallback(
+      snapshot("2026-07-09T10:00:00+00:00"),
+      monotonic,
+      utc("2026-07-10T10:00:00Z"),
+    );
+
+    assert!(state.is_fallback);
+    assert_eq!(
+      state.source_fetched_at.as_deref(),
+      Some("2026-07-09T10:00:00+00:00")
+    );
+    assert_eq!(state.last_live_success_at, None);
+    assert!(cache.needs_live_refresh(Duration::from_secs(300), monotonic));
+    assert!(cache.needs_live_refresh(Duration::from_secs(300), monotonic + Duration::from_secs(1)));
+  }
+
+  #[test]
+  fn fallback_preserves_source_and_last_success() {
+    let cache = LiveQuotaCache::new();
+    let monotonic = Instant::now();
+    let live = snapshot("2026-07-10T10:05:00Z");
+    cache.publish_live(Arc::clone(&live), monotonic, utc("2026-07-10T10:06:00Z"));
+
+    let state = cache.publish_fallback(
+      snapshot("2026-07-10T10:00:00Z"),
+      monotonic + Duration::from_secs(1),
+      utc("2026-07-10T10:07:00Z"),
+    );
+
+    assert!(state.is_fallback);
+    assert_eq!(
+      state.source_fetched_at.as_deref(),
+      Some("2026-07-10T10:05:00Z")
+    );
+    assert_eq!(
+      state.last_live_success_at.as_deref(),
+      Some("2026-07-10T10:06:00+00:00")
+    );
+    assert_eq!(state.cached_at, "2026-07-10T10:06:00+00:00");
+    let cached = cache
+      .rate_limits()
+      .expect("newer in-memory snapshot remains");
+    assert!(Arc::ptr_eq(&cached, &live));
+    assert!(cache.needs_live_refresh(Duration::from_secs(300), monotonic));
+
+    let current_only = LiveQuotaCache::new();
+    current_only.publish_live(Arc::clone(&live), monotonic, utc("2026-07-10T10:06:00Z"));
+    let marked = current_only.mark_current_as_fallback();
+    assert!(marked.is_fallback);
+    assert_eq!(marked.cached_at, "2026-07-10T10:06:00+00:00");
+    assert_eq!(
+      marked.source_fetched_at.as_deref(),
+      Some("2026-07-10T10:05:00Z")
+    );
+    assert_eq!(
+      marked.last_live_success_at.as_deref(),
+      Some("2026-07-10T10:06:00+00:00")
+    );
+    assert!(current_only.needs_live_refresh(Duration::from_secs(300), monotonic));
+  }
+
+  #[test]
+  fn persistence_retry_is_capped() {
+    let mut retries = LivePersistenceRetryState::new();
+    let initial_snapshot = snapshot("2026-07-10T10:05:00Z");
+    let mut now = Instant::now();
+    retries.publish(Arc::clone(&initial_snapshot), 7, now);
+
+    for (index, expected) in [5, 15, 30, 60, 120, 300, 300].into_iter().enumerate() {
+      let work = retries
+        .take_ready(now, false)
+        .expect("published or retried snapshot is ready");
+      retries.finish(
+        &work,
+        Err("database busy".to_string()),
+        now,
+        Duration::from_secs(1_000),
+      );
+      let deadline = retries.retry_deadline().expect("failure schedules retry");
+      assert_eq!(
+        deadline.saturating_duration_since(now),
+        Duration::from_secs(expected)
+      );
+      assert_eq!(retries.failure_streak(), index as u32 + 1);
+      now = deadline;
+    }
+
+    let mut interval_capped = LivePersistenceRetryState::new();
+    interval_capped.publish(Arc::clone(&initial_snapshot), 7, now);
+    let first = interval_capped
+      .take_ready(now, false)
+      .expect("first capped work");
+    interval_capped.finish(
+      &first,
+      Err("database busy".to_string()),
+      now,
+      Duration::from_secs(12),
+    );
+    now = interval_capped
+      .retry_deadline()
+      .expect("first capped deadline");
+    let second = interval_capped
+      .take_ready(now, false)
+      .expect("second capped work");
+    interval_capped.finish(
+      &second,
+      Err("database busy".to_string()),
+      now,
+      Duration::from_secs(12),
+    );
+    assert_eq!(
+      interval_capped
+        .retry_deadline()
+        .expect("interval-capped deadline")
+        .saturating_duration_since(now),
+      Duration::from_secs(12)
+    );
+
+    let mut zero_interval = LivePersistenceRetryState::new();
+    zero_interval.publish(initial_snapshot, 7, now);
+    let work = zero_interval
+      .take_ready(now, false)
+      .expect("zero interval work");
+    zero_interval.finish(&work, Err("database busy".to_string()), now, Duration::ZERO);
+    assert_eq!(
+      zero_interval
+        .retry_deadline()
+        .expect("nonzero retry deadline")
+        .saturating_duration_since(now),
+      Duration::from_secs(1)
+    );
+
+    let mut superseded = LivePersistenceRetryState::new();
+    superseded.publish(snapshot("2026-07-10T10:05:00Z"), 7, now);
+    let old = superseded
+      .take_ready(now, false)
+      .expect("old persistence work");
+    superseded.publish(snapshot("2026-07-10T10:06:00Z"), 7, now);
+    superseded.finish(
+      &old,
+      Err("old write failed".to_string()),
+      now,
+      Duration::from_secs(300),
+    );
+    assert_eq!(superseded.failure_streak(), 0);
+    let latest = superseded
+      .take_ready(now, false)
+      .expect("newer work stays immediate");
+    superseded.finish(
+      &latest,
+      Err("new write failed".to_string()),
+      now,
+      Duration::from_secs(300),
+    );
+    assert_eq!(
+      superseded
+        .retry_deadline()
+        .expect("new value starts at first retry")
+        .saturating_duration_since(now),
+      Duration::from_secs(5)
+    );
+  }
+}

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use live_cache::{LivePersistenceRetryState, LivePersistenceWork, Live
 #[allow(unused_imports)]
 pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
 #[allow(unused_imports)]
-pub(crate) use power::{begin_scheduler_activity, ActivityFactory, SystemActivityFactory};
+pub(crate) use power::{ActivityFactory, SystemActivityFactory};
 #[allow(unused_imports)]
 pub(crate) use runtime::{
   LaneStatus, LiveQuotaFetcher, LiveQuotaPersister, ManualLiveTicket, ManualRefreshTicket,

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -1,10 +1,12 @@
 #![allow(dead_code)]
 
+mod live_cache;
 mod mutation;
 mod power;
 mod runtime;
 mod schedule;
 
+pub(crate) use live_cache::{LivePersistenceRetryState, LivePersistenceWork, LiveQuotaCache};
 #[allow(unused_imports)]
 pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
 #[allow(unused_imports)]

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -10,9 +10,13 @@ use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};
 
 #[allow(unused_imports)]
-pub(crate) use schedule::{CoordinatorAction, CoordinatorEvent, CoordinatorState};
+pub(crate) use schedule::{
+  CoordinatorAction, CoordinatorEvent, CoordinatorSnapshot, CoordinatorState, LaneScheduleSnapshot,
+};
 
 pub(crate) const LIVE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const REFRESH_WAITER_CAPACITY: usize = 32;
+pub(crate) const REFRESH_DETAIL_MAX_BYTES: usize = 256;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -24,12 +28,12 @@ pub(crate) enum RefreshLane {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub(crate) enum RefreshReason {
-  Startup,
-  Scheduled,
-  Manual,
-  SettingsChanged,
-  Wake,
-  Fallback,
+  Startup = 0,
+  Scheduled = 1,
+  Manual = 2,
+  SettingsChanged = 3,
+  Wake = 4,
+  Fallback = 5,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -39,6 +43,7 @@ pub(crate) enum TokenScanKind {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
 pub(crate) struct ReasonSet(u8);
 
 impl ReasonSet {
@@ -67,6 +72,10 @@ impl ReasonSet {
   pub(crate) fn is_empty(self) -> bool {
     self.0 == 0
   }
+
+  pub(crate) fn bits(self) -> u8 {
+    self.0
+  }
 }
 
 impl From<RefreshReason> for ReasonSet {
@@ -75,11 +84,54 @@ impl From<RefreshReason> for ReasonSet {
   }
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct TokenWaiterIds(Vec<TokenWaiterId>);
+
+impl TokenWaiterIds {
+  pub(crate) fn try_push(&mut self, waiter: TokenWaiterId) -> Result<(), RefreshRejectionCode> {
+    if self.0.contains(&waiter) {
+      return Ok(());
+    }
+    if self.0.len() >= REFRESH_WAITER_CAPACITY {
+      return Err(RefreshRejectionCode::Busy);
+    }
+    self.0.push(waiter);
+    Ok(())
+  }
+
+  pub(crate) fn as_slice(&self) -> &[TokenWaiterId] {
+    &self.0
+  }
+
+  pub(crate) fn len(&self) -> usize {
+    self.0.len()
+  }
+
+  pub(crate) fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+
+  pub(crate) fn contains(&self, waiter: &TokenWaiterId) -> bool {
+    self.0.contains(waiter)
+  }
+
+  pub(crate) fn clear(&mut self) {
+    self.0.clear();
+  }
+
+  fn into_vec(self) -> Vec<TokenWaiterId> {
+    self.0
+  }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct TokenRequest {
   pub reasons: ReasonSet,
   pub kind: TokenScanKind,
   pub codex_home: Option<String>,
+  pub waiter_ids: TokenWaiterIds,
+  pub planned_due_at: Option<Instant>,
+  source_generation: Option<u64>,
 }
 
 impl TokenRequest {
@@ -92,7 +144,16 @@ impl TokenRequest {
       reasons: reason.into(),
       kind: TokenScanKind::Incremental,
       codex_home: None,
+      waiter_ids: TokenWaiterIds::default(),
+      planned_due_at: None,
+      source_generation: None,
     }
+  }
+
+  pub(crate) fn for_reason_at(reason: RefreshReason, planned_due_at: Instant) -> Self {
+    let mut request = Self::for_reason(reason);
+    request.planned_due_at = Some(planned_due_at);
+    request
   }
 
   pub(crate) fn manual_full(codex_home: Option<String>) -> Self {
@@ -100,25 +161,147 @@ impl TokenRequest {
       reasons: RefreshReason::Manual.into(),
       kind: TokenScanKind::Full,
       codex_home,
+      waiter_ids: TokenWaiterIds::default(),
+      planned_due_at: None,
+      source_generation: None,
     }
   }
 
-  fn merge(&mut self, other: Self) {
+  pub(crate) fn manual_full_with_waiter(codex_home: Option<String>, waiter: TokenWaiterId) -> Self {
+    let mut request = Self::manual_full(codex_home);
+    request
+      .try_add_waiter(waiter)
+      .expect("an empty token request accepts one waiter");
+    request
+  }
+
+  pub(crate) fn try_add_waiter(
+    &mut self,
+    waiter: TokenWaiterId,
+  ) -> Result<(), RefreshRejectionCode> {
+    self.waiter_ids.try_push(waiter)
+  }
+
+  pub(crate) fn waiter_ids(&self) -> &[TokenWaiterId] {
+    self.waiter_ids.as_slice()
+  }
+
+  fn try_merge(&mut self, other: Self) -> Result<(), Self> {
+    if !self.same_source_identity(&other) {
+      return Err(other);
+    }
     self.reasons.merge(other.reasons);
     self.kind = self.kind.max(other.kind);
-    if other.codex_home.is_some() || self.codex_home.is_none() {
-      self.codex_home = other.codex_home;
+    for waiter in other.waiter_ids.into_vec() {
+      self
+        .waiter_ids
+        .try_push(waiter)
+        .expect("coordinator waiter capacity is enforced before request merges");
     }
+    self.planned_due_at = earliest_due(self.planned_due_at, other.planned_due_at);
+    Ok(())
+  }
+
+  fn same_source_identity(&self, other: &Self) -> bool {
+    self.codex_home == other.codex_home && self.source_generation == other.source_generation
+  }
+
+  fn bind_configured_source(&mut self, source_generation: u64, codex_home: Option<String>) {
+    self.codex_home = codex_home;
+    self.source_generation = Some(source_generation);
+  }
+
+  fn bind_source_if_needed(&mut self, source_generation: u64, codex_home: Option<String>) {
+    if self.source_generation.is_some() {
+      return;
+    }
+    if self.codex_home.is_none() || self.codex_home == codex_home {
+      self.bind_configured_source(source_generation, codex_home);
+    }
+  }
+
+  fn is_bound_to_source_generation(&self, source_generation: u64) -> bool {
+    self.source_generation == Some(source_generation)
+  }
+
+  fn drain_waiters(&mut self) -> Vec<TokenWaiterId> {
+    std::mem::take(&mut self.waiter_ids).into_vec()
+  }
+}
+
+fn earliest_due(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.min(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
   }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct TokenWaiterId(pub(crate) u64);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct LiveWaiterId(pub(crate) u64);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshFailureCode {
+  ExecutionFailed,
+  SourceChanged,
+  InvalidCompletion,
+  PreparedPayloadMissing,
+  WorkerPanicked,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshRejectionCode {
+  Busy,
+  InvalidRequest,
+  Superseded,
+  SourceChanged,
+  Shutdown,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(transparent)]
+pub(crate) struct RefreshDetail(String);
+
+impl RefreshDetail {
+  pub(crate) fn new(value: impl AsRef<str>) -> Self {
+    let value = value.as_ref();
+    if value.len() <= REFRESH_DETAIL_MAX_BYTES {
+      return Self(value.to_string());
+    }
+    let mut end = REFRESH_DETAIL_MAX_BYTES;
+    while !value.is_char_boundary(end) {
+      end -= 1;
+    }
+    Self(value[..end].to_string())
+  }
+
+  pub(crate) fn as_str(&self) -> &str {
+    &self.0
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshWaiterOutcome {
+  Completed {
+    generation: u64,
+    succeeded: bool,
+    failure_code: Option<RefreshFailureCode>,
+    detail: Option<RefreshDetail>,
+  },
+  Rejected {
+    code: RefreshRejectionCode,
+    detail: Option<RefreshDetail>,
+  },
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct LiveRequest {
   pub reasons: ReasonSet,
   pub waiter: Option<LiveWaiterId>,
+  pub planned_due_at: Option<Instant>,
 }
 
 impl LiveRequest {
@@ -130,13 +313,21 @@ impl LiveRequest {
     Self {
       reasons: reason.into(),
       waiter: None,
+      planned_due_at: None,
     }
+  }
+
+  pub(crate) fn for_reason_at(reason: RefreshReason, planned_due_at: Instant) -> Self {
+    let mut request = Self::for_reason(reason);
+    request.planned_due_at = Some(planned_due_at);
+    request
   }
 
   pub(crate) fn manual(waiter: LiveWaiterId) -> Self {
     Self {
       reasons: RefreshReason::Manual.into(),
       waiter: Some(waiter),
+      planned_due_at: None,
     }
   }
 }
@@ -153,6 +344,7 @@ pub(crate) struct LiveExecutionRequest {
   pub generation: u64,
   pub source_generation: u64,
   pub reasons: ReasonSet,
+  pub planned_due_at: Option<Instant>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -175,6 +367,7 @@ pub(crate) struct ExecutionCompletion {
   pub generation: u64,
   pub source_generation: u64,
   pub succeeded: bool,
+  pub failure_code: Option<RefreshFailureCode>,
   pub failure: Option<String>,
   pub completed_at: String,
   pub commit: Option<CommitMarker>,

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -13,10 +13,11 @@ pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordi
 pub(crate) use power::{ActivityFactory, SystemActivityFactory};
 #[allow(unused_imports)]
 pub(crate) use runtime::{
-  LaneStatus, LiveQuotaFetcher, LiveQuotaPersister, ManualLiveTicket, ManualRefreshTicket,
-  ManualTokenTicket, MutationPhase, PreparedTokenRefresh, RefreshCoordinatorHandle, RefreshError,
-  RefreshEventSink, RefreshLaneMetrics, RefreshMetricsSnapshot, RefreshRuntime,
-  RefreshRuntimeDependencies, RefreshStatus, ShutdownResult, TokenRefreshExecutor,
+  EpochMaintenanceBatch, EpochMaintenanceExecutor, LaneStatus, LiveQuotaFetcher,
+  LiveQuotaPersister, ManualLiveTicket, ManualRefreshTicket, ManualTokenTicket, MutationPhase,
+  PreparedTokenRefresh, RefreshCoordinatorHandle, RefreshError, RefreshEventSink,
+  RefreshLaneMetrics, RefreshMetricsSnapshot, RefreshRuntime, RefreshRuntimeDependencies,
+  RefreshStatus, ShutdownResult, TokenRefreshExecutor,
 };
 
 use chrono::{DateTime, Utc};

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -3,7 +3,7 @@
 mod schedule;
 
 use chrono::{DateTime, Utc};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[allow(unused_imports)]
 pub(crate) use schedule::{CoordinatorAction, CoordinatorEvent, CoordinatorState};
@@ -18,6 +18,7 @@ pub(crate) enum RefreshLane {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
 pub(crate) enum RefreshReason {
   Startup,
   Scheduled,
@@ -31,6 +32,163 @@ pub(crate) enum RefreshReason {
 pub(crate) enum TokenScanKind {
   Incremental,
   Full,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ReasonSet(u8);
+
+impl ReasonSet {
+  pub(crate) fn from_reason(reason: RefreshReason) -> Self {
+    let mut reasons = Self::default();
+    reasons.insert(reason);
+    reasons
+  }
+
+  pub(crate) fn insert(&mut self, reason: RefreshReason) {
+    self.0 |= 1 << reason as u8;
+  }
+
+  pub(crate) fn remove(&mut self, reason: RefreshReason) {
+    self.0 &= !(1 << reason as u8);
+  }
+
+  pub(crate) fn contains(self, reason: RefreshReason) -> bool {
+    self.0 & (1 << reason as u8) != 0
+  }
+
+  pub(crate) fn merge(&mut self, other: Self) {
+    self.0 |= other.0;
+  }
+
+  pub(crate) fn is_empty(self) -> bool {
+    self.0 == 0
+  }
+}
+
+impl From<RefreshReason> for ReasonSet {
+  fn from(reason: RefreshReason) -> Self {
+    Self::from_reason(reason)
+  }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TokenRequest {
+  pub reasons: ReasonSet,
+  pub kind: TokenScanKind,
+  pub codex_home: Option<String>,
+}
+
+impl TokenRequest {
+  pub(crate) fn scheduled() -> Self {
+    Self::for_reason(RefreshReason::Scheduled)
+  }
+
+  pub(crate) fn for_reason(reason: RefreshReason) -> Self {
+    Self {
+      reasons: reason.into(),
+      kind: TokenScanKind::Incremental,
+      codex_home: None,
+    }
+  }
+
+  pub(crate) fn manual_full(codex_home: Option<String>) -> Self {
+    Self {
+      reasons: RefreshReason::Manual.into(),
+      kind: TokenScanKind::Full,
+      codex_home,
+    }
+  }
+
+  fn merge(&mut self, other: Self) {
+    self.reasons.merge(other.reasons);
+    self.kind = self.kind.max(other.kind);
+    if other.codex_home.is_some() || self.codex_home.is_none() {
+      self.codex_home = other.codex_home;
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct LiveWaiterId(pub(crate) u64);
+
+#[derive(Clone, Debug)]
+pub(crate) struct LiveRequest {
+  pub reasons: ReasonSet,
+  pub waiter: Option<LiveWaiterId>,
+}
+
+impl LiveRequest {
+  pub(crate) fn scheduled() -> Self {
+    Self::for_reason(RefreshReason::Scheduled)
+  }
+
+  pub(crate) fn for_reason(reason: RefreshReason) -> Self {
+    Self {
+      reasons: reason.into(),
+      waiter: None,
+    }
+  }
+
+  pub(crate) fn manual(waiter: LiveWaiterId) -> Self {
+    Self {
+      reasons: RefreshReason::Manual.into(),
+      waiter: Some(waiter),
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TokenExecutionRequest {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub request: TokenRequest,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LiveExecutionRequest {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub reasons: ReasonSet,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CommitMarker {
+  pub sequence: u64,
+  pub committed_at: Instant,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DisplayInvalidation {
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub settings_revision: u64,
+  pub source_generation: u64,
+  pub commit: CommitMarker,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ExecutionCompletion {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub succeeded: bool,
+  pub failure: Option<String>,
+  pub completed_at: String,
+  pub commit: Option<CommitMarker>,
+  pub retry_jitter: Duration,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshCompletedEvent {
+  pub refresh_revision: u64,
+  pub lane: RefreshLane,
+  pub generation: u64,
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub source_generation: u64,
+  pub succeeded: bool,
+  pub failure: Option<String>,
+  pub completed_at: String,
 }
 
 #[derive(Clone, Debug)]

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -1,6 +1,10 @@
 #![allow(dead_code)]
 
+mod mutation;
 mod schedule;
+
+#[allow(unused_imports)]
+pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
 
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -1,10 +1,21 @@
 #![allow(dead_code)]
 
 mod mutation;
+mod power;
+mod runtime;
 mod schedule;
 
 #[allow(unused_imports)]
 pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
+#[allow(unused_imports)]
+pub(crate) use power::{begin_scheduler_activity, ActivityFactory, SystemActivityFactory};
+#[allow(unused_imports)]
+pub(crate) use runtime::{
+  LaneStatus, LiveQuotaFetcher, LiveQuotaPersister, ManualLiveTicket, ManualRefreshTicket,
+  ManualTokenTicket, MutationPhase, PreparedTokenRefresh, RefreshCoordinatorHandle, RefreshError,
+  RefreshEventSink, RefreshLaneMetrics, RefreshMetricsSnapshot, RefreshRuntime,
+  RefreshRuntimeDependencies, RefreshStatus, ShutdownResult, TokenRefreshExecutor,
+};
 
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -1,0 +1,49 @@
+#![allow(dead_code)]
+
+mod schedule;
+
+use chrono::{DateTime, Utc};
+use std::time::Duration;
+
+#[allow(unused_imports)]
+pub(crate) use schedule::{CoordinatorAction, CoordinatorEvent, CoordinatorState};
+
+pub(crate) const LIVE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RefreshLane {
+  Token,
+  Live,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshReason {
+  Startup,
+  Scheduled,
+  Manual,
+  SettingsChanged,
+  Wake,
+  Fallback,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum TokenScanKind {
+  Incremental,
+  Full,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RefreshConfig {
+  pub auto_scan_enabled: bool,
+  pub interval: Duration,
+  pub codex_home: Option<String>,
+  pub token_last_success_wall: Option<DateTime<Utc>>,
+  pub live_last_success_wall: Option<DateTime<Utc>>,
+}
+
+pub(crate) fn parse_persisted_success_wall(value: Option<&str>) -> Option<DateTime<Utc>> {
+  value
+    .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+    .map(|value| value.with_timezone(&Utc))
+}

--- a/src-tauri/src/refresh/mutation.rs
+++ b/src-tauri/src/refresh/mutation.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
@@ -46,6 +47,42 @@ impl UsageMutationCoordinator {
     MutationOutcome { value, queue_wait }
   }
 
+  pub(crate) fn run_cancellable<T>(
+    &self,
+    priority: MutationPriority,
+    cancelled: &AtomicBool,
+    mutation: impl FnOnce() -> T,
+  ) -> Option<MutationOutcome<T>> {
+    let queued_at = Instant::now();
+    let ticket = self.enqueue(priority);
+    let slot = self.wait_for_turn_cancellable(ticket, cancelled)?;
+    let queue_wait = queued_at.elapsed();
+
+    let value = mutation();
+    drop(slot);
+
+    Some(MutationOutcome { value, queue_wait })
+  }
+
+  pub(crate) fn cancel(&self, cancelled: &AtomicBool) {
+    cancelled.store(true, Ordering::Release);
+    let state = lock_state(&self.inner.state);
+    drop(state);
+    self.inner.changed.notify_all();
+  }
+
+  #[cfg(test)]
+  pub(crate) fn wait_for_queued_for_test(&self, expected: usize, timeout: Duration) {
+    let state = lock_state(&self.inner.state);
+    let (state, timed_out) = self
+      .inner
+      .changed
+      .wait_timeout_while(state, timeout, |state| state.queued.len() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(state.queued.len(), expected, "mutation queue length");
+    assert!(!timed_out.timed_out(), "timed out waiting for mutation queue");
+  }
+
   fn enqueue(&self, priority: MutationPriority) -> QueuedTicket {
     let mut state = lock_state(&self.inner.state);
     let ticket = QueuedTicket {
@@ -76,6 +113,43 @@ impl UsageMutationCoordinator {
         return ActiveMutationSlot {
           inner: Arc::clone(&self.inner),
         };
+      }
+
+      state = self
+        .inner
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+
+  fn wait_for_turn_cancellable(
+    &self,
+    ticket: QueuedTicket,
+    cancelled: &AtomicBool,
+  ) -> Option<ActiveMutationSlot> {
+    let mut state = lock_state(&self.inner.state);
+    loop {
+      if cancelled.load(Ordering::Acquire) {
+        if let Some(position) = state.queued.iter().position(|queued| *queued == ticket) {
+          state.queued.remove(position);
+        }
+        drop(state);
+        self.inner.changed.notify_all();
+        return None;
+      }
+
+      if !state.active && state.next_ticket() == Some(ticket) {
+        let position = state
+          .queued
+          .iter()
+          .position(|queued| *queued == ticket)
+          .expect("selected usage mutation ticket remains queued");
+        state.queued.remove(position);
+        state.active = true;
+        return Some(ActiveMutationSlot {
+          inner: Arc::clone(&self.inner),
+        });
       }
 
       state = self
@@ -143,9 +217,11 @@ fn lock_state(state: &Mutex<MutationState>) -> MutexGuard<'_, MutationState> {
 
 #[cfg(test)]
 mod tests {
-  use super::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
+  use super::{lock_state, MutationOutcome, MutationPriority, UsageMutationCoordinator};
   use std::panic::{self, AssertUnwindSafe};
+  use std::sync::atomic::{AtomicBool, Ordering};
   use std::sync::mpsc::{self, Receiver, Sender};
+  use std::sync::Arc;
   use std::thread::{self, JoinHandle};
   use std::time::Duration;
 
@@ -351,5 +427,139 @@ mod tests {
     assert!(panic_result.is_err());
     let outcome = coordinator.run(MutationPriority::Pricing, || 42);
     assert_eq!(outcome.value, 42);
+  }
+
+  #[test]
+  fn queued_cancellation_removes_maintenance_ticket_promptly() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Pricing);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_coordinator = coordinator.clone();
+    let worker_cancelled = Arc::clone(&cancelled);
+    let (finished_tx, finished_rx) = mpsc::sync_channel(1);
+    let maintenance = thread::spawn(move || {
+      let outcome = worker_coordinator.run_cancellable(
+        MutationPriority::Maintenance,
+        &worker_cancelled,
+        || "unexpected",
+      );
+      finished_tx.send(outcome).expect("report cancellation");
+    });
+    wait_for_queued(&coordinator, 1);
+
+    coordinator.cancel(&cancelled);
+
+    assert!(finished_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("queued waiter wakes")
+      .is_none());
+    assert!(lock_state(&coordinator.inner.state).queued.is_empty());
+    release_blocker.send(()).expect("release blocker");
+    blocker.join().expect("blocker exits");
+    maintenance.join().expect("maintenance exits");
+  }
+
+  #[test]
+  fn queued_cancellation_preserves_other_priority_and_fifo_order() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Pricing);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancelled_coordinator = coordinator.clone();
+    let cancelled_token = Arc::clone(&cancelled);
+    let cancelled_handle = thread::spawn(move || {
+      cancelled_coordinator.run_cancellable(
+        MutationPriority::Maintenance,
+        &cancelled_token,
+        || "cancelled",
+      )
+    });
+    wait_for_queued(&coordinator, 1);
+    let (order_tx, order_rx) = mpsc::channel();
+    let first_maintenance = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "maintenance-first",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 2);
+    let second_maintenance = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "maintenance-second",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 3);
+    let refresh = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Refresh,
+      "refresh",
+      order_tx,
+    );
+    wait_for_queued(&coordinator, 4);
+
+    coordinator.cancel(&cancelled);
+    assert!(cancelled.load(Ordering::Acquire));
+    release_blocker.send(()).expect("release blocker");
+
+    assert_eq!(recv_order(&order_rx), "refresh");
+    assert_eq!(recv_order(&order_rx), "maintenance-first");
+    assert_eq!(recv_order(&order_rx), "maintenance-second");
+    assert!(cancelled_handle
+      .join()
+      .expect("cancelled waiter exits")
+      .is_none());
+    blocker.join().expect("blocker exits");
+    first_maintenance.join().expect("first maintenance exits");
+    second_maintenance.join().expect("second maintenance exits");
+    refresh.join().expect("refresh exits");
+  }
+
+  #[test]
+  fn active_cancellation_releases_slot_only_after_closure_returns() {
+    let coordinator = UsageMutationCoordinator::new();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let active_coordinator = coordinator.clone();
+    let active_cancelled = Arc::clone(&cancelled);
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let active = thread::spawn(move || {
+      active_coordinator.run_cancellable(
+        MutationPriority::Maintenance,
+        &active_cancelled,
+        || {
+          entered_tx.send(()).expect("report active entry");
+          release_rx.recv().expect("release active mutation");
+          "finished"
+        },
+      )
+    });
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("maintenance owns slot");
+    coordinator.cancel(&cancelled);
+
+    let (follower_tx, follower_rx) = mpsc::sync_channel(1);
+    let follower_coordinator = coordinator.clone();
+    let follower = thread::spawn(move || {
+      follower_coordinator.run(MutationPriority::Refresh, || {
+        follower_tx.send(()).expect("report follower entry");
+      })
+    });
+    wait_for_queued(&coordinator, 1);
+    assert!(follower_rx.try_recv().is_err(), "active closure still owns slot");
+
+    release_tx.send(()).expect("release active closure");
+    follower_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("follower enters after active closure returns");
+    assert_eq!(
+      active
+        .join()
+        .expect("active thread exits")
+        .expect("active mutation had acquired slot")
+        .value,
+      "finished"
+    );
+    follower.join().expect("follower exits");
   }
 }

--- a/src-tauri/src/refresh/mutation.rs
+++ b/src-tauri/src/refresh/mutation.rs
@@ -1,0 +1,355 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum MutationPriority {
+  Pricing,
+  Maintenance,
+  Refresh,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct MutationOutcome<T> {
+  pub(crate) value: T,
+  pub(crate) queue_wait: Duration,
+}
+
+#[derive(Clone)]
+pub(crate) struct UsageMutationCoordinator {
+  inner: Arc<MutationCoordinatorInner>,
+}
+
+impl UsageMutationCoordinator {
+  pub(crate) fn new() -> Self {
+    Self {
+      inner: Arc::new(MutationCoordinatorInner {
+        state: Mutex::new(MutationState::default()),
+        changed: Condvar::new(),
+      }),
+    }
+  }
+
+  pub(crate) fn run<T>(
+    &self,
+    priority: MutationPriority,
+    mutation: impl FnOnce() -> T,
+  ) -> MutationOutcome<T> {
+    let queued_at = Instant::now();
+    let ticket = self.enqueue(priority);
+    let slot = self.wait_for_turn(ticket);
+    let queue_wait = queued_at.elapsed();
+
+    let value = mutation();
+    drop(slot);
+
+    MutationOutcome { value, queue_wait }
+  }
+
+  fn enqueue(&self, priority: MutationPriority) -> QueuedTicket {
+    let mut state = lock_state(&self.inner.state);
+    let ticket = QueuedTicket {
+      priority,
+      sequence: state.next_sequence,
+    };
+    state.next_sequence = state
+      .next_sequence
+      .checked_add(1)
+      .expect("usage mutation ticket sequence overflowed");
+    state.queued.push_back(ticket);
+    drop(state);
+    self.inner.changed.notify_all();
+    ticket
+  }
+
+  fn wait_for_turn(&self, ticket: QueuedTicket) -> ActiveMutationSlot {
+    let mut state = lock_state(&self.inner.state);
+    loop {
+      if !state.active && state.next_ticket() == Some(ticket) {
+        let position = state
+          .queued
+          .iter()
+          .position(|queued| *queued == ticket)
+          .expect("selected usage mutation ticket remains queued");
+        state.queued.remove(position);
+        state.active = true;
+        return ActiveMutationSlot {
+          inner: Arc::clone(&self.inner),
+        };
+      }
+
+      state = self
+        .inner
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+}
+
+impl Default for UsageMutationCoordinator {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+struct MutationCoordinatorInner {
+  state: Mutex<MutationState>,
+  changed: Condvar,
+}
+
+#[derive(Default)]
+struct MutationState {
+  active: bool,
+  next_sequence: u64,
+  queued: VecDeque<QueuedTicket>,
+}
+
+impl MutationState {
+  fn next_ticket(&self) -> Option<QueuedTicket> {
+    let priority = self.queued.iter().map(|ticket| ticket.priority).max()?;
+    self
+      .queued
+      .iter()
+      .find(|ticket| ticket.priority == priority)
+      .copied()
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct QueuedTicket {
+  priority: MutationPriority,
+  sequence: u64,
+}
+
+struct ActiveMutationSlot {
+  inner: Arc<MutationCoordinatorInner>,
+}
+
+impl Drop for ActiveMutationSlot {
+  fn drop(&mut self) {
+    let mut state = lock_state(&self.inner.state);
+    state.active = false;
+    drop(state);
+    self.inner.changed.notify_all();
+  }
+}
+
+fn lock_state(state: &Mutex<MutationState>) -> MutexGuard<'_, MutationState> {
+  state
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
+  use std::panic::{self, AssertUnwindSafe};
+  use std::sync::mpsc::{self, Receiver, Sender};
+  use std::thread::{self, JoinHandle};
+  use std::time::Duration;
+
+  const TEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+  fn wait_for_queued(coordinator: &UsageMutationCoordinator, expected: usize) {
+    let state = coordinator
+      .inner
+      .state
+      .lock()
+      .expect("mutation state locks");
+    let (state, timeout) = coordinator
+      .inner
+      .changed
+      .wait_timeout_while(state, TEST_TIMEOUT, |state| state.queued.len() < expected)
+      .expect("mutation state remains lockable");
+
+    assert_eq!(state.queued.len(), expected, "queued ticket count");
+    assert!(!timeout.timed_out(), "timed out waiting for queued ticket");
+  }
+
+  fn start_blocker(
+    coordinator: &UsageMutationCoordinator,
+    priority: MutationPriority,
+  ) -> (Sender<()>, JoinHandle<MutationOutcome<()>>) {
+    let coordinator = coordinator.clone();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+      coordinator.run(priority, || {
+        entered_tx.send(()).expect("report blocker entry");
+        release_rx.recv().expect("release blocker");
+      })
+    });
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("blocker enters mutation closure");
+    (release_tx, handle)
+  }
+
+  fn start_ordered_mutation(
+    coordinator: &UsageMutationCoordinator,
+    priority: MutationPriority,
+    label: &'static str,
+    order_tx: Sender<&'static str>,
+  ) -> JoinHandle<MutationOutcome<&'static str>> {
+    let coordinator = coordinator.clone();
+    thread::spawn(move || {
+      coordinator.run(priority, || {
+        order_tx.send(label).expect("record mutation order");
+        label
+      })
+    })
+  }
+
+  fn recv_order(order_rx: &Receiver<&'static str>) -> &'static str {
+    order_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("mutation reports execution order")
+  }
+
+  #[test]
+  fn mutation_priorities_order_refresh_before_maintenance_before_pricing() {
+    assert!(MutationPriority::Refresh > MutationPriority::Maintenance);
+    assert!(MutationPriority::Maintenance > MutationPriority::Pricing);
+  }
+
+  #[test]
+  fn mutations_are_serialized() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Maintenance);
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let follower_coordinator = coordinator.clone();
+    let follower = thread::spawn(move || {
+      follower_coordinator.run(MutationPriority::Refresh, || {
+        entered_tx.send(()).expect("report follower entry");
+      })
+    });
+
+    wait_for_queued(&coordinator, 1);
+    assert!(
+      entered_rx.try_recv().is_err(),
+      "follower entered concurrently"
+    );
+
+    release_blocker.send(()).expect("release active mutation");
+    blocker.join().expect("blocker exits normally");
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("follower enters after blocker");
+    follower.join().expect("follower exits normally");
+  }
+
+  #[test]
+  fn same_priority_is_fifo() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Refresh);
+    let (order_tx, order_rx) = mpsc::channel();
+
+    let first = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "first",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 1);
+    let second = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "second",
+      order_tx,
+    );
+    wait_for_queued(&coordinator, 2);
+
+    release_blocker.send(()).expect("release active mutation");
+
+    assert_eq!(recv_order(&order_rx), "first");
+    assert_eq!(recv_order(&order_rx), "second");
+    blocker.join().expect("blocker exits normally");
+    first.join().expect("first mutation exits normally");
+    second.join().expect("second mutation exits normally");
+  }
+
+  #[test]
+  fn pricing_waits_behind_refresh_mutation() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_refresh, refresh) = start_blocker(&coordinator, MutationPriority::Refresh);
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let pricing_coordinator = coordinator.clone();
+    let pricing = thread::spawn(move || {
+      pricing_coordinator.run(MutationPriority::Pricing, || {
+        entered_tx.send(()).expect("report pricing entry");
+        "priced"
+      })
+    });
+
+    wait_for_queued(&coordinator, 1);
+    assert!(
+      entered_rx.try_recv().is_err(),
+      "pricing entered during refresh"
+    );
+    thread::sleep(Duration::from_millis(25));
+    release_refresh.send(()).expect("release refresh mutation");
+
+    refresh.join().expect("refresh exits normally");
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("pricing enters after refresh");
+    let outcome = pricing.join().expect("pricing exits normally");
+    assert_eq!(outcome.value, "priced");
+    assert!(outcome.queue_wait >= Duration::from_millis(20));
+  }
+
+  #[test]
+  fn higher_priority_is_selected_after_active_blocker() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Maintenance);
+    let (order_tx, order_rx) = mpsc::channel();
+
+    let pricing = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Pricing,
+      "pricing",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 1);
+    let refresh = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Refresh,
+      "refresh",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 2);
+    let maintenance = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "maintenance",
+      order_tx,
+    );
+    wait_for_queued(&coordinator, 3);
+
+    release_blocker.send(()).expect("release active mutation");
+
+    assert_eq!(recv_order(&order_rx), "refresh");
+    assert_eq!(recv_order(&order_rx), "maintenance");
+    assert_eq!(recv_order(&order_rx), "pricing");
+    blocker.join().expect("blocker exits normally");
+    pricing.join().expect("pricing exits normally");
+    refresh.join().expect("refresh exits normally");
+    maintenance.join().expect("maintenance exits normally");
+  }
+
+  #[test]
+  fn panic_releases_mutation_slot() {
+    let coordinator = UsageMutationCoordinator::new();
+
+    let panic_result = panic::catch_unwind(AssertUnwindSafe(|| {
+      coordinator.run(MutationPriority::Refresh, || {
+        panic!("intentional mutation panic");
+      });
+    }));
+
+    assert!(panic_result.is_err());
+    let outcome = coordinator.run(MutationPriority::Pricing, || 42);
+    assert_eq!(outcome.value, 42);
+  }
+}

--- a/src-tauri/src/refresh/power.rs
+++ b/src-tauri/src/refresh/power.rs
@@ -1,0 +1,193 @@
+#[cfg(test)]
+use std::sync::Arc;
+
+#[cfg(target_os = "macos")]
+use objc2::{
+  rc::Retained,
+  runtime::{NSObjectProtocol, ProtocolObject},
+};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
+
+pub(crate) trait ActivityGuard {}
+
+pub(crate) trait ActivityFactory: Send + Sync {
+  fn begin(&self) -> Box<dyn ActivityGuard>;
+}
+
+#[derive(Default)]
+pub(crate) struct SystemActivityFactory;
+
+impl ActivityFactory for SystemActivityFactory {
+  fn begin(&self) -> Box<dyn ActivityGuard> {
+    Box::new(SchedulerActivity::begin())
+  }
+}
+
+pub(crate) fn begin_scheduler_activity() -> Box<dyn ActivityGuard> {
+  SystemActivityFactory.begin()
+}
+
+#[cfg(target_os = "macos")]
+struct SchedulerActivity {
+  activity: Retained<ProtocolObject<dyn NSObjectProtocol>>,
+}
+
+#[cfg(target_os = "macos")]
+impl SchedulerActivity {
+  fn begin() -> Self {
+    let reason = NSString::from_str("Codex Pacer background refresh");
+    let activity = NSProcessInfo::processInfo()
+      .beginActivityWithOptions_reason(NSActivityOptions::Background, &reason);
+    Self { activity }
+  }
+}
+
+#[cfg(target_os = "macos")]
+impl ActivityGuard for SchedulerActivity {}
+
+#[cfg(target_os = "macos")]
+impl Drop for SchedulerActivity {
+  fn drop(&mut self) {
+    unsafe {
+      NSProcessInfo::processInfo().endActivity(&self.activity);
+    }
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+struct SchedulerActivity;
+
+#[cfg(not(target_os = "macos"))]
+impl SchedulerActivity {
+  fn begin() -> Self {
+    Self
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+impl ActivityGuard for SchedulerActivity {}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub(crate) struct CountingActivityFactory {
+  state: Arc<CountingActivityState>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct CountingActivityState {
+  active: std::sync::atomic::AtomicU64,
+  started: std::sync::atomic::AtomicU64,
+}
+
+#[cfg(test)]
+impl CountingActivityFactory {
+  pub(crate) fn begin(&self) -> Box<dyn ActivityGuard> {
+    <Self as ActivityFactory>::begin(self)
+  }
+
+  pub(crate) fn active(&self) -> u64 {
+    self.active_count()
+  }
+
+  pub(crate) fn started(&self) -> u64 {
+    self
+      .state
+      .started
+      .load(std::sync::atomic::Ordering::Acquire)
+  }
+
+  pub(crate) fn active_count(&self) -> u64 {
+    self.state.active.load(std::sync::atomic::Ordering::Acquire)
+  }
+}
+
+#[cfg(test)]
+impl ActivityFactory for CountingActivityFactory {
+  fn begin(&self) -> Box<dyn ActivityGuard> {
+    saturating_increment(&self.state.started);
+    saturating_increment(&self.state.active);
+    Box::new(CountingActivityGuard {
+      state: Arc::clone(&self.state),
+    })
+  }
+}
+
+#[cfg(test)]
+struct CountingActivityGuard {
+  state: Arc<CountingActivityState>,
+}
+
+#[cfg(test)]
+impl ActivityGuard for CountingActivityGuard {}
+
+#[cfg(test)]
+impl Drop for CountingActivityGuard {
+  fn drop(&mut self) {
+    let _ = self.state.active.fetch_update(
+      std::sync::atomic::Ordering::AcqRel,
+      std::sync::atomic::Ordering::Acquire,
+      |value| Some(value.saturating_sub(1)),
+    );
+  }
+}
+
+#[cfg(test)]
+fn saturating_increment(value: &std::sync::atomic::AtomicU64) {
+  let mut current = value.load(std::sync::atomic::Ordering::Acquire);
+  loop {
+    let next = current.saturating_add(1);
+    match value.compare_exchange_weak(
+      current,
+      next,
+      std::sync::atomic::Ordering::AcqRel,
+      std::sync::atomic::Ordering::Acquire,
+    ) {
+      Ok(_) => return,
+      Err(observed) => current = observed,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::CountingActivityFactory;
+
+  #[test]
+  fn injected_activity_factory_counts_only_live_guards() {
+    let factory = CountingActivityFactory::default();
+    assert_eq!(factory.active(), 0);
+
+    let first = factory.begin();
+    assert_eq!(factory.active(), 1);
+    {
+      let second = factory.begin();
+      assert_eq!(factory.active(), 2);
+      drop(second);
+    }
+    assert_eq!(factory.active(), 1);
+    drop(first);
+
+    assert_eq!(factory.active(), 0);
+    assert_eq!(factory.started(), 2);
+  }
+
+  #[test]
+  fn legacy_scheduler_activity_scope_is_narrow() {
+    let source = include_str!("../lib.rs");
+    assert!(
+      !source.contains("spawn(move || {\n      let _scheduler_activity"),
+      "the infinite scheduler loop must not own an activity"
+    );
+    assert!(
+      source.contains("let result = {\n    let _activity = begin_scheduler_activity();\n    scan(")
+    );
+    assert!(source.contains(
+      "let query_result = {\n    let _activity = begin_scheduler_activity();\n    query_live_rate_limits("
+    ));
+    assert!(source.contains(
+      "let _activity = begin_scheduler_activity();\n        let conn = open_connection("
+    ));
+  }
+}

--- a/src-tauri/src/refresh/power.rs
+++ b/src-tauri/src/refresh/power.rs
@@ -24,10 +24,6 @@ impl ActivityFactory for SystemActivityFactory {
   }
 }
 
-pub(crate) fn begin_scheduler_activity() -> Box<dyn ActivityGuard> {
-  SystemActivityFactory.begin()
-}
-
 #[cfg(target_os = "macos")]
 struct SchedulerActivity {
   activity: Retained<ProtocolObject<dyn NSObjectProtocol>>,
@@ -174,20 +170,19 @@ mod tests {
   }
 
   #[test]
-  fn legacy_scheduler_activity_scope_is_narrow() {
+  fn lib_removes_legacy_scheduler_activity_paths() {
     let source = include_str!("../lib.rs");
     assert!(
-      !source.contains("spawn(move || {\n      let _scheduler_activity"),
-      "the infinite scheduler loop must not own an activity"
+      !source.contains("spawn_scheduler"),
+      "the legacy scheduler entry point must stay removed"
     );
     assert!(
-      source.contains("let result = {\n    let _activity = begin_scheduler_activity();\n    scan(")
+      !source.contains("run_due_background_refresh"),
+      "commands and popup reads must not run legacy refresh work"
     );
-    assert!(source.contains(
-      "let query_result = {\n    let _activity = begin_scheduler_activity();\n    query_live_rate_limits("
-    ));
-    assert!(source.contains(
-      "let _activity = begin_scheduler_activity();\n        let conn = open_connection("
-    ));
+    assert!(
+      !source.contains("begin_scheduler_activity"),
+      "runtime executors own the only refresh activity scopes"
+    );
   }
 }

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
   use super::{
-    MetricsState, PanicPhase, RefreshClock, RefreshConfig, RefreshError, RefreshStatus,
-    RuntimeTestRig, SaturatingCounter, TestClock, TestLiveExecutor,
+    MetricsState, PanicPhase, PreparedTokenRefresh, RefreshClock, RefreshConfig, RefreshError,
+    RefreshStatus, RuntimeTestRig, SaturatingCounter, TestClock, TestLiveExecutor,
   };
   use crate::refresh::{RefreshFailureCode, RefreshRejectionCode, REFRESH_WAITER_CAPACITY};
   use chrono::{DateTime, Duration as ChronoDuration};
@@ -677,6 +677,66 @@ mod tests {
   }
 
   #[test]
+  fn settings_update_waits_for_saturated_queue_and_is_not_lost() {
+    let rig = RuntimeTestRig::disabled();
+    let pause = rig.pause_coordinator();
+    rig.fill_runtime_channel_until_busy();
+    let mut replacement = rig.config_with_source("replacement");
+    replacement.auto_scan_enabled = true;
+    let handle = rig.handle.clone();
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    let update = std::thread::spawn(move || {
+      let _ = result_tx.send(handle.update_settings(replacement));
+    });
+
+    rig.wait_for_reliable_in_flight(1, TEST_TIMEOUT);
+    assert_eq!(rig.handle.try_wake(), Err(RefreshError::Busy));
+    assert!(matches!(
+      rig.handle.request_manual_token(None),
+      Err(RefreshError::Busy)
+    ));
+    assert!(matches!(
+      rig.handle.request_manual_live(),
+      Err(RefreshError::Busy)
+    ));
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_intake_closed(TEST_TIMEOUT);
+    assert!(
+      !rig
+        .runtime
+        .lifecycle
+        .shutdown_requested
+        .load(std::sync::atomic::Ordering::Acquire),
+      "shutdown waits for the accepted settings update to finish"
+    );
+    assert!(matches!(
+      rig
+        .handle
+        .update_settings(rig.config_with_source("rejected-after-shutdown")),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    pause.release();
+    let result = result_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("settings update is acknowledged after capacity recovers");
+    update.join().expect("settings update thread exits");
+    let joined = shutdown.wait(TEST_TIMEOUT);
+
+    assert_eq!(result, Ok(()));
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+    assert_eq!(
+      super::lock(&rig.handle.inner.intake).reliable_in_flight,
+      0
+    );
+    let status = rig.handle.status();
+    assert_eq!(status.source_generation, 1);
+    assert!(status.auto_scan_enabled);
+  }
+
+  #[test]
   fn fixed_counters_saturate_without_wrap() {
     let counter = SaturatingCounter::new(u64::MAX - 1);
     counter.increment();
@@ -697,6 +757,23 @@ mod tests {
       metrics.start_lag_histogram[super::HISTOGRAM_BUCKETS - 2],
       u64::MAX
     );
+    rig.shutdown();
+  }
+
+  #[test]
+  fn prepared_token_refresh_constructor_initializes_test_defaults() {
+    let rig = RuntimeTestRig::disabled();
+    let (seed, _) = rig.token.make_prepared_for_test(1, 0, false);
+    let super::PreparedTokenRefresh { prepared_scan, .. } = seed;
+    let started_at = rig.clock.wall_now();
+
+    let prepared = PreparedTokenRefresh::new(7, 3, started_at, prepared_scan);
+
+    assert_eq!(prepared.generation, 7);
+    assert_eq!(prepared.source_generation, 3);
+    assert_eq!(prepared.started_at, started_at);
+    assert!(!prepared.omit_payload_for_test());
+    assert!(prepared.drop_probe.is_none());
     rig.shutdown();
   }
 
@@ -1252,6 +1329,26 @@ pub(crate) struct PreparedTokenRefresh {
   omit_payload: bool,
 }
 
+impl PreparedTokenRefresh {
+  pub(crate) fn new(
+    generation: u64,
+    source_generation: u64,
+    started_at: DateTime<Utc>,
+    prepared_scan: PreparedScan,
+  ) -> Self {
+    Self {
+      generation,
+      source_generation,
+      started_at,
+      prepared_scan,
+      #[cfg(test)]
+      drop_probe: None,
+      #[cfg(test)]
+      omit_payload: false,
+    }
+  }
+}
+
 pub(crate) trait LiveQuotaFetcher: Send + Sync {
   fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String>;
 
@@ -1637,6 +1734,7 @@ impl WaiterRegistries {
 
 struct IntakeState {
   accepting: bool,
+  reliable_in_flight: usize,
   sender: SyncSender<RuntimeMessage>,
   #[cfg(test)]
   pause_after_check: Option<Arc<TestGateState>>,
@@ -1644,12 +1742,31 @@ struct IntakeState {
 
 struct HandleInner {
   intake: Arc<Mutex<IntakeState>>,
+  reliable_changed: Arc<Condvar>,
   waiters: Arc<Mutex<WaiterRegistries>>,
   status: Arc<Mutex<RefreshStatus>>,
   metrics: Arc<MetricsState>,
   clock: Arc<dyn RefreshClock>,
   next_token_waiter: AtomicU64,
   next_live_waiter: AtomicU64,
+}
+
+struct ReliableInFlightGuard {
+  intake: Arc<Mutex<IntakeState>>,
+  changed: Arc<Condvar>,
+}
+
+impl Drop for ReliableInFlightGuard {
+  fn drop(&mut self) {
+    let mut intake = lock(&self.intake);
+    if intake.reliable_in_flight == 0 {
+      log::error!("Reliable refresh intake guard dropped without registration.");
+    } else {
+      intake.reliable_in_flight -= 1;
+    }
+    drop(intake);
+    self.changed.notify_all();
+  }
 }
 
 #[derive(Clone)]
@@ -1714,7 +1831,7 @@ impl RefreshCoordinatorHandle {
   }
 
   pub(crate) fn update_settings(&self, config: RefreshConfig) -> Result<(), RefreshError> {
-    self.send_acknowledged(|reply| RuntimeMessage::SettingsChanged(config, reply))
+    self.send_reliable_acknowledged(|reply| RuntimeMessage::SettingsChanged(config, reply))
   }
 
   pub(crate) fn wake(&self) -> Result<(), RefreshError> {
@@ -1747,6 +1864,39 @@ impl RefreshCoordinatorHandle {
     reply_rx
       .recv()
       .map_err(|_| RefreshError::CoordinatorUnavailable)
+  }
+
+  fn send_reliable_acknowledged(
+    &self,
+    build: impl FnOnce(SyncSender<()>) -> RuntimeMessage,
+  ) -> Result<(), RefreshError> {
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    let (sender, in_flight) = {
+      let mut intake = lock(&self.inner.intake);
+      if !intake.accepting {
+        return Err(shutdown_error());
+      }
+      intake.reliable_in_flight = intake
+        .reliable_in_flight
+        .checked_add(1)
+        .ok_or(RefreshError::Busy)?;
+      (
+        intake.sender.clone(),
+        ReliableInFlightGuard {
+          intake: Arc::clone(&self.inner.intake),
+          changed: Arc::clone(&self.inner.reliable_changed),
+        },
+      )
+    };
+    self.inner.reliable_changed.notify_all();
+    sender
+      .send(build(reply_tx))
+      .map_err(|_| RefreshError::CoordinatorUnavailable)?;
+    let result = reply_rx
+      .recv()
+      .map_err(|_| RefreshError::CoordinatorUnavailable);
+    drop(in_flight);
+    result
   }
 
   pub(crate) fn status(&self) -> RefreshStatus {
@@ -1815,6 +1965,7 @@ struct RuntimeLifecycle {
   changed: Condvar,
   coordinator: Mutex<Option<JoinHandle<()>>>,
   intake: Arc<Mutex<IntakeState>>,
+  reliable_changed: Arc<Condvar>,
   shutdown_requested: Arc<AtomicBool>,
   shutdown: Arc<AtomicBool>,
 }
@@ -1860,9 +2011,25 @@ impl RefreshRuntime {
     if owns_shutdown {
       let operation: Result<Arc<ShutdownResult>, RefreshError> = (|| {
         let (reply_tx, reply_rx) = mpsc::sync_channel(1);
-        {
+        let sender = {
           let mut intake = lock(&self.lifecycle.intake);
           intake.accepting = false;
+          intake.sender.clone()
+        };
+        self.lifecycle.reliable_changed.notify_all();
+        // Accepted settings updates finish before shutdown is published, while
+        // ordinary intake remains free to observe the closed state.
+        {
+          let mut intake = lock(&self.lifecycle.intake);
+          while intake.reliable_in_flight != 0 {
+            intake = self
+              .lifecycle
+              .reliable_changed
+              .wait(intake)
+              .unwrap_or_else(|poisoned| poisoned.into_inner());
+          }
+        }
+        {
           let shutdown_state = lock(&self.lifecycle.state);
           self
             .lifecycle
@@ -1870,11 +2037,10 @@ impl RefreshRuntime {
             .store(true, Ordering::Release);
           self.lifecycle.changed.notify_all();
           drop(shutdown_state);
-          intake
-            .sender
-            .send(RuntimeMessage::Shutdown(reply_tx))
-            .map_err(|_| RefreshError::CoordinatorUnavailable)?;
         }
+        sender
+          .send(RuntimeMessage::Shutdown(reply_tx))
+          .map_err(|_| RefreshError::CoordinatorUnavailable)?;
         let mut result = reply_rx
           .recv()
           .map_err(|_| RefreshError::CoordinatorUnavailable)?;
@@ -2139,8 +2305,10 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     hooks: Arc::clone(&hooks),
   })?;
 
+  let reliable_changed = Arc::new(Condvar::new());
   let shared_intake = Arc::new(Mutex::new(IntakeState {
     accepting: true,
+    reliable_in_flight: 0,
     sender: runtime_tx.clone(),
     #[cfg(test)]
     pause_after_check: None,
@@ -2148,6 +2316,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
   let handle = RefreshCoordinatorHandle {
     inner: Arc::new(HandleInner {
       intake: Arc::clone(&shared_intake),
+      reliable_changed: Arc::clone(&reliable_changed),
       waiters: Arc::clone(&waiters),
       status: Arc::clone(&status),
       metrics: Arc::clone(&metrics),
@@ -2198,6 +2367,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     changed: Condvar::new(),
     coordinator: Mutex::new(Some(coordinator)),
     intake: shared_intake,
+    reliable_changed,
     shutdown_requested,
     shutdown,
   });
@@ -5098,6 +5268,35 @@ impl RuntimeTestRig {
         Err(error) => panic!("unexpected command fill error: {error:?}"),
       }
     }
+  }
+
+  fn wait_for_reliable_in_flight(&self, expected: usize, timeout: Duration) {
+    let intake = lock(&self.handle.inner.intake);
+    let (intake, timed_out) = self
+      .handle
+      .inner
+      .reliable_changed
+      .wait_timeout_while(intake, timeout, |state| {
+        state.reliable_in_flight < expected
+      })
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(intake.reliable_in_flight, expected);
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for reliable refresh intake"
+    );
+  }
+
+  fn wait_for_intake_closed(&self, timeout: Duration) {
+    let intake = lock(&self.handle.inner.intake);
+    let (intake, timed_out) = self
+      .handle
+      .inner
+      .reliable_changed
+      .wait_timeout_while(intake, timeout, |state| state.accepting)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(!intake.accepting);
+    assert!(!timed_out.timed_out(), "timed out waiting for intake close");
   }
 
   fn start_intake_race_after_accept_check(&self) -> IntakeRace {

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -2,7 +2,7 @@
 mod tests {
   use super::{
     MetricsState, PanicPhase, RefreshClock, RefreshConfig, RefreshError, RefreshStatus,
-    RuntimeTestRig, SaturatingCounter, TestClock,
+    RuntimeTestRig, SaturatingCounter, TestClock, TestLiveExecutor,
   };
   use crate::refresh::{RefreshFailureCode, RefreshRejectionCode, REFRESH_WAITER_CAPACITY};
   use chrono::{DateTime, Duration as ChronoDuration};
@@ -10,6 +10,22 @@ mod tests {
   use std::time::Duration;
 
   const TEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+  fn assert_same_deadline(expected: &Option<String>, actual: &Option<String>) {
+    let expected = DateTime::parse_from_rfc3339(expected.as_deref().expect("expected deadline"))
+      .expect("expected RFC3339 deadline");
+    let actual = DateTime::parse_from_rfc3339(actual.as_deref().expect("actual deadline"))
+      .expect("actual RFC3339 deadline");
+    assert!(
+      actual
+        .signed_duration_since(expected)
+        .num_microseconds()
+        .unwrap_or(i64::MAX)
+        .unsigned_abs()
+        <= 1_000,
+      "normal live deadline moved: expected {expected}, actual {actual}"
+    );
+  }
 
   #[test]
   fn token_worker_does_not_delay_live_worker_start() {
@@ -325,6 +341,7 @@ mod tests {
       .expect("recovery live ticket")
       .wait_timeout(TEST_TIMEOUT)
       .is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
     assert_eq!(rig.live.fetch_calls(), 2);
     assert_eq!(rig.live.unique_fetch_worker_ids(), 1);
     assert_eq!(rig.live.worker_name(), "codex-pacer-refresh-live");
@@ -333,31 +350,28 @@ mod tests {
   }
 
   #[test]
-  fn persist_panic_becomes_failure_and_worker_recovers() {
+  fn persist_panic_does_not_fail_live_and_retry_recovers() {
     let rig = RuntimeTestRig::disabled();
     rig.live.panic_once(PanicPhase::Persist);
-    let failed = rig
+    let result = rig
       .handle
       .request_manual_live()
       .expect("failed live ticket")
       .wait_timeout(TEST_TIMEOUT);
-    assert!(matches!(
-      failed,
-      Err(RefreshError::Failed {
-        code: RefreshFailureCode::WorkerPanicked,
-        ..
-      })
-    ));
+    assert!(
+      result.is_ok(),
+      "persistence panic cannot fail fetched live quota"
+    );
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    assert_eq!(rig.live.fetch_calls(), 1);
+    assert_eq!(rig.live.persist_calls(), 1);
+    assert_eq!(rig.events.invalidation_count(), 1);
 
-    assert!(rig
-      .handle
-      .request_manual_live()
-      .expect("recovery live ticket")
-      .wait_timeout(TEST_TIMEOUT)
-      .is_ok());
+    rig.clock.advance(Duration::from_secs(5));
+    rig.handle.wake().expect("wake persistence retry");
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
     assert_eq!(rig.live.persist_calls(), 2);
-    assert_eq!(rig.live.unique_persist_worker_ids(), 1);
-    assert_eq!(rig.live.worker_name(), "codex-pacer-refresh-live");
+    assert_eq!(rig.live.fetch_calls(), 1, "retry cannot refetch");
     assert_eq!(rig.activities.active(), 0);
     rig.shutdown();
   }
@@ -371,6 +385,7 @@ mod tests {
     let live = rig.handle.request_manual_live().expect("live ticket");
     assert!(token.wait_timeout(TEST_TIMEOUT).is_ok());
     assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
     assert_eq!(rig.token.commit_calls(), 1);
     assert_eq!(rig.live.persist_calls(), 1);
     rig.shutdown();
@@ -814,6 +829,28 @@ mod tests {
   }
 
   #[test]
+  fn shutdown_drains_saturated_channel_and_joins_persistence_task() {
+    let rig = RuntimeTestRig::disabled();
+    let persist = rig.live.block_next_persist();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+    persist.wait_entered(TEST_TIMEOUT);
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+
+    let pause = rig.pause_coordinator();
+    rig.fill_runtime_channel_until_busy();
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    persist.release();
+    pause.release();
+
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.token_joined && joined.live_joined && joined.coordinator_joined);
+    assert_eq!(rig.activities.active(), 0);
+    assert!(!rig.live_cache.state().refreshing);
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+  }
+
+  #[test]
   fn shutdown_during_live_fetch_joins_after_bounded_completion() {
     let rig = RuntimeTestRig::disabled();
     let fetch = rig.live.block_next_fetch();
@@ -874,30 +911,38 @@ mod tests {
   }
 
   #[test]
-  fn source_change_during_live_persist_is_not_published_as_success() {
+  fn stale_persist_outcome_does_not_clear_newer_pending_snapshot() {
     let rig = RuntimeTestRig::disabled();
     let persist = rig.live.block_next_persist();
     let replacement = rig.token.block_parse_call(1);
-    let previous_success = rig.handle.status().live.last_success_at;
     let invalidations = rig.events.invalidation_count();
     let ticket = rig.handle.request_manual_live().expect("live ticket");
     persist.wait_entered(TEST_TIMEOUT);
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.events.invalidation_count(), invalidations + 1);
     rig
       .handle
       .update_settings(rig.config_with_source("replacement"))
       .expect("source update during persistence");
-    persist.release();
-
-    assert!(matches!(
-      ticket.wait_timeout(TEST_TIMEOUT),
-      Err(RefreshError::Failed {
-        code: RefreshFailureCode::SourceChanged,
-        ..
-      })
-    ));
     replacement.wait_worker_ready(TEST_TIMEOUT);
-    assert_eq!(rig.events.invalidation_count(), invalidations);
-    assert_eq!(rig.handle.status().live.last_success_at, previous_success);
+
+    let newer = TestLiveExecutor::snapshot_at("2026-07-11T00:02:00Z");
+    rig.live.queue_snapshot(Arc::clone(&newer));
+    let latest = rig
+      .handle
+      .request_manual_live()
+      .expect("new-source live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("new-source live result");
+    assert_eq!(latest.fetched_at, newer.fetched_at);
+    persist.release();
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
+    assert_eq!(rig.events.invalidation_count(), invalidations + 2);
+    assert_eq!(rig.live.persist_calls(), 2);
+    assert_eq!(
+      rig.live.persisted_fetched_at(),
+      ["2026-07-11T00:00:00Z", "2026-07-11T00:02:00Z"]
+    );
     let shutdown = rig.shutdown_in_background();
     rig.wait_for_shutdown_requested(TEST_TIMEOUT);
     replacement.release();
@@ -974,15 +1019,199 @@ mod tests {
     assert_eq!(rig.activities.active(), 1, "persist body owns one guard");
     persist.release();
     assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
     assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn fresh_value_is_visible_before_persistence_finishes() {
+    let rig = RuntimeTestRig::disabled();
+    let persist = rig.live.block_next_persist();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+    persist.wait_entered(TEST_TIMEOUT);
+
+    let result = ticket
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("waiter resolves before persistence finishes");
+    let produced = rig.live.fetched_arc(1, TEST_TIMEOUT);
+    let cached = rig.live_cache.rate_limits().expect("published live cache");
+    assert!(Arc::ptr_eq(&result, &produced));
+    assert!(Arc::ptr_eq(&result, &cached));
+    assert_eq!(
+      rig.events.trace_prefix(),
+      [
+        "live_cache_publish",
+        "live_invalidation",
+        "live_completion",
+        "live_waiter_reply",
+        "live_persist_start",
+      ]
+    );
+
+    persist.release();
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn fetch_receives_ten_second_timeout() {
+    let rig = RuntimeTestRig::disabled();
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(
+      rig.live.last_timeout(),
+      Some(crate::refresh::LIVE_QUERY_TIMEOUT)
+    );
+    assert_eq!(rig.live.last_timeout(), Some(Duration::from_secs(10)));
+    rig.shutdown();
+  }
+
+  #[test]
+  fn live_failure_does_not_run_token_inline() {
+    let rig = RuntimeTestRig::paused_clock();
+    let fallback = TestLiveExecutor::snapshot_at("2026-07-10T23:59:00Z");
+    rig
+      .live
+      .fail_next_fetch_with_fallback(Arc::clone(&fallback));
+    let parse = rig.token.block_next_parse();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::ExecutionFailed,
+        ..
+      })
+    ));
+    parse.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.live.fallback_calls(), 1);
+    assert!(rig.live_cache.state().is_fallback);
+    assert_eq!(
+      rig.events.trace_prefix(),
+      [
+        "live_cache_fallback",
+        "live_completion",
+        "live_waiter_reply",
+        "token_fallback_start",
+      ]
+    );
+
+    parse.release();
+    rig.token.wait_for_commit_calls(1, TEST_TIMEOUT);
+    rig.shutdown();
+
+    let no_fallback = RuntimeTestRig::paused_clock();
+    no_fallback.live.fail_next_fetch();
+    let parse = no_fallback.token.block_next_parse();
+    let ticket = no_fallback
+      .handle
+      .request_manual_live()
+      .expect("live ticket without fallback");
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_err());
+    parse.wait_entered(TEST_TIMEOUT);
+    assert_eq!(
+      no_fallback.events.trace_prefix(),
+      [
+        "live_completion",
+        "live_waiter_reply",
+        "token_fallback_start",
+      ]
+    );
+    parse.release();
+    no_fallback.token.wait_for_commit_calls(1, TEST_TIMEOUT);
+    no_fallback.shutdown();
+  }
+
+  #[test]
+  fn persistence_failure_retries_without_refetch() {
+    let rig = RuntimeTestRig::disabled();
+    rig.live.fail_next_persist();
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    assert_eq!(rig.live.fetch_calls(), 1);
+    assert_eq!(rig.live.persist_calls(), 1);
+
+    rig.clock.advance(Duration::from_secs(5));
+    rig.handle.wake().expect("wake persistence retry");
+    rig.live.wait_for_persist_calls(2, TEST_TIMEOUT);
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
+    assert_eq!(rig.live.fetch_calls(), 1, "retry must not refetch");
+    assert_eq!(rig.live.persist_calls(), 2);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn newer_live_snapshot_supersedes_pending_persistence_retry() {
+    let rig = RuntimeTestRig::disabled();
+    rig.live.fail_next_persist();
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("first live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+
+    let newer = TestLiveExecutor::snapshot_at("2026-07-11T00:01:00Z");
+    rig.live.queue_snapshot(Arc::clone(&newer));
+    let second = rig
+      .handle
+      .request_manual_live()
+      .expect("second live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("second live result");
+    assert_eq!(second.fetched_at, newer.fetched_at);
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
+    assert_eq!(
+      rig.live.persisted_fetched_at(),
+      ["2026-07-11T00:00:00Z", "2026-07-11T00:01:00Z"]
+    );
+
+    rig.clock.advance(Duration::from_secs(5));
+    rig.handle.wake().expect("wake past superseded retry");
+    rig.handle.barrier().expect("drain wake");
+    assert_eq!(rig.live.persist_calls(), 2, "old retry stays superseded");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn persistence_retry_does_not_move_live_deadline() {
+    let rig = RuntimeTestRig::disabled();
+    let initial_deadline = rig.handle.status().live.next_due_at;
+    rig.live.fail_next_persist();
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    assert_same_deadline(&initial_deadline, &rig.handle.status().live.next_due_at);
+
+    rig.clock.advance(Duration::from_secs(5));
+    rig.handle.wake().expect("wake persistence retry");
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
+    assert_same_deadline(&initial_deadline, &rig.handle.status().live.next_due_at);
+    assert_eq!(rig.live.fetch_calls(), 1);
     rig.shutdown();
   }
 }
 use super::power::{ActivityFactory, SystemActivityFactory};
 use super::{
   CommitMarker, CoordinatorAction, CoordinatorEvent, CoordinatorState, DisplayInvalidation,
-  ExecutionCompletion, LiveExecutionRequest, LiveRequest, LiveWaiterId, MutationPriority,
-  RefreshCompletedEvent, RefreshConfig, RefreshDetail, RefreshFailureCode, RefreshRejectionCode,
+  ExecutionCompletion, LiveExecutionRequest, LivePersistenceRetryState, LivePersistenceWork,
+  LiveQuotaCache, LiveRequest, LiveWaiterId, MutationPriority, RefreshCompletedEvent,
+  RefreshConfig, RefreshDetail, RefreshFailureCode, RefreshReason, RefreshRejectionCode,
   RefreshWaiterOutcome, TokenExecutionRequest, TokenRequest, TokenWaiterId,
   UsageMutationCoordinator, LIVE_QUERY_TIMEOUT, REFRESH_WAITER_CAPACITY,
 };
@@ -991,6 +1220,8 @@ use crate::models::{LiveRateLimitSnapshot, ScanResult};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use std::array;
 use std::collections::HashMap;
+#[cfg(test)]
+use std::collections::VecDeque;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, SyncSender, TrySendError};
@@ -1536,6 +1767,7 @@ pub(crate) struct RefreshRuntimeDependencies {
   pub token_executor: Arc<dyn TokenRefreshExecutor>,
   pub live_fetcher: Arc<dyn LiveQuotaFetcher>,
   pub live_persister: Arc<dyn LiveQuotaPersister>,
+  pub live_cache: LiveQuotaCache,
   pub event_sink: Arc<dyn RefreshEventSink>,
   pub mutation: UsageMutationCoordinator,
   pub activity_factory: Arc<dyn ActivityFactory>,
@@ -1551,6 +1783,7 @@ impl RefreshRuntimeDependencies {
     token_executor: Arc<dyn TokenRefreshExecutor>,
     live_fetcher: Arc<dyn LiveQuotaFetcher>,
     live_persister: Arc<dyn LiveQuotaPersister>,
+    live_cache: LiveQuotaCache,
     event_sink: Arc<dyn RefreshEventSink>,
     mutation: UsageMutationCoordinator,
   ) -> Self {
@@ -1559,6 +1792,7 @@ impl RefreshRuntimeDependencies {
       token_executor,
       live_fetcher,
       live_persister,
+      live_cache,
       event_sink,
       mutation,
       activity_factory: Arc::new(SystemActivityFactory),
@@ -1715,6 +1949,7 @@ enum RuntimeMessage {
   WakeNoReply,
   Barrier(SyncSender<()>),
   Worker(WorkerOutcome),
+  Persistence(PersistenceWorkerOutcome),
   Shutdown(SyncSender<ShutdownResult>),
   #[cfg(test)]
   PauseCoordinator(Arc<TestGateState>, SyncSender<()>),
@@ -1789,11 +2024,22 @@ enum LiveWorkerOutcome {
     code: RefreshFailureCode,
     detail: RefreshDetail,
     fetch_duration: Duration,
+    fallback: Option<Arc<LiveRateLimitSnapshot>>,
   },
   Stale {
     generation: u64,
     source_generation: u64,
   },
+}
+
+enum PersistenceWorkerResult {
+  Completed(Result<(), String>),
+  Stale,
+}
+
+struct PersistenceWorkerOutcome {
+  work: LivePersistenceWork,
+  result: PersistenceWorkerResult,
 }
 
 struct PreparedSlot {
@@ -1810,10 +2056,16 @@ struct CoordinatorRuntime {
   current_live_result: Option<(u64, Arc<LiveRateLimitSnapshot>)>,
   token_sender: Option<SyncSender<TokenWorkerCommand>>,
   live_sender: Option<SyncSender<LiveWorkerCommand>>,
+  runtime_sender: SyncSender<RuntimeMessage>,
   waiters: Arc<Mutex<WaiterRegistries>>,
   status: Arc<Mutex<RefreshStatus>>,
   metrics: Arc<MetricsState>,
   event_sink: Arc<dyn RefreshEventSink>,
+  live_cache: LiveQuotaCache,
+  live_persister: Arc<dyn LiveQuotaPersister>,
+  activity_factory: Arc<dyn ActivityFactory>,
+  persistence: LivePersistenceRetryState,
+  persistence_handle: Option<JoinHandle<()>>,
   clock: Arc<dyn RefreshClock>,
   source_generation: Arc<AtomicU64>,
   shutdown: Arc<AtomicBool>,
@@ -1832,6 +2084,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     token_executor,
     live_fetcher,
     live_persister,
+    live_cache,
     event_sink,
     mutation,
     activity_factory,
@@ -1874,8 +2127,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     receiver: live_rx,
     runtime_sender: runtime_tx.clone(),
     fetcher: live_fetcher,
-    persister: live_persister,
-    activity_factory,
+    activity_factory: Arc::clone(&activity_factory),
     status: Arc::clone(&status),
     metrics: Arc::clone(&metrics),
     source_generation: Arc::clone(&source_generation),
@@ -1889,7 +2141,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
 
   let shared_intake = Arc::new(Mutex::new(IntakeState {
     accepting: true,
-    sender: runtime_tx,
+    sender: runtime_tx.clone(),
     #[cfg(test)]
     pause_after_check: None,
   }));
@@ -1914,10 +2166,16 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     current_live_result: None,
     token_sender: Some(token_tx),
     live_sender: Some(live_tx),
+    runtime_sender: runtime_tx.clone(),
     waiters,
     status,
     metrics,
     event_sink,
+    live_cache,
+    live_persister,
+    activity_factory,
+    persistence: LivePersistenceRetryState::new(),
+    persistence_handle: None,
     clock,
     source_generation,
     shutdown: Arc::clone(&shutdown),
@@ -2160,7 +2418,6 @@ struct LiveWorkerParameters {
   receiver: Receiver<LiveWorkerCommand>,
   runtime_sender: SyncSender<RuntimeMessage>,
   fetcher: Arc<dyn LiveQuotaFetcher>,
-  persister: Arc<dyn LiveQuotaPersister>,
   activity_factory: Arc<dyn ActivityFactory>,
   status: Arc<Mutex<RefreshStatus>>,
   metrics: Arc<MetricsState>,
@@ -2249,12 +2506,26 @@ fn run_live_refresh(
       if normalized.contains("timeout") || normalized.contains("timed out") {
         parameters.metrics.live_timeout_count.increment();
       }
+      if parameters.shutdown_requested.load(Ordering::Acquire)
+        || parameters.shutdown.load(Ordering::Acquire)
+        || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
+      {
+        return LiveWorkerOutcome::Stale {
+          generation: request.generation,
+          source_generation: request.source_generation,
+        };
+      }
+      let fallback = panic::catch_unwind(AssertUnwindSafe(|| parameters.fetcher.fallback()))
+        .ok()
+        .flatten()
+        .map(Arc::new);
       return LiveWorkerOutcome::Failed {
         generation: request.generation,
         source_generation: request.source_generation,
         code: RefreshFailureCode::ExecutionFailed,
         detail: RefreshDetail::new(detail),
         fetch_duration,
+        fallback,
       };
     }
     Err(_) => {
@@ -2264,6 +2535,7 @@ fn run_live_refresh(
         code: RefreshFailureCode::WorkerPanicked,
         detail: RefreshDetail::new("live fetch executor panicked"),
         fetch_duration,
+        fallback: None,
       };
     }
   };
@@ -2277,53 +2549,20 @@ fn run_live_refresh(
       source_generation: request.source_generation,
     };
   }
+  let snapshot = Arc::new(snapshot);
   #[cfg(test)]
-  parameters.hooks.before_live_persist();
-  let persisted = panic::catch_unwind(AssertUnwindSafe(|| {
-    let _activity = parameters.activity_factory.begin();
-    parameters.persister.persist(&snapshot)
-  }));
-  match persisted {
-    Ok(Ok(())) => {
-      if parameters.shutdown_requested.load(Ordering::Acquire)
-        || parameters.shutdown.load(Ordering::Acquire)
-        || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
-      {
-        return LiveWorkerOutcome::Stale {
-          generation: request.generation,
-          source_generation: request.source_generation,
-        };
-      }
-      let snapshot = Arc::new(snapshot);
-      #[cfg(test)]
-      parameters
-        .hooks
-        .record_live_arc(request.generation, Arc::clone(&snapshot));
-      LiveWorkerOutcome::Completed {
-        generation: request.generation,
-        source_generation: request.source_generation,
-        snapshot,
-        commit: CommitMarker {
-          sequence: parameters.commit_sequence.increment(),
-          committed_at: parameters.clock.monotonic_now(),
-        },
-        fetch_duration,
-      }
-    }
-    Ok(Err(detail)) => LiveWorkerOutcome::Failed {
-      generation: request.generation,
-      source_generation: request.source_generation,
-      code: RefreshFailureCode::ExecutionFailed,
-      detail: RefreshDetail::new(detail),
-      fetch_duration,
+  parameters
+    .hooks
+    .record_live_arc(request.generation, Arc::clone(&snapshot));
+  LiveWorkerOutcome::Completed {
+    generation: request.generation,
+    source_generation: request.source_generation,
+    snapshot,
+    commit: CommitMarker {
+      sequence: parameters.commit_sequence.increment(),
+      committed_at: parameters.clock.monotonic_now(),
     },
-    Err(_) => LiveWorkerOutcome::Failed {
-      generation: request.generation,
-      source_generation: request.source_generation,
-      code: RefreshFailureCode::WorkerPanicked,
-      detail: RefreshDetail::new("live persist executor panicked"),
-      fetch_duration,
-    },
+    fetch_duration,
   }
 }
 
@@ -2422,6 +2661,64 @@ impl Drop for ActiveLiveGuard<'_> {
   }
 }
 
+struct PersistenceTaskParameters {
+  work: LivePersistenceWork,
+  runtime_sender: SyncSender<RuntimeMessage>,
+  persister: Arc<dyn LiveQuotaPersister>,
+  activity_factory: Arc<dyn ActivityFactory>,
+  source_generation: Arc<AtomicU64>,
+  shutdown: Arc<AtomicBool>,
+  shutdown_requested: Arc<AtomicBool>,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn spawn_persistence_task(parameters: PersistenceTaskParameters) -> Result<JoinHandle<()>, String> {
+  thread::Builder::new()
+    .name("codex-pacer-live-persist".to_string())
+    .spawn(move || {
+      let result = run_persistence_task(&parameters);
+      let _ =
+        parameters
+          .runtime_sender
+          .send(RuntimeMessage::Persistence(PersistenceWorkerOutcome {
+            work: parameters.work.clone(),
+            result,
+          }));
+    })
+    .map_err(|error| error.to_string())
+}
+
+fn run_persistence_task(parameters: &PersistenceTaskParameters) -> PersistenceWorkerResult {
+  if persistence_task_is_stale(parameters) {
+    return PersistenceWorkerResult::Stale;
+  }
+  #[cfg(test)]
+  parameters.hooks.before_live_persist();
+  if persistence_task_is_stale(parameters) {
+    return PersistenceWorkerResult::Stale;
+  }
+  let result = panic::catch_unwind(AssertUnwindSafe(|| {
+    let _activity = parameters.activity_factory.begin();
+    parameters.persister.persist(parameters.work.snapshot())
+  }));
+  if persistence_task_is_stale(parameters) {
+    return PersistenceWorkerResult::Stale;
+  }
+  match result {
+    Ok(result) => PersistenceWorkerResult::Completed(result),
+    Err(_) => PersistenceWorkerResult::Completed(Err(
+      "live quota persistence executor panicked".to_string(),
+    )),
+  }
+}
+
+fn persistence_task_is_stale(parameters: &PersistenceTaskParameters) -> bool {
+  parameters.shutdown.load(Ordering::Acquire)
+    || parameters.shutdown_requested.load(Ordering::Acquire)
+    || parameters.source_generation.load(Ordering::Acquire) != parameters.work.source_generation()
+}
+
 fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: CoordinatorRuntime) {
   #[cfg(test)]
   runtime.hooks.record_thread_name();
@@ -2429,11 +2726,12 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
     let message = if runtime.shutdown_requested.load(Ordering::Acquire) {
       receiver.recv().map_err(|_| RecvError)
     } else {
-      match runtime.schedule.next_wait(runtime.clock.monotonic_now()) {
+      match runtime.next_wait() {
         Some(wait) => match receiver.recv_timeout(wait) {
           Ok(message) => Ok(message),
           Err(RecvTimeoutError::Timeout) => {
             runtime.process_schedule_event(CoordinatorEvent::Timer);
+            runtime.maybe_start_persistence();
             continue;
           }
           Err(RecvTimeoutError::Disconnected) => Err(RecvError),
@@ -2455,11 +2753,14 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
     match message {
       RuntimeMessage::RequestToken(request) => {
         runtime.process_schedule_event(CoordinatorEvent::RequestToken(request));
+        runtime.maybe_start_persistence();
       }
       RuntimeMessage::RequestLive(request) => {
         runtime.process_schedule_event(CoordinatorEvent::RequestLive(request));
+        runtime.maybe_start_persistence();
       }
       RuntimeMessage::SettingsChanged(config, reply) => {
+        let previous_source_generation = runtime.schedule.snapshot().source_generation;
         let actions = runtime.schedule.handle(
           runtime.clock.monotonic_now(),
           CoordinatorEvent::SettingsChanged(config),
@@ -2468,19 +2769,31 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
         runtime
           .source_generation
           .store(snapshot.source_generation, Ordering::Release);
+        if snapshot.source_generation != previous_source_generation {
+          runtime.persistence.reset_source(snapshot.source_generation);
+        }
         runtime.sync_schedule_snapshot();
         runtime.process_actions(actions);
+        runtime.maybe_start_persistence();
         let _ = reply.send(());
       }
       RuntimeMessage::Wake(reply) => {
         runtime.process_schedule_event(CoordinatorEvent::Wake);
+        runtime.maybe_start_persistence();
         let _ = reply.send(());
       }
-      RuntimeMessage::WakeNoReply => runtime.process_schedule_event(CoordinatorEvent::Wake),
+      RuntimeMessage::WakeNoReply => {
+        runtime.process_schedule_event(CoordinatorEvent::Wake);
+        runtime.maybe_start_persistence();
+      }
       RuntimeMessage::Barrier(reply) => {
         let _ = reply.send(());
       }
-      RuntimeMessage::Worker(outcome) => runtime.process_worker_outcome(outcome),
+      RuntimeMessage::Worker(outcome) => {
+        runtime.process_worker_outcome(outcome);
+        runtime.maybe_start_persistence();
+      }
+      RuntimeMessage::Persistence(outcome) => runtime.process_persistence_outcome(outcome),
       RuntimeMessage::Shutdown(reply) => {
         runtime.shutdown_and_join_workers(&receiver, reply);
         return;
@@ -2509,6 +2822,92 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
 }
 
 impl CoordinatorRuntime {
+  fn next_wait(&self) -> Option<Duration> {
+    let now = self.clock.monotonic_now();
+    let schedule = self.schedule.next_wait(now);
+    let live_running = self.schedule.snapshot().live.running_generation.is_some();
+    let persistence = self.persistence.next_wait(now, live_running);
+    match (schedule, persistence) {
+      (Some(schedule), Some(persistence)) => Some(schedule.min(persistence)),
+      (Some(wait), None) | (None, Some(wait)) => Some(wait),
+      (None, None) => None,
+    }
+  }
+
+  fn maybe_start_persistence(&mut self) {
+    if self.shutdown_requested.load(Ordering::Acquire)
+      || self.shutdown.load(Ordering::Acquire)
+      || self.persistence_handle.is_some()
+    {
+      return;
+    }
+    let live_running = self.schedule.snapshot().live.running_generation.is_some();
+    let Some(work) = self
+      .persistence
+      .take_ready(self.clock.monotonic_now(), live_running)
+    else {
+      return;
+    };
+    #[cfg(test)]
+    self.hooks.trace("live_persist_start");
+    let spawn = spawn_persistence_task(PersistenceTaskParameters {
+      work: work.clone(),
+      runtime_sender: self.runtime_sender.clone(),
+      persister: Arc::clone(&self.live_persister),
+      activity_factory: Arc::clone(&self.activity_factory),
+      source_generation: Arc::clone(&self.source_generation),
+      shutdown: Arc::clone(&self.shutdown),
+      shutdown_requested: Arc::clone(&self.shutdown_requested),
+      #[cfg(test)]
+      hooks: Arc::clone(&self.hooks),
+    });
+    match spawn {
+      Ok(handle) => self.persistence_handle = Some(handle),
+      Err(error) => {
+        log::warn!("Failed to start live quota persistence task: {error}");
+        self.persistence.finish(
+          &work,
+          Err(error),
+          self.clock.monotonic_now(),
+          self.schedule.snapshot().interval,
+        );
+        #[cfg(test)]
+        self.hooks.record_persistence_outcome();
+      }
+    }
+  }
+
+  fn process_persistence_outcome(&mut self, outcome: PersistenceWorkerOutcome) {
+    if let Some(handle) = self.persistence_handle.take() {
+      if handle.join().is_err() {
+        log::warn!("Live quota persistence task panicked after reporting its outcome.");
+      }
+    }
+    match outcome.result {
+      PersistenceWorkerResult::Completed(result) => {
+        if let Err(error) = &result {
+          log::warn!("Failed to persist live quota snapshot: {error}");
+        }
+        self.persistence.finish(
+          &outcome.work,
+          result,
+          self.clock.monotonic_now(),
+          self.schedule.snapshot().interval,
+        );
+      }
+      PersistenceWorkerResult::Stale => {
+        self.persistence.abandon(&outcome.work);
+      }
+    }
+    #[cfg(test)]
+    self.hooks.record_persistence_outcome();
+    if self.shutdown_requested.load(Ordering::Acquire) || self.shutdown.load(Ordering::Acquire) {
+      self.persistence.cancel_pending();
+    } else {
+      self.maybe_start_persistence();
+    }
+  }
+
   fn handle_message_while_shutdown_pending(&mut self, message: RuntimeMessage) {
     match message {
       RuntimeMessage::SettingsChanged(_, reply)
@@ -2521,6 +2920,10 @@ impl CoordinatorRuntime {
       }
       RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
         self.live_exited = true;
+      }
+      RuntimeMessage::Persistence(outcome) => {
+        self.process_persistence_outcome(outcome);
+        self.persistence.cancel_pending();
       }
       RuntimeMessage::Worker(_)
       | RuntimeMessage::RequestToken(_)
@@ -2712,17 +3115,25 @@ impl CoordinatorRuntime {
             generation,
             source_generation,
             RefreshFailureCode::SourceChanged,
-            RefreshDetail::new("refresh source changed during live persistence"),
+            RefreshDetail::new("refresh source changed before live publication"),
             self.clock.wall_now(),
           )));
           return;
         }
         lock(&self.metrics.mutable).live.app_server_duration_ms =
           nonzero_duration_millis(fetch_duration);
+        self.live_cache.publish_live(
+          Arc::clone(&snapshot),
+          self.clock.monotonic_now(),
+          self.clock.wall_now(),
+        );
+        lock(&self.metrics.mutable).live.fallback_age_ms = None;
+        #[cfg(test)]
+        self.hooks.trace("live_cache_publish");
         self.finish_live_timing(true);
         #[cfg(test)]
         self.hooks.set_completion_slots_empty(false);
-        self.current_live_result = Some((generation, snapshot));
+        self.current_live_result = Some((generation, Arc::clone(&snapshot)));
         self.process_schedule_event(CoordinatorEvent::LiveFinished(successful_completion(
           generation,
           source_generation,
@@ -2732,6 +3143,9 @@ impl CoordinatorRuntime {
         self.current_live_result = None;
         #[cfg(test)]
         self.hooks.set_completion_slots_empty(true);
+        self
+          .persistence
+          .publish(snapshot, source_generation, self.clock.monotonic_now());
       }
       LiveWorkerOutcome::Failed {
         generation,
@@ -2739,12 +3153,40 @@ impl CoordinatorRuntime {
         code,
         detail,
         fetch_duration,
+        fallback,
       } => {
-        if self.schedule.snapshot().live.running_generation != Some(generation) {
+        let coordinator_snapshot = self.schedule.snapshot();
+        if coordinator_snapshot.live.running_generation != Some(generation) {
+          return;
+        }
+        if coordinator_snapshot.source_generation != source_generation {
+          self.live_cache.set_refreshing(false);
+          self.finish_live_timing(false);
+          self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+            generation,
+            source_generation,
+            RefreshFailureCode::SourceChanged,
+            RefreshDetail::new("refresh source changed before live fallback publication"),
+            self.clock.wall_now(),
+          )));
           return;
         }
         lock(&self.metrics.mutable).live.app_server_duration_ms =
           nonzero_duration_millis(fetch_duration);
+        let submit_fallback_intent = code == RefreshFailureCode::ExecutionFailed;
+        if let Some(fallback) = fallback {
+          let state = self.live_cache.publish_fallback(
+            fallback,
+            self.clock.monotonic_now(),
+            self.clock.wall_now(),
+          );
+          self.record_fallback_age(state.source_fetched_at.as_deref());
+          #[cfg(test)]
+          self.hooks.trace("live_cache_fallback");
+        } else {
+          let state = self.live_cache.mark_current_as_fallback();
+          self.record_fallback_age(state.source_fetched_at.as_deref());
+        }
         self.finish_live_timing(false);
         self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
           generation,
@@ -2753,6 +3195,11 @@ impl CoordinatorRuntime {
           detail,
           self.clock.wall_now(),
         )));
+        if submit_fallback_intent {
+          self.process_schedule_event(CoordinatorEvent::RequestToken(TokenRequest::for_reason(
+            RefreshReason::Fallback,
+          )));
+        }
       }
       LiveWorkerOutcome::Stale {
         generation,
@@ -2761,6 +3208,7 @@ impl CoordinatorRuntime {
         if self.schedule.snapshot().live.running_generation != Some(generation) {
           return;
         }
+        self.live_cache.set_refreshing(false);
         self.finish_live_timing(false);
         self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
           generation,
@@ -2819,9 +3267,15 @@ impl CoordinatorRuntime {
           }
         }
         CoordinatorAction::PublishInvalidation(value) => {
+          #[cfg(test)]
+          let is_live = self.current_live_result.is_some();
           self.event_sink.publish_invalidation(value);
           #[cfg(test)]
-          self.hooks.trace("token_invalidation");
+          self.hooks.trace(if is_live {
+            "live_invalidation"
+          } else {
+            "token_invalidation"
+          });
         }
         CoordinatorAction::PublishCompletion(value) => {
           #[cfg(test)]
@@ -2847,7 +3301,9 @@ impl CoordinatorRuntime {
     self.record_lane_start(true, request.generation, request.request.planned_due_at);
     set_mutation_phase(&self.status, MutationPhase::Parsing);
     #[cfg(test)]
-    if request.generation > 1 {
+    if request.request.reasons.contains(RefreshReason::Fallback) {
+      self.hooks.trace("token_fallback_start");
+    } else if request.generation > 1 {
       self.hooks.trace("token_follow_up_start");
     }
     let result = self.token_sender.as_ref().ok_or(()).and_then(|sender| {
@@ -2867,12 +3323,14 @@ impl CoordinatorRuntime {
 
   fn start_live(&mut self, request: LiveExecutionRequest) {
     self.record_lane_start(false, request.generation, request.planned_due_at);
+    self.live_cache.set_refreshing(true);
     let result = self.live_sender.as_ref().ok_or(()).and_then(|sender| {
       sender
         .try_send(LiveWorkerCommand::Run(request.clone()))
         .map_err(|_| ())
     });
     if result.is_err() {
+      self.live_cache.set_refreshing(false);
       self.finish_live_timing(false);
       self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
         request.generation,
@@ -2950,6 +3408,24 @@ impl CoordinatorRuntime {
         let _ = reply.send(clone_result(&result));
       }
     }
+    drop(waiters);
+    #[cfg(test)]
+    self.hooks.trace("live_waiter_reply");
+  }
+
+  fn record_fallback_age(&self, source_fetched_at: Option<&str>) {
+    let age = source_fetched_at
+      .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+      .and_then(|fetched| {
+        self
+          .clock
+          .wall_now()
+          .signed_duration_since(fetched.with_timezone(&Utc))
+          .to_std()
+          .ok()
+      })
+      .map(duration_as_millis);
+    lock(&self.metrics.mutable).live.fallback_age_ms = age;
   }
 
   fn record_lane_start(&mut self, token: bool, generation: u64, due: Option<Instant>) {
@@ -3059,6 +3535,8 @@ impl CoordinatorRuntime {
   ) {
     // Required order: deny is linearized by the owner, then drain, drop, flag, close.
     drain_waiters_for_shutdown(&self.waiters);
+    self.live_cache.set_refreshing(false);
+    self.persistence.cancel_pending();
     self.prepared_slot = None;
     #[cfg(test)]
     self.hooks.set_prepared_slot_empty(true);
@@ -3074,7 +3552,7 @@ impl CoordinatorRuntime {
       status.mutation_phase = None;
     }
 
-    while !self.token_exited || !self.live_exited {
+    while !self.token_exited || !self.live_exited || self.persistence_handle.is_some() {
       let Ok(message) = receiver.recv() else {
         break;
       };
@@ -3084,6 +3562,10 @@ impl CoordinatorRuntime {
         }
         RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
           self.live_exited = true;
+        }
+        RuntimeMessage::Persistence(outcome) => {
+          self.process_persistence_outcome(outcome);
+          self.persistence.cancel_pending();
         }
         RuntimeMessage::Worker(_) => {}
         RuntimeMessage::SettingsChanged(_, ack)
@@ -3431,6 +3913,7 @@ struct TestHookData {
   token_waiting_count: u64,
   prepared_slot_empty: bool,
   completion_slots_empty: bool,
+  persistence_outcomes: u64,
 }
 
 #[cfg(test)]
@@ -3502,6 +3985,13 @@ impl RuntimeTestHooks {
 
   fn set_completion_slots_empty(&self, empty: bool) {
     lock(&self.data).completion_slots_empty = empty;
+    self.changed.notify_all();
+  }
+
+  fn record_persistence_outcome(&self) {
+    let mut data = lock(&self.data);
+    data.persistence_outcomes = data.persistence_outcomes.saturating_add(1);
+    drop(data);
     self.changed.notify_all();
   }
 
@@ -3955,6 +4445,11 @@ struct TestLiveBehavior {
   fetch_thread_ids: Vec<String>,
   persist_thread_ids: Vec<String>,
   last_timeout: Option<Duration>,
+  fail_next_fetch: bool,
+  fallback_snapshot: Option<Arc<LiveRateLimitSnapshot>>,
+  queued_snapshots: VecDeque<Arc<LiveRateLimitSnapshot>>,
+  fail_next_persist: bool,
+  persisted_fetched_at: Vec<String>,
 }
 
 #[cfg(test)]
@@ -3966,6 +4461,7 @@ struct TestLiveExecutor {
   persist_calls: AtomicU64,
   active: AtomicU64,
   maximum_active: AtomicU64,
+  fallback_calls: AtomicU64,
 }
 
 #[cfg(test)]
@@ -3979,6 +4475,7 @@ impl TestLiveExecutor {
       persist_calls: AtomicU64::new(0),
       active: AtomicU64::new(0),
       maximum_active: AtomicU64::new(0),
+      fallback_calls: AtomicU64::new(0),
     }
   }
 
@@ -4013,6 +4510,30 @@ impl TestLiveExecutor {
     lock(&self.behavior).panic_once.insert(phase, 1);
   }
 
+  fn fail_next_fetch_with_fallback(&self, fallback: Arc<LiveRateLimitSnapshot>) {
+    let mut behavior = lock(&self.behavior);
+    behavior.fail_next_fetch = true;
+    behavior.fallback_snapshot = Some(fallback);
+  }
+
+  fn fail_next_fetch(&self) {
+    let mut behavior = lock(&self.behavior);
+    behavior.fail_next_fetch = true;
+    behavior.fallback_snapshot = None;
+  }
+
+  fn fallback_calls(&self) -> u64 {
+    self.fallback_calls.load(Ordering::Acquire)
+  }
+
+  fn fail_next_persist(&self) {
+    lock(&self.behavior).fail_next_persist = true;
+  }
+
+  fn queue_snapshot(&self, snapshot: Arc<LiveRateLimitSnapshot>) {
+    lock(&self.behavior).queued_snapshots.push_back(snapshot);
+  }
+
   fn fetch_calls(&self) -> u64 {
     self.fetch_calls.load(Ordering::Acquire)
   }
@@ -4029,6 +4550,19 @@ impl TestLiveExecutor {
       .unwrap_or_else(|poisoned| poisoned.into_inner());
     assert!(self.fetch_calls() >= expected);
     assert!(!timed_out.timed_out(), "timed out waiting for live fetch");
+  }
+
+  fn wait_for_persist_calls(&self, expected: u64, timeout: Duration) {
+    let behavior = lock(&self.behavior);
+    let (_behavior, timed_out) = self
+      .changed
+      .wait_timeout_while(behavior, timeout, |_| self.persist_calls() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(self.persist_calls() >= expected);
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for live persistence"
+    );
   }
 
   fn maximum_active_fetches(&self) -> u64 {
@@ -4071,6 +4605,17 @@ impl TestLiveExecutor {
     lock(&self.behavior).last_timeout
   }
 
+  fn persisted_fetched_at(&self) -> Vec<String> {
+    lock(&self.behavior).persisted_fetched_at.clone()
+  }
+
+  fn snapshot_at(fetched_at: &str) -> Arc<LiveRateLimitSnapshot> {
+    Arc::new(LiveRateLimitSnapshot {
+      fetched_at: fetched_at.to_string(),
+      ..Self::snapshot()
+    })
+  }
+
   fn snapshot() -> LiveRateLimitSnapshot {
     LiveRateLimitSnapshot {
       limit_id: Some("runtime-test".to_string()),
@@ -4100,7 +4645,7 @@ impl LiveQuotaFetcher for TestLiveExecutor {
         Err(observed) => maximum = observed,
       }
     }
-    let (body_gate, pre_body, panic_now) = {
+    let (body_gate, pre_body, panic_now, fail_now, snapshot) = {
       let mut behavior = lock(&self.behavior);
       behavior
         .fetch_thread_ids
@@ -4111,6 +4656,8 @@ impl LiveQuotaFetcher for TestLiveExecutor {
         behavior.fetch_body_gates.remove(&call),
         behavior.pre_body_fetch_states.remove(&call),
         panic_now,
+        std::mem::take(&mut behavior.fail_next_fetch),
+        behavior.queued_snapshots.pop_front(),
       )
     };
     self.changed.notify_all();
@@ -4124,21 +4671,43 @@ impl LiveQuotaFetcher for TestLiveExecutor {
     if panic_now {
       panic!("intentional fetch panic");
     }
-    Ok(Self::snapshot())
+    if fail_now {
+      return Err("intentional live fetch failure".to_string());
+    }
+    Ok(
+      snapshot
+        .map(|snapshot| snapshot.as_ref().clone())
+        .unwrap_or_else(Self::snapshot),
+    )
+  }
+
+  fn fallback(&self) -> Option<LiveRateLimitSnapshot> {
+    self.fallback_calls.fetch_add(1, Ordering::AcqRel);
+    lock(&self.behavior)
+      .fallback_snapshot
+      .as_ref()
+      .map(|snapshot| snapshot.as_ref().clone())
   }
 }
 
 #[cfg(test)]
 impl LiveQuotaPersister for TestLiveExecutor {
-  fn persist(&self, _snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
+  fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
     let call = self.persist_calls.fetch_add(1, Ordering::AcqRel) + 1;
-    let (body_gate, panic_now) = {
+    let (body_gate, panic_now, fail_now) = {
       let mut behavior = lock(&self.behavior);
       behavior
         .persist_thread_ids
         .push(format!("{:?}", thread::current().id()));
       let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Persist);
-      (behavior.persist_body_gates.remove(&call), panic_now)
+      behavior
+        .persisted_fetched_at
+        .push(snapshot.fetched_at.clone());
+      (
+        behavior.persist_body_gates.remove(&call),
+        panic_now,
+        std::mem::take(&mut behavior.fail_next_persist),
+      )
     };
     self.changed.notify_all();
     if let Some(body_gate) = body_gate {
@@ -4146,6 +4715,9 @@ impl LiveQuotaPersister for TestLiveExecutor {
     }
     if panic_now {
       panic!("intentional persist panic");
+    }
+    if fail_now {
+      return Err("intentional persistence failure".to_string());
     }
     Ok(())
   }
@@ -4283,6 +4855,7 @@ struct RuntimeTestRig {
   handle: RefreshCoordinatorHandle,
   token: Arc<TestTokenExecutor>,
   live: Arc<TestLiveExecutor>,
+  live_cache: LiveQuotaCache,
   events: Arc<TestEvents>,
   mutation: UsageMutationCoordinator,
   activities: super::power::CountingActivityFactory,
@@ -4368,11 +4941,13 @@ impl RuntimeTestRig {
     let events = Arc::new(TestEvents::new(Arc::clone(&hooks)));
     let mutation = UsageMutationCoordinator::new();
     let activities = super::power::CountingActivityFactory::default();
+    let live_cache = LiveQuotaCache::new();
     let dependencies = RefreshRuntimeDependencies {
       config,
       token_executor: token.clone(),
       live_fetcher: live.clone(),
       live_persister: live.clone(),
+      live_cache: live_cache.clone(),
       event_sink: events.clone(),
       mutation: mutation.clone(),
       activity_factory: Arc::new(activities.clone()),
@@ -4387,6 +4962,7 @@ impl RuntimeTestRig {
       handle,
       token,
       live,
+      live_cache,
       events,
       mutation,
       activities,
@@ -4410,6 +4986,13 @@ impl RuntimeTestRig {
       let status = self.handle.status();
       !status.token.running && !status.live.running
     });
+  }
+
+  fn wait_for_persist_outcomes(&self, expected: u64, timeout: Duration) {
+    self
+      .runtime
+      .test_hooks
+      .wait_for(timeout, |data| data.persistence_outcomes >= expected);
   }
 
   fn shutdown(&self) {

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -751,6 +751,31 @@ mod tests {
   }
 
   #[test]
+  fn epoch_backfill_shutdown_publish_cancels_attempt_installed_across_race() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let (rig, before_install, shutdown_gap, between_install_and_send) =
+      RuntimeTestRig::build_with_maintenance_shutdown_install_gates(Arc::clone(&maintenance));
+    before_install.wait_worker_ready(TEST_TIMEOUT);
+
+    let shutdown = rig.shutdown_in_background();
+    shutdown_gap.wait_worker_ready(TEST_TIMEOUT);
+    before_install.release();
+    between_install_and_send.wait_worker_ready(TEST_TIMEOUT);
+    let was_cancelled_before_send = rig.maintenance_cancelled_between_install_and_send();
+    between_install_and_send.release();
+    shutdown_gap.release();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+    assert!(
+      was_cancelled_before_send,
+      "shutdown is visible and cancels the attempt before its command is sent"
+    );
+    assert_eq!(maintenance.calls(), 0, "shutdown enters no maintenance executor");
+  }
+
+  #[test]
   fn scheduled_start_lag_is_recorded() {
     let rig = RuntimeTestRig::scheduled_overdue(Duration::from_secs(2));
     rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
@@ -2456,13 +2481,15 @@ impl RefreshRuntime {
         }
         {
           let shutdown_state = lock(&self.lifecycle.state);
-          if let Some(control) = &self.lifecycle.maintenance_control {
-            control.cancel_current();
-          }
           self
             .lifecycle
             .shutdown_requested
             .store(true, Ordering::Release);
+          #[cfg(test)]
+          self.test_hooks.between_shutdown_publish_and_cancel();
+          if let Some(control) = &self.lifecycle.maintenance_control {
+            control.cancel_current();
+          }
           self.lifecycle.changed.notify_all();
           drop(shutdown_state);
         }
@@ -3681,6 +3708,8 @@ impl CoordinatorRuntime {
     if self.maintenance_wait(now) != Some(Duration::ZERO) {
       return;
     }
+    #[cfg(test)]
+    self.hooks.before_maintenance_install();
     let Some(sender) = self.maintenance_sender.clone() else {
       return;
     };
@@ -3691,6 +3720,16 @@ impl CoordinatorRuntime {
       return;
     };
     let cancellation = Arc::new(AtomicBool::new(false));
+    self
+      .maintenance_control
+      .install(attempt_id, Arc::clone(&cancellation));
+    if self.shutdown_requested.load(Ordering::Acquire) {
+      self.maintenance_control.cancel_current();
+    }
+    #[cfg(test)]
+    self
+      .hooks
+      .between_maintenance_install_and_send(&cancellation);
     let command = EpochMaintenanceWorkerCommand {
       attempt_id,
       cancellation: Arc::clone(&cancellation),
@@ -3699,19 +3738,18 @@ impl CoordinatorRuntime {
       Ok(()) => {
         self.maintenance.next_attempt_id = attempt_id;
         self.maintenance.next_eligible_at = None;
-        self
-          .maintenance_control
-          .install(attempt_id, Arc::clone(&cancellation));
         self.maintenance.running = Some(EpochMaintenanceAttempt { id: attempt_id });
         if self.shutdown_requested.load(Ordering::Acquire) {
           self.maintenance_control.cancel_current();
         }
       }
       Err(TrySendError::Full(_)) => {
+        self.maintenance_control.clear(attempt_id);
         log::warn!("Epoch maintenance command queue was unexpectedly full.");
         self.maintenance.next_eligible_at = now.checked_add(EPOCH_MAINTENANCE_PACE);
       }
       Err(TrySendError::Disconnected(_)) => {
+        self.maintenance_control.clear(attempt_id);
         log::warn!("Epoch maintenance worker became unavailable.");
         self.maintenance.pending = false;
         self.maintenance_sender = None;
@@ -4845,6 +4883,7 @@ struct TestHookData {
   persistence_outcomes: u64,
   maintenance_outcomes: u64,
   maintenance_exited: bool,
+  maintenance_cancelled_between_install_and_send: Option<bool>,
 }
 
 #[cfg(test)]
@@ -4854,6 +4893,9 @@ struct RuntimeTestHooks {
   token_commit_pre_body: IndexedPreBodyGates,
   live_fetch_pre_body: IndexedPreBodyGates,
   live_persist_pre_body: IndexedPreBodyGates,
+  maintenance_before_install: Mutex<Option<Arc<TestGateState>>>,
+  shutdown_between_publish_and_cancel: Mutex<Option<Arc<TestGateState>>>,
+  maintenance_between_install_and_send: Mutex<Option<Arc<TestGateState>>>,
   data: Mutex<TestHookData>,
   changed: Condvar,
 }
@@ -4874,6 +4916,45 @@ impl RuntimeTestHooks {
 
   fn before_live_persist(&self) {
     self.live_persist_pre_body.before_call();
+  }
+
+  fn block_maintenance_before_install(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    *lock(&self.maintenance_before_install) = Some(Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn before_maintenance_install(&self) {
+    if let Some(gate) = lock(&self.maintenance_before_install).take() {
+      gate.mark_worker_ready_and_wait();
+    }
+  }
+
+  fn block_shutdown_between_publish_and_cancel(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    *lock(&self.shutdown_between_publish_and_cancel) = Some(Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn between_shutdown_publish_and_cancel(&self) {
+    if let Some(gate) = lock(&self.shutdown_between_publish_and_cancel).take() {
+      gate.mark_worker_ready_and_wait();
+    }
+  }
+
+  fn block_between_maintenance_install_and_send(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    *lock(&self.maintenance_between_install_and_send) = Some(Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn between_maintenance_install_and_send(&self, cancellation: &AtomicBool) {
+    lock(&self.data).maintenance_cancelled_between_install_and_send =
+      Some(cancellation.load(Ordering::Acquire));
+    self.changed.notify_all();
+    if let Some(gate) = lock(&self.maintenance_between_install_and_send).take() {
+      gate.mark_worker_ready_and_wait();
+    }
   }
 
   fn notify_token_waiting_to_commit(&self) {
@@ -6019,6 +6100,36 @@ impl RuntimeTestRig {
     )
   }
 
+  fn build_with_maintenance_shutdown_install_gates(
+    maintenance: Arc<TestEpochMaintenanceExecutor>,
+  ) -> (
+    Self,
+    PhaseGateControl,
+    PhaseGateControl,
+    PhaseGateControl,
+  ) {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let before_install = hooks.block_maintenance_before_install();
+    let shutdown_gap = hooks.block_shutdown_between_publish_and_cancel();
+    let between_install_and_send = hooks.block_between_maintenance_install_and_send();
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    (
+      Self::build_with_components_and_options(
+        TestRigSchedule::Disabled,
+        hooks,
+        token,
+        live,
+        Some(maintenance),
+        None,
+      ),
+      before_install,
+      shutdown_gap,
+      between_install_and_send,
+    )
+  }
+
   fn build_with_maintenance_and_mutation(
     schedule: TestRigSchedule,
     maintenance: Arc<TestEpochMaintenanceExecutor>,
@@ -6154,6 +6265,12 @@ impl RuntimeTestRig {
       .runtime
       .test_hooks
       .wait_for(timeout, |data| data.maintenance_exited);
+  }
+
+  fn maintenance_cancelled_between_install_and_send(&self) -> bool {
+    lock(&self.runtime.test_hooks.data)
+      .maintenance_cancelled_between_install_and_send
+      .expect("recorded maintenance install/send cancellation state")
   }
 
   fn wait_for_mutation_queue(&self, expected: usize, timeout: Duration) {

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -1,0 +1,4742 @@
+#[cfg(test)]
+mod tests {
+  use super::{
+    MetricsState, PanicPhase, RefreshClock, RefreshConfig, RefreshError, RefreshStatus,
+    RuntimeTestRig, SaturatingCounter, TestClock,
+  };
+  use crate::refresh::{RefreshFailureCode, RefreshRejectionCode, REFRESH_WAITER_CAPACITY};
+  use chrono::{DateTime, Duration as ChronoDuration};
+  use std::sync::Arc;
+  use std::time::Duration;
+
+  const TEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+  #[test]
+  fn token_worker_does_not_delay_live_worker_start() {
+    let rig = RuntimeTestRig::disabled();
+    let parse = rig.token.block_next_parse();
+    let fetch = rig.live.block_next_fetch();
+    let token_ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+
+    let live_ticket = rig.handle.request_manual_live().expect("live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.token.parse_calls(), 1);
+    assert_eq!(rig.live.fetch_calls(), 1);
+
+    fetch.release();
+    parse.release();
+    assert!(token_ticket.wait().is_ok());
+    assert!(live_ticket.wait().is_ok());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn concurrent_live_callers_share_one_executor_generation() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let first = rig.handle.request_manual_live().expect("first live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    let second = rig
+      .handle
+      .request_manual_live()
+      .expect("second live ticket");
+
+    fetch.release();
+    let first = first.wait().expect("first live result");
+    let second = second.wait().expect("second live result");
+    assert!(Arc::ptr_eq(&first, &second));
+    assert_eq!(rig.live.fetch_calls(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn active_live_children_never_exceeds_one() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let first = rig.handle.request_manual_live().expect("first live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    let mut joined = Vec::new();
+    for _ in 1..REFRESH_WAITER_CAPACITY {
+      joined.push(
+        rig
+          .handle
+          .request_manual_live()
+          .expect("joined live ticket"),
+      );
+    }
+
+    assert_eq!(rig.metrics().live.active_executor_count, 1);
+    assert_eq!(rig.live.maximum_active_fetches(), 1);
+    fetch.release();
+    assert!(first.wait_timeout(TEST_TIMEOUT).is_ok());
+    for ticket in joined {
+      assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    }
+    assert_eq!(rig.metrics().live.active_executor_count, 0);
+    assert_eq!(rig.live.maximum_active_fetches(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn startup_status_is_busy_before_worker_body_runs() {
+    let (rig, parse, fetch) = RuntimeTestRig::startup_due_with_pre_body_gates();
+    parse.wait_worker_ready(TEST_TIMEOUT);
+    fetch.wait_worker_ready(TEST_TIMEOUT);
+
+    let status = rig.handle.status();
+    assert!(status.token.running);
+    assert!(status.live.running);
+    assert_eq!(status.token.generation, Some(1));
+    assert_eq!(status.live.generation, Some(1));
+    assert_eq!(status.mutation_phase, Some(super::MutationPhase::Parsing));
+    assert_eq!(rig.token.parse_calls(), 0, "executor body has not entered");
+    assert_eq!(rig.live.fetch_calls(), 0, "executor body has not entered");
+
+    rig.clock.advance(Duration::from_secs(7));
+    parse.release();
+    fetch.release();
+    parse.wait_entered(TEST_TIMEOUT);
+    fetch.wait_entered(TEST_TIMEOUT);
+    rig.wait_until_idle(TEST_TIMEOUT);
+    let metrics = rig.metrics();
+    assert!(metrics.token.lane.start_lag_ms > 5_000);
+    assert!(metrics.live.lane.start_lag_ms > 5_000);
+    assert_eq!(metrics.start_lag_warning_count, 2);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn completion_services_one_pending_follow_up() {
+    let rig = RuntimeTestRig::disabled();
+    let first_parse = rig.token.block_next_parse();
+    let follow_up_parse = rig.token.block_parse_call(2);
+    let first = rig
+      .handle
+      .request_manual_token(None)
+      .expect("first token ticket");
+    first_parse.wait_entered(TEST_TIMEOUT);
+    let follow_up = rig
+      .handle
+      .request_manual_token(None)
+      .expect("follow-up token ticket");
+    first_parse.release();
+
+    follow_up_parse.wait_worker_ready(TEST_TIMEOUT);
+    assert!(
+      first.wait_timeout(TEST_TIMEOUT).is_ok(),
+      "first waiter resolves before follow-up body"
+    );
+    assert_eq!(
+      rig.events.trace_prefix(),
+      [
+        "token_invalidation",
+        "token_completion",
+        "token_waiter_reply",
+        "token_follow_up_start"
+      ]
+    );
+    assert!(rig.current_completion_slots_are_empty());
+    follow_up_parse.release();
+    assert!(follow_up.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.token.wait_for_parse_calls(2, TEST_TIMEOUT);
+    assert_eq!(rig.token.parse_calls(), 2);
+    assert_eq!(rig.token.commit_calls(), 2);
+    assert!(!rig.handle.status().token.pending);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn successful_token_waiter_receives_exact_scan_result() {
+    let rig = RuntimeTestRig::disabled();
+    let first_parse = rig.token.block_next_parse();
+    let first = rig
+      .handle
+      .request_manual_token(None)
+      .expect("first token ticket");
+    first_parse.wait_entered(TEST_TIMEOUT);
+    let follow_up_one = rig
+      .handle
+      .request_manual_token(None)
+      .expect("first follow-up ticket");
+    let follow_up_two = rig
+      .handle
+      .request_manual_token(None)
+      .expect("second follow-up ticket");
+    first_parse.release();
+
+    let first = first
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("first generation result");
+    let follow_up_one = follow_up_one
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("first follow-up result");
+    let follow_up_two = follow_up_two
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("second follow-up result");
+    let produced = rig.token.committed_arc(2, TEST_TIMEOUT);
+    assert!(!Arc::ptr_eq(&first, &follow_up_one));
+    assert!(Arc::ptr_eq(&follow_up_one, &follow_up_two));
+    assert!(Arc::ptr_eq(&follow_up_one, &produced));
+    rig.token.assert_result_for_generation(&follow_up_one, 2);
+    assert_eq!(rig.token.commit_calls(), 2);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn successful_live_waiters_receive_exact_same_snapshot() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let first = rig.handle.request_manual_live().expect("first live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    let second = rig
+      .handle
+      .request_manual_live()
+      .expect("second live ticket");
+    fetch.release();
+
+    let first = first.wait().expect("first snapshot");
+    let second = second.wait().expect("second snapshot");
+    let produced = rig.live.fetched_arc(1, TEST_TIMEOUT);
+    assert!(Arc::ptr_eq(&first, &second));
+    assert!(Arc::ptr_eq(&first, &produced));
+    assert!(rig.current_completion_slots_are_empty());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn prepared_discard_drops_spool_before_follow_up() {
+    let rig = RuntimeTestRig::disabled();
+    let parse = rig.token.block_next_spooled_parse_with_drop_probe();
+    rig
+      .token
+      .assert_probe_dropped_before_next_parse(parse.probe());
+    let first = rig
+      .handle
+      .request_manual_token(None)
+      .expect("first token ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+    rig
+      .handle
+      .update_settings(rig.config_with_source("replacement"))
+      .expect("source update");
+    parse.release();
+
+    rig.token.wait_for_parse_calls(2, TEST_TIMEOUT);
+    parse.wait_dropped(TEST_TIMEOUT);
+    assert!(parse.used_spool());
+    assert!(rig.token.follow_up_observed_probe_dropped());
+    assert!(matches!(
+      first.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::SourceChanged,
+        ..
+      })
+    ));
+    rig.shutdown();
+  }
+
+  #[test]
+  fn parse_panic_becomes_failure_and_worker_recovers() {
+    let rig = RuntimeTestRig::disabled();
+    rig.token.panic_once(PanicPhase::Parse);
+    let failed = rig
+      .handle
+      .request_manual_token(None)
+      .expect("failed token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      failed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::WorkerPanicked,
+        ..
+      })
+    ));
+    assert_eq!(
+      rig.handle.status().mutation_phase,
+      Some(super::MutationPhase::Failed)
+    );
+    assert!(!rig.handle.status().token.running);
+
+    let recovered = rig
+      .handle
+      .request_manual_token(None)
+      .expect("recovery token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(recovered.is_ok());
+    assert_eq!(rig.token.parse_calls(), 2);
+    assert_eq!(rig.token.unique_parse_worker_ids(), 1);
+    assert_eq!(rig.token.worker_name(), "codex-pacer-refresh-token");
+    assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn commit_panic_becomes_failure_and_worker_recovers() {
+    let rig = RuntimeTestRig::disabled();
+    rig.token.panic_once(PanicPhase::Commit);
+    let failed = rig
+      .handle
+      .request_manual_token(None)
+      .expect("failed token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      failed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::WorkerPanicked,
+        ..
+      })
+    ));
+
+    assert!(rig
+      .handle
+      .request_manual_token(None)
+      .expect("recovery token ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(rig.token.commit_calls(), 2);
+    assert_eq!(rig.token.unique_commit_worker_ids(), 1);
+    assert_eq!(rig.token.worker_name(), "codex-pacer-refresh-token");
+    assert_eq!(rig.activities.active(), 0);
+    assert!(rig.mutation_slot_is_free());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn fetch_panic_becomes_failure_and_worker_recovers() {
+    let rig = RuntimeTestRig::disabled();
+    rig.live.panic_once(PanicPhase::Fetch);
+    let failed = rig
+      .handle
+      .request_manual_live()
+      .expect("failed live ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      failed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::WorkerPanicked,
+        ..
+      })
+    ));
+
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("recovery live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(rig.live.fetch_calls(), 2);
+    assert_eq!(rig.live.unique_fetch_worker_ids(), 1);
+    assert_eq!(rig.live.worker_name(), "codex-pacer-refresh-live");
+    assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn persist_panic_becomes_failure_and_worker_recovers() {
+    let rig = RuntimeTestRig::disabled();
+    rig.live.panic_once(PanicPhase::Persist);
+    let failed = rig
+      .handle
+      .request_manual_live()
+      .expect("failed live ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      failed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::WorkerPanicked,
+        ..
+      })
+    ));
+
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("recovery live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(rig.live.persist_calls(), 2);
+    assert_eq!(rig.live.unique_persist_worker_ids(), 1);
+    assert_eq!(rig.live.worker_name(), "codex-pacer-refresh-live");
+    assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn disabled_scheduler_runs_manual_requests() {
+    let rig = RuntimeTestRig::disabled();
+    assert!(!rig.handle.status().auto_scan_enabled);
+
+    let token = rig.handle.request_manual_token(None).expect("token ticket");
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    assert!(token.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.token.commit_calls(), 1);
+    assert_eq!(rig.live.persist_calls(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn scheduled_start_lag_is_recorded() {
+    let rig = RuntimeTestRig::scheduled_overdue(Duration::from_secs(2));
+    rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
+    rig.live.wait_for_fetch_calls(1, TEST_TIMEOUT);
+    rig.wait_until_idle(TEST_TIMEOUT);
+
+    let metrics = rig.metrics();
+    assert!(metrics.token.lane.scheduled_due_at.is_some());
+    assert!(metrics.live.lane.scheduled_due_at.is_some());
+    assert!(metrics.token.lane.started_at.is_some());
+    assert!(metrics.live.lane.started_at.is_some());
+    assert!(metrics.token.lane.start_lag_ms >= 1_000);
+    assert!(metrics.live.lane.start_lag_ms >= 1_000);
+    assert_eq!(metrics.start_lag_histogram.iter().sum::<u64>(), 2);
+    assert!(metrics.token.lane.duration_ms > 0);
+    assert!(metrics.live.lane.duration_ms > 0);
+    assert!(metrics.token.lane.last_success_age_ms.is_some());
+    assert!(metrics.live.lane.last_success_age_ms.is_some());
+    assert_eq!(metrics.token.lane.failure_streak, 0);
+    assert_eq!(metrics.live.lane.failure_streak, 0);
+    assert!(metrics.token.lane.retry_at.is_none());
+    assert!(metrics.live.lane.retry_at.is_none());
+    assert_eq!(metrics.token.lane.running_generation, None);
+    assert_eq!(metrics.live.lane.running_generation, None);
+    assert_eq!(metrics.token.lane.pending_reasons, 0);
+    assert_eq!(metrics.live.lane.pending_reasons, 0);
+    assert_eq!(metrics.token.append_fast_path_count, 0);
+    assert!(metrics.token.files_visited > 0);
+    assert!(metrics.token.bytes_read > 0);
+    assert!(metrics.token.full_rebuild_count > 0);
+    assert!(metrics.token.commit_wait_ms <= metrics.token.lane.duration_ms);
+    assert_eq!(metrics.token.database_busy_count, 0);
+    assert_eq!(metrics.live.last_query_timeout_ms, 10_000);
+    assert!(metrics.live.app_server_duration_ms > 0);
+    assert_eq!(metrics.live.timeout_count, 0);
+    assert_eq!(metrics.live.active_executor_count, 0);
+    assert_eq!(metrics.live.waiter_count, 0);
+    assert!(metrics.live.fallback_age_ms.is_none());
+    assert!(rig.handle.status().token.next_due_at.is_some());
+    assert!(rig.handle.status().live.next_due_at.is_some());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn start_lag_above_five_seconds_warns() {
+    let rig = RuntimeTestRig::scheduled_overdue(Duration::from_secs(7));
+    rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
+    rig.live.wait_for_fetch_calls(1, TEST_TIMEOUT);
+    rig.wait_until_idle(TEST_TIMEOUT);
+
+    let metrics = rig.metrics();
+    assert!(metrics.token.lane.start_lag_ms > 5_000);
+    assert!(metrics.live.lane.start_lag_ms > 5_000);
+    assert_eq!(metrics.start_lag_warning_count, 2);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn resume_starts_overdue_lanes_within_five_seconds() {
+    let rig = RuntimeTestRig::paused_clock();
+    rig.clock.advance(Duration::from_secs(61));
+    rig.handle.wake().expect("wake command");
+    rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
+    rig.live.wait_for_fetch_calls(1, TEST_TIMEOUT);
+
+    let metrics = rig.metrics();
+    assert!(metrics.token.lane.start_lag_ms <= 5_000);
+    assert!(metrics.live.lane.start_lag_ms <= 5_000);
+    rig.wait_until_idle(TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn token_parse_runs_before_usage_commit_lock() {
+    let rig = RuntimeTestRig::disabled();
+    let mutation = rig.hold_mutation_slot();
+    let parse = rig.token.block_next_parse();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+
+    parse.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.token.parse_calls(), 1);
+    assert_eq!(rig.token.commit_calls(), 0);
+    parse.release();
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+    assert_eq!(rig.token.commit_calls(), 0);
+    mutation.release();
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn held_usage_commit_lock_does_not_delay_live_lane() {
+    let rig = RuntimeTestRig::disabled();
+    let mutation = rig.hold_mutation_slot();
+    let token = rig.handle.request_manual_token(None).expect("token ticket");
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+
+    let fetch = rig.live.block_next_fetch();
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.live.fetch_calls(), 1);
+    assert_eq!(rig.token.commit_calls(), 0);
+    fetch.release();
+    assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+
+    mutation.release();
+    assert!(token.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn source_change_while_waiting_skips_token_commit() {
+    let rig = RuntimeTestRig::disabled();
+    let mutation = rig.hold_mutation_slot();
+    let old = rig.token.use_spooled_prepared_for_next_parse();
+    let replacement = rig.token.block_parse_call(2);
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+    rig
+      .handle
+      .update_settings(rig.config_with_source("replacement"))
+      .expect("source update");
+
+    mutation.release();
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::SourceChanged,
+        ..
+      })
+    ));
+    assert_eq!(rig.token.commit_calls(), 0);
+    old.wait_dropped(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 0);
+    replacement.wait_worker_ready(TEST_TIMEOUT);
+    replacement.release();
+    rig.token.wait_for_commit_calls(1, TEST_TIMEOUT);
+    assert_eq!(rig.token.commit_calls_for_source("replacement"), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn missing_or_mismatched_prepared_slot_fails_without_hang() {
+    let rig = RuntimeTestRig::disabled();
+    rig.token.omit_prepared_payload_once();
+    let missing = rig
+      .handle
+      .request_manual_token(None)
+      .expect("missing token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      missing,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::PreparedPayloadMissing,
+        ..
+      })
+    ));
+    assert!(!rig.handle.status().token.running);
+
+    rig.token.return_mismatched_prepared_once();
+    let malformed = rig
+      .handle
+      .request_manual_token(None)
+      .expect("malformed token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      malformed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::PreparedPayloadMissing,
+        ..
+      })
+    ));
+    assert!(!rig.handle.status().token.running);
+
+    assert!(rig
+      .handle
+      .request_manual_token(None)
+      .expect("recovery token ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(rig.token.commit_calls(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn duplicate_worker_outcome_is_ignored() {
+    let rig = RuntimeTestRig::disabled();
+    let first = rig
+      .handle
+      .request_manual_token(None)
+      .expect("token ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("token result");
+    let completions = rig.events.completion_count();
+    rig.inject_duplicate_prepared_after_take(1);
+    rig.inject_duplicate_token_completion(1, Arc::clone(&first));
+    let next_parse = rig.token.block_parse_call(2);
+    let next = rig
+      .handle
+      .request_manual_token(None)
+      .expect("next token ticket");
+    next_parse.wait_worker_ready(TEST_TIMEOUT);
+    rig.inject_duplicate_token_completion(1, Arc::clone(&first));
+    rig.handle.barrier().expect("coordinator barrier");
+
+    assert_eq!(rig.events.completion_count(), completions);
+    assert_eq!(rig.handle.status().token.generation, Some(2));
+    next_parse.release();
+    assert!(next.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn waiter_and_command_capacity_are_bounded() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let mut tickets = Vec::new();
+    tickets.push(rig.handle.request_manual_live().expect("first live ticket"));
+    fetch.wait_entered(TEST_TIMEOUT);
+    for _ in 1..REFRESH_WAITER_CAPACITY {
+      tickets.push(
+        rig
+          .handle
+          .request_manual_live()
+          .expect("bounded live ticket"),
+      );
+    }
+    assert!(matches!(
+      rig.handle.request_manual_live(),
+      Err(RefreshError::Busy)
+    ));
+    assert_eq!(
+      rig.metrics().live.waiter_count,
+      REFRESH_WAITER_CAPACITY as u64
+    );
+
+    let parse = rig.token.block_next_parse();
+    let active_token = rig
+      .handle
+      .request_manual_token(None)
+      .expect("active token ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+    let mut token_tickets = Vec::new();
+    for _ in 1..REFRESH_WAITER_CAPACITY {
+      match rig.handle.request_manual_token(None) {
+        Ok(ticket) => token_tickets.push(ticket),
+        Err(RefreshError::Busy) => break,
+        Err(error) => panic!("unexpected token capacity error: {error:?}"),
+      }
+    }
+    assert_eq!(token_tickets.len(), REFRESH_WAITER_CAPACITY - 1);
+    assert!(matches!(
+      rig.handle.request_manual_token(None),
+      Err(RefreshError::Busy)
+    ));
+    assert_eq!(rig.token_schedule_waiter_count(), REFRESH_WAITER_CAPACITY);
+
+    let pause = rig.pause_coordinator();
+    for _ in 0..super::RUNTIME_COMMAND_CAPACITY {
+      rig.handle.try_wake().expect("bounded command slot");
+    }
+    assert!(matches!(rig.handle.try_wake(), Err(RefreshError::Busy)));
+    pause.release();
+
+    fetch.release();
+    for ticket in tickets {
+      assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    }
+    parse.release();
+    assert!(active_token.wait_timeout(TEST_TIMEOUT).is_ok());
+    for ticket in token_tickets {
+      assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    }
+    assert!(
+      rig.handle.request_manual_live().is_ok(),
+      "live capacity recovers"
+    );
+    assert!(
+      rig.handle.request_manual_token(None).is_ok(),
+      "token capacity recovers"
+    );
+    rig.shutdown();
+  }
+
+  #[test]
+  fn fixed_counters_saturate_without_wrap() {
+    let counter = SaturatingCounter::new(u64::MAX - 1);
+    counter.increment();
+    counter.increment();
+    assert_eq!(counter.load(), u64::MAX);
+
+    let rig = RuntimeTestRig::disabled();
+    rig.metrics_handle.set_warning_count_for_test(u64::MAX - 1);
+    rig
+      .metrics_handle
+      .set_start_lag_bucket_for_test(super::HISTOGRAM_BUCKETS - 2, u64::MAX - 1);
+    rig.metrics_handle.record_start_lag(Duration::from_secs(6));
+    rig.metrics_handle.record_start_lag(Duration::from_secs(6));
+    let metrics = rig.metrics();
+    assert_eq!(metrics.start_lag_warning_count, u64::MAX);
+    assert_eq!(metrics.start_lag_histogram.len(), super::HISTOGRAM_BUCKETS);
+    assert_eq!(
+      metrics.start_lag_histogram[super::HISTOGRAM_BUCKETS - 2],
+      u64::MAX
+    );
+    rig.shutdown();
+  }
+
+  #[test]
+  fn coordinator_shutdown_resolves_waiters() {
+    let rig = RuntimeTestRig::disabled();
+    let parse = rig.token.block_next_parse();
+    let fetch = rig.live.block_next_fetch();
+    let token = rig.handle.request_manual_token(None).expect("token ticket");
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+    fetch.wait_entered(TEST_TIMEOUT);
+
+    let pause = rig.pause_coordinator();
+    for _ in 0..(super::RUNTIME_COMMAND_CAPACITY - 1) {
+      rig.handle.try_wake().expect("reserve final command slot");
+    }
+    let race = rig.start_intake_race_after_accept_check();
+    race.wait_checked(TEST_TIMEOUT);
+    let shutdown = rig.shutdown_in_background();
+    race.release();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    parse.release();
+    fetch.release();
+    pause.release();
+    assert!(matches!(
+      token.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    assert!(matches!(
+      live.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    assert!(matches!(
+      rig.handle.request_manual_live(),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    assert!(matches!(
+      race.wait_result(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+  }
+
+  #[test]
+  fn shutdown_during_parse_wait_drops_prepared() {
+    let rig = RuntimeTestRig::disabled();
+    let parse = rig.token.block_next_spooled_parse_with_drop_probe();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+    let shutdown = rig.shutdown_in_background();
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+
+    parse.release();
+    parse.wait_dropped(TEST_TIMEOUT);
+    assert!(parse.used_spool());
+    shutdown.wait(TEST_TIMEOUT);
+    assert_eq!(rig.token.commit_calls(), 0);
+  }
+
+  #[test]
+  fn shutdown_with_prepared_slot_drops_spool() {
+    let rig = RuntimeTestRig::disabled();
+    let prepared = rig.install_spooled_prepared_slot_via_coordinator();
+    assert!(prepared.used_spool());
+
+    let shutdown = rig.runtime.shutdown_and_join().expect("shutdown");
+    prepared.wait_dropped(TEST_TIMEOUT);
+    assert!(shutdown.token_joined && shutdown.live_joined && shutdown.coordinator_joined);
+    assert!(rig.prepared_slot_is_empty_via_coordinator());
+  }
+
+  #[test]
+  fn shutdown_during_commit_queue_skips_commit_and_joins() {
+    let rig = RuntimeTestRig::disabled();
+    let mutation = rig.hold_mutation_slot();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+
+    let shutdown = rig.shutdown_in_background();
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    mutation.release();
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.token_joined && joined.live_joined && joined.coordinator_joined);
+    assert_eq!(rig.token.commit_calls(), 0);
+  }
+
+  #[test]
+  fn shutdown_is_idempotent_and_joins_all_threads() {
+    let rig = RuntimeTestRig::disabled();
+    let first = rig.runtime.shutdown_and_join().expect("first shutdown");
+    let second = rig.runtime.shutdown_and_join().expect("second shutdown");
+
+    assert!(Arc::ptr_eq(&first, &second));
+    assert!(first.token_joined && first.live_joined && first.coordinator_joined);
+    assert_eq!(
+      rig.thread_names(),
+      [
+        "codex-pacer-refresh-coordinator",
+        "codex-pacer-refresh-live",
+        "codex-pacer-refresh-token",
+      ]
+    );
+  }
+
+  #[test]
+  fn shutdown_during_live_fetch_joins_after_bounded_completion() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    assert_eq!(
+      rig.live.last_timeout(),
+      Some(crate::refresh::LIVE_QUERY_TIMEOUT)
+    );
+
+    let shutdown = rig.shutdown_in_background();
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    assert!(
+      !shutdown.is_finished(),
+      "join waits for bounded in-flight fetch"
+    );
+    fetch.release();
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.live_joined && joined.token_joined && joined.coordinator_joined);
+    assert_eq!(rig.live.persist_calls(), 0);
+  }
+
+  #[test]
+  fn source_change_during_commit_is_not_published_as_success() {
+    let rig = RuntimeTestRig::disabled();
+    let commit = rig.token.block_next_commit();
+    let replacement = rig.token.block_parse_call(2);
+    let previous_success = rig.handle.status().token.last_success_at;
+    let invalidations = rig.events.invalidation_count();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    commit.wait_entered(TEST_TIMEOUT);
+    rig
+      .handle
+      .update_settings(rig.config_with_source("replacement"))
+      .expect("source update during commit");
+    commit.release();
+
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::SourceChanged,
+        ..
+      })
+    ));
+    replacement.wait_worker_ready(TEST_TIMEOUT);
+    assert_eq!(rig.events.invalidation_count(), invalidations);
+    assert_eq!(rig.handle.status().token.last_success_at, previous_success);
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    replacement.release();
+    shutdown.wait(TEST_TIMEOUT);
+  }
+
+  #[test]
+  fn source_change_during_live_persist_is_not_published_as_success() {
+    let rig = RuntimeTestRig::disabled();
+    let persist = rig.live.block_next_persist();
+    let replacement = rig.token.block_parse_call(1);
+    let previous_success = rig.handle.status().live.last_success_at;
+    let invalidations = rig.events.invalidation_count();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+    persist.wait_entered(TEST_TIMEOUT);
+    rig
+      .handle
+      .update_settings(rig.config_with_source("replacement"))
+      .expect("source update during persistence");
+    persist.release();
+
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::SourceChanged,
+        ..
+      })
+    ));
+    replacement.wait_worker_ready(TEST_TIMEOUT);
+    assert_eq!(rig.events.invalidation_count(), invalidations);
+    assert_eq!(rig.handle.status().live.last_success_at, previous_success);
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    replacement.release();
+    shutdown.wait(TEST_TIMEOUT);
+  }
+
+  #[test]
+  fn persisted_success_age_survives_short_monotonic_uptime() {
+    let clock = TestClock::new();
+    let success = clock.wall_now() - ChronoDuration::hours(24);
+    let config = RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(60),
+      codex_home: None,
+      token_last_success_wall: Some(success),
+      live_last_success_wall: Some(success),
+    };
+    let status = RefreshStatus::new(&config);
+    assert_eq!(status.token.last_success_at, Some(success.to_rfc3339()));
+    assert_eq!(status.live.last_success_at, Some(success.to_rfc3339()));
+    let metrics = MetricsState::new(&config, &clock);
+    let first = metrics.snapshot(0, clock.monotonic_now());
+    assert!(first.token.lane.last_success_age_ms.unwrap() >= 86_400_000);
+    clock.advance(Duration::from_secs(2));
+    let second = metrics.snapshot(0, clock.monotonic_now());
+    assert!(
+      second.token.lane.last_success_age_ms.unwrap()
+        >= first.token.lane.last_success_age_ms.unwrap() + 2_000
+    );
+  }
+
+  #[test]
+  fn extreme_interval_status_timestamp_is_clamped_without_panic() {
+    let rig = RuntimeTestRig::huge_interval();
+    let status = rig.handle.status();
+    assert!(status.token.next_due_at.is_some());
+    assert!(status.live.next_due_at.is_some());
+    DateTime::parse_from_rfc3339(status.token.next_due_at.as_deref().unwrap())
+      .expect("clamped token deadline is RFC3339");
+    DateTime::parse_from_rfc3339(status.live.next_due_at.as_deref().unwrap())
+      .expect("clamped live deadline is RFC3339");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn activity_guard_excludes_wait_and_queue_time() {
+    let rig = RuntimeTestRig::disabled();
+    assert_eq!(rig.activities.active(), 0, "idle coordinator owns no guard");
+    let mutation = rig.hold_mutation_slot();
+    let parse = rig.token.block_next_parse();
+    let commit = rig.token.block_next_commit();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+
+    parse.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 1, "parse body owns one guard");
+    parse.release();
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 0, "mutation wait owns no guard");
+
+    mutation.release();
+    commit.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 1, "commit body owns one guard");
+    commit.release();
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.activities.active(), 0);
+
+    let fetch = rig.live.block_next_fetch();
+    let persist = rig.live.block_next_persist();
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 1, "fetch body owns one guard");
+    fetch.release();
+    persist.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 1, "persist body owns one guard");
+    persist.release();
+    assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+}
+use super::power::{ActivityFactory, SystemActivityFactory};
+use super::{
+  CommitMarker, CoordinatorAction, CoordinatorEvent, CoordinatorState, DisplayInvalidation,
+  ExecutionCompletion, LiveExecutionRequest, LiveRequest, LiveWaiterId, MutationPriority,
+  RefreshCompletedEvent, RefreshConfig, RefreshDetail, RefreshFailureCode, RefreshRejectionCode,
+  RefreshWaiterOutcome, TokenExecutionRequest, TokenRequest, TokenWaiterId,
+  UsageMutationCoordinator, LIVE_QUERY_TIMEOUT, REFRESH_WAITER_CAPACITY,
+};
+use crate::importer::{PreparedScan, PreparedScanStats};
+use crate::models::{LiveRateLimitSnapshot, ScanResult};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use std::array;
+use std::collections::HashMap;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, SyncSender, TrySendError};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+pub(crate) const RUNTIME_COMMAND_CAPACITY: usize = REFRESH_WAITER_CAPACITY;
+const WORKER_COMMAND_CAPACITY: usize = 1;
+pub(crate) const HISTOGRAM_BUCKETS: usize = 8;
+const START_LAG_WARNING: Duration = Duration::from_secs(5);
+const HISTOGRAM_UPPER_BOUNDS_MS: [u64; HISTOGRAM_BUCKETS] =
+  [0, 10, 100, 500, 1_000, 5_000, 30_000, u64::MAX];
+
+pub(crate) trait TokenRefreshExecutor: Send + Sync {
+  fn parse(&self, request: TokenExecutionRequest) -> Result<PreparedTokenRefresh, String>;
+  fn commit(&self, prepared: PreparedTokenRefresh) -> Result<ScanResult, String>;
+}
+
+pub(crate) struct PreparedTokenRefresh {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub started_at: DateTime<Utc>,
+  pub prepared_scan: PreparedScan,
+  #[cfg(test)]
+  drop_probe: Option<TestPreparedDropProbe>,
+  #[cfg(test)]
+  omit_payload: bool,
+}
+
+pub(crate) trait LiveQuotaFetcher: Send + Sync {
+  fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String>;
+
+  fn fallback(&self) -> Option<LiveRateLimitSnapshot> {
+    None
+  }
+}
+
+pub(crate) trait LiveQuotaPersister: Send + Sync {
+  fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String>;
+}
+
+pub(crate) trait RefreshEventSink: Send + Sync {
+  fn publish_invalidation(&self, value: DisplayInvalidation);
+  fn publish_completion(&self, value: RefreshCompletedEvent);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MutationPhase {
+  Queued,
+  Parsing,
+  WaitingToCommit,
+  Committed,
+  Failed,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LaneStatus {
+  pub running: bool,
+  pub generation: Option<u64>,
+  pub pending: bool,
+  pub last_success_at: Option<String>,
+  pub next_due_at: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshStatus {
+  pub token: LaneStatus,
+  pub live: LaneStatus,
+  pub mutation_phase: Option<MutationPhase>,
+  pub source_generation: u64,
+  pub auto_scan_enabled: bool,
+}
+
+impl RefreshStatus {
+  fn new(config: &RefreshConfig) -> Self {
+    let token = LaneStatus {
+      running: false,
+      generation: None,
+      pending: false,
+      last_success_at: config
+        .token_last_success_wall
+        .map(|value| value.to_rfc3339()),
+      next_due_at: None,
+    };
+    let live = LaneStatus {
+      last_success_at: config
+        .live_last_success_wall
+        .map(|value| value.to_rfc3339()),
+      ..token.clone()
+    };
+    Self {
+      token,
+      live,
+      mutation_phase: None,
+      source_generation: 0,
+      auto_scan_enabled: config.auto_scan_enabled,
+    }
+  }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RefreshLaneMetrics {
+  pub scheduled_due_at: Option<String>,
+  pub started_at: Option<String>,
+  pub start_lag_ms: u64,
+  pub duration_ms: u64,
+  pub last_success_age_ms: Option<u64>,
+  pub failure_streak: u32,
+  pub retry_at: Option<String>,
+  pub missed_deadline_count: u64,
+  pub coalesced_trigger_count: u64,
+  pub running_generation: Option<u64>,
+  pub pending_reasons: u8,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct TokenRefreshMetrics {
+  pub lane: RefreshLaneMetrics,
+  pub files_visited: u64,
+  pub bytes_read: u64,
+  pub append_fast_path_count: u64,
+  pub full_rebuild_count: u64,
+  pub commit_wait_ms: u64,
+  pub database_busy_count: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct LiveRefreshMetrics {
+  pub lane: RefreshLaneMetrics,
+  pub app_server_duration_ms: u64,
+  pub last_query_timeout_ms: u64,
+  pub timeout_count: u64,
+  pub active_executor_count: u64,
+  pub waiter_count: u64,
+  pub fallback_age_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RefreshMetricsSnapshot {
+  pub token: TokenRefreshMetrics,
+  pub live: LiveRefreshMetrics,
+  pub start_lag_warning_count: u64,
+  pub active_live_warning_count: u64,
+  pub start_lag_histogram: [u64; HISTOGRAM_BUCKETS],
+  pub duration_histogram: [u64; HISTOGRAM_BUCKETS],
+}
+
+#[derive(Debug)]
+pub(crate) struct SaturatingCounter(AtomicU64);
+
+impl SaturatingCounter {
+  pub(crate) const fn new(value: u64) -> Self {
+    Self(AtomicU64::new(value))
+  }
+
+  pub(crate) fn increment(&self) -> u64 {
+    self.add(1)
+  }
+
+  pub(crate) fn add(&self, amount: u64) -> u64 {
+    let mut current = self.0.load(Ordering::Acquire);
+    loop {
+      let next = current.saturating_add(amount);
+      match self
+        .0
+        .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+      {
+        Ok(_) => return next,
+        Err(observed) => current = observed,
+      }
+    }
+  }
+
+  pub(crate) fn load(&self) -> u64 {
+    self.0.load(Ordering::Acquire)
+  }
+
+  #[cfg(test)]
+  fn store(&self, value: u64) {
+    self.0.store(value, Ordering::Release);
+  }
+}
+
+struct FixedHistogram {
+  buckets: [SaturatingCounter; HISTOGRAM_BUCKETS],
+}
+
+impl FixedHistogram {
+  fn new() -> Self {
+    Self {
+      buckets: array::from_fn(|_| SaturatingCounter::new(0)),
+    }
+  }
+
+  fn record(&self, duration: Duration) {
+    let value = duration_as_millis(duration);
+    let index = HISTOGRAM_UPPER_BOUNDS_MS
+      .iter()
+      .position(|upper| value <= *upper)
+      .unwrap_or(HISTOGRAM_BUCKETS - 1);
+    self.buckets[index].increment();
+  }
+
+  fn snapshot(&self) -> [u64; HISTOGRAM_BUCKETS] {
+    array::from_fn(|index| self.buckets[index].load())
+  }
+}
+
+#[derive(Default)]
+struct MetricsMutable {
+  token: TokenRefreshMetrics,
+  live: LiveRefreshMetrics,
+  token_last_success: Option<SuccessAgeAnchor>,
+  live_last_success: Option<SuccessAgeAnchor>,
+  token_started: Option<Instant>,
+  live_started: Option<Instant>,
+}
+
+struct SuccessAgeAnchor {
+  baseline_age: Duration,
+  observed_at: Instant,
+}
+
+struct MetricsState {
+  mutable: Mutex<MetricsMutable>,
+  start_lag_warning_count: SaturatingCounter,
+  active_live_warning_count: SaturatingCounter,
+  live_timeout_count: SaturatingCounter,
+  database_busy_count: SaturatingCounter,
+  active_live: AtomicU64,
+  start_lag_histogram: FixedHistogram,
+  duration_histogram: FixedHistogram,
+}
+
+impl MetricsState {
+  fn new(config: &RefreshConfig, clock: &dyn RefreshClock) -> Self {
+    let now = clock.monotonic_now();
+    Self {
+      mutable: Mutex::new(MetricsMutable {
+        token_last_success: config
+          .token_last_success_wall
+          .map(|wall| success_age_anchor(now, clock.wall_now(), wall)),
+        live_last_success: config
+          .live_last_success_wall
+          .map(|wall| success_age_anchor(now, clock.wall_now(), wall)),
+        ..MetricsMutable::default()
+      }),
+      start_lag_warning_count: SaturatingCounter::new(0),
+      active_live_warning_count: SaturatingCounter::new(0),
+      live_timeout_count: SaturatingCounter::new(0),
+      database_busy_count: SaturatingCounter::new(0),
+      active_live: AtomicU64::new(0),
+      start_lag_histogram: FixedHistogram::new(),
+      duration_histogram: FixedHistogram::new(),
+    }
+  }
+
+  fn snapshot(&self, waiter_count: usize, now: Instant) -> RefreshMetricsSnapshot {
+    let mut mutable = lock(&self.mutable);
+    mutable.token.lane.last_success_age_ms = mutable.token_last_success.as_ref().map(|success| {
+      duration_as_millis(
+        success
+          .baseline_age
+          .saturating_add(now.saturating_duration_since(success.observed_at)),
+      )
+    });
+    mutable.live.lane.last_success_age_ms = mutable.live_last_success.as_ref().map(|success| {
+      duration_as_millis(
+        success
+          .baseline_age
+          .saturating_add(now.saturating_duration_since(success.observed_at)),
+      )
+    });
+    mutable.live.waiter_count = waiter_count as u64;
+    mutable.live.active_executor_count = self.active_live.load(Ordering::Acquire);
+    mutable.live.timeout_count = self.live_timeout_count.load();
+    mutable.token.database_busy_count = self.database_busy_count.load();
+    RefreshMetricsSnapshot {
+      token: mutable.token.clone(),
+      live: mutable.live.clone(),
+      start_lag_warning_count: self.start_lag_warning_count.load(),
+      active_live_warning_count: self.active_live_warning_count.load(),
+      start_lag_histogram: self.start_lag_histogram.snapshot(),
+      duration_histogram: self.duration_histogram.snapshot(),
+    }
+  }
+
+  fn record_start_lag(&self, lag: Duration) {
+    self.start_lag_histogram.record(lag);
+    if lag > START_LAG_WARNING {
+      self.start_lag_warning_count.increment();
+      log::warn!("Refresh worker start lag exceeded five seconds.");
+    }
+  }
+
+  fn record_worker_start(
+    &self,
+    token: bool,
+    generation: u64,
+    due: Option<Instant>,
+    clock: &dyn RefreshClock,
+  ) {
+    let now = clock.monotonic_now();
+    let wall = clock.wall_now();
+    let lag = due.map_or(Duration::ZERO, |due| now.saturating_duration_since(due));
+    self.record_start_lag(lag);
+    let mut metrics = lock(&self.mutable);
+    let lane = if token {
+      metrics.token_started = Some(now);
+      &mut metrics.token.lane
+    } else {
+      metrics.live_started = Some(now);
+      &mut metrics.live.lane
+    };
+    lane.scheduled_due_at = due.map(|due| wall_time_for_instant(clock, due).to_rfc3339());
+    lane.started_at = Some(wall.to_rfc3339());
+    lane.start_lag_ms = duration_as_millis(lag);
+    lane.running_generation = Some(generation);
+  }
+
+  #[cfg(test)]
+  fn set_warning_count_for_test(&self, value: u64) {
+    self.start_lag_warning_count.store(value);
+  }
+
+  #[cfg(test)]
+  fn set_start_lag_bucket_for_test(&self, index: usize, value: u64) {
+    self.start_lag_histogram.buckets[index].store(value);
+  }
+}
+
+pub(crate) trait RefreshClock: Send + Sync {
+  fn monotonic_now(&self) -> Instant;
+  fn wall_now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Default)]
+struct SystemRefreshClock;
+
+impl RefreshClock for SystemRefreshClock {
+  fn monotonic_now(&self) -> Instant {
+    Instant::now()
+  }
+
+  fn wall_now(&self) -> DateTime<Utc> {
+    Utc::now()
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshError {
+  Busy,
+  Failed {
+    code: RefreshFailureCode,
+    detail: Option<RefreshDetail>,
+  },
+  Rejected {
+    code: RefreshRejectionCode,
+    detail: Option<RefreshDetail>,
+  },
+  CoordinatorUnavailable,
+}
+
+pub(crate) struct ManualRefreshTicket<T> {
+  reply: Receiver<Result<Arc<T>, RefreshError>>,
+}
+
+impl<T> ManualRefreshTicket<T> {
+  pub(crate) fn wait(self) -> Result<Arc<T>, RefreshError> {
+    self
+      .reply
+      .recv()
+      .unwrap_or(Err(RefreshError::CoordinatorUnavailable))
+  }
+
+  pub(crate) fn wait_timeout(self, timeout: Duration) -> Result<Arc<T>, RefreshError> {
+    match self.reply.recv_timeout(timeout) {
+      Ok(result) => result,
+      Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => {
+        Err(RefreshError::CoordinatorUnavailable)
+      }
+    }
+  }
+}
+
+pub(crate) type ManualTokenTicket = ManualRefreshTicket<ScanResult>;
+pub(crate) type ManualLiveTicket = ManualRefreshTicket<LiveRateLimitSnapshot>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ShutdownResult {
+  pub coordinator_joined: bool,
+  pub token_joined: bool,
+  pub live_joined: bool,
+}
+
+struct WaiterRegistries {
+  token: HashMap<TokenWaiterId, SyncSender<Result<Arc<ScanResult>, RefreshError>>>,
+  live: HashMap<LiveWaiterId, SyncSender<Result<Arc<LiveRateLimitSnapshot>, RefreshError>>>,
+}
+
+impl WaiterRegistries {
+  fn new() -> Self {
+    Self {
+      token: HashMap::with_capacity(REFRESH_WAITER_CAPACITY),
+      live: HashMap::with_capacity(REFRESH_WAITER_CAPACITY),
+    }
+  }
+}
+
+struct IntakeState {
+  accepting: bool,
+  sender: SyncSender<RuntimeMessage>,
+  #[cfg(test)]
+  pause_after_check: Option<Arc<TestGateState>>,
+}
+
+struct HandleInner {
+  intake: Arc<Mutex<IntakeState>>,
+  waiters: Arc<Mutex<WaiterRegistries>>,
+  status: Arc<Mutex<RefreshStatus>>,
+  metrics: Arc<MetricsState>,
+  clock: Arc<dyn RefreshClock>,
+  next_token_waiter: AtomicU64,
+  next_live_waiter: AtomicU64,
+}
+
+#[derive(Clone)]
+pub(crate) struct RefreshCoordinatorHandle {
+  inner: Arc<HandleInner>,
+}
+
+impl RefreshCoordinatorHandle {
+  pub(crate) fn request_manual_token(
+    &self,
+    codex_home: Option<String>,
+  ) -> Result<ManualTokenTicket, RefreshError> {
+    let waiter = TokenWaiterId(next_id(&self.inner.next_token_waiter)?);
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    #[allow(unused_mut)]
+    let mut intake = lock(&self.inner.intake);
+    if !intake.accepting {
+      return Err(shutdown_error());
+    }
+    #[cfg(test)]
+    wait_on_optional_gate(&mut intake.pause_after_check);
+    {
+      let mut waiters = lock(&self.inner.waiters);
+      if waiters.token.len() >= REFRESH_WAITER_CAPACITY {
+        return Err(RefreshError::Busy);
+      }
+      waiters.token.insert(waiter, reply_tx);
+    }
+    let request = TokenRequest::manual_full_with_waiter(codex_home, waiter);
+    if let Err(error) = try_send_public(&intake.sender, RuntimeMessage::RequestToken(request)) {
+      lock(&self.inner.waiters).token.remove(&waiter);
+      return Err(error);
+    }
+    Ok(ManualRefreshTicket { reply: reply_rx })
+  }
+
+  pub(crate) fn request_manual_live(&self) -> Result<ManualLiveTicket, RefreshError> {
+    let waiter = LiveWaiterId(next_id(&self.inner.next_live_waiter)?);
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    #[allow(unused_mut)]
+    let mut intake = lock(&self.inner.intake);
+    if !intake.accepting {
+      return Err(shutdown_error());
+    }
+    #[cfg(test)]
+    wait_on_optional_gate(&mut intake.pause_after_check);
+    {
+      let mut waiters = lock(&self.inner.waiters);
+      if waiters.live.len() >= REFRESH_WAITER_CAPACITY {
+        return Err(RefreshError::Busy);
+      }
+      waiters.live.insert(waiter, reply_tx);
+    }
+    if let Err(error) = try_send_public(
+      &intake.sender,
+      RuntimeMessage::RequestLive(LiveRequest::manual(waiter)),
+    ) {
+      lock(&self.inner.waiters).live.remove(&waiter);
+      return Err(error);
+    }
+    Ok(ManualRefreshTicket { reply: reply_rx })
+  }
+
+  pub(crate) fn update_settings(&self, config: RefreshConfig) -> Result<(), RefreshError> {
+    self.send_acknowledged(|reply| RuntimeMessage::SettingsChanged(config, reply))
+  }
+
+  pub(crate) fn wake(&self) -> Result<(), RefreshError> {
+    self.send_acknowledged(RuntimeMessage::Wake)
+  }
+
+  pub(crate) fn try_wake(&self) -> Result<(), RefreshError> {
+    let intake = lock(&self.inner.intake);
+    if !intake.accepting {
+      return Err(shutdown_error());
+    }
+    try_send_public(&intake.sender, RuntimeMessage::WakeNoReply)
+  }
+
+  pub(crate) fn barrier(&self) -> Result<(), RefreshError> {
+    self.send_acknowledged(RuntimeMessage::Barrier)
+  }
+
+  fn send_acknowledged(
+    &self,
+    build: impl FnOnce(SyncSender<()>) -> RuntimeMessage,
+  ) -> Result<(), RefreshError> {
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    let intake = lock(&self.inner.intake);
+    if !intake.accepting {
+      return Err(shutdown_error());
+    }
+    try_send_public(&intake.sender, build(reply_tx))?;
+    drop(intake);
+    reply_rx
+      .recv()
+      .map_err(|_| RefreshError::CoordinatorUnavailable)
+  }
+
+  pub(crate) fn status(&self) -> RefreshStatus {
+    lock(&self.inner.status).clone()
+  }
+
+  pub(crate) fn metrics(&self) -> RefreshMetricsSnapshot {
+    let live_waiters = lock(&self.inner.waiters).live.len();
+    self
+      .inner
+      .metrics
+      .snapshot(live_waiters, self.inner.clock.monotonic_now())
+  }
+}
+
+pub(crate) struct RefreshRuntimeDependencies {
+  pub config: RefreshConfig,
+  pub token_executor: Arc<dyn TokenRefreshExecutor>,
+  pub live_fetcher: Arc<dyn LiveQuotaFetcher>,
+  pub live_persister: Arc<dyn LiveQuotaPersister>,
+  pub event_sink: Arc<dyn RefreshEventSink>,
+  pub mutation: UsageMutationCoordinator,
+  pub activity_factory: Arc<dyn ActivityFactory>,
+  pub clock: Arc<dyn RefreshClock>,
+  #[cfg(test)]
+  test_hooks: Option<Arc<RuntimeTestHooks>>,
+}
+
+impl RefreshRuntimeDependencies {
+  #[allow(dead_code)]
+  pub(crate) fn with_system_defaults(
+    config: RefreshConfig,
+    token_executor: Arc<dyn TokenRefreshExecutor>,
+    live_fetcher: Arc<dyn LiveQuotaFetcher>,
+    live_persister: Arc<dyn LiveQuotaPersister>,
+    event_sink: Arc<dyn RefreshEventSink>,
+    mutation: UsageMutationCoordinator,
+  ) -> Self {
+    Self {
+      config,
+      token_executor,
+      live_fetcher,
+      live_persister,
+      event_sink,
+      mutation,
+      activity_factory: Arc::new(SystemActivityFactory),
+      clock: Arc::new(SystemRefreshClock),
+      #[cfg(test)]
+      test_hooks: None,
+    }
+  }
+}
+
+enum ShutdownLifecycle {
+  Running,
+  ShuttingDown,
+  Complete(Arc<ShutdownResult>),
+  Failed(RefreshError),
+}
+
+struct RuntimeLifecycle {
+  state: Mutex<ShutdownLifecycle>,
+  changed: Condvar,
+  coordinator: Mutex<Option<JoinHandle<()>>>,
+  intake: Arc<Mutex<IntakeState>>,
+  shutdown_requested: Arc<AtomicBool>,
+  shutdown: Arc<AtomicBool>,
+}
+
+pub(crate) struct RefreshRuntime {
+  handle: RefreshCoordinatorHandle,
+  lifecycle: Arc<RuntimeLifecycle>,
+  #[cfg(test)]
+  test_hooks: Arc<RuntimeTestHooks>,
+}
+
+impl RefreshRuntime {
+  pub(crate) fn start(dependencies: RefreshRuntimeDependencies) -> Result<Self, String> {
+    start_runtime(dependencies)
+  }
+
+  pub(crate) fn handle(&self) -> RefreshCoordinatorHandle {
+    self.handle.clone()
+  }
+
+  pub(crate) fn shutdown_and_join(&self) -> Result<Arc<ShutdownResult>, RefreshError> {
+    let owns_shutdown = {
+      let mut state = lock(&self.lifecycle.state);
+      loop {
+        match &*state {
+          ShutdownLifecycle::Complete(result) => return Ok(Arc::clone(result)),
+          ShutdownLifecycle::Failed(error) => return Err(error.clone()),
+          ShutdownLifecycle::Running => {
+            *state = ShutdownLifecycle::ShuttingDown;
+            break true;
+          }
+          ShutdownLifecycle::ShuttingDown => {
+            state = self
+              .lifecycle
+              .changed
+              .wait(state)
+              .unwrap_or_else(|poisoned| poisoned.into_inner());
+          }
+        }
+      }
+    };
+
+    if owns_shutdown {
+      let operation: Result<Arc<ShutdownResult>, RefreshError> = (|| {
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        {
+          let mut intake = lock(&self.lifecycle.intake);
+          intake.accepting = false;
+          let shutdown_state = lock(&self.lifecycle.state);
+          self
+            .lifecycle
+            .shutdown_requested
+            .store(true, Ordering::Release);
+          self.lifecycle.changed.notify_all();
+          drop(shutdown_state);
+          intake
+            .sender
+            .send(RuntimeMessage::Shutdown(reply_tx))
+            .map_err(|_| RefreshError::CoordinatorUnavailable)?;
+        }
+        let mut result = reply_rx
+          .recv()
+          .map_err(|_| RefreshError::CoordinatorUnavailable)?;
+        if let Some(coordinator) = lock(&self.lifecycle.coordinator).take() {
+          coordinator
+            .join()
+            .map_err(|_| RefreshError::CoordinatorUnavailable)?;
+          result.coordinator_joined = true;
+        }
+        Ok(Arc::new(result))
+      })();
+      let mut state = lock(&self.lifecycle.state);
+      match &operation {
+        Ok(result) => *state = ShutdownLifecycle::Complete(Arc::clone(result)),
+        Err(error) => *state = ShutdownLifecycle::Failed(error.clone()),
+      }
+      drop(state);
+      self.lifecycle.changed.notify_all();
+      return operation;
+    }
+    unreachable!("shutdown owner is selected in the lifecycle loop")
+  }
+}
+
+fn next_id(sequence: &AtomicU64) -> Result<u64, RefreshError> {
+  let mut current = sequence.load(Ordering::Acquire);
+  loop {
+    if current == u64::MAX {
+      return Err(RefreshError::Busy);
+    }
+    let next = current + 1;
+    match sequence.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+      Ok(_) => return Ok(next),
+      Err(observed) => current = observed,
+    }
+  }
+}
+
+fn try_send_public(
+  sender: &SyncSender<RuntimeMessage>,
+  message: RuntimeMessage,
+) -> Result<(), RefreshError> {
+  match sender.try_send(message) {
+    Ok(()) => Ok(()),
+    Err(TrySendError::Full(_)) => Err(RefreshError::Busy),
+    Err(TrySendError::Disconnected(_)) => Err(RefreshError::CoordinatorUnavailable),
+  }
+}
+
+fn shutdown_error() -> RefreshError {
+  RefreshError::Rejected {
+    code: RefreshRejectionCode::Shutdown,
+    detail: None,
+  }
+}
+
+fn duration_as_millis(value: Duration) -> u64 {
+  value.as_millis().min(u64::MAX as u128) as u64
+}
+
+fn lock<T>(value: &Mutex<T>) -> MutexGuard<'_, T> {
+  value
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+enum RuntimeMessage {
+  RequestToken(TokenRequest),
+  RequestLive(LiveRequest),
+  SettingsChanged(RefreshConfig, SyncSender<()>),
+  Wake(SyncSender<()>),
+  WakeNoReply,
+  Barrier(SyncSender<()>),
+  Worker(WorkerOutcome),
+  Shutdown(SyncSender<ShutdownResult>),
+  #[cfg(test)]
+  PauseCoordinator(Arc<TestGateState>, SyncSender<()>),
+  #[cfg(test)]
+  InstallPreparedSlot(PreparedTokenRefresh, SyncSender<()>),
+  #[cfg(test)]
+  PreparedSlotEmpty(SyncSender<bool>),
+}
+
+enum WorkerOutcome {
+  Token(TokenWorkerOutcome),
+  Live(LiveWorkerOutcome),
+  Exited(WorkerLane),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkerLane {
+  Token,
+  Live,
+}
+
+enum TokenWorkerCommand {
+  Parse(TokenExecutionRequest),
+  Commit(PreparedTokenRefresh),
+}
+
+enum LiveWorkerCommand {
+  Run(LiveExecutionRequest),
+}
+
+enum TokenWorkerOutcome {
+  Prepared {
+    expected_generation: u64,
+    expected_source_generation: u64,
+    prepared: PreparedTokenRefresh,
+  },
+  PreparedMissing {
+    generation: u64,
+    source_generation: u64,
+  },
+  Committed {
+    generation: u64,
+    source_generation: u64,
+    result: Arc<ScanResult>,
+    commit: CommitMarker,
+    queue_wait: Duration,
+  },
+  Failed {
+    generation: u64,
+    source_generation: u64,
+    code: RefreshFailureCode,
+    detail: RefreshDetail,
+    queue_wait: Option<Duration>,
+  },
+  Stale {
+    generation: u64,
+    source_generation: u64,
+  },
+}
+
+enum LiveWorkerOutcome {
+  Completed {
+    generation: u64,
+    source_generation: u64,
+    snapshot: Arc<LiveRateLimitSnapshot>,
+    commit: CommitMarker,
+    fetch_duration: Duration,
+  },
+  Failed {
+    generation: u64,
+    source_generation: u64,
+    code: RefreshFailureCode,
+    detail: RefreshDetail,
+    fetch_duration: Duration,
+  },
+  Stale {
+    generation: u64,
+    source_generation: u64,
+  },
+}
+
+struct PreparedSlot {
+  generation: u64,
+  source_generation: u64,
+  prepared: PreparedTokenRefresh,
+}
+
+struct CoordinatorRuntime {
+  schedule: CoordinatorState,
+  prepared_slot: Option<PreparedSlot>,
+  token_commit_dispatched: Option<(u64, u64)>,
+  current_token_result: Option<(u64, Arc<ScanResult>)>,
+  current_live_result: Option<(u64, Arc<LiveRateLimitSnapshot>)>,
+  token_sender: Option<SyncSender<TokenWorkerCommand>>,
+  live_sender: Option<SyncSender<LiveWorkerCommand>>,
+  waiters: Arc<Mutex<WaiterRegistries>>,
+  status: Arc<Mutex<RefreshStatus>>,
+  metrics: Arc<MetricsState>,
+  event_sink: Arc<dyn RefreshEventSink>,
+  clock: Arc<dyn RefreshClock>,
+  source_generation: Arc<AtomicU64>,
+  shutdown: Arc<AtomicBool>,
+  shutdown_requested: Arc<AtomicBool>,
+  token_handle: Option<JoinHandle<()>>,
+  live_handle: Option<JoinHandle<()>>,
+  token_exited: bool,
+  live_exited: bool,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRuntime, String> {
+  let RefreshRuntimeDependencies {
+    config,
+    token_executor,
+    live_fetcher,
+    live_persister,
+    event_sink,
+    mutation,
+    activity_factory,
+    clock,
+    #[cfg(test)]
+    test_hooks,
+  } = dependencies;
+  let (runtime_tx, runtime_rx) = mpsc::sync_channel(RUNTIME_COMMAND_CAPACITY);
+  let (token_tx, token_rx) = mpsc::sync_channel(WORKER_COMMAND_CAPACITY);
+  let (live_tx, live_rx) = mpsc::sync_channel(WORKER_COMMAND_CAPACITY);
+  let waiters = Arc::new(Mutex::new(WaiterRegistries::new()));
+  let status = Arc::new(Mutex::new(RefreshStatus::new(&config)));
+  let metrics = Arc::new(MetricsState::new(&config, &*clock));
+  let source_generation = Arc::new(AtomicU64::new(0));
+  let shutdown = Arc::new(AtomicBool::new(false));
+  let shutdown_requested = Arc::new(AtomicBool::new(false));
+  let commit_sequence = Arc::new(SaturatingCounter::new(0));
+  #[cfg(test)]
+  let hooks = test_hooks.unwrap_or_else(|| Arc::new(RuntimeTestHooks::default()));
+  #[cfg(test)]
+  let returned_hooks = Arc::clone(&hooks);
+
+  let token_handle = spawn_token_worker(TokenWorkerParameters {
+    receiver: token_rx,
+    runtime_sender: runtime_tx.clone(),
+    executor: token_executor,
+    mutation,
+    activity_factory: Arc::clone(&activity_factory),
+    status: Arc::clone(&status),
+    metrics: Arc::clone(&metrics),
+    source_generation: Arc::clone(&source_generation),
+    shutdown: Arc::clone(&shutdown),
+    shutdown_requested: Arc::clone(&shutdown_requested),
+    commit_sequence: Arc::clone(&commit_sequence),
+    clock: Arc::clone(&clock),
+    #[cfg(test)]
+    hooks: Arc::clone(&hooks),
+  })?;
+  let live_handle = spawn_live_worker(LiveWorkerParameters {
+    receiver: live_rx,
+    runtime_sender: runtime_tx.clone(),
+    fetcher: live_fetcher,
+    persister: live_persister,
+    activity_factory,
+    status: Arc::clone(&status),
+    metrics: Arc::clone(&metrics),
+    source_generation: Arc::clone(&source_generation),
+    shutdown: Arc::clone(&shutdown),
+    shutdown_requested: Arc::clone(&shutdown_requested),
+    commit_sequence,
+    clock: Arc::clone(&clock),
+    #[cfg(test)]
+    hooks: Arc::clone(&hooks),
+  })?;
+
+  let shared_intake = Arc::new(Mutex::new(IntakeState {
+    accepting: true,
+    sender: runtime_tx,
+    #[cfg(test)]
+    pause_after_check: None,
+  }));
+  let handle = RefreshCoordinatorHandle {
+    inner: Arc::new(HandleInner {
+      intake: Arc::clone(&shared_intake),
+      waiters: Arc::clone(&waiters),
+      status: Arc::clone(&status),
+      metrics: Arc::clone(&metrics),
+      clock: Arc::clone(&clock),
+      next_token_waiter: AtomicU64::new(0),
+      next_live_waiter: AtomicU64::new(0),
+    }),
+  };
+
+  let schedule = CoordinatorState::new(config, clock.monotonic_now(), clock.wall_now());
+  let coordinator_runtime = CoordinatorRuntime {
+    schedule,
+    prepared_slot: None,
+    token_commit_dispatched: None,
+    current_token_result: None,
+    current_live_result: None,
+    token_sender: Some(token_tx),
+    live_sender: Some(live_tx),
+    waiters,
+    status,
+    metrics,
+    event_sink,
+    clock,
+    source_generation,
+    shutdown: Arc::clone(&shutdown),
+    shutdown_requested: Arc::clone(&shutdown_requested),
+    token_handle: Some(token_handle),
+    live_handle: Some(live_handle),
+    token_exited: false,
+    live_exited: false,
+    #[cfg(test)]
+    hooks,
+  };
+  coordinator_runtime.sync_schedule_snapshot();
+  let coordinator = thread::Builder::new()
+    .name("codex-pacer-refresh-coordinator".to_string())
+    .spawn(move || coordinator_loop(runtime_rx, coordinator_runtime))
+    .map_err(|error| format!("Failed to start refresh coordinator: {error}"))?;
+
+  let lifecycle = Arc::new(RuntimeLifecycle {
+    state: Mutex::new(ShutdownLifecycle::Running),
+    changed: Condvar::new(),
+    coordinator: Mutex::new(Some(coordinator)),
+    intake: shared_intake,
+    shutdown_requested,
+    shutdown,
+  });
+  Ok(RefreshRuntime {
+    handle,
+    lifecycle,
+    #[cfg(test)]
+    test_hooks: returned_hooks,
+  })
+}
+
+struct TokenWorkerParameters {
+  receiver: Receiver<TokenWorkerCommand>,
+  runtime_sender: SyncSender<RuntimeMessage>,
+  executor: Arc<dyn TokenRefreshExecutor>,
+  mutation: UsageMutationCoordinator,
+  activity_factory: Arc<dyn ActivityFactory>,
+  status: Arc<Mutex<RefreshStatus>>,
+  metrics: Arc<MetricsState>,
+  source_generation: Arc<AtomicU64>,
+  shutdown: Arc<AtomicBool>,
+  shutdown_requested: Arc<AtomicBool>,
+  commit_sequence: Arc<SaturatingCounter>,
+  clock: Arc<dyn RefreshClock>,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn spawn_token_worker(parameters: TokenWorkerParameters) -> Result<JoinHandle<()>, String> {
+  thread::Builder::new()
+    .name("codex-pacer-refresh-token".to_string())
+    .spawn(move || {
+      let sender = parameters.runtime_sender.clone();
+      #[cfg(test)]
+      parameters.hooks.record_thread_name();
+      let _ = panic::catch_unwind(AssertUnwindSafe(|| token_worker_loop(parameters)));
+      let _ = sender.send(RuntimeMessage::Worker(WorkerOutcome::Exited(
+        WorkerLane::Token,
+      )));
+    })
+    .map_err(|error| format!("Failed to start token refresh worker: {error}"))
+}
+
+fn token_worker_loop(parameters: TokenWorkerParameters) {
+  while let Ok(command) = parameters.receiver.recv() {
+    let outcome = match command {
+      TokenWorkerCommand::Parse(request) => run_token_parse(&parameters, request),
+      TokenWorkerCommand::Commit(prepared) => run_token_commit(&parameters, prepared),
+    };
+    if parameters
+      .runtime_sender
+      .send(RuntimeMessage::Worker(WorkerOutcome::Token(outcome)))
+      .is_err()
+    {
+      return;
+    }
+  }
+}
+
+fn run_token_parse(
+  parameters: &TokenWorkerParameters,
+  request: TokenExecutionRequest,
+) -> TokenWorkerOutcome {
+  let generation = request.generation;
+  let source_generation = request.source_generation;
+  if parameters.shutdown.load(Ordering::Acquire)
+    || parameters.shutdown_requested.load(Ordering::Acquire)
+    || parameters.source_generation.load(Ordering::Acquire) != source_generation
+  {
+    return TokenWorkerOutcome::Stale {
+      generation,
+      source_generation,
+    };
+  }
+  set_mutation_phase(&parameters.status, MutationPhase::Parsing);
+  #[cfg(test)]
+  parameters.hooks.before_token_parse();
+  parameters.metrics.record_worker_start(
+    true,
+    generation,
+    request.request.planned_due_at,
+    &*parameters.clock,
+  );
+  let result = panic::catch_unwind(AssertUnwindSafe(|| {
+    let _activity = parameters.activity_factory.begin();
+    parameters.executor.parse(request)
+  }));
+  match result {
+    Ok(Ok(prepared)) => {
+      #[cfg(test)]
+      if prepared.omit_payload_for_test() {
+        return TokenWorkerOutcome::PreparedMissing {
+          generation,
+          source_generation,
+        };
+      }
+      TokenWorkerOutcome::Prepared {
+        expected_generation: generation,
+        expected_source_generation: source_generation,
+        prepared,
+      }
+    }
+    Ok(Err(detail)) => TokenWorkerOutcome::Failed {
+      generation,
+      source_generation,
+      code: RefreshFailureCode::ExecutionFailed,
+      detail: RefreshDetail::new(detail),
+      queue_wait: None,
+    },
+    Err(_) => TokenWorkerOutcome::Failed {
+      generation,
+      source_generation,
+      code: RefreshFailureCode::WorkerPanicked,
+      detail: RefreshDetail::new("token parse executor panicked"),
+      queue_wait: None,
+    },
+  }
+}
+
+enum CommitAttempt {
+  Committed(Result<ScanResult, String>),
+  Panicked,
+  Stale,
+}
+
+fn run_token_commit(
+  parameters: &TokenWorkerParameters,
+  prepared: PreparedTokenRefresh,
+) -> TokenWorkerOutcome {
+  let generation = prepared.generation;
+  let source_generation = prepared.source_generation;
+  set_mutation_phase(&parameters.status, MutationPhase::WaitingToCommit);
+  #[cfg(test)]
+  parameters.hooks.notify_token_waiting_to_commit();
+  let mutation = parameters.mutation.run(MutationPriority::Refresh, || {
+    if parameters.shutdown.load(Ordering::Acquire)
+      || parameters.shutdown_requested.load(Ordering::Acquire)
+      || parameters.source_generation.load(Ordering::Acquire) != source_generation
+    {
+      drop(prepared);
+      return CommitAttempt::Stale;
+    }
+    #[cfg(test)]
+    parameters.hooks.before_token_commit();
+    match panic::catch_unwind(AssertUnwindSafe(|| {
+      let _activity = parameters.activity_factory.begin();
+      parameters.executor.commit(prepared)
+    })) {
+      Ok(result) => CommitAttempt::Committed(result),
+      Err(_) => CommitAttempt::Panicked,
+    }
+  });
+  {
+    let mut metrics = lock(&parameters.metrics.mutable);
+    metrics.token.commit_wait_ms = duration_as_millis(mutation.queue_wait);
+  }
+  match mutation.value {
+    CommitAttempt::Committed(Ok(result)) => {
+      if parameters.shutdown_requested.load(Ordering::Acquire)
+        || parameters.shutdown.load(Ordering::Acquire)
+        || parameters.source_generation.load(Ordering::Acquire) != source_generation
+      {
+        drop(result);
+        set_mutation_phase(&parameters.status, MutationPhase::Failed);
+        return TokenWorkerOutcome::Stale {
+          generation,
+          source_generation,
+        };
+      }
+      set_mutation_phase(&parameters.status, MutationPhase::Committed);
+      let result = Arc::new(result);
+      #[cfg(test)]
+      parameters
+        .hooks
+        .record_token_arc(generation, Arc::clone(&result));
+      TokenWorkerOutcome::Committed {
+        generation,
+        source_generation,
+        result,
+        commit: CommitMarker {
+          sequence: parameters.commit_sequence.increment(),
+          committed_at: parameters.clock.monotonic_now(),
+        },
+        queue_wait: mutation.queue_wait,
+      }
+    }
+    CommitAttempt::Committed(Err(detail)) => {
+      set_mutation_phase(&parameters.status, MutationPhase::Failed);
+      if is_database_busy(&detail) {
+        parameters.metrics.database_busy_count.increment();
+      }
+      TokenWorkerOutcome::Failed {
+        generation,
+        source_generation,
+        code: RefreshFailureCode::ExecutionFailed,
+        detail: RefreshDetail::new(detail),
+        queue_wait: Some(mutation.queue_wait),
+      }
+    }
+    CommitAttempt::Panicked => {
+      set_mutation_phase(&parameters.status, MutationPhase::Failed);
+      TokenWorkerOutcome::Failed {
+        generation,
+        source_generation,
+        code: RefreshFailureCode::WorkerPanicked,
+        detail: RefreshDetail::new("token commit executor panicked"),
+        queue_wait: Some(mutation.queue_wait),
+      }
+    }
+    CommitAttempt::Stale => TokenWorkerOutcome::Stale {
+      generation,
+      source_generation,
+    },
+  }
+}
+
+struct LiveWorkerParameters {
+  receiver: Receiver<LiveWorkerCommand>,
+  runtime_sender: SyncSender<RuntimeMessage>,
+  fetcher: Arc<dyn LiveQuotaFetcher>,
+  persister: Arc<dyn LiveQuotaPersister>,
+  activity_factory: Arc<dyn ActivityFactory>,
+  status: Arc<Mutex<RefreshStatus>>,
+  metrics: Arc<MetricsState>,
+  source_generation: Arc<AtomicU64>,
+  shutdown: Arc<AtomicBool>,
+  shutdown_requested: Arc<AtomicBool>,
+  commit_sequence: Arc<SaturatingCounter>,
+  clock: Arc<dyn RefreshClock>,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn spawn_live_worker(parameters: LiveWorkerParameters) -> Result<JoinHandle<()>, String> {
+  thread::Builder::new()
+    .name("codex-pacer-refresh-live".to_string())
+    .spawn(move || {
+      let sender = parameters.runtime_sender.clone();
+      #[cfg(test)]
+      parameters.hooks.record_thread_name();
+      let _ = panic::catch_unwind(AssertUnwindSafe(|| live_worker_loop(parameters)));
+      let _ = sender.send(RuntimeMessage::Worker(WorkerOutcome::Exited(
+        WorkerLane::Live,
+      )));
+    })
+    .map_err(|error| format!("Failed to start live refresh worker: {error}"))
+}
+
+fn live_worker_loop(parameters: LiveWorkerParameters) {
+  while let Ok(LiveWorkerCommand::Run(request)) = parameters.receiver.recv() {
+    let outcome = run_live_refresh(&parameters, request);
+    if parameters
+      .runtime_sender
+      .send(RuntimeMessage::Worker(WorkerOutcome::Live(outcome)))
+      .is_err()
+    {
+      return;
+    }
+  }
+}
+
+fn run_live_refresh(
+  parameters: &LiveWorkerParameters,
+  request: LiveExecutionRequest,
+) -> LiveWorkerOutcome {
+  if parameters.shutdown.load(Ordering::Acquire)
+    || parameters.shutdown_requested.load(Ordering::Acquire)
+    || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
+  {
+    return LiveWorkerOutcome::Stale {
+      generation: request.generation,
+      source_generation: request.source_generation,
+    };
+  }
+  #[cfg(test)]
+  parameters.hooks.before_live_fetch();
+  parameters.metrics.record_worker_start(
+    false,
+    request.generation,
+    request.planned_due_at,
+    &*parameters.clock,
+  );
+  let previous = increment_saturating_atomic(&parameters.metrics.active_live).saturating_sub(1);
+  let active_guard = ActiveLiveGuard {
+    active: &parameters.metrics.active_live,
+  };
+  if previous >= 1 {
+    parameters.metrics.active_live_warning_count.increment();
+    log::warn!("More than one live quota executor became active.");
+  }
+  let fetch_started = Instant::now();
+  let fetched = panic::catch_unwind(AssertUnwindSafe(|| {
+    let _activity = parameters.activity_factory.begin();
+    parameters.fetcher.fetch(LIVE_QUERY_TIMEOUT)
+  }));
+  let fetch_duration = fetch_started.elapsed();
+  drop(active_guard);
+  {
+    let mut metrics = lock(&parameters.metrics.mutable);
+    metrics.live.app_server_duration_ms = nonzero_duration_millis(fetch_duration);
+    metrics.live.last_query_timeout_ms = duration_as_millis(LIVE_QUERY_TIMEOUT);
+  }
+  let snapshot = match fetched {
+    Ok(Ok(snapshot)) => snapshot,
+    Ok(Err(detail)) => {
+      let normalized = detail.to_ascii_lowercase();
+      if normalized.contains("timeout") || normalized.contains("timed out") {
+        parameters.metrics.live_timeout_count.increment();
+      }
+      return LiveWorkerOutcome::Failed {
+        generation: request.generation,
+        source_generation: request.source_generation,
+        code: RefreshFailureCode::ExecutionFailed,
+        detail: RefreshDetail::new(detail),
+        fetch_duration,
+      };
+    }
+    Err(_) => {
+      return LiveWorkerOutcome::Failed {
+        generation: request.generation,
+        source_generation: request.source_generation,
+        code: RefreshFailureCode::WorkerPanicked,
+        detail: RefreshDetail::new("live fetch executor panicked"),
+        fetch_duration,
+      };
+    }
+  };
+  if parameters.shutdown_requested.load(Ordering::Acquire)
+    || parameters.shutdown.load(Ordering::Acquire)
+    || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
+  {
+    drop(snapshot);
+    return LiveWorkerOutcome::Stale {
+      generation: request.generation,
+      source_generation: request.source_generation,
+    };
+  }
+  #[cfg(test)]
+  parameters.hooks.before_live_persist();
+  let persisted = panic::catch_unwind(AssertUnwindSafe(|| {
+    let _activity = parameters.activity_factory.begin();
+    parameters.persister.persist(&snapshot)
+  }));
+  match persisted {
+    Ok(Ok(())) => {
+      if parameters.shutdown_requested.load(Ordering::Acquire)
+        || parameters.shutdown.load(Ordering::Acquire)
+        || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
+      {
+        return LiveWorkerOutcome::Stale {
+          generation: request.generation,
+          source_generation: request.source_generation,
+        };
+      }
+      let snapshot = Arc::new(snapshot);
+      #[cfg(test)]
+      parameters
+        .hooks
+        .record_live_arc(request.generation, Arc::clone(&snapshot));
+      LiveWorkerOutcome::Completed {
+        generation: request.generation,
+        source_generation: request.source_generation,
+        snapshot,
+        commit: CommitMarker {
+          sequence: parameters.commit_sequence.increment(),
+          committed_at: parameters.clock.monotonic_now(),
+        },
+        fetch_duration,
+      }
+    }
+    Ok(Err(detail)) => LiveWorkerOutcome::Failed {
+      generation: request.generation,
+      source_generation: request.source_generation,
+      code: RefreshFailureCode::ExecutionFailed,
+      detail: RefreshDetail::new(detail),
+      fetch_duration,
+    },
+    Err(_) => LiveWorkerOutcome::Failed {
+      generation: request.generation,
+      source_generation: request.source_generation,
+      code: RefreshFailureCode::WorkerPanicked,
+      detail: RefreshDetail::new("live persist executor panicked"),
+      fetch_duration,
+    },
+  }
+}
+
+fn set_mutation_phase(status: &Mutex<RefreshStatus>, phase: MutationPhase) {
+  lock(status).mutation_phase = Some(phase);
+}
+
+fn is_database_busy(detail: &str) -> bool {
+  let detail = detail.to_ascii_lowercase();
+  detail.contains("database is locked") || detail.contains("database busy")
+}
+
+fn nonzero_duration_millis(value: Duration) -> u64 {
+  if value.is_zero() {
+    0
+  } else {
+    duration_as_millis(value).max(1)
+  }
+}
+
+fn wall_time_for_instant(clock: &dyn RefreshClock, target: Instant) -> DateTime<Utc> {
+  let monotonic_now = clock.monotonic_now();
+  let wall_now = clock.wall_now();
+  if target >= monotonic_now {
+    wall_now
+      .checked_add_signed(
+        ChronoDuration::from_std(target.duration_since(monotonic_now))
+          .unwrap_or(ChronoDuration::MAX),
+      )
+      .unwrap_or_else(rfc3339_max_utc)
+  } else {
+    wall_now
+      .checked_sub_signed(
+        ChronoDuration::from_std(monotonic_now.duration_since(target))
+          .unwrap_or(ChronoDuration::MAX),
+      )
+      .unwrap_or_else(rfc3339_min_utc)
+  }
+}
+
+fn rfc3339_max_utc() -> DateTime<Utc> {
+  DateTime::parse_from_rfc3339("9999-12-31T23:59:59.999999999Z")
+    .expect("RFC3339 maximum timestamp is valid")
+    .with_timezone(&Utc)
+}
+
+fn rfc3339_min_utc() -> DateTime<Utc> {
+  DateTime::parse_from_rfc3339("0001-01-01T00:00:00Z")
+    .expect("RFC3339 minimum timestamp is valid")
+    .with_timezone(&Utc)
+}
+
+fn success_age_anchor(
+  monotonic_now: Instant,
+  wall_now: DateTime<Utc>,
+  success_wall: DateTime<Utc>,
+) -> SuccessAgeAnchor {
+  let baseline_age = wall_now
+    .signed_duration_since(success_wall)
+    .to_std()
+    .unwrap_or(Duration::ZERO);
+  SuccessAgeAnchor {
+    baseline_age,
+    observed_at: monotonic_now,
+  }
+}
+
+fn increment_saturating_atomic(value: &AtomicU64) -> u64 {
+  let mut current = value.load(Ordering::Acquire);
+  loop {
+    let next = current.saturating_add(1);
+    match value.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+      Ok(_) => return next,
+      Err(observed) => current = observed,
+    }
+  }
+}
+
+struct ActiveLiveGuard<'a> {
+  active: &'a AtomicU64,
+}
+
+impl Drop for ActiveLiveGuard<'_> {
+  fn drop(&mut self) {
+    let mut current = self.active.load(Ordering::Acquire);
+    loop {
+      let next = current.saturating_sub(1);
+      match self
+        .active
+        .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+      {
+        Ok(_) => return,
+        Err(observed) => current = observed,
+      }
+    }
+  }
+}
+
+fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: CoordinatorRuntime) {
+  #[cfg(test)]
+  runtime.hooks.record_thread_name();
+  loop {
+    let message = if runtime.shutdown_requested.load(Ordering::Acquire) {
+      receiver.recv().map_err(|_| RecvError)
+    } else {
+      match runtime.schedule.next_wait(runtime.clock.monotonic_now()) {
+        Some(wait) => match receiver.recv_timeout(wait) {
+          Ok(message) => Ok(message),
+          Err(RecvTimeoutError::Timeout) => {
+            runtime.process_schedule_event(CoordinatorEvent::Timer);
+            continue;
+          }
+          Err(RecvTimeoutError::Disconnected) => Err(RecvError),
+        },
+        None => receiver.recv(),
+      }
+    };
+    let Ok(message) = message else {
+      return;
+    };
+
+    if runtime.shutdown_requested.load(Ordering::Acquire)
+      && !matches!(message, RuntimeMessage::Shutdown(_))
+    {
+      runtime.handle_message_while_shutdown_pending(message);
+      continue;
+    }
+
+    match message {
+      RuntimeMessage::RequestToken(request) => {
+        runtime.process_schedule_event(CoordinatorEvent::RequestToken(request));
+      }
+      RuntimeMessage::RequestLive(request) => {
+        runtime.process_schedule_event(CoordinatorEvent::RequestLive(request));
+      }
+      RuntimeMessage::SettingsChanged(config, reply) => {
+        let actions = runtime.schedule.handle(
+          runtime.clock.monotonic_now(),
+          CoordinatorEvent::SettingsChanged(config),
+        );
+        let snapshot = runtime.schedule.snapshot();
+        runtime
+          .source_generation
+          .store(snapshot.source_generation, Ordering::Release);
+        runtime.sync_schedule_snapshot();
+        runtime.process_actions(actions);
+        let _ = reply.send(());
+      }
+      RuntimeMessage::Wake(reply) => {
+        runtime.process_schedule_event(CoordinatorEvent::Wake);
+        let _ = reply.send(());
+      }
+      RuntimeMessage::WakeNoReply => runtime.process_schedule_event(CoordinatorEvent::Wake),
+      RuntimeMessage::Barrier(reply) => {
+        let _ = reply.send(());
+      }
+      RuntimeMessage::Worker(outcome) => runtime.process_worker_outcome(outcome),
+      RuntimeMessage::Shutdown(reply) => {
+        runtime.shutdown_and_join_workers(&receiver, reply);
+        return;
+      }
+      #[cfg(test)]
+      RuntimeMessage::PauseCoordinator(gate, ready) => {
+        let _ = ready.send(());
+        gate.wait_for_release();
+      }
+      #[cfg(test)]
+      RuntimeMessage::InstallPreparedSlot(prepared, reply) => {
+        runtime.prepared_slot = Some(PreparedSlot {
+          generation: prepared.generation,
+          source_generation: prepared.source_generation,
+          prepared,
+        });
+        runtime.hooks.set_prepared_slot_empty(false);
+        let _ = reply.send(());
+      }
+      #[cfg(test)]
+      RuntimeMessage::PreparedSlotEmpty(reply) => {
+        let _ = reply.send(runtime.prepared_slot.is_none());
+      }
+    }
+  }
+}
+
+impl CoordinatorRuntime {
+  fn handle_message_while_shutdown_pending(&mut self, message: RuntimeMessage) {
+    match message {
+      RuntimeMessage::SettingsChanged(_, reply)
+      | RuntimeMessage::Wake(reply)
+      | RuntimeMessage::Barrier(reply) => {
+        let _ = reply.send(());
+      }
+      RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Token)) => {
+        self.token_exited = true;
+      }
+      RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
+        self.live_exited = true;
+      }
+      RuntimeMessage::Worker(_)
+      | RuntimeMessage::RequestToken(_)
+      | RuntimeMessage::RequestLive(_) => {}
+      RuntimeMessage::WakeNoReply => {}
+      RuntimeMessage::Shutdown(_) => unreachable!("shutdown message handled by the main loop"),
+      #[cfg(test)]
+      RuntimeMessage::PauseCoordinator(gate, ready) => {
+        let _ = ready.send(());
+        gate.wait_for_release();
+      }
+      #[cfg(test)]
+      RuntimeMessage::InstallPreparedSlot(prepared, reply) => {
+        drop(prepared);
+        let _ = reply.send(());
+      }
+      #[cfg(test)]
+      RuntimeMessage::PreparedSlotEmpty(reply) => {
+        let _ = reply.send(true);
+      }
+    }
+  }
+
+  fn process_schedule_event(&mut self, event: CoordinatorEvent) {
+    let actions = self.schedule.handle(self.clock.monotonic_now(), event);
+    self.sync_schedule_snapshot();
+    self.process_actions(actions);
+  }
+
+  fn process_worker_outcome(&mut self, outcome: WorkerOutcome) {
+    match outcome {
+      WorkerOutcome::Token(outcome) => self.process_token_outcome(outcome),
+      WorkerOutcome::Live(outcome) => self.process_live_outcome(outcome),
+      WorkerOutcome::Exited(WorkerLane::Token) => self.token_exited = true,
+      WorkerOutcome::Exited(WorkerLane::Live) => self.live_exited = true,
+    }
+  }
+
+  fn process_token_outcome(&mut self, outcome: TokenWorkerOutcome) {
+    match outcome {
+      TokenWorkerOutcome::Prepared {
+        expected_generation,
+        expected_source_generation,
+        prepared,
+      } => {
+        if self.schedule.snapshot().token.running_generation != Some(expected_generation) {
+          drop(prepared);
+          return;
+        }
+        if self.token_commit_dispatched == Some((expected_generation, expected_source_generation)) {
+          drop(prepared);
+          return;
+        }
+        if prepared.generation != expected_generation
+          || prepared.source_generation != expected_source_generation
+          || self.prepared_slot.is_some()
+        {
+          drop(prepared);
+          self.fail_running_token(
+            expected_generation,
+            expected_source_generation,
+            RefreshFailureCode::PreparedPayloadMissing,
+            "prepared token payload did not match the running generation",
+          );
+          return;
+        }
+        self.record_prepared_stats(prepared.prepared_scan.stats());
+        self.prepared_slot = Some(PreparedSlot {
+          generation: expected_generation,
+          source_generation: expected_source_generation,
+          prepared,
+        });
+        #[cfg(test)]
+        self.hooks.set_prepared_slot_empty(false);
+        self.process_schedule_event(CoordinatorEvent::TokenPrepared {
+          generation: expected_generation,
+          source_generation: expected_source_generation,
+        });
+      }
+      TokenWorkerOutcome::PreparedMissing {
+        generation,
+        source_generation,
+      } => self.fail_running_token(
+        generation,
+        source_generation,
+        RefreshFailureCode::PreparedPayloadMissing,
+        "prepared token payload was missing",
+      ),
+      TokenWorkerOutcome::Committed {
+        generation,
+        source_generation,
+        result,
+        commit,
+        queue_wait,
+      } => {
+        let snapshot = self.schedule.snapshot();
+        if snapshot.token.running_generation != Some(generation) {
+          return;
+        }
+        if snapshot.source_generation != source_generation {
+          drop(result);
+          self.token_commit_dispatched = None;
+          set_mutation_phase(&self.status, MutationPhase::Failed);
+          self.finish_token_timing(false);
+          self.process_schedule_event(CoordinatorEvent::TokenFinished(failed_completion(
+            generation,
+            source_generation,
+            RefreshFailureCode::SourceChanged,
+            RefreshDetail::new("refresh source changed during token commit"),
+            self.clock.wall_now(),
+          )));
+          return;
+        }
+        self.token_commit_dispatched = None;
+        lock(&self.metrics.mutable).token.commit_wait_ms = duration_as_millis(queue_wait);
+        self.finish_token_timing(true);
+        #[cfg(test)]
+        self.hooks.set_completion_slots_empty(false);
+        self.current_token_result = Some((generation, result));
+        let completion =
+          successful_completion(generation, source_generation, commit, self.clock.wall_now());
+        self.process_schedule_event(CoordinatorEvent::TokenFinished(completion));
+        self.current_token_result = None;
+        #[cfg(test)]
+        self.hooks.set_completion_slots_empty(true);
+      }
+      TokenWorkerOutcome::Failed {
+        generation,
+        source_generation,
+        code,
+        detail,
+        queue_wait,
+      } => {
+        if self.schedule.snapshot().token.running_generation != Some(generation) {
+          return;
+        }
+        self.token_commit_dispatched = None;
+        set_mutation_phase(&self.status, MutationPhase::Failed);
+        if let Some(queue_wait) = queue_wait {
+          lock(&self.metrics.mutable).token.commit_wait_ms = duration_as_millis(queue_wait);
+        }
+        self.finish_token_timing(false);
+        self.process_schedule_event(CoordinatorEvent::TokenFinished(failed_completion(
+          generation,
+          source_generation,
+          code,
+          detail,
+          self.clock.wall_now(),
+        )));
+      }
+      TokenWorkerOutcome::Stale {
+        generation,
+        source_generation,
+      } => {
+        if self.schedule.snapshot().token.running_generation != Some(generation) {
+          return;
+        }
+        self.token_commit_dispatched = None;
+        set_mutation_phase(&self.status, MutationPhase::Failed);
+        self.finish_token_timing(false);
+        self.process_schedule_event(CoordinatorEvent::TokenFinished(failed_completion(
+          generation,
+          source_generation,
+          RefreshFailureCode::SourceChanged,
+          RefreshDetail::new("refresh source changed before token commit"),
+          self.clock.wall_now(),
+        )));
+      }
+    }
+  }
+
+  fn process_live_outcome(&mut self, outcome: LiveWorkerOutcome) {
+    match outcome {
+      LiveWorkerOutcome::Completed {
+        generation,
+        source_generation,
+        snapshot,
+        commit,
+        fetch_duration,
+      } => {
+        let coordinator_snapshot = self.schedule.snapshot();
+        if coordinator_snapshot.live.running_generation != Some(generation) {
+          return;
+        }
+        if coordinator_snapshot.source_generation != source_generation {
+          drop(snapshot);
+          self.finish_live_timing(false);
+          self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+            generation,
+            source_generation,
+            RefreshFailureCode::SourceChanged,
+            RefreshDetail::new("refresh source changed during live persistence"),
+            self.clock.wall_now(),
+          )));
+          return;
+        }
+        lock(&self.metrics.mutable).live.app_server_duration_ms =
+          nonzero_duration_millis(fetch_duration);
+        self.finish_live_timing(true);
+        #[cfg(test)]
+        self.hooks.set_completion_slots_empty(false);
+        self.current_live_result = Some((generation, snapshot));
+        self.process_schedule_event(CoordinatorEvent::LiveFinished(successful_completion(
+          generation,
+          source_generation,
+          commit,
+          self.clock.wall_now(),
+        )));
+        self.current_live_result = None;
+        #[cfg(test)]
+        self.hooks.set_completion_slots_empty(true);
+      }
+      LiveWorkerOutcome::Failed {
+        generation,
+        source_generation,
+        code,
+        detail,
+        fetch_duration,
+      } => {
+        if self.schedule.snapshot().live.running_generation != Some(generation) {
+          return;
+        }
+        lock(&self.metrics.mutable).live.app_server_duration_ms =
+          nonzero_duration_millis(fetch_duration);
+        self.finish_live_timing(false);
+        self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+          generation,
+          source_generation,
+          code,
+          detail,
+          self.clock.wall_now(),
+        )));
+      }
+      LiveWorkerOutcome::Stale {
+        generation,
+        source_generation,
+      } => {
+        if self.schedule.snapshot().live.running_generation != Some(generation) {
+          return;
+        }
+        self.finish_live_timing(false);
+        self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+          generation,
+          source_generation,
+          RefreshFailureCode::SourceChanged,
+          RefreshDetail::new("refresh source changed before live fetch"),
+          self.clock.wall_now(),
+        )));
+      }
+    }
+  }
+
+  fn fail_running_token(
+    &mut self,
+    generation: u64,
+    source_generation: u64,
+    code: RefreshFailureCode,
+    detail: &str,
+  ) {
+    if self.schedule.snapshot().token.running_generation != Some(generation) {
+      return;
+    }
+    self.prepared_slot = None;
+    #[cfg(test)]
+    self.hooks.set_prepared_slot_empty(true);
+    self.token_commit_dispatched = None;
+    set_mutation_phase(&self.status, MutationPhase::Failed);
+    self.finish_token_timing(false);
+    self.process_schedule_event(CoordinatorEvent::TokenFinished(failed_completion(
+      generation,
+      source_generation,
+      code,
+      RefreshDetail::new(detail),
+      self.clock.wall_now(),
+    )));
+  }
+
+  fn process_actions(&mut self, actions: Vec<CoordinatorAction>) {
+    for action in actions {
+      match action {
+        CoordinatorAction::StartToken(request) => self.start_token(request),
+        CoordinatorAction::StartLive(request) => self.start_live(request),
+        CoordinatorAction::CommitToken {
+          generation,
+          source_generation,
+        } => self.commit_token(generation, source_generation),
+        CoordinatorAction::DiscardToken {
+          generation,
+          source_generation,
+        } => {
+          let should_drop = self.prepared_slot.as_ref().is_some_and(|slot| {
+            slot.generation == generation && slot.source_generation == source_generation
+          });
+          if should_drop {
+            self.prepared_slot = None;
+          }
+        }
+        CoordinatorAction::PublishInvalidation(value) => {
+          self.event_sink.publish_invalidation(value);
+          #[cfg(test)]
+          self.hooks.trace("token_invalidation");
+        }
+        CoordinatorAction::PublishCompletion(value) => {
+          #[cfg(test)]
+          self.hooks.trace(match value.lane {
+            super::RefreshLane::Token => "token_completion",
+            super::RefreshLane::Live => "live_completion",
+          });
+          self.event_sink.publish_completion(value);
+        }
+        CoordinatorAction::ResolveLiveWaiters {
+          waiter_ids,
+          outcome,
+        } => self.resolve_live_waiters(waiter_ids, outcome),
+        CoordinatorAction::ResolveTokenWaiters {
+          waiter_ids,
+          outcome,
+        } => self.resolve_token_waiters(waiter_ids, outcome),
+      }
+    }
+  }
+
+  fn start_token(&mut self, request: TokenExecutionRequest) {
+    self.record_lane_start(true, request.generation, request.request.planned_due_at);
+    set_mutation_phase(&self.status, MutationPhase::Parsing);
+    #[cfg(test)]
+    if request.generation > 1 {
+      self.hooks.trace("token_follow_up_start");
+    }
+    let result = self.token_sender.as_ref().ok_or(()).and_then(|sender| {
+      sender
+        .try_send(TokenWorkerCommand::Parse(request.clone()))
+        .map_err(|_| ())
+    });
+    if result.is_err() {
+      self.fail_running_token(
+        request.generation,
+        request.source_generation,
+        RefreshFailureCode::ExecutionFailed,
+        "token worker command queue was busy",
+      );
+    }
+  }
+
+  fn start_live(&mut self, request: LiveExecutionRequest) {
+    self.record_lane_start(false, request.generation, request.planned_due_at);
+    let result = self.live_sender.as_ref().ok_or(()).and_then(|sender| {
+      sender
+        .try_send(LiveWorkerCommand::Run(request.clone()))
+        .map_err(|_| ())
+    });
+    if result.is_err() {
+      self.finish_live_timing(false);
+      self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+        request.generation,
+        request.source_generation,
+        RefreshFailureCode::ExecutionFailed,
+        RefreshDetail::new("live worker command queue was busy"),
+        self.clock.wall_now(),
+      )));
+    }
+  }
+
+  fn commit_token(&mut self, generation: u64, source_generation: u64) {
+    let matching = self.prepared_slot.as_ref().is_some_and(|slot| {
+      slot.generation == generation && slot.source_generation == source_generation
+    });
+    if !matching {
+      self.prepared_slot = None;
+      self.fail_running_token(
+        generation,
+        source_generation,
+        RefreshFailureCode::PreparedPayloadMissing,
+        "prepared token payload was missing at commit dispatch",
+      );
+      return;
+    }
+    let prepared = self
+      .prepared_slot
+      .take()
+      .expect("matching prepared slot was checked")
+      .prepared;
+    #[cfg(test)]
+    self.hooks.set_prepared_slot_empty(true);
+    self.token_commit_dispatched = Some((generation, source_generation));
+    let result = self.token_sender.as_ref().ok_or(()).and_then(|sender| {
+      sender
+        .try_send(TokenWorkerCommand::Commit(prepared))
+        .map_err(|_| ())
+    });
+    if result.is_err() {
+      self.fail_running_token(
+        generation,
+        source_generation,
+        RefreshFailureCode::ExecutionFailed,
+        "token worker commit queue was busy",
+      );
+    }
+  }
+
+  fn resolve_token_waiters(
+    &mut self,
+    waiter_ids: Vec<TokenWaiterId>,
+    outcome: RefreshWaiterOutcome,
+  ) {
+    let result = waiter_result_for_token(&outcome, self.current_token_result.take());
+    #[cfg(test)]
+    self.hooks.set_completion_slots_empty(true);
+    let mut waiters = lock(&self.waiters);
+    for waiter in waiter_ids {
+      if let Some(reply) = waiters.token.remove(&waiter) {
+        let _ = reply.send(clone_result(&result));
+      }
+    }
+    drop(waiters);
+    #[cfg(test)]
+    self.hooks.trace("token_waiter_reply");
+  }
+
+  fn resolve_live_waiters(&mut self, waiter_ids: Vec<LiveWaiterId>, outcome: RefreshWaiterOutcome) {
+    let result = waiter_result_for_live(&outcome, self.current_live_result.take());
+    #[cfg(test)]
+    self.hooks.set_completion_slots_empty(true);
+    let mut waiters = lock(&self.waiters);
+    for waiter in waiter_ids {
+      if let Some(reply) = waiters.live.remove(&waiter) {
+        let _ = reply.send(clone_result(&result));
+      }
+    }
+  }
+
+  fn record_lane_start(&mut self, token: bool, generation: u64, due: Option<Instant>) {
+    let mut metrics = lock(&self.metrics.mutable);
+    let lane = if token {
+      &mut metrics.token.lane
+    } else {
+      &mut metrics.live.lane
+    };
+    lane.scheduled_due_at = due.map(|due| wall_time_for_instant(&*self.clock, due).to_rfc3339());
+    lane.started_at = None;
+    lane.start_lag_ms = 0;
+    lane.running_generation = Some(generation);
+    drop(metrics);
+    self.sync_schedule_snapshot();
+  }
+
+  fn finish_token_timing(&mut self, succeeded: bool) {
+    let started = lock(&self.metrics.mutable).token_started.take();
+    if let Some(started) = started {
+      let duration = self
+        .clock
+        .monotonic_now()
+        .saturating_duration_since(started);
+      self.metrics.duration_histogram.record(duration);
+      let mut metrics = lock(&self.metrics.mutable);
+      metrics.token.lane.duration_ms = nonzero_duration_millis(duration);
+      metrics.token.lane.running_generation = None;
+      if succeeded {
+        metrics.token_last_success = Some(SuccessAgeAnchor {
+          baseline_age: Duration::ZERO,
+          observed_at: self.clock.monotonic_now(),
+        });
+        lock(&self.status).token.last_success_at = Some(self.clock.wall_now().to_rfc3339());
+      }
+    }
+  }
+
+  fn finish_live_timing(&mut self, succeeded: bool) {
+    let started = lock(&self.metrics.mutable).live_started.take();
+    if let Some(started) = started {
+      let duration = self
+        .clock
+        .monotonic_now()
+        .saturating_duration_since(started);
+      self.metrics.duration_histogram.record(duration);
+      let mut metrics = lock(&self.metrics.mutable);
+      metrics.live.lane.duration_ms = nonzero_duration_millis(duration);
+      metrics.live.lane.running_generation = None;
+      if succeeded {
+        metrics.live_last_success = Some(SuccessAgeAnchor {
+          baseline_age: Duration::ZERO,
+          observed_at: self.clock.monotonic_now(),
+        });
+        lock(&self.status).live.last_success_at = Some(self.clock.wall_now().to_rfc3339());
+      }
+    }
+  }
+
+  fn record_prepared_stats(&self, stats: PreparedScanStats) {
+    let mut metrics = lock(&self.metrics.mutable);
+    metrics.token.files_visited = stats.files_visited as u64;
+    metrics.token.bytes_read = stats.source_bytes_read;
+    if stats.full_rebuild {
+      metrics.token.full_rebuild_count = metrics.token.full_rebuild_count.saturating_add(1);
+    }
+  }
+
+  fn sync_schedule_snapshot(&self) {
+    let snapshot = self.schedule.snapshot();
+    let token_deadline = snapshot
+      .token
+      .retry_deadline
+      .map_or(snapshot.token.next_normal_deadline, |retry| {
+        retry.min(snapshot.token.next_normal_deadline)
+      });
+    let live_deadline = snapshot
+      .live
+      .retry_deadline
+      .map_or(snapshot.live.next_normal_deadline, |retry| {
+        retry.min(snapshot.live.next_normal_deadline)
+      });
+    let token_next_due = wall_time_for_instant(&*self.clock, token_deadline).to_rfc3339();
+    let live_next_due = wall_time_for_instant(&*self.clock, live_deadline).to_rfc3339();
+    {
+      let mut status = lock(&self.status);
+      status.token.running = snapshot.token.running_generation.is_some();
+      status.token.generation = snapshot.token.running_generation;
+      status.token.pending = snapshot.token.pending;
+      status.token.next_due_at = Some(token_next_due);
+      status.live.running = snapshot.live.running_generation.is_some();
+      status.live.generation = snapshot.live.running_generation;
+      status.live.pending = snapshot.live.pending;
+      status.live.next_due_at = Some(live_next_due);
+      status.source_generation = snapshot.source_generation;
+      status.auto_scan_enabled = snapshot.auto_scan_enabled;
+    }
+    let mut metrics = lock(&self.metrics.mutable);
+    sync_lane_metrics(&mut metrics.token.lane, snapshot.token, &*self.clock);
+    sync_lane_metrics(&mut metrics.live.lane, snapshot.live, &*self.clock);
+  }
+
+  fn shutdown_and_join_workers(
+    &mut self,
+    receiver: &Receiver<RuntimeMessage>,
+    reply: SyncSender<ShutdownResult>,
+  ) {
+    // Required order: deny is linearized by the owner, then drain, drop, flag, close.
+    drain_waiters_for_shutdown(&self.waiters);
+    self.prepared_slot = None;
+    #[cfg(test)]
+    self.hooks.set_prepared_slot_empty(true);
+    self.shutdown.store(true, Ordering::Release);
+    self.token_sender = None;
+    self.live_sender = None;
+    {
+      let mut status = lock(&self.status);
+      status.token.running = false;
+      status.token.pending = false;
+      status.live.running = false;
+      status.live.pending = false;
+      status.mutation_phase = None;
+    }
+
+    while !self.token_exited || !self.live_exited {
+      let Ok(message) = receiver.recv() else {
+        break;
+      };
+      match message {
+        RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Token)) => {
+          self.token_exited = true;
+        }
+        RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
+          self.live_exited = true;
+        }
+        RuntimeMessage::Worker(_) => {}
+        RuntimeMessage::SettingsChanged(_, ack)
+        | RuntimeMessage::Wake(ack)
+        | RuntimeMessage::Barrier(ack) => {
+          let _ = ack.send(());
+        }
+        RuntimeMessage::RequestToken(_)
+        | RuntimeMessage::RequestLive(_)
+        | RuntimeMessage::WakeNoReply => {}
+        RuntimeMessage::Shutdown(other) => {
+          let _ = other.send(ShutdownResult {
+            coordinator_joined: false,
+            token_joined: false,
+            live_joined: false,
+          });
+        }
+        #[cfg(test)]
+        RuntimeMessage::PauseCoordinator(gate, ready) => {
+          let _ = ready.send(());
+          gate.wait_for_release();
+        }
+        #[cfg(test)]
+        RuntimeMessage::InstallPreparedSlot(prepared, ack) => {
+          drop(prepared);
+          let _ = ack.send(());
+        }
+        #[cfg(test)]
+        RuntimeMessage::PreparedSlotEmpty(value) => {
+          let _ = value.send(true);
+        }
+      }
+    }
+
+    let token_joined = self
+      .token_handle
+      .take()
+      .map(|handle| handle.join().is_ok())
+      .unwrap_or(true);
+    let live_joined = self
+      .live_handle
+      .take()
+      .map(|handle| handle.join().is_ok())
+      .unwrap_or(true);
+    let _ = reply.send(ShutdownResult {
+      coordinator_joined: false,
+      token_joined,
+      live_joined,
+    });
+  }
+}
+
+fn sync_lane_metrics(
+  target: &mut RefreshLaneMetrics,
+  source: super::LaneScheduleSnapshot,
+  clock: &dyn RefreshClock,
+) {
+  target.failure_streak = source.failure_streak;
+  target.retry_at = source
+    .retry_deadline
+    .map(|retry| wall_time_for_instant(clock, retry).to_rfc3339());
+  target.missed_deadline_count = source.missed_deadline_count;
+  target.coalesced_trigger_count = source.coalesced_trigger_count;
+  target.running_generation = source.running_generation;
+  target.pending_reasons = source.pending_reasons.bits();
+}
+
+fn successful_completion(
+  generation: u64,
+  source_generation: u64,
+  commit: CommitMarker,
+  completed_at: DateTime<Utc>,
+) -> ExecutionCompletion {
+  ExecutionCompletion {
+    generation,
+    source_generation,
+    succeeded: true,
+    failure_code: None,
+    failure: None,
+    completed_at: completed_at.to_rfc3339(),
+    commit: Some(commit),
+    retry_jitter: Duration::ZERO,
+  }
+}
+
+fn failed_completion(
+  generation: u64,
+  source_generation: u64,
+  code: RefreshFailureCode,
+  detail: RefreshDetail,
+  completed_at: DateTime<Utc>,
+) -> ExecutionCompletion {
+  ExecutionCompletion {
+    generation,
+    source_generation,
+    succeeded: false,
+    failure_code: Some(code),
+    failure: Some(detail.as_str().to_string()),
+    completed_at: completed_at.to_rfc3339(),
+    commit: None,
+    retry_jitter: Duration::ZERO,
+  }
+}
+
+fn waiter_error(outcome: &RefreshWaiterOutcome) -> RefreshError {
+  match outcome {
+    RefreshWaiterOutcome::Completed {
+      failure_code,
+      detail,
+      ..
+    } => RefreshError::Failed {
+      code: failure_code.unwrap_or(RefreshFailureCode::ExecutionFailed),
+      detail: detail.clone(),
+    },
+    RefreshWaiterOutcome::Rejected { code, detail } => RefreshError::Rejected {
+      code: *code,
+      detail: detail.clone(),
+    },
+  }
+}
+
+fn waiter_result_for_token(
+  outcome: &RefreshWaiterOutcome,
+  current: Option<(u64, Arc<ScanResult>)>,
+) -> Result<Arc<ScanResult>, RefreshError> {
+  match outcome {
+    RefreshWaiterOutcome::Completed {
+      generation,
+      succeeded: true,
+      ..
+    } => current
+      .filter(|(result_generation, _)| result_generation == generation)
+      .map(|(_, result)| result)
+      .ok_or_else(|| RefreshError::Failed {
+        code: RefreshFailureCode::PreparedPayloadMissing,
+        detail: Some(RefreshDetail::new(
+          "successful token completion had no exact result",
+        )),
+      }),
+    _ => Err(waiter_error(outcome)),
+  }
+}
+
+fn waiter_result_for_live(
+  outcome: &RefreshWaiterOutcome,
+  current: Option<(u64, Arc<LiveRateLimitSnapshot>)>,
+) -> Result<Arc<LiveRateLimitSnapshot>, RefreshError> {
+  match outcome {
+    RefreshWaiterOutcome::Completed {
+      generation,
+      succeeded: true,
+      ..
+    } => current
+      .filter(|(result_generation, _)| result_generation == generation)
+      .map(|(_, result)| result)
+      .ok_or_else(|| RefreshError::Failed {
+        code: RefreshFailureCode::PreparedPayloadMissing,
+        detail: Some(RefreshDetail::new(
+          "successful live completion had no exact snapshot",
+        )),
+      }),
+    _ => Err(waiter_error(outcome)),
+  }
+}
+
+fn clone_result<T>(result: &Result<Arc<T>, RefreshError>) -> Result<Arc<T>, RefreshError> {
+  match result {
+    Ok(value) => Ok(Arc::clone(value)),
+    Err(error) => Err(error.clone()),
+  }
+}
+
+fn drain_waiters_for_shutdown(waiters: &Mutex<WaiterRegistries>) {
+  let mut waiters = lock(waiters);
+  for (_, reply) in waiters.token.drain() {
+    let _ = reply.send(Err(shutdown_error()));
+  }
+  for (_, reply) in waiters.live.drain() {
+    let _ = reply.send(Err(shutdown_error()));
+  }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestGateSnapshot {
+  worker_ready: bool,
+  entered: bool,
+  released: bool,
+  dropped: bool,
+  used_spool: bool,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestGateState {
+  state: Mutex<TestGateSnapshot>,
+  changed: Condvar,
+}
+
+#[cfg(test)]
+impl TestGateState {
+  fn mark_worker_ready_and_wait(&self) {
+    let mut state = lock(&self.state);
+    state.worker_ready = true;
+    self.changed.notify_all();
+    while !state.released {
+      state = self
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+
+  fn mark_entered_and_wait(&self) {
+    let mut state = lock(&self.state);
+    state.entered = true;
+    self.changed.notify_all();
+    while !state.released {
+      state = self
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+
+  fn mark_entered(&self) {
+    lock(&self.state).entered = true;
+    self.changed.notify_all();
+  }
+
+  fn wait_for_release(&self) {
+    let mut state = lock(&self.state);
+    while !state.released {
+      state = self
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+
+  fn release(&self) {
+    lock(&self.state).released = true;
+    self.changed.notify_all();
+  }
+
+  fn wait_for(&self, timeout: Duration, predicate: impl Fn(&TestGateSnapshot) -> bool) {
+    let state = lock(&self.state);
+    let (state, timed_out) = self
+      .changed
+      .wait_timeout_while(state, timeout, |state| !predicate(state))
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(predicate(&state), "gate condition was not reached");
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for gate condition"
+    );
+  }
+
+  fn mark_dropped(&self) {
+    lock(&self.state).dropped = true;
+    self.changed.notify_all();
+  }
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct PhaseGateControl {
+  state: Arc<TestGateState>,
+}
+
+#[cfg(test)]
+impl PhaseGateControl {
+  fn wait_worker_ready(&self, timeout: Duration) {
+    self.state.wait_for(timeout, |state| state.worker_ready);
+  }
+
+  fn wait_entered(&self, timeout: Duration) {
+    self.state.wait_for(timeout, |state| state.entered);
+  }
+
+  fn release(&self) {
+    self.state.release();
+  }
+
+  fn wait_dropped(&self, timeout: Duration) {
+    self.state.wait_for(timeout, |state| state.dropped);
+  }
+
+  fn used_spool(&self) -> bool {
+    lock(&self.state.state).used_spool
+  }
+
+  fn probe(&self) -> Arc<TestGateState> {
+    Arc::clone(&self.state)
+  }
+}
+
+#[cfg(test)]
+struct TestPreparedDropProbe {
+  state: Arc<TestGateState>,
+}
+
+#[cfg(test)]
+impl Drop for TestPreparedDropProbe {
+  fn drop(&mut self) {
+    self.state.mark_dropped();
+  }
+}
+
+#[cfg(test)]
+impl PreparedTokenRefresh {
+  fn omit_payload_for_test(&self) -> bool {
+    self.omit_payload
+  }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct IndexedPreBodyGates {
+  next_call: AtomicU64,
+  gates: Mutex<HashMap<u64, Arc<TestGateState>>>,
+}
+
+#[cfg(test)]
+impl IndexedPreBodyGates {
+  fn arm(&self, call: u64, gate: Arc<TestGateState>) {
+    lock(&self.gates).insert(call, gate);
+  }
+
+  fn before_call(&self) {
+    let call = self.next_call.fetch_add(1, Ordering::AcqRel) + 1;
+    if let Some(gate) = lock(&self.gates).remove(&call) {
+      gate.mark_worker_ready_and_wait();
+    }
+  }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestHookData {
+  token_arcs: HashMap<u64, Arc<ScanResult>>,
+  live_arcs: HashMap<u64, Arc<LiveRateLimitSnapshot>>,
+  trace: Vec<&'static str>,
+  thread_names: Vec<String>,
+  token_waiting_count: u64,
+  prepared_slot_empty: bool,
+  completion_slots_empty: bool,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct RuntimeTestHooks {
+  token_parse_pre_body: IndexedPreBodyGates,
+  token_commit_pre_body: IndexedPreBodyGates,
+  live_fetch_pre_body: IndexedPreBodyGates,
+  live_persist_pre_body: IndexedPreBodyGates,
+  data: Mutex<TestHookData>,
+  changed: Condvar,
+}
+
+#[cfg(test)]
+impl RuntimeTestHooks {
+  fn before_token_parse(&self) {
+    self.token_parse_pre_body.before_call();
+  }
+
+  fn before_token_commit(&self) {
+    self.token_commit_pre_body.before_call();
+  }
+
+  fn before_live_fetch(&self) {
+    self.live_fetch_pre_body.before_call();
+  }
+
+  fn before_live_persist(&self) {
+    self.live_persist_pre_body.before_call();
+  }
+
+  fn notify_token_waiting_to_commit(&self) {
+    let mut data = lock(&self.data);
+    data.token_waiting_count = data.token_waiting_count.saturating_add(1);
+    drop(data);
+    self.changed.notify_all();
+  }
+
+  fn record_token_arc(&self, generation: u64, result: Arc<ScanResult>) {
+    lock(&self.data).token_arcs.insert(generation, result);
+    self.changed.notify_all();
+  }
+
+  fn record_live_arc(&self, generation: u64, result: Arc<LiveRateLimitSnapshot>) {
+    lock(&self.data).live_arcs.insert(generation, result);
+    self.changed.notify_all();
+  }
+
+  fn trace(&self, value: &'static str) {
+    lock(&self.data).trace.push(value);
+    self.changed.notify_all();
+  }
+
+  fn record_thread_name(&self) {
+    if let Some(name) = thread::current().name() {
+      let mut data = lock(&self.data);
+      if !data.thread_names.iter().any(|existing| existing == name) {
+        data.thread_names.push(name.to_string());
+      }
+      drop(data);
+      self.changed.notify_all();
+    }
+  }
+
+  fn set_prepared_slot_empty(&self, empty: bool) {
+    lock(&self.data).prepared_slot_empty = empty;
+    self.changed.notify_all();
+  }
+
+  fn set_completion_slots_empty(&self, empty: bool) {
+    lock(&self.data).completion_slots_empty = empty;
+    self.changed.notify_all();
+  }
+
+  fn wait_for(&self, timeout: Duration, predicate: impl Fn(&TestHookData) -> bool) {
+    let data = lock(&self.data);
+    let (data, timed_out) = self
+      .changed
+      .wait_timeout_while(data, timeout, |data| !predicate(data))
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(predicate(&data), "runtime hook condition was not reached");
+    assert!(!timed_out.timed_out(), "timed out waiting for runtime hook");
+  }
+}
+
+#[cfg(test)]
+fn wait_on_optional_gate(gate: &mut Option<Arc<TestGateState>>) {
+  if let Some(gate) = gate.take() {
+    gate.mark_worker_ready_and_wait();
+  }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum PanicPhase {
+  Parse,
+  Commit,
+  Fetch,
+  Persist,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestTokenBehavior {
+  parse_body_gates: HashMap<u64, Arc<TestGateState>>,
+  commit_body_gates: HashMap<u64, Arc<TestGateState>>,
+  pre_body_parse_states: HashMap<u64, Arc<TestGateState>>,
+  panic_once: HashMap<PanicPhase, u64>,
+  spool_calls: HashMap<u64, Arc<TestGateState>>,
+  omit_prepared_once: bool,
+  mismatch_prepared_once: bool,
+  assert_drop_before_next: Option<(u64, Arc<TestGateState>)>,
+  follow_up_observed_drop: bool,
+  commit_sources: Vec<String>,
+  parse_thread_ids: Vec<String>,
+  commit_thread_ids: Vec<String>,
+}
+
+#[cfg(test)]
+struct TestScanEnvironment {
+  _root: tempfile::TempDir,
+  db_path: std::path::PathBuf,
+  primary: std::path::PathBuf,
+  replacement: std::path::PathBuf,
+}
+
+#[cfg(test)]
+impl TestScanEnvironment {
+  fn new() -> Self {
+    let root = tempfile::tempdir().expect("test scan root");
+    let db_path = root.path().join("runtime.sqlite");
+    let conn = crate::database::open_connection(&db_path).expect("open runtime test database");
+    crate::database::init_db(&conn).expect("initialize runtime test database");
+    drop(conn);
+    let primary = root.path().join("primary");
+    let replacement = root.path().join("replacement");
+    write_runtime_session(&primary, "11111111-1111-1111-1111-111111111111", false);
+    write_runtime_session(&replacement, "22222222-2222-2222-2222-222222222222", false);
+    Self {
+      _root: root,
+      db_path,
+      primary,
+      replacement,
+    }
+  }
+
+  fn prepare(&self, request: &TokenExecutionRequest, spool: bool) -> PreparedScan {
+    let source = request
+      .request
+      .codex_home
+      .as_ref()
+      .map(std::path::PathBuf::from)
+      .unwrap_or_else(|| self.primary.clone());
+    if spool {
+      write_runtime_session(&source, "33333333-3333-3333-3333-333333333333", true);
+      write_runtime_session(&source, "44444444-4444-4444-4444-444444444444", true);
+    }
+    crate::importer::prepare_scan(
+      &self.db_path,
+      Some(source.to_string_lossy().to_string()),
+      crate::importer::ScanKind::Full,
+    )
+    .expect("prepare runtime test scan")
+  }
+}
+
+#[cfg(test)]
+fn write_runtime_session(home: &std::path::Path, id: &str, large: bool) {
+  let sessions = home.join("sessions");
+  std::fs::create_dir_all(&sessions).expect("create runtime sessions directory");
+  let path = sessions.join(format!("rollout-2026-07-10T00-00-00-{id}.jsonl"));
+  if path.exists() {
+    return;
+  }
+  let mut body = format!(
+    concat!(
+      "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+      "\"payload\":{{\"id\":\"{}\"}}}}\n",
+      "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+      "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+    ),
+    id
+  );
+  let line = concat!(
+    "{\"timestamp\":\"2026-07-10T00:00:02Z\",\"type\":\"event_msg\",",
+    "\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
+    "\"input_tokens\":10,\"cached_input_tokens\":0,\"output_tokens\":0,",
+    "\"reasoning_output_tokens\":0,\"total_tokens\":10}},",
+    "\"rate_limits\":{\"plan_type\":\"pro\"}}}\n"
+  );
+  body.push_str(line);
+  if large {
+    while body.len() < 160 * 1024 {
+      body.push_str(line);
+    }
+  }
+  std::fs::write(path, body).expect("write runtime session");
+}
+
+#[cfg(test)]
+struct TestTokenExecutor {
+  environment: TestScanEnvironment,
+  hooks: Arc<RuntimeTestHooks>,
+  behavior: Mutex<TestTokenBehavior>,
+  changed: Condvar,
+  parse_calls: AtomicU64,
+  commit_calls: AtomicU64,
+}
+
+#[cfg(test)]
+impl TestTokenExecutor {
+  fn new(hooks: Arc<RuntimeTestHooks>) -> Self {
+    Self {
+      environment: TestScanEnvironment::new(),
+      hooks,
+      behavior: Mutex::new(TestTokenBehavior::default()),
+      changed: Condvar::new(),
+      parse_calls: AtomicU64::new(0),
+      commit_calls: AtomicU64::new(0),
+    }
+  }
+
+  fn primary_source(&self) -> String {
+    self.environment.primary.to_string_lossy().to_string()
+  }
+
+  fn replacement_source(&self) -> String {
+    self.environment.replacement.to_string_lossy().to_string()
+  }
+
+  fn next_parse_call(&self) -> u64 {
+    self.parse_calls.load(Ordering::Acquire) + 1
+  }
+
+  fn next_commit_call(&self) -> u64 {
+    self.commit_calls.load(Ordering::Acquire) + 1
+  }
+
+  fn block_next_parse(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    lock(&self.behavior)
+      .parse_body_gates
+      .insert(self.next_parse_call(), Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_parse_call(&self, call: u64) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    self
+      .hooks
+      .token_parse_pre_body
+      .arm(call, Arc::clone(&state));
+    lock(&self.behavior)
+      .pre_body_parse_states
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_next_commit(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    lock(&self.behavior)
+      .commit_body_gates
+      .insert(self.next_commit_call(), Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_next_spooled_parse_with_drop_probe(&self) -> PhaseGateControl {
+    let control = self.block_next_parse();
+    lock(&self.behavior)
+      .spool_calls
+      .insert(self.next_parse_call(), control.probe());
+    control
+  }
+
+  fn use_spooled_prepared_for_next_parse(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    state.release();
+    lock(&self.behavior)
+      .spool_calls
+      .insert(self.next_parse_call(), Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn assert_probe_dropped_before_next_parse(&self, probe: Arc<TestGateState>) {
+    lock(&self.behavior).assert_drop_before_next = Some((self.next_parse_call() + 1, probe));
+  }
+
+  fn follow_up_observed_probe_dropped(&self) -> bool {
+    lock(&self.behavior).follow_up_observed_drop
+  }
+
+  fn panic_once(&self, phase: PanicPhase) {
+    lock(&self.behavior).panic_once.insert(phase, 1);
+  }
+
+  fn omit_prepared_payload_once(&self) {
+    lock(&self.behavior).omit_prepared_once = true;
+  }
+
+  fn return_mismatched_prepared_once(&self) {
+    lock(&self.behavior).mismatch_prepared_once = true;
+  }
+
+  fn parse_calls(&self) -> u64 {
+    self.parse_calls.load(Ordering::Acquire)
+  }
+
+  fn commit_calls(&self) -> u64 {
+    self.commit_calls.load(Ordering::Acquire)
+  }
+
+  fn wait_for_parse_calls(&self, expected: u64, timeout: Duration) {
+    self.wait_for_counter(&self.parse_calls, expected, timeout);
+  }
+
+  fn wait_for_commit_calls(&self, expected: u64, timeout: Duration) {
+    self.wait_for_counter(&self.commit_calls, expected, timeout);
+  }
+
+  fn wait_for_counter(&self, counter: &AtomicU64, expected: u64, timeout: Duration) {
+    let state = lock(&self.behavior);
+    let (_state, timed_out) = self
+      .changed
+      .wait_timeout_while(state, timeout, |_| {
+        counter.load(Ordering::Acquire) < expected
+      })
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(counter.load(Ordering::Acquire) >= expected);
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for executor calls"
+    );
+  }
+
+  fn committed_arc(&self, generation: u64, timeout: Duration) -> Arc<ScanResult> {
+    self
+      .hooks
+      .wait_for(timeout, |data| data.token_arcs.contains_key(&generation));
+    Arc::clone(
+      lock(&self.hooks.data)
+        .token_arcs
+        .get(&generation)
+        .expect("recorded token arc"),
+    )
+  }
+
+  fn assert_result_for_generation(&self, result: &ScanResult, generation: u64) {
+    assert_eq!(result.imported_sessions, generation as usize);
+    assert_eq!(result.updated_sessions, generation as usize);
+  }
+
+  fn unique_parse_worker_ids(&self) -> usize {
+    let ids = &lock(&self.behavior).parse_thread_ids;
+    ids.iter().collect::<std::collections::HashSet<_>>().len()
+  }
+
+  fn unique_commit_worker_ids(&self) -> usize {
+    let ids = &lock(&self.behavior).commit_thread_ids;
+    ids.iter().collect::<std::collections::HashSet<_>>().len()
+  }
+
+  fn worker_name(&self) -> String {
+    "codex-pacer-refresh-token".to_string()
+  }
+
+  fn commit_calls_for_source(&self, label: &str) -> usize {
+    lock(&self.behavior)
+      .commit_sources
+      .iter()
+      .filter(|source| source.contains(label))
+      .count()
+  }
+
+  fn make_prepared_for_test(
+    &self,
+    generation: u64,
+    source_generation: u64,
+    spool: bool,
+  ) -> (PreparedTokenRefresh, PhaseGateControl) {
+    let state = Arc::new(TestGateState::default());
+    state.release();
+    let mut request = TokenRequest::manual_full(Some(self.primary_source()));
+    request.planned_due_at = None;
+    let execution = TokenExecutionRequest {
+      generation,
+      source_generation,
+      request,
+    };
+    let prepared_scan = self.environment.prepare(&execution, spool);
+    lock(&state.state).used_spool = prepared_scan.stats().used_spool;
+    (
+      PreparedTokenRefresh {
+        generation,
+        source_generation,
+        started_at: Utc::now(),
+        prepared_scan,
+        drop_probe: Some(TestPreparedDropProbe {
+          state: Arc::clone(&state),
+        }),
+        omit_payload: false,
+      },
+      PhaseGateControl { state },
+    )
+  }
+}
+
+#[cfg(test)]
+impl TokenRefreshExecutor for TestTokenExecutor {
+  fn parse(&self, request: TokenExecutionRequest) -> Result<PreparedTokenRefresh, String> {
+    let call = self.parse_calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let thread_id = format!("{:?}", thread::current().id());
+    let (body_gate, pre_body, spool_state, panic_now, omit, mismatch, observed_drop) = {
+      let mut behavior = lock(&self.behavior);
+      behavior.parse_thread_ids.push(thread_id);
+      let observed_drop = behavior
+        .assert_drop_before_next
+        .as_ref()
+        .filter(|(target, _)| *target == call)
+        .map(|(_, probe)| lock(&probe.state).dropped);
+      if let Some(dropped) = observed_drop {
+        behavior.follow_up_observed_drop = dropped;
+        behavior.assert_drop_before_next = None;
+      }
+      let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Parse);
+      (
+        behavior.parse_body_gates.remove(&call),
+        behavior.pre_body_parse_states.remove(&call),
+        behavior.spool_calls.remove(&call),
+        panic_now,
+        std::mem::take(&mut behavior.omit_prepared_once),
+        std::mem::take(&mut behavior.mismatch_prepared_once),
+        observed_drop,
+      )
+    };
+    self.changed.notify_all();
+    if let Some(pre_body) = pre_body {
+      pre_body.mark_entered();
+    }
+    if let Some(body_gate) = body_gate {
+      body_gate.mark_entered_and_wait();
+    }
+    if observed_drop == Some(false) {
+      panic!("follow-up parse entered before prepared spool dropped");
+    }
+    if panic_now {
+      panic!("intentional parse panic");
+    }
+    let mut generation = request.generation;
+    if mismatch {
+      generation = generation.saturating_add(1);
+    }
+    let prepared_scan = self.environment.prepare(&request, spool_state.is_some());
+    if let Some(state) = &spool_state {
+      lock(&state.state).used_spool = prepared_scan.stats().used_spool;
+    }
+    Ok(PreparedTokenRefresh {
+      generation,
+      source_generation: request.source_generation,
+      started_at: Utc::now(),
+      prepared_scan,
+      drop_probe: spool_state.map(|state| TestPreparedDropProbe { state }),
+      omit_payload: omit,
+    })
+  }
+
+  fn commit(&self, prepared: PreparedTokenRefresh) -> Result<ScanResult, String> {
+    let call = self.commit_calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let thread_id = format!("{:?}", thread::current().id());
+    let (body_gate, panic_now) = {
+      let mut behavior = lock(&self.behavior);
+      behavior.commit_thread_ids.push(thread_id);
+      behavior.commit_sources.push(
+        prepared
+          .prepared_scan
+          .source_key()
+          .resolved_home()
+          .to_string_lossy()
+          .to_string(),
+      );
+      let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Commit);
+      (behavior.commit_body_gates.remove(&call), panic_now)
+    };
+    self.changed.notify_all();
+    if let Some(body_gate) = body_gate {
+      body_gate.mark_entered_and_wait();
+    }
+    if panic_now {
+      panic!("intentional commit panic");
+    }
+    let generation = prepared.generation;
+    drop(prepared);
+    Ok(ScanResult {
+      codex_home: format!("generation-{generation}"),
+      scanned_files: generation as usize,
+      imported_sessions: generation as usize,
+      updated_sessions: generation as usize,
+      missing_sessions: 0,
+      last_completed_at: "2026-07-11T00:00:00Z".to_string(),
+    })
+  }
+}
+
+#[cfg(test)]
+fn take_panic(panics: &mut HashMap<PanicPhase, u64>, phase: PanicPhase) -> bool {
+  let Some(remaining) = panics.get_mut(&phase) else {
+    return false;
+  };
+  if *remaining == 0 {
+    return false;
+  }
+  *remaining -= 1;
+  true
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestLiveBehavior {
+  fetch_body_gates: HashMap<u64, Arc<TestGateState>>,
+  persist_body_gates: HashMap<u64, Arc<TestGateState>>,
+  pre_body_fetch_states: HashMap<u64, Arc<TestGateState>>,
+  panic_once: HashMap<PanicPhase, u64>,
+  fetch_thread_ids: Vec<String>,
+  persist_thread_ids: Vec<String>,
+  last_timeout: Option<Duration>,
+}
+
+#[cfg(test)]
+struct TestLiveExecutor {
+  hooks: Arc<RuntimeTestHooks>,
+  behavior: Mutex<TestLiveBehavior>,
+  changed: Condvar,
+  fetch_calls: AtomicU64,
+  persist_calls: AtomicU64,
+  active: AtomicU64,
+  maximum_active: AtomicU64,
+}
+
+#[cfg(test)]
+impl TestLiveExecutor {
+  fn new(hooks: Arc<RuntimeTestHooks>) -> Self {
+    Self {
+      hooks,
+      behavior: Mutex::new(TestLiveBehavior::default()),
+      changed: Condvar::new(),
+      fetch_calls: AtomicU64::new(0),
+      persist_calls: AtomicU64::new(0),
+      active: AtomicU64::new(0),
+      maximum_active: AtomicU64::new(0),
+    }
+  }
+
+  fn block_next_fetch(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    let call = self.fetch_calls.load(Ordering::Acquire) + 1;
+    lock(&self.behavior)
+      .fetch_body_gates
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_fetch_call_before_body(&self, call: u64) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    self.hooks.live_fetch_pre_body.arm(call, Arc::clone(&state));
+    lock(&self.behavior)
+      .pre_body_fetch_states
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_next_persist(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    let call = self.persist_calls.load(Ordering::Acquire) + 1;
+    lock(&self.behavior)
+      .persist_body_gates
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn panic_once(&self, phase: PanicPhase) {
+    lock(&self.behavior).panic_once.insert(phase, 1);
+  }
+
+  fn fetch_calls(&self) -> u64 {
+    self.fetch_calls.load(Ordering::Acquire)
+  }
+
+  fn persist_calls(&self) -> u64 {
+    self.persist_calls.load(Ordering::Acquire)
+  }
+
+  fn wait_for_fetch_calls(&self, expected: u64, timeout: Duration) {
+    let behavior = lock(&self.behavior);
+    let (_behavior, timed_out) = self
+      .changed
+      .wait_timeout_while(behavior, timeout, |_| self.fetch_calls() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(self.fetch_calls() >= expected);
+    assert!(!timed_out.timed_out(), "timed out waiting for live fetch");
+  }
+
+  fn maximum_active_fetches(&self) -> u64 {
+    self.maximum_active.load(Ordering::Acquire)
+  }
+
+  fn fetched_arc(&self, generation: u64, timeout: Duration) -> Arc<LiveRateLimitSnapshot> {
+    self
+      .hooks
+      .wait_for(timeout, |data| data.live_arcs.contains_key(&generation));
+    Arc::clone(
+      lock(&self.hooks.data)
+        .live_arcs
+        .get(&generation)
+        .expect("recorded live arc"),
+    )
+  }
+
+  fn unique_fetch_worker_ids(&self) -> usize {
+    lock(&self.behavior)
+      .fetch_thread_ids
+      .iter()
+      .collect::<std::collections::HashSet<_>>()
+      .len()
+  }
+
+  fn unique_persist_worker_ids(&self) -> usize {
+    lock(&self.behavior)
+      .persist_thread_ids
+      .iter()
+      .collect::<std::collections::HashSet<_>>()
+      .len()
+  }
+
+  fn worker_name(&self) -> String {
+    "codex-pacer-refresh-live".to_string()
+  }
+
+  fn last_timeout(&self) -> Option<Duration> {
+    lock(&self.behavior).last_timeout
+  }
+
+  fn snapshot() -> LiveRateLimitSnapshot {
+    LiveRateLimitSnapshot {
+      limit_id: Some("runtime-test".to_string()),
+      limit_name: Some("Runtime Test".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: None,
+      fetched_at: "2026-07-11T00:00:00Z".to_string(),
+    }
+  }
+}
+
+#[cfg(test)]
+impl LiveQuotaFetcher for TestLiveExecutor {
+  fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+    let call = self.fetch_calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let active = increment_saturating_atomic(&self.active);
+    let mut maximum = self.maximum_active.load(Ordering::Acquire);
+    while active > maximum {
+      match self.maximum_active.compare_exchange_weak(
+        maximum,
+        active,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+      ) {
+        Ok(_) => break,
+        Err(observed) => maximum = observed,
+      }
+    }
+    let (body_gate, pre_body, panic_now) = {
+      let mut behavior = lock(&self.behavior);
+      behavior
+        .fetch_thread_ids
+        .push(format!("{:?}", thread::current().id()));
+      behavior.last_timeout = Some(timeout);
+      let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Fetch);
+      (
+        behavior.fetch_body_gates.remove(&call),
+        behavior.pre_body_fetch_states.remove(&call),
+        panic_now,
+      )
+    };
+    self.changed.notify_all();
+    if let Some(pre_body) = pre_body {
+      pre_body.mark_entered();
+    }
+    if let Some(body_gate) = body_gate {
+      body_gate.mark_entered_and_wait();
+    }
+    decrement_saturating_atomic(&self.active);
+    if panic_now {
+      panic!("intentional fetch panic");
+    }
+    Ok(Self::snapshot())
+  }
+}
+
+#[cfg(test)]
+impl LiveQuotaPersister for TestLiveExecutor {
+  fn persist(&self, _snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
+    let call = self.persist_calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let (body_gate, panic_now) = {
+      let mut behavior = lock(&self.behavior);
+      behavior
+        .persist_thread_ids
+        .push(format!("{:?}", thread::current().id()));
+      let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Persist);
+      (behavior.persist_body_gates.remove(&call), panic_now)
+    };
+    self.changed.notify_all();
+    if let Some(body_gate) = body_gate {
+      body_gate.mark_entered_and_wait();
+    }
+    if panic_now {
+      panic!("intentional persist panic");
+    }
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+fn decrement_saturating_atomic(value: &AtomicU64) {
+  let mut current = value.load(Ordering::Acquire);
+  loop {
+    match value.compare_exchange_weak(
+      current,
+      current.saturating_sub(1),
+      Ordering::AcqRel,
+      Ordering::Acquire,
+    ) {
+      Ok(_) => return,
+      Err(observed) => current = observed,
+    }
+  }
+}
+
+#[cfg(test)]
+struct TestClock {
+  base_monotonic: Instant,
+  base_wall: DateTime<Utc>,
+  offset: Mutex<Duration>,
+}
+
+#[cfg(test)]
+impl TestClock {
+  fn new() -> Self {
+    Self {
+      base_monotonic: Instant::now(),
+      base_wall: Utc::now(),
+      offset: Mutex::new(Duration::ZERO),
+    }
+  }
+
+  fn advance(&self, duration: Duration) {
+    let mut offset = lock(&self.offset);
+    *offset = offset.saturating_add(duration);
+  }
+}
+
+#[cfg(test)]
+impl RefreshClock for TestClock {
+  fn monotonic_now(&self) -> Instant {
+    let elapsed = self.base_monotonic.elapsed();
+    self
+      .base_monotonic
+      .checked_add(elapsed.saturating_add(*lock(&self.offset)))
+      .unwrap_or(self.base_monotonic)
+  }
+
+  fn wall_now(&self) -> DateTime<Utc> {
+    let elapsed = self.base_monotonic.elapsed();
+    self
+      .base_wall
+      .checked_add_signed(
+        ChronoDuration::from_std(elapsed.saturating_add(*lock(&self.offset)))
+          .unwrap_or(ChronoDuration::MAX),
+      )
+      .unwrap_or(DateTime::<Utc>::MAX_UTC)
+  }
+}
+
+#[cfg(test)]
+struct TestEvents {
+  invalidations: SaturatingCounter,
+  completions: SaturatingCounter,
+  hooks: Arc<RuntimeTestHooks>,
+  changed: Condvar,
+  gate: Mutex<()>,
+}
+
+#[cfg(test)]
+impl TestEvents {
+  fn new(hooks: Arc<RuntimeTestHooks>) -> Self {
+    Self {
+      invalidations: SaturatingCounter::new(0),
+      completions: SaturatingCounter::new(0),
+      hooks,
+      changed: Condvar::new(),
+      gate: Mutex::new(()),
+    }
+  }
+
+  fn completion_count(&self) -> u64 {
+    self.completions.load()
+  }
+
+  fn invalidation_count(&self) -> u64 {
+    self.invalidations.load()
+  }
+
+  fn trace_prefix(&self) -> Vec<&'static str> {
+    lock(&self.hooks.data).trace.clone()
+  }
+
+  fn wait_for_completions(&self, expected: u64, timeout: Duration) {
+    let gate = lock(&self.gate);
+    let (_gate, timed_out) = self
+      .changed
+      .wait_timeout_while(gate, timeout, |_| self.completion_count() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(self.completion_count() >= expected);
+    assert!(!timed_out.timed_out(), "timed out waiting for completions");
+  }
+}
+
+#[cfg(test)]
+impl RefreshEventSink for TestEvents {
+  fn publish_invalidation(&self, _value: DisplayInvalidation) {
+    self.invalidations.increment();
+  }
+
+  fn publish_completion(&self, _value: RefreshCompletedEvent) {
+    self.completions.increment();
+    self.changed.notify_all();
+  }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+enum TestRigSchedule {
+  Disabled,
+  StartupDue,
+  Paused,
+  HugeInterval,
+}
+
+#[cfg(test)]
+struct RuntimeTestRig {
+  runtime: Arc<RefreshRuntime>,
+  handle: RefreshCoordinatorHandle,
+  token: Arc<TestTokenExecutor>,
+  live: Arc<TestLiveExecutor>,
+  events: Arc<TestEvents>,
+  mutation: UsageMutationCoordinator,
+  activities: super::power::CountingActivityFactory,
+  clock: Arc<TestClock>,
+  metrics_handle: Arc<MetricsState>,
+}
+
+#[cfg(test)]
+impl RuntimeTestRig {
+  fn disabled() -> Self {
+    Self::build(TestRigSchedule::Disabled).0
+  }
+
+  fn startup_due_with_pre_body_gates() -> (Self, PhaseGateControl, PhaseGateControl) {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    let parse = token.block_parse_call(1);
+    let fetch = live.block_fetch_call_before_body(1);
+    (
+      Self::build_with_components(TestRigSchedule::StartupDue, hooks, token, live),
+      parse,
+      fetch,
+    )
+  }
+
+  fn scheduled_overdue(overdue: Duration) -> Self {
+    let rig = Self::build(TestRigSchedule::Paused).0;
+    rig
+      .clock
+      .advance(Duration::from_secs(60).saturating_add(overdue));
+    rig.handle.wake().expect("wake overdue test runtime");
+    rig
+  }
+
+  fn paused_clock() -> Self {
+    Self::build(TestRigSchedule::Paused).0
+  }
+
+  fn huge_interval() -> Self {
+    Self::build(TestRigSchedule::HugeInterval).0
+  }
+
+  fn build(schedule: TestRigSchedule) -> (Self, Arc<RuntimeTestHooks>) {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    let rig = Self::build_with_components(schedule, Arc::clone(&hooks), token, live);
+    (rig, hooks)
+  }
+
+  fn build_with_components(
+    schedule: TestRigSchedule,
+    hooks: Arc<RuntimeTestHooks>,
+    token: Arc<TestTokenExecutor>,
+    live: Arc<TestLiveExecutor>,
+  ) -> Self {
+    let clock = Arc::new(TestClock::new());
+    let interval = if matches!(schedule, TestRigSchedule::HugeInterval) {
+      Duration::MAX
+    } else {
+      Duration::from_secs(60)
+    };
+    let wall_now = clock.wall_now();
+    let (auto_scan_enabled, success_wall) = match schedule {
+      TestRigSchedule::Disabled => (false, Some(wall_now)),
+      TestRigSchedule::StartupDue => (
+        true,
+        Some(wall_now - ChronoDuration::from_std(interval + Duration::from_secs(1)).unwrap()),
+      ),
+      TestRigSchedule::Paused => (true, Some(wall_now)),
+      TestRigSchedule::HugeInterval => (false, Some(wall_now)),
+    };
+    let config = RefreshConfig {
+      auto_scan_enabled,
+      interval,
+      codex_home: Some(token.primary_source()),
+      token_last_success_wall: success_wall,
+      live_last_success_wall: success_wall,
+    };
+    let events = Arc::new(TestEvents::new(Arc::clone(&hooks)));
+    let mutation = UsageMutationCoordinator::new();
+    let activities = super::power::CountingActivityFactory::default();
+    let dependencies = RefreshRuntimeDependencies {
+      config,
+      token_executor: token.clone(),
+      live_fetcher: live.clone(),
+      live_persister: live.clone(),
+      event_sink: events.clone(),
+      mutation: mutation.clone(),
+      activity_factory: Arc::new(activities.clone()),
+      clock: clock.clone(),
+      test_hooks: Some(Arc::clone(&hooks)),
+    };
+    let runtime = Arc::new(RefreshRuntime::start(dependencies).expect("start test runtime"));
+    let handle = runtime.handle();
+    let metrics_handle = Arc::clone(&handle.inner.metrics);
+    Self {
+      runtime,
+      handle,
+      token,
+      live,
+      events,
+      mutation,
+      activities,
+      clock,
+      metrics_handle,
+    }
+  }
+
+  fn metrics(&self) -> RefreshMetricsSnapshot {
+    self.handle.metrics()
+  }
+
+  fn wait_until_idle(&self, timeout: Duration) {
+    let initial = self.events.completion_count();
+    if self.handle.status().token.running || self.handle.status().live.running {
+      self
+        .events
+        .wait_for_completions(initial.saturating_add(1), timeout);
+    }
+    self.runtime.test_hooks.wait_for(timeout, |_| {
+      let status = self.handle.status();
+      !status.token.running && !status.live.running
+    });
+  }
+
+  fn shutdown(&self) {
+    self
+      .runtime
+      .shutdown_and_join()
+      .expect("shutdown test runtime");
+  }
+
+  fn config_with_source(&self, _label: &str) -> RefreshConfig {
+    RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(60),
+      codex_home: Some(self.token.replacement_source()),
+      token_last_success_wall: Some(self.clock.wall_now()),
+      live_last_success_wall: Some(self.clock.wall_now()),
+    }
+  }
+
+  fn thread_names(&self) -> [String; 3] {
+    self
+      .runtime
+      .test_hooks
+      .wait_for(Duration::from_secs(2), |data| data.thread_names.len() == 3);
+    let mut names = lock(&self.runtime.test_hooks.data).thread_names.clone();
+    names.sort();
+    names.try_into().expect("three runtime thread names")
+  }
+
+  fn current_completion_slots_are_empty(&self) -> bool {
+    lock(&self.runtime.test_hooks.data).completion_slots_empty
+  }
+
+  fn hold_mutation_slot(&self) -> MutationHold {
+    MutationHold::start(self.mutation.clone(), Arc::clone(&self.runtime.test_hooks))
+  }
+
+  fn mutation_slot_is_free(&self) -> bool {
+    self.mutation.run(MutationPriority::Pricing, || true).value
+  }
+
+  fn token_schedule_waiter_count(&self) -> usize {
+    lock(&self.handle.inner.waiters).token.len()
+  }
+
+  fn runtime_sender(&self) -> SyncSender<RuntimeMessage> {
+    lock(&self.handle.inner.intake).sender.clone()
+  }
+
+  fn inject_duplicate_prepared_after_take(&self, generation: u64) {
+    let (prepared, _) = self.token.make_prepared_for_test(generation, 0, false);
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::Worker(WorkerOutcome::Token(
+        TokenWorkerOutcome::Prepared {
+          expected_generation: generation,
+          expected_source_generation: 0,
+          prepared,
+        },
+      )))
+      .expect("inject duplicate prepared outcome");
+  }
+
+  fn inject_duplicate_token_completion(&self, generation: u64, result: Arc<ScanResult>) {
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::Worker(WorkerOutcome::Token(
+        TokenWorkerOutcome::Committed {
+          generation,
+          source_generation: 0,
+          result,
+          commit: CommitMarker {
+            sequence: generation,
+            committed_at: self.clock.monotonic_now(),
+          },
+          queue_wait: Duration::ZERO,
+        },
+      )))
+      .expect("inject duplicate token completion");
+  }
+
+  fn pause_coordinator(&self) -> CoordinatorPause {
+    let gate = Arc::new(TestGateState::default());
+    let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::PauseCoordinator(
+        Arc::clone(&gate),
+        ready_tx,
+      ))
+      .expect("pause coordinator command");
+    ready_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("coordinator pauses");
+    CoordinatorPause { gate }
+  }
+
+  fn fill_runtime_channel_until_busy(&self) {
+    loop {
+      match self.handle.try_wake() {
+        Ok(()) => {}
+        Err(RefreshError::Busy) => return,
+        Err(error) => panic!("unexpected command fill error: {error:?}"),
+      }
+    }
+  }
+
+  fn start_intake_race_after_accept_check(&self) -> IntakeRace {
+    let gate = Arc::new(TestGateState::default());
+    lock(&self.handle.inner.intake).pause_after_check = Some(Arc::clone(&gate));
+    let handle = self.handle.clone();
+    let (result_tx, result_rx) = mpsc::sync_channel(1);
+    let join = thread::spawn(move || {
+      let result = handle
+        .request_manual_live()
+        .and_then(|ticket| ticket.wait_timeout(Duration::from_secs(2)));
+      let _ = result_tx.send(result);
+    });
+    IntakeRace {
+      gate,
+      result: Mutex::new(Some(result_rx)),
+      join: Mutex::new(Some(join)),
+    }
+  }
+
+  fn shutdown_in_background(&self) -> BackgroundShutdown {
+    BackgroundShutdown::start(Arc::clone(&self.runtime))
+  }
+
+  fn wait_for_shutdown_requested(&self, timeout: Duration) {
+    let state = lock(&self.runtime.lifecycle.state);
+    let (_state, timed_out) = self
+      .runtime
+      .lifecycle
+      .changed
+      .wait_timeout_while(state, timeout, |_| {
+        !self
+          .runtime
+          .lifecycle
+          .shutdown_requested
+          .load(Ordering::Acquire)
+      })
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(
+      self
+        .runtime
+        .lifecycle
+        .shutdown_requested
+        .load(Ordering::Acquire),
+      "shutdown request was not linearized"
+    );
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for shutdown request"
+    );
+  }
+
+  fn install_spooled_prepared_slot_via_coordinator(&self) -> PhaseGateControl {
+    let (prepared, control) = self.token.make_prepared_for_test(999, 0, true);
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::InstallPreparedSlot(prepared, reply_tx))
+      .expect("install coordinator prepared slot");
+    reply_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("coordinator owns prepared slot");
+    control
+  }
+
+  fn prepared_slot_is_empty_via_coordinator(&self) -> bool {
+    lock(&self.runtime.test_hooks.data).prepared_slot_empty
+  }
+}
+
+#[cfg(test)]
+fn initialize_test_hooks(hooks: &RuntimeTestHooks) {
+  let mut data = lock(&hooks.data);
+  data.prepared_slot_empty = true;
+  data.completion_slots_empty = true;
+}
+
+#[cfg(test)]
+struct MutationHold {
+  release: Mutex<Option<mpsc::Sender<()>>>,
+  join: Mutex<Option<JoinHandle<()>>>,
+  hooks: Arc<RuntimeTestHooks>,
+  waiting_baseline: u64,
+}
+
+#[cfg(test)]
+impl MutationHold {
+  fn start(mutation: UsageMutationCoordinator, hooks: Arc<RuntimeTestHooks>) -> Self {
+    let waiting_baseline = lock(&hooks.data).token_waiting_count;
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::channel();
+    let join = thread::spawn(move || {
+      mutation.run(MutationPriority::Maintenance, || {
+        let _ = entered_tx.send(());
+        let _ = release_rx.recv();
+      });
+    });
+    entered_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("mutation blocker enters");
+    Self {
+      release: Mutex::new(Some(release_tx)),
+      join: Mutex::new(Some(join)),
+      hooks,
+      waiting_baseline,
+    }
+  }
+
+  fn wait_until_refresh_queued(&self, timeout: Duration) {
+    self.hooks.wait_for(timeout, |data| {
+      data.token_waiting_count > self.waiting_baseline
+    });
+  }
+
+  fn release(&self) {
+    if let Some(release) = lock(&self.release).take() {
+      let _ = release.send(());
+    }
+    if let Some(join) = lock(&self.join).take() {
+      join.join().expect("mutation blocker exits");
+    }
+  }
+}
+
+#[cfg(test)]
+struct CoordinatorPause {
+  gate: Arc<TestGateState>,
+}
+
+#[cfg(test)]
+impl CoordinatorPause {
+  fn release(&self) {
+    self.gate.release();
+  }
+}
+
+#[cfg(test)]
+struct IntakeRace {
+  gate: Arc<TestGateState>,
+  result: Mutex<Option<Receiver<Result<Arc<LiveRateLimitSnapshot>, RefreshError>>>>,
+  join: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[cfg(test)]
+impl IntakeRace {
+  fn wait_checked(&self, timeout: Duration) {
+    self.gate.wait_for(timeout, |state| state.worker_ready);
+  }
+
+  fn release(&self) {
+    self.gate.release();
+  }
+
+  fn wait_result(&self, timeout: Duration) -> Result<Arc<LiveRateLimitSnapshot>, RefreshError> {
+    let result = lock(&self.result)
+      .take()
+      .expect("intake race result receiver")
+      .recv_timeout(timeout)
+      .expect("intake race reports result");
+    if let Some(join) = lock(&self.join).take() {
+      join.join().expect("intake race thread exits");
+    }
+    result
+  }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct BackgroundShutdownState {
+  result: Option<Result<Arc<ShutdownResult>, RefreshError>>,
+  finished: bool,
+}
+
+#[cfg(test)]
+struct BackgroundShutdown {
+  state: Arc<(Mutex<BackgroundShutdownState>, Condvar)>,
+  join: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[cfg(test)]
+impl BackgroundShutdown {
+  fn start(runtime: Arc<RefreshRuntime>) -> Self {
+    let state = Arc::new((
+      Mutex::new(BackgroundShutdownState::default()),
+      Condvar::new(),
+    ));
+    let thread_state = Arc::clone(&state);
+    let join = thread::spawn(move || {
+      let result = runtime.shutdown_and_join();
+      let (lock_state, changed) = &*thread_state;
+      let mut state = lock(lock_state);
+      state.result = Some(result);
+      state.finished = true;
+      drop(state);
+      changed.notify_all();
+    });
+    Self {
+      state,
+      join: Mutex::new(Some(join)),
+    }
+  }
+
+  fn is_finished(&self) -> bool {
+    lock(&self.state.0).finished
+  }
+
+  fn wait(&self, timeout: Duration) -> Arc<ShutdownResult> {
+    let (state, changed) = &*self.state;
+    let state = lock(state);
+    let (mut state, timed_out) = changed
+      .wait_timeout_while(state, timeout, |state| !state.finished)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(!timed_out.timed_out(), "timed out waiting for shutdown");
+    let result = state
+      .result
+      .take()
+      .expect("shutdown result")
+      .expect("shutdown succeeds");
+    drop(state);
+    if let Some(join) = lock(&self.join).take() {
+      join.join().expect("shutdown thread exits");
+    }
+    result
+  }
+}

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod tests {
   use super::{
-    MetricsState, PanicPhase, PreparedTokenRefresh, RefreshClock, RefreshConfig, RefreshError,
-    RefreshStatus, RuntimeTestRig, SaturatingCounter, TestClock, TestLiveExecutor,
+    EpochMaintenanceBatch, MetricsState, PanicPhase, PreparedTokenRefresh, RefreshClock,
+    RefreshConfig, RefreshError, RefreshStatus, RuntimeTestRig, SaturatingCounter, TestClock,
+    TestEpochMaintenanceExecutor, TestLiveExecutor, TestRigSchedule,
   };
   use crate::refresh::{RefreshFailureCode, RefreshRejectionCode, REFRESH_WAITER_CAPACITY};
   use chrono::{DateTime, Duration as ChronoDuration};
-  use std::sync::Arc;
+  use std::sync::atomic::Ordering;
+  use std::sync::{mpsc, Arc};
+  use std::thread;
   use std::time::Duration;
 
   const TEST_TIMEOUT: Duration = Duration::from_secs(2);
@@ -389,6 +392,362 @@ mod tests {
     assert_eq!(rig.token.commit_calls(), 1);
     assert_eq!(rig.live.persist_calls(), 1);
     rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_runs_one_batch_per_maintenance_dispatch() {
+    assert_eq!(super::EPOCH_MAINTENANCE_COMMAND_CAPACITY, 1);
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 1_000,
+      complete: false,
+    }));
+    let first = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+
+    first.wait_entered(TEST_TIMEOUT);
+    assert_eq!(maintenance.limits(), [1_000]);
+    for _ in 0..4 {
+      rig.handle.wake().expect("wake gated maintenance");
+      rig.handle.barrier().expect("drain wake");
+    }
+    assert_eq!(maintenance.calls(), 1, "only one bounded batch is active");
+
+    first.release();
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.handle.wake().expect("wake before pacing deadline");
+    rig.handle.barrier().expect("drain early wake");
+    assert_eq!(maintenance.calls(), 1, "outcome alone cannot chain a batch");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_progresses_when_auto_scan_is_disabled() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+
+    maintenance.wait_for_calls(1, TEST_TIMEOUT);
+    assert!(!rig.handle.status().auto_scan_enabled);
+    rig.wait_for_maintenance_exit(TEST_TIMEOUT);
+    assert_eq!(maintenance.calls(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_waits_while_token_or_live_lane_is_busy() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let (rig, parse, fetch) =
+      RuntimeTestRig::startup_due_with_pre_body_gates_and_maintenance(Arc::clone(&maintenance));
+    parse.wait_worker_ready(TEST_TIMEOUT);
+    fetch.wait_worker_ready(TEST_TIMEOUT);
+    rig.handle.barrier().expect("observe both busy lanes");
+    assert_eq!(maintenance.calls(), 0);
+
+    parse.release();
+    rig.token.wait_for_commit_calls(1, TEST_TIMEOUT);
+    rig.handle.barrier().expect("observe live lane still busy");
+    assert_eq!(maintenance.calls(), 0);
+
+    fetch.release();
+    maintenance.wait_for_calls(1, TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_respects_thirty_second_refresh_deadline_guard() {
+    let exact = Arc::new(TestEpochMaintenanceExecutor::new());
+    let exact_rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::ThirtySecondDeadline,
+      Arc::clone(&exact),
+    );
+    exact_rig.handle.barrier().expect("observe exact deadline");
+    assert_eq!(exact.calls(), 0, "exactly thirty seconds is guarded");
+    exact_rig.shutdown();
+
+    let beyond = Arc::new(TestEpochMaintenanceExecutor::new());
+    beyond.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let beyond_rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::ThirtyOneSecondDeadline,
+      Arc::clone(&beyond),
+    );
+    beyond.wait_for_calls(1, TEST_TIMEOUT);
+    beyond_rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_incomplete_batches_are_paced_without_busy_loop() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 1_000,
+      complete: false,
+    }));
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 7,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.handle.wake().expect("wake before two-second pace");
+    rig.handle.barrier().expect("drain early wake");
+    assert_eq!(maintenance.calls(), 1);
+
+    rig.clock.advance(Duration::from_secs(2));
+    rig.handle.wake().expect("wake at pacing deadline");
+    maintenance.wait_for_calls(2, TEST_TIMEOUT);
+    rig.wait_for_maintenance_exit(TEST_TIMEOUT);
+    assert_eq!(maintenance.unique_worker_ids(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn stale_or_duplicate_epoch_backfill_outcomes_are_ignored() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 1_000,
+      complete: false,
+    }));
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+
+    rig.inject_maintenance_outcome(
+      1,
+      Ok(EpochMaintenanceBatch::Progress {
+        processed_rows: 0,
+        complete: true,
+      }),
+    );
+    rig.handle.barrier().expect("drain duplicate outcome");
+    rig.clock.advance(Duration::from_secs(2));
+    rig.handle.wake().expect("wake next real attempt");
+
+    maintenance.wait_for_calls(2, TEST_TIMEOUT);
+    rig.wait_for_maintenance_exit(TEST_TIMEOUT);
+    assert_eq!(maintenance.calls(), 2, "duplicate did not complete the repair");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_failure_uses_backoff_without_hot_loop() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Err("injected maintenance failure".to_string()));
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+
+    rig.clock.advance(Duration::from_secs(29));
+    rig.handle.wake().expect("wake before retry backoff");
+    rig.handle.barrier().expect("drain early retry wake");
+    assert_eq!(maintenance.calls(), 1);
+    rig.clock.advance(Duration::from_secs(1));
+    rig.handle.wake().expect("wake at retry backoff");
+    maintenance.wait_for_calls(2, TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_failure_backoff_is_bounded_to_five_minutes() {
+    assert_eq!(
+      super::epoch_maintenance_retry_delay(1),
+      Duration::from_secs(30)
+    );
+    assert_eq!(
+      super::epoch_maintenance_retry_delay(2),
+      Duration::from_secs(60)
+    );
+    assert_eq!(
+      super::epoch_maintenance_retry_delay(5),
+      Duration::from_secs(5 * 60)
+    );
+    assert_eq!(
+      super::epoch_maintenance_retry_delay(u32::MAX),
+      Duration::from_secs(5 * 60)
+    );
+  }
+
+  #[test]
+  fn epoch_backfill_panic_uses_backoff_and_worker_recovers() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.panic_batch(1);
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    assert_eq!(maintenance.calls(), 1);
+
+    rig.clock.advance(Duration::from_secs(30));
+    rig.handle.wake().expect("wake after panic backoff");
+    maintenance.wait_for_calls(2, TEST_TIMEOUT);
+    rig.wait_for_maintenance_exit(TEST_TIMEOUT);
+    assert_eq!(maintenance.unique_worker_ids(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn snapshot_getter_remains_available_while_epoch_backfill_waits() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let gate = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    gate.wait_entered(TEST_TIMEOUT);
+
+    let status = rig.handle.status();
+    let metrics = rig.handle.metrics();
+    assert!(!status.token.running && !status.live.running);
+    assert_eq!(metrics.token.lane.running_generation, None);
+
+    gate.release();
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn refresh_priority_overtakes_queued_epoch_maintenance() {
+    let mutation = crate::refresh::UsageMutationCoordinator::new();
+    let blocker_mutation = mutation.clone();
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let blocker = thread::spawn(move || {
+      blocker_mutation.run(crate::refresh::MutationPriority::Pricing, || {
+        entered_tx.send(()).expect("report blocker entry");
+        release_rx.recv().expect("release blocker");
+      });
+    });
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("pricing blocker owns mutation slot");
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let retry_gate = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance_and_mutation(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+      mutation,
+    );
+    rig.wait_for_mutation_queue(1, TEST_TIMEOUT);
+    let token = rig.handle.request_manual_token(None).expect("token ticket");
+    rig.token.wait_until_waiting_to_commit(TEST_TIMEOUT);
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.wait_for_mutation_queue(1, TEST_TIMEOUT);
+    assert_eq!(maintenance.calls(), 0, "queued maintenance never enters executor");
+
+    release_tx.send(()).expect("release blocker");
+    assert!(token.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.token.commit_calls(), 1);
+
+    rig.clock.advance(Duration::from_secs(2));
+    rig.handle.wake().expect("wake paced maintenance retry");
+    retry_gate.wait_entered(TEST_TIMEOUT);
+    retry_gate.release();
+    blocker.join().expect("blocker exits");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn ready_live_persistence_cancels_epoch_maintenance_then_persists_first() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let first = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    first.wait_entered(TEST_TIMEOUT);
+
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.handle.barrier().expect("process ready persistence");
+    assert!(maintenance.cancellation(1).load(Ordering::Acquire));
+    assert_eq!(rig.live.persist_calls(), 0, "persistence waits for batch outcome");
+
+    first.release();
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    assert_eq!(rig.live.persist_calls(), 1);
+    assert_eq!(maintenance.calls(), 1, "maintenance retry remains paced");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_shutdown_joins_worker_without_followup() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let first = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    first.wait_entered(TEST_TIMEOUT);
+
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    assert!(maintenance.cancellation(1).load(Ordering::Acquire));
+    assert!(!shutdown.is_finished());
+    first.release();
+
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+    assert_eq!(maintenance.calls(), 1);
+    assert_eq!(maintenance.unique_worker_ids(), 1);
+  }
+
+  #[test]
+  fn epoch_backfill_shutdown_drains_saturated_outcome_without_deadlock() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let first = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    first.wait_entered(TEST_TIMEOUT);
+    let pause = rig.pause_coordinator();
+    rig.fill_runtime_channel_until_busy();
+
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    first.release();
+    pause.release();
+
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+    assert_eq!(maintenance.calls(), 1);
+    assert_eq!(maintenance.unique_worker_ids(), 1);
   }
 
   #[test]
@@ -1308,6 +1667,13 @@ use std::time::{Duration, Instant};
 
 pub(crate) const RUNTIME_COMMAND_CAPACITY: usize = REFRESH_WAITER_CAPACITY;
 const WORKER_COMMAND_CAPACITY: usize = 1;
+pub(crate) const EPOCH_MAINTENANCE_COMMAND_CAPACITY: usize = 1;
+const EPOCH_MAINTENANCE_STACK_SIZE: usize = 512 * 1024;
+const EPOCH_MAINTENANCE_BATCH_SIZE: usize = 1_000;
+const EPOCH_MAINTENANCE_PACE: Duration = Duration::from_secs(2);
+const EPOCH_MAINTENANCE_DEADLINE_GUARD: Duration = Duration::from_secs(30);
+const EPOCH_MAINTENANCE_RETRY_BASE: Duration = Duration::from_secs(30);
+const EPOCH_MAINTENANCE_RETRY_MAX: Duration = Duration::from_secs(5 * 60);
 pub(crate) const HISTOGRAM_BUCKETS: usize = 8;
 const START_LAG_WARNING: Duration = Duration::from_secs(5);
 const HISTOGRAM_UPPER_BOUNDS_MS: [u64; HISTOGRAM_BUCKETS] =
@@ -1359,6 +1725,23 @@ pub(crate) trait LiveQuotaFetcher: Send + Sync {
 
 pub(crate) trait LiveQuotaPersister: Send + Sync {
   fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String>;
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EpochMaintenanceBatch {
+  Progress {
+    processed_rows: usize,
+    complete: bool,
+  },
+  Cancelled,
+}
+
+pub(crate) trait EpochMaintenanceExecutor: Send + Sync {
+  fn run_batch(
+    &self,
+    limit: usize,
+    cancellation: Arc<AtomicBool>,
+  ) -> Result<EpochMaintenanceBatch, String>;
 }
 
 pub(crate) trait RefreshEventSink: Send + Sync {
@@ -1922,6 +2305,7 @@ pub(crate) struct RefreshRuntimeDependencies {
   pub mutation: UsageMutationCoordinator,
   pub activity_factory: Arc<dyn ActivityFactory>,
   pub clock: Arc<dyn RefreshClock>,
+  pub epoch_maintenance_executor: Option<Arc<dyn EpochMaintenanceExecutor>>,
   #[cfg(test)]
   test_hooks: Option<Arc<RuntimeTestHooks>>,
 }
@@ -1947,9 +2331,18 @@ impl RefreshRuntimeDependencies {
       mutation,
       activity_factory: Arc::new(SystemActivityFactory),
       clock: Arc::new(SystemRefreshClock),
+      epoch_maintenance_executor: None,
       #[cfg(test)]
       test_hooks: None,
     }
+  }
+
+  pub(crate) fn with_epoch_maintenance(
+    mut self,
+    executor: Arc<dyn EpochMaintenanceExecutor>,
+  ) -> Self {
+    self.epoch_maintenance_executor = Some(executor);
+    self
   }
 }
 
@@ -1968,6 +2361,38 @@ struct RuntimeLifecycle {
   reliable_changed: Arc<Condvar>,
   shutdown_requested: Arc<AtomicBool>,
   shutdown: Arc<AtomicBool>,
+  maintenance_control: Option<Arc<EpochMaintenanceControl>>,
+}
+
+struct EpochMaintenanceControl {
+  current: Mutex<Option<(u64, Arc<AtomicBool>)>>,
+  mutation: UsageMutationCoordinator,
+}
+
+impl EpochMaintenanceControl {
+  fn new(mutation: UsageMutationCoordinator) -> Self {
+    Self {
+      current: Mutex::new(None),
+      mutation,
+    }
+  }
+
+  fn install(&self, attempt_id: u64, cancellation: Arc<AtomicBool>) {
+    *lock(&self.current) = Some((attempt_id, cancellation));
+  }
+
+  fn clear(&self, attempt_id: u64) {
+    let mut current = lock(&self.current);
+    if current.as_ref().is_some_and(|(id, _)| *id == attempt_id) {
+      *current = None;
+    }
+  }
+
+  fn cancel_current(&self) {
+    if let Some((_, cancellation)) = lock(&self.current).as_ref() {
+      self.mutation.cancel(cancellation.as_ref());
+    }
+  }
 }
 
 pub(crate) struct RefreshRuntime {
@@ -2031,6 +2456,9 @@ impl RefreshRuntime {
         }
         {
           let shutdown_state = lock(&self.lifecycle.state);
+          if let Some(control) = &self.lifecycle.maintenance_control {
+            control.cancel_current();
+          }
           self
             .lifecycle
             .shutdown_requested
@@ -2128,6 +2556,7 @@ enum RuntimeMessage {
 enum WorkerOutcome {
   Token(TokenWorkerOutcome),
   Live(LiveWorkerOutcome),
+  Maintenance(EpochMaintenanceWorkerOutcome),
   Exited(WorkerLane),
 }
 
@@ -2135,6 +2564,7 @@ enum WorkerOutcome {
 enum WorkerLane {
   Token,
   Live,
+  Maintenance,
 }
 
 enum TokenWorkerCommand {
@@ -2144,6 +2574,16 @@ enum TokenWorkerCommand {
 
 enum LiveWorkerCommand {
   Run(LiveExecutionRequest),
+}
+
+struct EpochMaintenanceWorkerCommand {
+  attempt_id: u64,
+  cancellation: Arc<AtomicBool>,
+}
+
+struct EpochMaintenanceWorkerOutcome {
+  attempt_id: u64,
+  result: Result<EpochMaintenanceBatch, String>,
 }
 
 enum TokenWorkerOutcome {
@@ -2214,6 +2654,30 @@ struct PreparedSlot {
   prepared: PreparedTokenRefresh,
 }
 
+struct EpochMaintenanceAttempt {
+  id: u64,
+}
+
+struct EpochMaintenanceState {
+  pending: bool,
+  running: Option<EpochMaintenanceAttempt>,
+  next_attempt_id: u64,
+  next_eligible_at: Option<Instant>,
+  failure_streak: u32,
+}
+
+impl EpochMaintenanceState {
+  fn new(pending: bool) -> Self {
+    Self {
+      pending,
+      running: None,
+      next_attempt_id: 0,
+      next_eligible_at: None,
+      failure_streak: 0,
+    }
+  }
+}
+
 struct CoordinatorRuntime {
   schedule: CoordinatorState,
   prepared_slot: Option<PreparedSlot>,
@@ -2222,6 +2686,8 @@ struct CoordinatorRuntime {
   current_live_result: Option<(u64, Arc<LiveRateLimitSnapshot>)>,
   token_sender: Option<SyncSender<TokenWorkerCommand>>,
   live_sender: Option<SyncSender<LiveWorkerCommand>>,
+  maintenance_sender: Option<SyncSender<EpochMaintenanceWorkerCommand>>,
+  maintenance_control: Arc<EpochMaintenanceControl>,
   runtime_sender: SyncSender<RuntimeMessage>,
   waiters: Arc<Mutex<WaiterRegistries>>,
   status: Arc<Mutex<RefreshStatus>>,
@@ -2238,8 +2704,11 @@ struct CoordinatorRuntime {
   shutdown_requested: Arc<AtomicBool>,
   token_handle: Option<JoinHandle<()>>,
   live_handle: Option<JoinHandle<()>>,
+  maintenance_handle: Option<JoinHandle<()>>,
+  maintenance: EpochMaintenanceState,
   token_exited: bool,
   live_exited: bool,
+  maintenance_exited: bool,
   #[cfg(test)]
   hooks: Arc<RuntimeTestHooks>,
 }
@@ -2255,6 +2724,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     mutation,
     activity_factory,
     clock,
+    epoch_maintenance_executor,
     #[cfg(test)]
     test_hooks,
   } = dependencies;
@@ -2272,12 +2742,14 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
   let hooks = test_hooks.unwrap_or_else(|| Arc::new(RuntimeTestHooks::default()));
   #[cfg(test)]
   let returned_hooks = Arc::clone(&hooks);
+  let maintenance_pending = epoch_maintenance_executor.is_some();
+  let maintenance_control = Arc::new(EpochMaintenanceControl::new(mutation.clone()));
 
   let token_handle = spawn_token_worker(TokenWorkerParameters {
     receiver: token_rx,
     runtime_sender: runtime_tx.clone(),
     executor: token_executor,
-    mutation,
+    mutation: mutation.clone(),
     activity_factory: Arc::clone(&activity_factory),
     status: Arc::clone(&status),
     metrics: Arc::clone(&metrics),
@@ -2289,6 +2761,22 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     #[cfg(test)]
     hooks: Arc::clone(&hooks),
   })?;
+  let (maintenance_sender, maintenance_handle) = match epoch_maintenance_executor {
+    Some(executor) => {
+      let (sender, receiver) =
+        mpsc::sync_channel(EPOCH_MAINTENANCE_COMMAND_CAPACITY);
+      let handle = spawn_epoch_maintenance_worker(EpochMaintenanceWorkerParameters {
+        receiver,
+        runtime_sender: runtime_tx.clone(),
+        executor,
+        mutation: mutation.clone(),
+        #[cfg(test)]
+        hooks: Arc::clone(&hooks),
+      })?;
+      (Some(sender), Some(handle))
+    }
+    None => (None, None),
+  };
   let live_handle = spawn_live_worker(LiveWorkerParameters {
     receiver: live_rx,
     runtime_sender: runtime_tx.clone(),
@@ -2335,6 +2823,8 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     current_live_result: None,
     token_sender: Some(token_tx),
     live_sender: Some(live_tx),
+    maintenance_sender,
+    maintenance_control: Arc::clone(&maintenance_control),
     runtime_sender: runtime_tx.clone(),
     waiters,
     status,
@@ -2351,8 +2841,11 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     shutdown_requested: Arc::clone(&shutdown_requested),
     token_handle: Some(token_handle),
     live_handle: Some(live_handle),
+    maintenance_handle,
+    maintenance: EpochMaintenanceState::new(maintenance_pending),
     token_exited: false,
     live_exited: false,
+    maintenance_exited: !maintenance_pending,
     #[cfg(test)]
     hooks,
   };
@@ -2370,6 +2863,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     reliable_changed,
     shutdown_requested,
     shutdown,
+    maintenance_control: maintenance_pending.then_some(maintenance_control),
   });
   Ok(RefreshRuntime {
     handle,
@@ -2377,6 +2871,72 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     #[cfg(test)]
     test_hooks: returned_hooks,
   })
+}
+
+struct EpochMaintenanceWorkerParameters {
+  receiver: Receiver<EpochMaintenanceWorkerCommand>,
+  runtime_sender: SyncSender<RuntimeMessage>,
+  executor: Arc<dyn EpochMaintenanceExecutor>,
+  mutation: UsageMutationCoordinator,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn spawn_epoch_maintenance_worker(
+  parameters: EpochMaintenanceWorkerParameters,
+) -> Result<JoinHandle<()>, String> {
+  thread::Builder::new()
+    .name("codex-pacer-epoch-maintenance".to_string())
+    .stack_size(EPOCH_MAINTENANCE_STACK_SIZE)
+    .spawn(move || {
+      let sender = parameters.runtime_sender.clone();
+      #[cfg(test)]
+      parameters.hooks.record_thread_name();
+      let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+        while let Ok(command) = parameters.receiver.recv() {
+          let attempt_id = command.attempt_id;
+          let result = run_epoch_maintenance_batch(&parameters, command.cancellation);
+          if sender
+            .send(RuntimeMessage::Worker(WorkerOutcome::Maintenance(
+              EpochMaintenanceWorkerOutcome { attempt_id, result },
+            )))
+            .is_err()
+          {
+            return;
+          }
+        }
+      }));
+      let _ = sender.send(RuntimeMessage::Worker(WorkerOutcome::Exited(
+        WorkerLane::Maintenance,
+      )));
+    })
+    .map_err(|error| format!("Failed to start epoch maintenance worker: {error}"))
+}
+
+fn run_epoch_maintenance_batch(
+  parameters: &EpochMaintenanceWorkerParameters,
+  cancellation: Arc<AtomicBool>,
+) -> Result<EpochMaintenanceBatch, String> {
+  let mutation = parameters.mutation.run_cancellable(
+    MutationPriority::Maintenance,
+    &cancellation,
+    || {
+      if cancellation.load(Ordering::Acquire) {
+        return Ok(EpochMaintenanceBatch::Cancelled);
+      }
+      match panic::catch_unwind(AssertUnwindSafe(|| {
+        parameters
+          .executor
+          .run_batch(EPOCH_MAINTENANCE_BATCH_SIZE, Arc::clone(&cancellation))
+      })) {
+        Ok(result) => result,
+        Err(_) => Err("epoch maintenance executor panicked".to_string()),
+      }
+    },
+  );
+  mutation
+    .map(|outcome| outcome.value)
+    .unwrap_or(Ok(EpochMaintenanceBatch::Cancelled))
 }
 
 struct TokenWorkerParameters {
@@ -2753,6 +3313,17 @@ fn nonzero_duration_millis(value: Duration) -> u64 {
   }
 }
 
+fn epoch_maintenance_retry_delay(failure_streak: u32) -> Duration {
+  let shift = failure_streak.saturating_sub(1).min(4);
+  let multiplier = 1_u64 << shift;
+  Duration::from_secs(
+    EPOCH_MAINTENANCE_RETRY_BASE
+      .as_secs()
+      .saturating_mul(multiplier)
+      .min(EPOCH_MAINTENANCE_RETRY_MAX.as_secs()),
+  )
+}
+
 fn wall_time_for_instant(clock: &dyn RefreshClock, target: Instant) -> DateTime<Utc> {
   let monotonic_now = clock.monotonic_now();
   let wall_now = clock.wall_now();
@@ -2892,6 +3463,7 @@ fn persistence_task_is_stale(parameters: &PersistenceTaskParameters) -> bool {
 fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: CoordinatorRuntime) {
   #[cfg(test)]
   runtime.hooks.record_thread_name();
+  runtime.drive_background_work();
   loop {
     let message = if runtime.shutdown_requested.load(Ordering::Acquire) {
       receiver.recv().map_err(|_| RecvError)
@@ -2901,7 +3473,7 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
           Ok(message) => Ok(message),
           Err(RecvTimeoutError::Timeout) => {
             runtime.process_schedule_event(CoordinatorEvent::Timer);
-            runtime.maybe_start_persistence();
+            runtime.drive_background_work();
             continue;
           }
           Err(RecvTimeoutError::Disconnected) => Err(RecvError),
@@ -2923,11 +3495,11 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
     match message {
       RuntimeMessage::RequestToken(request) => {
         runtime.process_schedule_event(CoordinatorEvent::RequestToken(request));
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
       }
       RuntimeMessage::RequestLive(request) => {
         runtime.process_schedule_event(CoordinatorEvent::RequestLive(request));
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
       }
       RuntimeMessage::SettingsChanged(config, reply) => {
         let previous_source_generation = runtime.schedule.snapshot().source_generation;
@@ -2944,26 +3516,30 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
         }
         runtime.sync_schedule_snapshot();
         runtime.process_actions(actions);
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
         let _ = reply.send(());
       }
       RuntimeMessage::Wake(reply) => {
         runtime.process_schedule_event(CoordinatorEvent::Wake);
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
         let _ = reply.send(());
       }
       RuntimeMessage::WakeNoReply => {
         runtime.process_schedule_event(CoordinatorEvent::Wake);
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
       }
       RuntimeMessage::Barrier(reply) => {
+        runtime.drive_background_work();
         let _ = reply.send(());
       }
       RuntimeMessage::Worker(outcome) => {
         runtime.process_worker_outcome(outcome);
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
       }
-      RuntimeMessage::Persistence(outcome) => runtime.process_persistence_outcome(outcome),
+      RuntimeMessage::Persistence(outcome) => {
+        runtime.process_persistence_outcome(outcome);
+        runtime.drive_background_work();
+      }
       RuntimeMessage::Shutdown(reply) => {
         runtime.shutdown_and_join_workers(&receiver, reply);
         return;
@@ -2997,11 +3573,16 @@ impl CoordinatorRuntime {
     let schedule = self.schedule.next_wait(now);
     let live_running = self.schedule.snapshot().live.running_generation.is_some();
     let persistence = self.persistence.next_wait(now, live_running);
-    match (schedule, persistence) {
-      (Some(schedule), Some(persistence)) => Some(schedule.min(persistence)),
-      (Some(wait), None) | (None, Some(wait)) => Some(wait),
-      (None, None) => None,
-    }
+    let maintenance = self.maintenance_wait(now);
+    [schedule, persistence, maintenance]
+      .into_iter()
+      .flatten()
+      .min()
+  }
+
+  fn drive_background_work(&mut self) {
+    self.maybe_start_persistence();
+    self.maybe_start_maintenance();
   }
 
   fn maybe_start_persistence(&mut self) {
@@ -3011,10 +3592,17 @@ impl CoordinatorRuntime {
     {
       return;
     }
+    let now = self.clock.monotonic_now();
     let live_running = self.schedule.snapshot().live.running_generation.is_some();
+    if self.persistence.next_wait(now, live_running) == Some(Duration::ZERO)
+      && self.maintenance.running.is_some()
+    {
+      self.cancel_epoch_maintenance();
+      return;
+    }
     let Some(work) = self
       .persistence
-      .take_ready(self.clock.monotonic_now(), live_running)
+      .take_ready(now, live_running)
     else {
       return;
     };
@@ -3047,6 +3635,139 @@ impl CoordinatorRuntime {
     }
   }
 
+  fn maintenance_wait(&self, now: Instant) -> Option<Duration> {
+    if !self.maintenance_dispatch_gates_open(now) {
+      return None;
+    }
+    Some(
+      self
+        .maintenance
+        .next_eligible_at
+        .map(|deadline| deadline.saturating_duration_since(now))
+        .unwrap_or(Duration::ZERO),
+    )
+  }
+
+  fn maintenance_dispatch_gates_open(&self, now: Instant) -> bool {
+    if !self.maintenance.pending
+      || self.maintenance.running.is_some()
+      || self.maintenance_sender.is_none()
+      || self.shutdown_requested.load(Ordering::Acquire)
+      || self.shutdown.load(Ordering::Acquire)
+      || self.persistence_handle.is_some()
+    {
+      return false;
+    }
+    let snapshot = self.schedule.snapshot();
+    if snapshot.token.running_generation.is_some()
+      || snapshot.live.running_generation.is_some()
+      || snapshot.token.pending
+      || snapshot.live.pending
+    {
+      return false;
+    }
+    if self
+      .schedule
+      .next_wait(now)
+      .is_some_and(|wait| wait <= EPOCH_MAINTENANCE_DEADLINE_GUARD)
+    {
+      return false;
+    }
+    self.persistence.next_wait(now, false) != Some(Duration::ZERO)
+  }
+
+  fn maybe_start_maintenance(&mut self) {
+    let now = self.clock.monotonic_now();
+    if self.maintenance_wait(now) != Some(Duration::ZERO) {
+      return;
+    }
+    let Some(sender) = self.maintenance_sender.clone() else {
+      return;
+    };
+    let Some(attempt_id) = self.maintenance.next_attempt_id.checked_add(1) else {
+      log::error!("Epoch maintenance attempt ID overflowed; disabling the repair worker.");
+      self.maintenance.pending = false;
+      self.maintenance_sender = None;
+      return;
+    };
+    let cancellation = Arc::new(AtomicBool::new(false));
+    let command = EpochMaintenanceWorkerCommand {
+      attempt_id,
+      cancellation: Arc::clone(&cancellation),
+    };
+    match sender.try_send(command) {
+      Ok(()) => {
+        self.maintenance.next_attempt_id = attempt_id;
+        self.maintenance.next_eligible_at = None;
+        self
+          .maintenance_control
+          .install(attempt_id, Arc::clone(&cancellation));
+        self.maintenance.running = Some(EpochMaintenanceAttempt { id: attempt_id });
+        if self.shutdown_requested.load(Ordering::Acquire) {
+          self.maintenance_control.cancel_current();
+        }
+      }
+      Err(TrySendError::Full(_)) => {
+        log::warn!("Epoch maintenance command queue was unexpectedly full.");
+        self.maintenance.next_eligible_at = now.checked_add(EPOCH_MAINTENANCE_PACE);
+      }
+      Err(TrySendError::Disconnected(_)) => {
+        log::warn!("Epoch maintenance worker became unavailable.");
+        self.maintenance.pending = false;
+        self.maintenance_sender = None;
+      }
+    }
+  }
+
+  fn cancel_epoch_maintenance(&self) {
+    if self.maintenance.running.is_some() {
+      self.maintenance_control.cancel_current();
+    }
+  }
+
+  fn process_maintenance_outcome(&mut self, outcome: EpochMaintenanceWorkerOutcome) {
+    let Some(attempt) = self.maintenance.running.as_ref() else {
+      return;
+    };
+    if attempt.id != outcome.attempt_id {
+      return;
+    }
+    self.maintenance_control.clear(outcome.attempt_id);
+    self.maintenance.running = None;
+    #[cfg(test)]
+    self.hooks.record_maintenance_outcome();
+    if self.shutdown_requested.load(Ordering::Acquire) || self.shutdown.load(Ordering::Acquire) {
+      return;
+    }
+    let now = self.clock.monotonic_now();
+    match outcome.result {
+      Ok(EpochMaintenanceBatch::Progress {
+        processed_rows,
+        complete,
+      }) => {
+        self.maintenance.failure_streak = 0;
+        if complete {
+          log::debug!("Epoch maintenance completed after a {processed_rows}-row slice.");
+          self.maintenance.pending = false;
+          self.maintenance.next_eligible_at = None;
+          self.maintenance_sender = None;
+        } else {
+          self.maintenance.next_eligible_at = now.checked_add(EPOCH_MAINTENANCE_PACE);
+        }
+      }
+      Ok(EpochMaintenanceBatch::Cancelled) => {
+        self.maintenance.failure_streak = 0;
+        self.maintenance.next_eligible_at = now.checked_add(EPOCH_MAINTENANCE_PACE);
+      }
+      Err(error) => {
+        self.maintenance.failure_streak = self.maintenance.failure_streak.saturating_add(1);
+        self.maintenance.next_eligible_at =
+          now.checked_add(epoch_maintenance_retry_delay(self.maintenance.failure_streak));
+        log::warn!("Epoch maintenance slice failed; retrying later: {error}");
+      }
+    }
+  }
+
   fn process_persistence_outcome(&mut self, outcome: PersistenceWorkerOutcome) {
     if let Some(handle) = self.persistence_handle.take() {
       if handle.join().is_err() {
@@ -3073,8 +3794,6 @@ impl CoordinatorRuntime {
     self.hooks.record_persistence_outcome();
     if self.shutdown_requested.load(Ordering::Acquire) || self.shutdown.load(Ordering::Acquire) {
       self.persistence.cancel_pending();
-    } else {
-      self.maybe_start_persistence();
     }
   }
 
@@ -3090,6 +3809,12 @@ impl CoordinatorRuntime {
       }
       RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
         self.live_exited = true;
+      }
+      RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Maintenance)) => {
+        self.finish_maintenance_worker_exit();
+      }
+      RuntimeMessage::Worker(WorkerOutcome::Maintenance(outcome)) => {
+        self.process_maintenance_outcome(outcome);
       }
       RuntimeMessage::Persistence(outcome) => {
         self.process_persistence_outcome(outcome);
@@ -3127,9 +3852,28 @@ impl CoordinatorRuntime {
     match outcome {
       WorkerOutcome::Token(outcome) => self.process_token_outcome(outcome),
       WorkerOutcome::Live(outcome) => self.process_live_outcome(outcome),
+      WorkerOutcome::Maintenance(outcome) => self.process_maintenance_outcome(outcome),
       WorkerOutcome::Exited(WorkerLane::Token) => self.token_exited = true,
       WorkerOutcome::Exited(WorkerLane::Live) => self.live_exited = true,
+      WorkerOutcome::Exited(WorkerLane::Maintenance) => self.finish_maintenance_worker_exit(),
     }
+  }
+
+  fn finish_maintenance_worker_exit(&mut self) {
+    self.maintenance_exited = true;
+    if let Some(handle) = self.maintenance_handle.take() {
+      if handle.join().is_err() {
+        log::warn!("Epoch maintenance worker panicked while exiting.");
+      }
+    }
+    if let Some(attempt) = self.maintenance.running.take() {
+      self.maintenance_control.clear(attempt.id);
+      log::warn!("Epoch maintenance worker exited before reporting its active attempt.");
+    }
+    self.maintenance.pending = false;
+    self.maintenance_sender = None;
+    #[cfg(test)]
+    self.hooks.record_maintenance_exit();
   }
 
   fn process_token_outcome(&mut self, outcome: TokenWorkerOutcome) {
@@ -3468,6 +4212,7 @@ impl CoordinatorRuntime {
   }
 
   fn start_token(&mut self, request: TokenExecutionRequest) {
+    self.cancel_epoch_maintenance();
     self.record_lane_start(true, request.generation, request.request.planned_due_at);
     set_mutation_phase(&self.status, MutationPhase::Parsing);
     #[cfg(test)]
@@ -3492,6 +4237,7 @@ impl CoordinatorRuntime {
   }
 
   fn start_live(&mut self, request: LiveExecutionRequest) {
+    self.cancel_epoch_maintenance();
     self.record_lane_start(false, request.generation, request.planned_due_at);
     self.live_cache.set_refreshing(true);
     let result = self.live_sender.as_ref().ok_or(()).and_then(|sender| {
@@ -3707,6 +4453,9 @@ impl CoordinatorRuntime {
     drain_waiters_for_shutdown(&self.waiters);
     self.live_cache.set_refreshing(false);
     self.persistence.cancel_pending();
+    self.cancel_epoch_maintenance();
+    self.maintenance.pending = false;
+    self.maintenance_sender = None;
     self.prepared_slot = None;
     #[cfg(test)]
     self.hooks.set_prepared_slot_empty(true);
@@ -3722,7 +4471,11 @@ impl CoordinatorRuntime {
       status.mutation_phase = None;
     }
 
-    while !self.token_exited || !self.live_exited || self.persistence_handle.is_some() {
+    while !self.token_exited
+      || !self.live_exited
+      || !self.maintenance_exited
+      || self.persistence_handle.is_some()
+    {
       let Ok(message) = receiver.recv() else {
         break;
       };
@@ -3732,6 +4485,12 @@ impl CoordinatorRuntime {
         }
         RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
           self.live_exited = true;
+        }
+        RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Maintenance)) => {
+          self.finish_maintenance_worker_exit();
+        }
+        RuntimeMessage::Worker(WorkerOutcome::Maintenance(outcome)) => {
+          self.process_maintenance_outcome(outcome);
         }
         RuntimeMessage::Persistence(outcome) => {
           self.process_persistence_outcome(outcome);
@@ -4084,6 +4843,8 @@ struct TestHookData {
   prepared_slot_empty: bool,
   completion_slots_empty: bool,
   persistence_outcomes: u64,
+  maintenance_outcomes: u64,
+  maintenance_exited: bool,
 }
 
 #[cfg(test)]
@@ -4162,6 +4923,18 @@ impl RuntimeTestHooks {
     let mut data = lock(&self.data);
     data.persistence_outcomes = data.persistence_outcomes.saturating_add(1);
     drop(data);
+    self.changed.notify_all();
+  }
+
+  fn record_maintenance_outcome(&self) {
+    let mut data = lock(&self.data);
+    data.maintenance_outcomes = data.maintenance_outcomes.saturating_add(1);
+    drop(data);
+    self.changed.notify_all();
+  }
+
+  fn record_maintenance_exit(&self) {
+    lock(&self.data).maintenance_exited = true;
     self.changed.notify_all();
   }
 
@@ -4408,6 +5181,12 @@ impl TestTokenExecutor {
 
   fn wait_for_commit_calls(&self, expected: u64, timeout: Duration) {
     self.wait_for_counter(&self.commit_calls, expected, timeout);
+  }
+
+  fn wait_until_waiting_to_commit(&self, timeout: Duration) {
+    self
+      .hooks
+      .wait_for(timeout, |data| data.token_waiting_count > 0);
   }
 
   fn wait_for_counter(&self, counter: &AtomicU64, expected: u64, timeout: Duration) {
@@ -4894,6 +5673,124 @@ impl LiveQuotaPersister for TestLiveExecutor {
 }
 
 #[cfg(test)]
+#[derive(Default)]
+struct TestEpochMaintenanceBehavior {
+  body_gates: HashMap<u64, Arc<TestGateState>>,
+  results: VecDeque<Result<EpochMaintenanceBatch, String>>,
+  limits: Vec<usize>,
+  cancellations: Vec<Arc<AtomicBool>>,
+  worker_ids: Vec<String>,
+  panic_calls: std::collections::HashSet<u64>,
+}
+
+#[cfg(test)]
+struct TestEpochMaintenanceExecutor {
+  behavior: Mutex<TestEpochMaintenanceBehavior>,
+  changed: Condvar,
+  calls: AtomicU64,
+}
+
+#[cfg(test)]
+impl TestEpochMaintenanceExecutor {
+  fn new() -> Self {
+    Self {
+      behavior: Mutex::new(TestEpochMaintenanceBehavior::default()),
+      changed: Condvar::new(),
+      calls: AtomicU64::new(0),
+    }
+  }
+
+  fn queue_result(&self, result: Result<EpochMaintenanceBatch, String>) {
+    lock(&self.behavior).results.push_back(result);
+  }
+
+  fn block_batch(&self, call: u64) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    lock(&self.behavior)
+      .body_gates
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn panic_batch(&self, call: u64) {
+    lock(&self.behavior).panic_calls.insert(call);
+  }
+
+  fn wait_for_calls(&self, expected: u64, timeout: Duration) {
+    let behavior = lock(&self.behavior);
+    let (_behavior, timed_out) = self
+      .changed
+      .wait_timeout_while(behavior, timeout, |_| self.calls() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(self.calls() >= expected, "maintenance call count");
+    assert!(!timed_out.timed_out(), "timed out waiting for maintenance call");
+  }
+
+  fn calls(&self) -> u64 {
+    self.calls.load(Ordering::Acquire)
+  }
+
+  fn limits(&self) -> Vec<usize> {
+    lock(&self.behavior).limits.clone()
+  }
+
+  fn cancellation(&self, call: usize) -> Arc<AtomicBool> {
+    Arc::clone(
+      lock(&self.behavior)
+        .cancellations
+        .get(call.saturating_sub(1))
+        .expect("recorded maintenance cancellation token"),
+    )
+  }
+
+  fn unique_worker_ids(&self) -> usize {
+    lock(&self.behavior)
+      .worker_ids
+      .iter()
+      .collect::<std::collections::HashSet<_>>()
+      .len()
+  }
+}
+
+#[cfg(test)]
+impl EpochMaintenanceExecutor for TestEpochMaintenanceExecutor {
+  fn run_batch(
+    &self,
+    limit: usize,
+    cancellation: Arc<AtomicBool>,
+  ) -> Result<EpochMaintenanceBatch, String> {
+    let call = self.calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let (gate, result, panic_now) = {
+      let mut behavior = lock(&self.behavior);
+      behavior.limits.push(limit);
+      behavior.cancellations.push(Arc::clone(&cancellation));
+      behavior
+        .worker_ids
+        .push(format!("{:?}", thread::current().id()));
+      let panic_now = behavior.panic_calls.remove(&call);
+      let result = (!panic_now).then(|| {
+        behavior.results.pop_front().unwrap_or(Ok(EpochMaintenanceBatch::Progress {
+          processed_rows: 1_000,
+          complete: false,
+        }))
+      });
+      (behavior.body_gates.remove(&call), result, panic_now)
+    };
+    self.changed.notify_all();
+    if let Some(gate) = gate {
+      gate.mark_entered_and_wait();
+    }
+    if panic_now {
+      panic!("intentional epoch maintenance panic");
+    }
+    if cancellation.load(Ordering::Acquire) {
+      return Ok(EpochMaintenanceBatch::Cancelled);
+    }
+    result.expect("non-panicking maintenance call has a result")
+  }
+}
+
+#[cfg(test)]
 fn decrement_saturating_atomic(value: &AtomicU64) {
   let mut current = value.load(Ordering::Acquire);
   loop {
@@ -5017,6 +5914,8 @@ enum TestRigSchedule {
   StartupDue,
   Paused,
   HugeInterval,
+  ThirtySecondDeadline,
+  ThirtyOneSecondDeadline,
 }
 
 #[cfg(test)]
@@ -5053,6 +5952,29 @@ impl RuntimeTestRig {
     )
   }
 
+  fn startup_due_with_pre_body_gates_and_maintenance(
+    maintenance: Arc<TestEpochMaintenanceExecutor>,
+  ) -> (Self, PhaseGateControl, PhaseGateControl) {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    let parse = token.block_parse_call(1);
+    let fetch = live.block_fetch_call_before_body(1);
+    (
+      Self::build_with_components_and_options(
+        TestRigSchedule::StartupDue,
+        hooks,
+        token,
+        live,
+        Some(maintenance),
+        None,
+      ),
+      parse,
+      fetch,
+    )
+  }
+
   fn scheduled_overdue(overdue: Duration) -> Self {
     let rig = Self::build(TestRigSchedule::Paused).0;
     rig
@@ -5079,17 +6001,66 @@ impl RuntimeTestRig {
     (rig, hooks)
   }
 
+  fn build_with_maintenance(
+    schedule: TestRigSchedule,
+    maintenance: Arc<TestEpochMaintenanceExecutor>,
+  ) -> Self {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    Self::build_with_components_and_options(
+      schedule,
+      hooks,
+      token,
+      live,
+      Some(maintenance),
+      None,
+    )
+  }
+
+  fn build_with_maintenance_and_mutation(
+    schedule: TestRigSchedule,
+    maintenance: Arc<TestEpochMaintenanceExecutor>,
+    mutation: UsageMutationCoordinator,
+  ) -> Self {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    Self::build_with_components_and_options(
+      schedule,
+      hooks,
+      token,
+      live,
+      Some(maintenance),
+      Some(mutation),
+    )
+  }
+
   fn build_with_components(
     schedule: TestRigSchedule,
     hooks: Arc<RuntimeTestHooks>,
     token: Arc<TestTokenExecutor>,
     live: Arc<TestLiveExecutor>,
   ) -> Self {
+    Self::build_with_components_and_options(schedule, hooks, token, live, None, None)
+  }
+
+  fn build_with_components_and_options(
+    schedule: TestRigSchedule,
+    hooks: Arc<RuntimeTestHooks>,
+    token: Arc<TestTokenExecutor>,
+    live: Arc<TestLiveExecutor>,
+    maintenance: Option<Arc<TestEpochMaintenanceExecutor>>,
+    mutation: Option<UsageMutationCoordinator>,
+  ) -> Self {
     let clock = Arc::new(TestClock::new());
-    let interval = if matches!(schedule, TestRigSchedule::HugeInterval) {
-      Duration::MAX
-    } else {
-      Duration::from_secs(60)
+    let interval = match schedule {
+      TestRigSchedule::HugeInterval => Duration::MAX,
+      TestRigSchedule::ThirtySecondDeadline => Duration::from_secs(30),
+      TestRigSchedule::ThirtyOneSecondDeadline => Duration::from_secs(31),
+      _ => Duration::from_secs(60),
     };
     let wall_now = clock.wall_now();
     let (auto_scan_enabled, success_wall) = match schedule {
@@ -5100,6 +6071,9 @@ impl RuntimeTestRig {
       ),
       TestRigSchedule::Paused => (true, Some(wall_now)),
       TestRigSchedule::HugeInterval => (false, Some(wall_now)),
+      TestRigSchedule::ThirtySecondDeadline | TestRigSchedule::ThirtyOneSecondDeadline => {
+        (true, Some(wall_now))
+      }
     };
     let config = RefreshConfig {
       auto_scan_enabled,
@@ -5109,7 +6083,7 @@ impl RuntimeTestRig {
       live_last_success_wall: success_wall,
     };
     let events = Arc::new(TestEvents::new(Arc::clone(&hooks)));
-    let mutation = UsageMutationCoordinator::new();
+    let mutation = mutation.unwrap_or_default();
     let activities = super::power::CountingActivityFactory::default();
     let live_cache = LiveQuotaCache::new();
     let dependencies = RefreshRuntimeDependencies {
@@ -5122,6 +6096,9 @@ impl RuntimeTestRig {
       mutation: mutation.clone(),
       activity_factory: Arc::new(activities.clone()),
       clock: clock.clone(),
+      epoch_maintenance_executor: maintenance
+        .as_ref()
+        .map(|executor| executor.clone() as Arc<dyn EpochMaintenanceExecutor>),
       test_hooks: Some(Arc::clone(&hooks)),
     };
     let runtime = Arc::new(RefreshRuntime::start(dependencies).expect("start test runtime"));
@@ -5163,6 +6140,24 @@ impl RuntimeTestRig {
       .runtime
       .test_hooks
       .wait_for(timeout, |data| data.persistence_outcomes >= expected);
+  }
+
+  fn wait_for_maintenance_outcomes(&self, expected: u64, timeout: Duration) {
+    self
+      .runtime
+      .test_hooks
+      .wait_for(timeout, |data| data.maintenance_outcomes >= expected);
+  }
+
+  fn wait_for_maintenance_exit(&self, timeout: Duration) {
+    self
+      .runtime
+      .test_hooks
+      .wait_for(timeout, |data| data.maintenance_exited);
+  }
+
+  fn wait_for_mutation_queue(&self, expected: usize, timeout: Duration) {
+    self.mutation.wait_for_queued_for_test(expected, timeout);
   }
 
   fn shutdown(&self) {
@@ -5242,6 +6237,19 @@ impl RuntimeTestRig {
         },
       )))
       .expect("inject duplicate token completion");
+  }
+
+  fn inject_maintenance_outcome(
+    &self,
+    attempt_id: u64,
+    result: Result<EpochMaintenanceBatch, String>,
+  ) {
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::Worker(WorkerOutcome::Maintenance(
+        EpochMaintenanceWorkerOutcome { attempt_id, result },
+      )))
+      .expect("inject maintenance outcome");
   }
 
   fn pause_coordinator(&self) -> CoordinatorPause {

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -24,6 +24,7 @@ struct LaneState {
   next_deadline: Instant,
   running: bool,
   startup_due: bool,
+  immediate_due: bool,
 }
 
 impl LaneState {
@@ -32,6 +33,7 @@ impl LaneState {
       next_deadline,
       running: false,
       startup_due: next_deadline <= monotonic_now,
+      immediate_due: false,
     }
   }
 
@@ -45,7 +47,23 @@ impl LaneState {
     } else {
       old_interval.saturating_add(now.duration_since(self.next_deadline))
     };
-    self.next_deadline = now + new_interval.saturating_sub(elapsed);
+    let remaining = if self.next_deadline.checked_sub(old_interval).is_some() {
+      let phase = duration_remainder(elapsed, new_interval);
+      if phase.is_zero() {
+        new_interval
+      } else {
+        new_interval - phase
+      }
+    } else {
+      let remaining = new_interval.saturating_sub(elapsed);
+      if remaining.is_zero() {
+        new_interval
+      } else {
+        remaining
+      }
+    };
+    self.next_deadline = now + remaining;
+    self.immediate_due |= elapsed >= new_interval;
   }
 
   fn take_due(
@@ -54,12 +72,15 @@ impl LaneState {
     interval: Duration,
     trigger_reason: RefreshReason,
   ) -> Option<RefreshReason> {
-    if self.next_deadline > now {
+    if !self.immediate_due && self.next_deadline > now {
       return None;
     }
 
-    let (next_deadline, _) = advance_fixed_deadline(self.next_deadline, interval, now);
-    self.next_deadline = next_deadline;
+    self.immediate_due = false;
+    if self.next_deadline <= now {
+      let (next_deadline, _) = advance_fixed_deadline(self.next_deadline, interval, now);
+      self.next_deadline = next_deadline;
+    }
     let reason = if self.startup_due {
       RefreshReason::Startup
     } else {
@@ -176,6 +197,14 @@ fn advance_fixed_deadline(
     elapsed_intervals += 1;
   }
   (deadline, elapsed_intervals.saturating_sub(1))
+}
+
+fn duration_remainder(value: Duration, modulus: Duration) -> Duration {
+  let remainder_nanos = value.as_nanos() % modulus.as_nanos();
+  Duration::new(
+    (remainder_nanos / 1_000_000_000) as u64,
+    (remainder_nanos % 1_000_000_000) as u32,
+  )
 }
 
 fn initial_deadline(
@@ -424,6 +453,33 @@ mod tests {
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(90));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(90));
+  }
+
+  #[test]
+  fn shorter_interval_preserves_unaligned_fixed_deadline() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(45),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(30), Some(wall))),
+    );
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert_eq!(
+      state.token_next_deadline().duration_since(base),
+      Duration::from_secs(60)
+    );
+    assert_eq!(
+      state.live_next_deadline().duration_since(base),
+      Duration::from_secs(60)
+    );
   }
 
   #[test]

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -35,18 +35,17 @@ impl LaneState {
     }
   }
 
-  fn recalculate_interval(&mut self, old_interval: Duration, new_interval: Duration) {
+  fn recalculate_interval(&mut self, now: Instant, old_interval: Duration, new_interval: Duration) {
     if self.startup_due || old_interval == new_interval {
       return;
     }
 
-    let Some(previous_planned_deadline) = self.next_deadline.checked_sub(old_interval) else {
-      return;
+    let elapsed = if self.next_deadline > now {
+      old_interval.saturating_sub(self.next_deadline.duration_since(now))
+    } else {
+      old_interval.saturating_add(now.duration_since(self.next_deadline))
     };
-    let Some(next_deadline) = previous_planned_deadline.checked_add(new_interval) else {
-      return;
-    };
-    self.next_deadline = next_deadline;
+    self.next_deadline = now + new_interval.saturating_sub(elapsed);
   }
 
   fn take_due(
@@ -125,10 +124,10 @@ impl CoordinatorState {
         let old_interval = self.config.interval;
         self
           .token
-          .recalculate_interval(old_interval, config.interval);
+          .recalculate_interval(now, old_interval, config.interval);
         self
           .live
-          .recalculate_interval(old_interval, config.interval);
+          .recalculate_interval(now, old_interval, config.interval);
         self.config = config;
         RefreshReason::SettingsChanged
       }
@@ -425,6 +424,41 @@ mod tests {
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(90));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(90));
+  }
+
+  #[test]
+  fn shorter_interval_recalculates_when_prior_anchor_predates_monotonic_epoch() {
+    let base = Instant::now();
+    let old_interval = Duration::MAX;
+    let old_next_deadline = base + Duration::from_secs(60);
+    assert!(old_next_deadline.checked_sub(old_interval).is_none());
+    let mut state = CoordinatorState {
+      config: test_config(old_interval, None),
+      token: LaneState::new(old_next_deadline, base),
+      live: LaneState::new(old_next_deadline, base),
+    };
+
+    let actions = state.handle(
+      base + Duration::from_secs(30),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(10), None)),
+    );
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert!(matches!(
+      actions.as_slice(),
+      [
+        CoordinatorAction::StartToken {
+          reason: RefreshReason::SettingsChanged,
+          ..
+        },
+        CoordinatorAction::StartLive {
+          reason: RefreshReason::SettingsChanged,
+        },
+      ]
+    ));
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(40));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(40));
   }
 
   #[test]

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -140,7 +140,8 @@ pub(crate) struct CoordinatorState {
   live: LaneState,
   token_running: Option<TokenExecutionRequest>,
   token_running_source_refresh: bool,
-  token_pending: Option<TokenRequest>,
+  token_pending_manual: Option<TokenRequest>,
+  token_pending_automatic: Option<TokenRequest>,
   token_source_refresh_pending: Option<TokenRequest>,
   token_retry_request: Option<TokenRequest>,
   token_retry_source_refresh: bool,
@@ -184,7 +185,8 @@ impl CoordinatorState {
       live: LaneState::new(live_next_deadline, monotonic_now),
       token_running: None,
       token_running_source_refresh: false,
-      token_pending: None,
+      token_pending_manual: None,
+      token_pending_automatic: None,
       token_source_refresh_pending: None,
       token_retry_request: None,
       token_retry_source_refresh: false,
@@ -315,7 +317,10 @@ impl CoordinatorState {
       if let Some(previous_source_refresh) = self.token_source_refresh_pending.take() {
         request.reasons.merge(previous_source_refresh.reasons);
       }
-      if let Some(mut pending) = self.token_pending.take() {
+      if let Some(pending) = self.token_pending_automatic.take() {
+        request.reasons.merge(pending.reasons);
+      }
+      if let Some(mut pending) = self.token_pending_manual.take() {
         let manual_for_another_home = pending.reasons.contains(RefreshReason::Manual)
           && pending.codex_home != self.config.codex_home;
         if manual_for_another_home {
@@ -323,7 +328,7 @@ impl CoordinatorState {
           automatic_reasons.remove(RefreshReason::Manual);
           request.reasons.merge(automatic_reasons);
           pending.reasons = RefreshReason::Manual.into();
-          self.token_pending = Some(pending);
+          self.token_pending_manual = Some(pending);
         } else {
           request.reasons.merge(pending.reasons);
         }
@@ -454,7 +459,7 @@ impl CoordinatorState {
           }
         }
       }
-      merge_token_request(&mut self.token_pending, request);
+      self.queue_token_pending_request(request);
       return;
     }
 
@@ -463,7 +468,7 @@ impl CoordinatorState {
         if source_retry.codex_home == request.codex_home {
           source_retry.merge(request);
         } else {
-          merge_token_request(&mut self.token_pending, request);
+          self.queue_token_pending_request(request);
         }
         return;
       }
@@ -471,11 +476,53 @@ impl CoordinatorState {
     }
 
     if let Some(mut retry) = self.token_retry_request.take() {
-      retry.merge(request);
-      request = retry;
+      if retry.codex_home == request.codex_home {
+        retry.merge(request);
+        request = retry;
+      }
     }
     self.token.retry_at = None;
     self.start_token_request(request, false, actions);
+  }
+
+  fn queue_token_pending_request(&mut self, mut request: TokenRequest) {
+    if request.reasons.contains(RefreshReason::Manual) {
+      let automatic_matches = self
+        .token_pending_automatic
+        .as_ref()
+        .is_some_and(|pending| pending.codex_home == request.codex_home);
+      if automatic_matches {
+        if let Some(automatic) = self.token_pending_automatic.take() {
+          request.merge(automatic);
+        }
+      }
+      if let Some(manual) = self.token_pending_manual.as_mut() {
+        if manual.codex_home == request.codex_home {
+          manual.merge(request);
+        } else {
+          *manual = request;
+        }
+      } else {
+        self.token_pending_manual = Some(request);
+      }
+      return;
+    }
+
+    if let Some(manual) = self.token_pending_manual.as_mut() {
+      if manual.codex_home == request.codex_home {
+        manual.merge(request);
+        return;
+      }
+    }
+    if let Some(automatic) = self.token_pending_automatic.as_mut() {
+      if automatic.codex_home == request.codex_home {
+        automatic.merge(request);
+      } else {
+        *automatic = request;
+      }
+    } else {
+      self.token_pending_automatic = Some(request);
+    }
   }
 
   fn start_token_request(
@@ -741,21 +788,22 @@ impl CoordinatorState {
       self.submit_source_refresh_request(request, actions);
       return;
     }
-    if let Some(request) = self.token_pending.take() {
-      if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
-        return;
-      }
+    if let Some(request) = self.token_pending_manual.take() {
       self.submit_token_request(request, actions);
+      return;
+    }
+    if let Some(request) = self.token_pending_automatic.take() {
+      if self.config.auto_scan_enabled {
+        self.submit_token_request(request, actions);
+      }
     }
   }
 
   fn prune_automatic_pending_work(&mut self) {
-    if let Some(mut pending) = self.token_pending.take() {
-      if pending.reasons.contains(RefreshReason::Manual) {
-        pending.reasons = RefreshReason::Manual.into();
-        self.token_pending = Some(pending);
-      }
+    if let Some(pending) = self.token_pending_manual.as_mut() {
+      pending.reasons = RefreshReason::Manual.into();
     }
+    self.token_pending_automatic = None;
     self.live_pending = ReasonSet::default();
   }
 
@@ -2108,5 +2156,88 @@ mod tests {
     assert!(completion_actions
       .iter()
       .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+  }
+
+  #[test]
+  fn later_automatic_trigger_does_not_retarget_pending_manual_home() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/configured-home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("configured-source Full refresh starts");
+
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home-c".to_string(),
+      ))),
+    );
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+
+    let protected_success = state.handle(
+      base + Duration::from_secs(5),
+      CoordinatorEvent::TokenFinished(execution_success(
+        protected.generation,
+        protected.source_generation,
+        2,
+        base + Duration::from_secs(5),
+      )),
+    );
+    let manual = protected_success
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual follow-up starts first");
+    assert_eq!(manual.request.kind, TokenScanKind::Full);
+    assert!(manual.request.reasons.contains(RefreshReason::Manual));
+    assert_eq!(
+      manual.request.codex_home.as_deref(),
+      Some("/normalized/manual-home-c")
+    );
+
+    let manual_success = state.handle(
+      base + Duration::from_secs(6),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual.generation,
+        manual.source_generation,
+        3,
+        base + Duration::from_secs(6),
+      )),
+    );
+    assert!(matches!(
+      manual_success.last(),
+      Some(CoordinatorAction::StartToken(request))
+        if request.request.reasons.contains(RefreshReason::Scheduled)
+          && !request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref()
+            == Some("/normalized/configured-home-b")
+    ));
   }
 }

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -1,0 +1,456 @@
+use super::{RefreshConfig, RefreshReason, TokenScanKind};
+use chrono::{DateTime, Utc};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug)]
+pub(crate) enum CoordinatorEvent {
+  Timer,
+  Wake,
+  SettingsChanged(RefreshConfig),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CoordinatorAction {
+  StartToken {
+    kind: TokenScanKind,
+    reason: RefreshReason,
+  },
+  StartLive {
+    reason: RefreshReason,
+  },
+}
+
+struct LaneState {
+  next_deadline: Instant,
+  running: bool,
+  startup_due: bool,
+}
+
+impl LaneState {
+  fn new(next_deadline: Instant, monotonic_now: Instant) -> Self {
+    Self {
+      next_deadline,
+      running: false,
+      startup_due: next_deadline <= monotonic_now,
+    }
+  }
+
+  fn recalculate_interval(&mut self, old_interval: Duration, new_interval: Duration) {
+    if self.startup_due || old_interval == new_interval {
+      return;
+    }
+
+    let Some(previous_planned_deadline) = self.next_deadline.checked_sub(old_interval) else {
+      return;
+    };
+    let Some(next_deadline) = previous_planned_deadline.checked_add(new_interval) else {
+      return;
+    };
+    self.next_deadline = next_deadline;
+  }
+
+  fn take_due(
+    &mut self,
+    now: Instant,
+    interval: Duration,
+    trigger_reason: RefreshReason,
+  ) -> Option<RefreshReason> {
+    if self.next_deadline > now {
+      return None;
+    }
+
+    let (next_deadline, _) = advance_fixed_deadline(self.next_deadline, interval, now);
+    self.next_deadline = next_deadline;
+    let reason = if self.startup_due {
+      RefreshReason::Startup
+    } else {
+      trigger_reason
+    };
+    self.startup_due = false;
+
+    if self.running {
+      return None;
+    }
+
+    self.running = true;
+    Some(reason)
+  }
+}
+
+pub(crate) struct CoordinatorState {
+  config: RefreshConfig,
+  token: LaneState,
+  live: LaneState,
+}
+
+impl CoordinatorState {
+  pub(crate) fn new(
+    config: RefreshConfig,
+    monotonic_now: Instant,
+    wall_now: DateTime<Utc>,
+  ) -> Self {
+    assert!(
+      !config.interval.is_zero(),
+      "refresh interval must be positive"
+    );
+    let token_next_deadline = initial_deadline(
+      monotonic_now,
+      wall_now,
+      config.token_last_success_wall,
+      config.interval,
+    );
+    let live_next_deadline = initial_deadline(
+      monotonic_now,
+      wall_now,
+      config.live_last_success_wall,
+      config.interval,
+    );
+
+    Self {
+      config,
+      token: LaneState::new(token_next_deadline, monotonic_now),
+      live: LaneState::new(live_next_deadline, monotonic_now),
+    }
+  }
+
+  pub(crate) fn handle(&mut self, now: Instant, event: CoordinatorEvent) -> Vec<CoordinatorAction> {
+    let trigger_reason = match event {
+      CoordinatorEvent::Timer => RefreshReason::Scheduled,
+      CoordinatorEvent::Wake => RefreshReason::Wake,
+      CoordinatorEvent::SettingsChanged(config) => {
+        assert!(
+          !config.interval.is_zero(),
+          "refresh interval must be positive"
+        );
+        let old_interval = self.config.interval;
+        self
+          .token
+          .recalculate_interval(old_interval, config.interval);
+        self
+          .live
+          .recalculate_interval(old_interval, config.interval);
+        self.config = config;
+        RefreshReason::SettingsChanged
+      }
+    };
+
+    if !self.config.auto_scan_enabled {
+      return Vec::new();
+    }
+
+    let mut actions = Vec::with_capacity(2);
+    if let Some(reason) = self
+      .token
+      .take_due(now, self.config.interval, trigger_reason)
+    {
+      actions.push(CoordinatorAction::StartToken {
+        kind: TokenScanKind::Incremental,
+        reason,
+      });
+    }
+    if let Some(reason) = self
+      .live
+      .take_due(now, self.config.interval, trigger_reason)
+    {
+      actions.push(CoordinatorAction::StartLive { reason });
+    }
+    actions
+  }
+
+  pub(crate) fn token_next_deadline(&self) -> Instant {
+    self.token.next_deadline
+  }
+
+  pub(crate) fn live_next_deadline(&self) -> Instant {
+    self.live.next_deadline
+  }
+}
+
+fn advance_fixed_deadline(
+  mut deadline: Instant,
+  interval: Duration,
+  now: Instant,
+) -> (Instant, u64) {
+  let mut elapsed_intervals = 0_u64;
+  while deadline <= now {
+    deadline += interval;
+    elapsed_intervals += 1;
+  }
+  (deadline, elapsed_intervals.saturating_sub(1))
+}
+
+fn initial_deadline(
+  monotonic_now: Instant,
+  wall_now: DateTime<Utc>,
+  last_success: Option<DateTime<Utc>>,
+  interval: Duration,
+) -> Instant {
+  let Some(age) =
+    last_success.and_then(|value| wall_now.signed_duration_since(value).to_std().ok())
+  else {
+    return monotonic_now;
+  };
+  monotonic_now + interval.saturating_sub(age)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use chrono::{DateTime, Duration as ChronoDuration, Utc};
+  use std::time::{Duration, Instant};
+
+  fn utc(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+      .expect("valid test timestamp")
+      .with_timezone(&Utc)
+  }
+
+  fn test_config(interval: Duration, last_success_wall: Option<DateTime<Utc>>) -> RefreshConfig {
+    RefreshConfig {
+      auto_scan_enabled: true,
+      interval,
+      codex_home: None,
+      token_last_success_wall: last_success_wall,
+      live_last_success_wall: last_success_wall,
+    }
+  }
+
+  fn token_starts(actions: &[CoordinatorAction]) -> usize {
+    actions
+      .iter()
+      .filter(|value| matches!(value, CoordinatorAction::StartToken { .. }))
+      .count()
+  }
+
+  fn live_starts(actions: &[CoordinatorAction]) -> usize {
+    actions
+      .iter()
+      .filter(|value| matches!(value, CoordinatorAction::StartLive { .. }))
+      .count()
+  }
+
+  #[test]
+  fn persisted_success_maps_remaining_wall_time_to_monotonic_deadline() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let last_success = wall - ChronoDuration::seconds(120);
+    let state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(last_success)),
+      base,
+      wall,
+    );
+
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(180));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(180));
+  }
+
+  #[test]
+  fn missing_persisted_success_starts_one_immediate_catch_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(test_config(Duration::from_secs(300), None), base, wall);
+
+    let first = state.handle(base, CoordinatorEvent::Timer);
+    let duplicate = state.handle(base + Duration::from_secs(1), CoordinatorEvent::Timer);
+
+    assert_eq!(token_starts(&first), 1);
+    assert_eq!(live_starts(&first), 1);
+    assert!(matches!(
+      first.as_slice(),
+      [
+        CoordinatorAction::StartToken {
+          kind: TokenScanKind::Incremental,
+          reason: RefreshReason::Startup,
+        },
+        CoordinatorAction::StartLive {
+          reason: RefreshReason::Startup,
+        },
+      ]
+    ));
+    assert!(duplicate.is_empty());
+  }
+
+  #[test]
+  fn invalid_persisted_success_starts_one_immediate_catch_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let malformed_success = crate::refresh::parse_persisted_success_wall(Some("not-a-timestamp"));
+    let future_success = wall + ChronoDuration::seconds(1);
+
+    assert_eq!(malformed_success, None);
+    for last_success in [malformed_success, Some(future_success)] {
+      let mut state = CoordinatorState::new(
+        test_config(Duration::from_secs(300), last_success),
+        base,
+        wall,
+      );
+
+      let first = state.handle(base, CoordinatorEvent::Timer);
+      let duplicate = state.handle(base, CoordinatorEvent::Timer);
+
+      assert_eq!(token_starts(&first), 1);
+      assert_eq!(live_starts(&first), 1);
+      assert!(duplicate.is_empty());
+    }
+  }
+
+  #[test]
+  fn overdue_persisted_success_starts_one_immediate_catch_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let overdue_success = wall - ChronoDuration::seconds(301);
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(overdue_success)),
+      base,
+      wall,
+    );
+
+    let first = state.handle(base, CoordinatorEvent::Timer);
+    let duplicate = state.handle(base + Duration::from_secs(1), CoordinatorEvent::Timer);
+
+    assert_eq!(token_starts(&first), 1);
+    assert_eq!(live_starts(&first), 1);
+    assert!(duplicate.is_empty());
+  }
+
+  #[test]
+  fn due_lanes_start_together_and_advance_from_planned_deadlines() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let config = test_config(Duration::from_secs(300), Some(wall));
+    let mut state = CoordinatorState::new(config, base, wall);
+
+    let actions = state.handle(base + Duration::from_secs(300), CoordinatorEvent::Timer);
+
+    assert!(actions
+      .iter()
+      .any(|value| matches!(value, CoordinatorAction::StartToken { .. })));
+    assert!(actions
+      .iter()
+      .any(|value| matches!(value, CoordinatorAction::StartLive { .. })));
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
+  }
+
+  #[test]
+  fn token_running_does_not_block_due_live_lane() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let config = RefreshConfig {
+      auto_scan_enabled: true,
+      interval: Duration::from_secs(300),
+      codex_home: None,
+      token_last_success_wall: None,
+      live_last_success_wall: Some(wall),
+    };
+    let mut state = CoordinatorState::new(config, base, wall);
+
+    let startup = state.handle(base, CoordinatorEvent::Timer);
+    let live_due = state.handle(base + Duration::from_secs(300), CoordinatorEvent::Timer);
+
+    assert_eq!(token_starts(&startup), 1);
+    assert_eq!(live_starts(&startup), 0);
+    assert_eq!(token_starts(&live_due), 0);
+    assert_eq!(live_starts(&live_due), 1);
+    assert!(matches!(
+      live_due.as_slice(),
+      [CoordinatorAction::StartLive {
+        reason: RefreshReason::Scheduled,
+      }]
+    ));
+  }
+
+  #[test]
+  fn missed_intervals_coalesce_into_one_catch_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let config = test_config(Duration::from_secs(300), Some(wall));
+    let mut state = CoordinatorState::new(config, base, wall);
+
+    let actions = state.handle(base + Duration::from_secs(950), CoordinatorEvent::Wake);
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert!(matches!(
+      actions.as_slice(),
+      [
+        CoordinatorAction::StartToken {
+          reason: RefreshReason::Wake,
+          ..
+        },
+        CoordinatorAction::StartLive {
+          reason: RefreshReason::Wake,
+        },
+      ]
+    ));
+    assert_eq!(
+      state.token_next_deadline(),
+      base + Duration::from_secs(1_200)
+    );
+    assert_eq!(
+      state.live_next_deadline(),
+      base + Duration::from_secs(1_200)
+    );
+  }
+
+  #[test]
+  fn shorter_interval_recalculates_deadline_immediately() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let shorter = test_config(Duration::from_secs(30), Some(wall));
+
+    let actions = state.handle(
+      base + Duration::from_secs(60),
+      CoordinatorEvent::SettingsChanged(shorter),
+    );
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert!(matches!(
+      actions.as_slice(),
+      [
+        CoordinatorAction::StartToken {
+          reason: RefreshReason::SettingsChanged,
+          ..
+        },
+        CoordinatorAction::StartLive {
+          reason: RefreshReason::SettingsChanged,
+        },
+      ]
+    ));
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(90));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(90));
+  }
+
+  #[test]
+  fn backward_wall_clock_does_not_move_runtime_deadline() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let future_wall_success = wall + ChronoDuration::hours(1);
+
+    let early = state.handle(
+      base + Duration::from_secs(299),
+      CoordinatorEvent::SettingsChanged(test_config(
+        Duration::from_secs(300),
+        Some(future_wall_success),
+      )),
+    );
+    let due = state.handle(base + Duration::from_secs(300), CoordinatorEvent::Timer);
+
+    assert!(early.is_empty());
+    assert_eq!(token_starts(&due), 1);
+    assert_eq!(live_starts(&due), 1);
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
+  }
+}

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -398,14 +398,19 @@ impl CoordinatorState {
           .token
           .take_normal_due(now, self.config.interval, trigger_reason)
       {
-        merge_token_request(
-          &mut request,
-          TokenRequest {
-            reasons: reason.into(),
-            kind: TokenScanKind::Incremental,
-            codex_home: self.config.codex_home.clone(),
-          },
-        );
+        let automatic = TokenRequest {
+          reasons: reason.into(),
+          kind: TokenScanKind::Incremental,
+          codex_home: self.config.codex_home.clone(),
+        };
+        let retry_has_different_home = request
+          .as_ref()
+          .is_some_and(|retry| retry.codex_home != automatic.codex_home);
+        if retry_has_different_home {
+          self.queue_token_pending_request(automatic);
+        } else {
+          merge_token_request(&mut request, automatic);
+        }
       }
     }
     request.map(|request| (request, source_refresh))
@@ -473,6 +478,16 @@ impl CoordinatorState {
         return;
       }
       self.token_retry_source_refresh = false;
+    }
+
+    let preserves_manual_retry = self.token_retry_request.as_ref().is_some_and(|retry| {
+      retry.reasons.contains(RefreshReason::Manual)
+        && !request.reasons.contains(RefreshReason::Manual)
+        && retry.codex_home != request.codex_home
+    });
+    if preserves_manual_retry {
+      self.queue_token_pending_request(request);
+      return;
     }
 
     if let Some(mut retry) = self.token_retry_request.take() {
@@ -2229,6 +2244,179 @@ mod tests {
         manual.source_generation,
         3,
         base + Duration::from_secs(6),
+      )),
+    );
+    assert!(matches!(
+      manual_success.last(),
+      Some(CoordinatorAction::StartToken(request))
+        if request.request.reasons.contains(RefreshReason::Scheduled)
+          && !request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref()
+            == Some("/normalized/configured-home-b")
+    ));
+  }
+
+  #[test]
+  fn failed_manual_retry_survives_different_home_automatic_pending() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/configured-home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("configured-source Full refresh starts");
+
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home-c".to_string(),
+      ))),
+    );
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    let protected_success = state.handle(
+      base + Duration::from_secs(5),
+      CoordinatorEvent::TokenFinished(execution_success(
+        protected.generation,
+        protected.source_generation,
+        2,
+        base + Duration::from_secs(5),
+      )),
+    );
+    let manual = protected_success
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual follow-up starts first");
+
+    let manual_failure = state.handle(
+      base + Duration::from_secs(6),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual.generation,
+        manual.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(token_starts(&manual_failure), 0);
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(11)));
+
+    let early = state.handle(base + Duration::from_secs(10), CoordinatorEvent::Timer);
+    assert_eq!(token_starts(&early), 0);
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(11)));
+
+    let retry_actions = state.handle(base + Duration::from_secs(11), CoordinatorEvent::Timer);
+    let manual_retry = retry_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual Full retry starts at its deadline");
+    assert_eq!(manual_retry.request.kind, TokenScanKind::Full);
+    assert!(manual_retry.request.reasons.contains(RefreshReason::Manual));
+    assert_eq!(
+      manual_retry.request.codex_home.as_deref(),
+      Some("/normalized/manual-home-c")
+    );
+
+    let manual_success = state.handle(
+      base + Duration::from_secs(12),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual_retry.generation,
+        manual_retry.source_generation,
+        3,
+        base + Duration::from_secs(12),
+      )),
+    );
+    assert!(matches!(
+      manual_success.last(),
+      Some(CoordinatorAction::StartToken(request))
+        if request.request.reasons.contains(RefreshReason::Scheduled)
+          && !request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref()
+            == Some("/normalized/configured-home-b")
+    ));
+  }
+
+  #[test]
+  fn due_automatic_trigger_does_not_retarget_manual_retry() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(5);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/configured-home-b".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let manual = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+          "/normalized/manual-home-c".to_string(),
+        ))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual Full refresh starts");
+
+    let failure_actions = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual.generation,
+        manual.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(token_starts(&failure_actions), 0);
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(6)));
+
+    let retry_actions = state.handle(base + Duration::from_secs(6), CoordinatorEvent::Timer);
+    let manual_retry = retry_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual Full retry starts at its deadline");
+    assert_eq!(manual_retry.request.kind, TokenScanKind::Full);
+    assert!(manual_retry.request.reasons.contains(RefreshReason::Manual));
+    assert_eq!(
+      manual_retry.request.codex_home.as_deref(),
+      Some("/normalized/manual-home-c")
+    );
+
+    let manual_success = state.handle(
+      base + Duration::from_secs(7),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual_retry.generation,
+        manual_retry.source_generation,
+        1,
+        base + Duration::from_secs(7),
       )),
     );
     assert!(matches!(

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -1,7 +1,8 @@
 use super::{
   CommitMarker, DisplayInvalidation, ExecutionCompletion, LiveExecutionRequest, LiveRequest,
-  LiveWaiterId, ReasonSet, RefreshCompletedEvent, RefreshConfig, RefreshLane, RefreshReason,
-  TokenExecutionRequest, TokenRequest, TokenScanKind,
+  LiveWaiterId, ReasonSet, RefreshCompletedEvent, RefreshConfig, RefreshDetail, RefreshFailureCode,
+  RefreshLane, RefreshReason, RefreshRejectionCode, RefreshWaiterOutcome, TokenExecutionRequest,
+  TokenRequest, TokenScanKind, TokenWaiterId, REFRESH_WAITER_CAPACITY,
 };
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};
@@ -37,20 +38,27 @@ pub(crate) enum CoordinatorAction {
   PublishCompletion(RefreshCompletedEvent),
   ResolveLiveWaiters {
     waiter_ids: Vec<LiveWaiterId>,
-    generation: u64,
-    succeeded: bool,
-    failure: Option<String>,
+    outcome: RefreshWaiterOutcome,
+  },
+  ResolveTokenWaiters {
+    waiter_ids: Vec<TokenWaiterId>,
+    outcome: RefreshWaiterOutcome,
   },
 }
 
 struct LaneState {
   next_deadline: Instant,
   startup_due: bool,
-  immediate_due: bool,
+  immediate_due_at: Option<Instant>,
   last_generation: u64,
   running_generation: Option<u64>,
   failure_streak: u32,
   retry_at: Option<Instant>,
+  missed_deadline_count: u64,
+  coalesced_trigger_count: u64,
+  suppress_next_missed_count: bool,
+  disabled_normal_overdue_lag: Option<Duration>,
+  disabled_retry_overdue_lag: Option<Duration>,
 }
 
 impl LaneState {
@@ -58,15 +66,26 @@ impl LaneState {
     Self {
       next_deadline,
       startup_due: next_deadline <= monotonic_now,
-      immediate_due: false,
+      immediate_due_at: None,
       last_generation: 0,
       running_generation: None,
       failure_streak: 0,
       retry_at: None,
+      missed_deadline_count: 0,
+      coalesced_trigger_count: 0,
+      suppress_next_missed_count: false,
+      disabled_normal_overdue_lag: None,
+      disabled_retry_overdue_lag: None,
     }
   }
 
-  fn recalculate_interval(&mut self, now: Instant, old_interval: Duration, new_interval: Duration) {
+  fn recalculate_interval(
+    &mut self,
+    now: Instant,
+    old_interval: Duration,
+    new_interval: Duration,
+    count_missed: bool,
+  ) {
     if self.startup_due || old_interval == new_interval {
       return;
     }
@@ -76,7 +95,8 @@ impl LaneState {
     } else {
       old_interval.saturating_add(now.duration_since(self.next_deadline))
     };
-    let remaining = if self.next_deadline.checked_sub(old_interval).is_some() {
+    let anchor = self.next_deadline.checked_sub(old_interval);
+    let remaining = if anchor.is_some() {
       let phase = duration_remainder(elapsed, new_interval);
       if phase.is_zero() {
         new_interval
@@ -91,8 +111,82 @@ impl LaneState {
         remaining
       }
     };
-    self.next_deadline = now + remaining;
-    self.immediate_due = elapsed >= new_interval;
+    self.next_deadline = saturating_instant_add(now, remaining);
+    self.immediate_due_at = if elapsed >= new_interval {
+      if count_missed {
+        let due_count = elapsed.as_nanos() / new_interval.as_nanos();
+        let missed = due_count.saturating_sub(1).min(u64::MAX as u128) as u64;
+        self.missed_deadline_count = self.missed_deadline_count.saturating_add(missed);
+      }
+      anchor
+        .and_then(|anchor| anchor.checked_add(new_interval))
+        .or_else(|| now.checked_sub(elapsed.saturating_sub(new_interval)))
+        .or(Some(now))
+    } else {
+      None
+    };
+  }
+
+  fn pause_normal_schedule(&mut self, now: Instant) {
+    self.disabled_normal_overdue_lag = self
+      .immediate_due_at
+      .map(|planned_due_at| now.saturating_duration_since(planned_due_at));
+  }
+
+  fn resume_normal_schedule(&mut self, now: Instant) {
+    if self.immediate_due_at.is_some() || self.next_deadline <= now {
+      self.immediate_due_at = Some(
+        self
+          .disabled_normal_overdue_lag
+          .and_then(|lag| now.checked_sub(lag))
+          .unwrap_or(now),
+      );
+    }
+    self.disabled_normal_overdue_lag = None;
+    self.suppress_next_missed_count = self.next_deadline <= now;
+  }
+
+  fn pause_automatic_retry(&mut self, now: Instant) {
+    self.disabled_retry_overdue_lag = self
+      .retry_at
+      .filter(|retry_at| *retry_at <= now)
+      .map(|retry_at| now.saturating_duration_since(retry_at));
+  }
+
+  fn resume_automatic_retry(&mut self, now: Instant) -> Option<Instant> {
+    let Some(retry_at) = self.retry_at else {
+      self.disabled_retry_overdue_lag = None;
+      return None;
+    };
+    if retry_at > now {
+      self.disabled_retry_overdue_lag = None;
+      return None;
+    }
+    let planned_due_at = self
+      .disabled_retry_overdue_lag
+      .take()
+      .and_then(|lag| now.checked_sub(lag))
+      .unwrap_or(now);
+    self.retry_at = Some(planned_due_at);
+    Some(planned_due_at)
+  }
+
+  fn capture_enabled_overdue(&mut self, now: Instant, interval: Duration) -> Option<Instant> {
+    if self.next_deadline > now {
+      return self.immediate_due_at;
+    }
+    let planned_due_at = self.immediate_due_at.unwrap_or(self.next_deadline);
+    let had_immediate_due = self.immediate_due_at.is_some();
+    let (next_deadline, missed) = advance_fixed_deadline(self.next_deadline, interval, now);
+    self.next_deadline = next_deadline;
+    let missed = if had_immediate_due {
+      missed.saturating_add(1)
+    } else {
+      missed
+    };
+    self.missed_deadline_count = self.missed_deadline_count.saturating_add(missed);
+    self.immediate_due_at = Some(planned_due_at);
+    self.immediate_due_at
   }
 
   fn take_normal_due(
@@ -100,23 +194,34 @@ impl LaneState {
     now: Instant,
     interval: Duration,
     trigger_reason: RefreshReason,
-  ) -> Option<RefreshReason> {
-    if !self.immediate_due && self.next_deadline > now {
+  ) -> Option<(RefreshReason, Instant)> {
+    if self.immediate_due_at.is_none() && self.next_deadline > now {
       return None;
     }
 
-    self.immediate_due = false;
+    let had_immediate_due = self.immediate_due_at.is_some();
+    let planned_due_at = self.immediate_due_at.unwrap_or(self.next_deadline);
+    self.immediate_due_at = None;
     if self.next_deadline <= now {
-      let (next_deadline, _) = advance_fixed_deadline(self.next_deadline, interval, now);
+      let (next_deadline, missed) = advance_fixed_deadline(self.next_deadline, interval, now);
       self.next_deadline = next_deadline;
+      if !self.suppress_next_missed_count {
+        let missed = if had_immediate_due {
+          missed.saturating_add(1)
+        } else {
+          missed
+        };
+        self.missed_deadline_count = self.missed_deadline_count.saturating_add(missed);
+      }
     }
+    self.suppress_next_missed_count = false;
     let reason = if self.startup_due {
       RefreshReason::Startup
     } else {
       trigger_reason
     };
     self.startup_due = false;
-    Some(reason)
+    Some((reason, planned_due_at))
   }
 
   fn start_generation(&mut self) -> u64 {
@@ -134,6 +239,27 @@ impl LaneState {
   }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct LaneScheduleSnapshot {
+  pub running_generation: Option<u64>,
+  pub next_normal_deadline: Instant,
+  pub retry_deadline: Option<Instant>,
+  pub failure_streak: u32,
+  pub pending: bool,
+  pub pending_reasons: ReasonSet,
+  pub missed_deadline_count: u64,
+  pub coalesced_trigger_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CoordinatorSnapshot {
+  pub token: LaneScheduleSnapshot,
+  pub live: LaneScheduleSnapshot,
+  pub source_generation: u64,
+  pub interval: Duration,
+  pub auto_scan_enabled: bool,
+}
+
 pub(crate) struct CoordinatorState {
   config: RefreshConfig,
   token: LaneState,
@@ -147,7 +273,9 @@ pub(crate) struct CoordinatorState {
   token_retry_source_refresh: bool,
   live_running: Option<LiveExecutionRequest>,
   live_pending: ReasonSet,
+  live_pending_due_at: Option<Instant>,
   live_retry_reasons: ReasonSet,
+  live_retry_planned_due_at: Option<Instant>,
   live_waiters: Vec<LiveWaiterId>,
   source_generation: u64,
   refresh_revision: u64,
@@ -158,7 +286,7 @@ pub(crate) struct CoordinatorState {
 
 impl CoordinatorState {
   pub(crate) fn new(
-    config: RefreshConfig,
+    mut config: RefreshConfig,
     monotonic_now: Instant,
     wall_now: DateTime<Utc>,
   ) -> Self {
@@ -166,6 +294,7 @@ impl CoordinatorState {
       !config.interval.is_zero(),
       "refresh interval must be positive"
     );
+    config.interval = effective_interval(monotonic_now, config.interval);
     let token_next_deadline = initial_deadline(
       monotonic_now,
       wall_now,
@@ -192,7 +321,9 @@ impl CoordinatorState {
       token_retry_source_refresh: false,
       live_running: None,
       live_pending: ReasonSet::default(),
+      live_pending_due_at: None,
       live_retry_reasons: ReasonSet::default(),
+      live_retry_planned_due_at: None,
       live_waiters: Vec::new(),
       source_generation: 0,
       refresh_revision: 0,
@@ -207,83 +338,243 @@ impl CoordinatorState {
       CoordinatorEvent::Timer => self.handle_due(now, RefreshReason::Scheduled),
       CoordinatorEvent::Wake => self.handle_due(now, RefreshReason::Wake),
       CoordinatorEvent::SettingsChanged(config) => self.handle_settings_changed(now, config),
-      CoordinatorEvent::RequestToken(request) => {
-        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
-          return Vec::new();
+      CoordinatorEvent::RequestToken(mut request) => {
+        let mut actions = Vec::with_capacity(2);
+        if !self.prepare_token_intake(&mut request, &mut actions) {
+          return actions;
         }
-        let mut actions = Vec::with_capacity(1);
-        self.submit_token_request(request, &mut actions);
+        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+          return actions;
+        }
+        self.submit_token_request_with_due(now, request, &mut actions);
         actions
       }
       CoordinatorEvent::RequestLive(request) => {
-        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
-          return Vec::new();
+        let mut actions = Vec::with_capacity(2);
+        if let Some(waiter) = request.waiter {
+          if !request.reasons.contains(RefreshReason::Manual) {
+            actions.push(CoordinatorAction::ResolveLiveWaiters {
+              waiter_ids: vec![waiter],
+              outcome: rejected_outcome(RefreshRejectionCode::InvalidRequest, None),
+            });
+            return actions;
+          }
         }
-        let mut actions = Vec::with_capacity(1);
-        self.submit_live_request(request, &mut actions);
+        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+          return actions;
+        }
+        if let Some(waiter) = request.waiter {
+          if !self.live_waiters.contains(&waiter)
+            && self.live_waiters.len() >= REFRESH_WAITER_CAPACITY
+          {
+            actions.push(CoordinatorAction::ResolveLiveWaiters {
+              waiter_ids: vec![waiter],
+              outcome: rejected_outcome(RefreshRejectionCode::Busy, None),
+            });
+            return actions;
+          }
+        }
+        self.submit_live_request_with_due(now, request, &mut actions);
         actions
       }
       CoordinatorEvent::TokenPrepared {
         generation,
         source_generation,
-      } => self.handle_token_prepared(generation, source_generation),
-      CoordinatorEvent::TokenFinished(completion) => {
-        self.handle_token_finished(now, completion)
-      }
-      CoordinatorEvent::LiveFinished(completion) => {
-        self.handle_live_finished(now, completion)
-      }
+      } => self.handle_token_prepared(now, generation, source_generation),
+      CoordinatorEvent::TokenFinished(completion) => self.handle_token_finished(now, completion),
+      CoordinatorEvent::LiveFinished(completion) => self.handle_live_finished(now, completion),
     }
   }
 
   fn handle_due(&mut self, now: Instant, trigger_reason: RefreshReason) -> Vec<CoordinatorAction> {
     let mut token_request = self.take_due_token_request(now, trigger_reason);
-    let mut live_reasons = self.take_due_live_reasons(now, trigger_reason);
+    let live_request = self.take_due_live_request(now, trigger_reason);
     let mut actions = Vec::with_capacity(2);
 
     if let Some((request, source_refresh)) = token_request.take() {
       if source_refresh {
         self.submit_source_refresh_request(request, &mut actions);
       } else {
-        self.submit_token_request(request, &mut actions);
+        self.submit_token_request(now, request, &mut actions);
       }
     }
-    if !live_reasons.is_empty() {
-      self.submit_live_request(
-        LiveRequest {
-          reasons: std::mem::take(&mut live_reasons),
-          waiter: None,
-        },
-        &mut actions,
-      );
+    if let Some(request) = live_request {
+      self.submit_live_request(now, request, &mut actions);
     }
 
     actions
   }
 
+  fn submit_token_request_with_due(
+    &mut self,
+    now: Instant,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    let Some((due, due_is_source_refresh)) =
+      self.take_due_token_request(now, RefreshReason::Scheduled)
+    else {
+      self.submit_token_request(now, request, actions);
+      return;
+    };
+
+    if request.same_source_identity(&due) {
+      request
+        .try_merge(due)
+        .expect("same source identity was checked before request-time due merge");
+      self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+      if due_is_source_refresh {
+        self.submit_source_refresh_request(request, actions);
+      } else {
+        self.submit_token_request(now, request, actions);
+      }
+      return;
+    }
+
+    let due_matches_protected = !due_is_source_refresh
+      && self
+        .token_source_refresh_pending
+        .as_ref()
+        .is_some_and(|protected| protected.same_source_identity(&due));
+    let due_matches_protected_retry = !due_is_source_refresh
+      && self.token_retry_source_refresh
+      && self
+        .token_retry_request
+        .as_ref()
+        .is_some_and(|protected| protected.same_source_identity(&due));
+    if due_matches_protected {
+      self
+        .token_source_refresh_pending
+        .as_mut()
+        .expect("matching protected source refresh remains pending")
+        .try_merge(due)
+        .expect("same source identity was checked before protected due merge");
+      self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+    } else if due_matches_protected_retry {
+      self
+        .token_retry_request
+        .as_mut()
+        .expect("matching protected retry remains pending")
+        .try_merge(due)
+        .expect("same source identity was checked before protected retry due merge");
+      self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+    } else if due_is_source_refresh {
+      self.submit_source_refresh_request(due, actions);
+    } else {
+      self.queue_token_pending_request(due, actions);
+    }
+    self.submit_token_request(now, request, actions);
+  }
+
+  fn submit_live_request_with_due(
+    &mut self,
+    now: Instant,
+    mut request: LiveRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if let Some(due) = self.take_due_live_request(now, RefreshReason::Scheduled) {
+      request.reasons.merge(due.reasons);
+      request.planned_due_at = earliest_planned_due(request.planned_due_at, due.planned_due_at);
+      self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
+    }
+    self.submit_live_request(now, request, actions);
+  }
+
   fn handle_settings_changed(
     &mut self,
     now: Instant,
-    config: RefreshConfig,
+    mut config: RefreshConfig,
   ) -> Vec<CoordinatorAction> {
     assert!(
       !config.interval.is_zero(),
       "refresh interval must be positive"
     );
+    config.interval = effective_interval(now, config.interval);
     let old_interval = self.config.interval;
     let source_changed = self.config.codex_home != config.codex_home;
     let disabling_auto_scan = self.config.auto_scan_enabled && !config.auto_scan_enabled;
+    let enabling_auto_scan = !self.config.auto_scan_enabled && config.auto_scan_enabled;
+    let auto_scan_remains_enabled = self.config.auto_scan_enabled && config.auto_scan_enabled;
     let settings_changed = self.config.auto_scan_enabled != config.auto_scan_enabled
       || old_interval != config.interval
       || source_changed;
 
-    self
-      .token
-      .recalculate_interval(now, old_interval, config.interval);
-    self
-      .live
-      .recalculate_interval(now, old_interval, config.interval);
+    let token_enabled_due = disabling_auto_scan
+      .then(|| self.token.capture_enabled_overdue(now, old_interval))
+      .flatten();
+    let live_enabled_due = disabling_auto_scan
+      .then(|| self.live.capture_enabled_overdue(now, old_interval))
+      .flatten();
+    if !self.config.auto_scan_enabled && old_interval != config.interval {
+      self.token.disabled_normal_overdue_lag = None;
+      self.live.disabled_normal_overdue_lag = None;
+    }
+
+    self.token.recalculate_interval(
+      now,
+      old_interval,
+      config.interval,
+      auto_scan_remains_enabled,
+    );
+    self.live.recalculate_interval(
+      now,
+      old_interval,
+      config.interval,
+      auto_scan_remains_enabled,
+    );
+    self.token.immediate_due_at =
+      earliest_planned_due(self.token.immediate_due_at, token_enabled_due);
+    self.live.immediate_due_at = earliest_planned_due(self.live.immediate_due_at, live_enabled_due);
+    if disabling_auto_scan {
+      self.token.pause_normal_schedule(now);
+      self.live.pause_normal_schedule(now);
+      let token_retry_is_automatic_only = !self.token_retry_source_refresh
+        && self
+          .token_retry_request
+          .as_ref()
+          .is_some_and(|request| !request.reasons.contains(RefreshReason::Manual));
+      if token_retry_is_automatic_only {
+        self.token.pause_automatic_retry(now);
+      } else {
+        self.token.disabled_retry_overdue_lag = None;
+      }
+      let live_retry_is_automatic_only = !self.live_retry_reasons.is_empty()
+        && !self.live_retry_reasons.contains(RefreshReason::Manual);
+      if live_retry_is_automatic_only {
+        self.live.pause_automatic_retry(now);
+      } else {
+        self.live.disabled_retry_overdue_lag = None;
+      }
+    }
     self.config = config;
+
+    if enabling_auto_scan {
+      self.token.resume_normal_schedule(now);
+      self.live.resume_normal_schedule(now);
+      let token_retry_is_automatic_only = !self.token_retry_source_refresh
+        && self
+          .token_retry_request
+          .as_ref()
+          .is_some_and(|request| !request.reasons.contains(RefreshReason::Manual));
+      if token_retry_is_automatic_only {
+        if let Some(planned_due_at) = self.token.resume_automatic_retry(now) {
+          if let Some(request) = self.token_retry_request.as_mut() {
+            request.planned_due_at = Some(planned_due_at);
+          }
+        }
+      } else {
+        self.token.disabled_retry_overdue_lag = None;
+      }
+      let live_retry_is_automatic_only = !self.live_retry_reasons.is_empty()
+        && !self.live_retry_reasons.contains(RefreshReason::Manual);
+      if live_retry_is_automatic_only {
+        if let Some(planned_due_at) = self.live.resume_automatic_retry(now) {
+          self.live_retry_planned_due_at = Some(planned_due_at);
+        }
+      } else {
+        self.live.disabled_retry_overdue_lag = None;
+      }
+    }
 
     if disabling_auto_scan {
       self.prune_automatic_pending_work();
@@ -295,7 +586,8 @@ impl CoordinatorState {
 
     let mut token_request = None;
     let mut token_request_is_source_refresh = false;
-    let mut live_reasons = ReasonSet::default();
+    let mut live_request = None;
+    let mut actions = Vec::with_capacity(4);
     if source_changed {
       self.source_generation = self
         .source_generation
@@ -303,67 +595,101 @@ impl CoordinatorState {
         .expect("refresh source generation overflowed");
       self.token.failure_streak = 0;
       self.token.retry_at = None;
-      self.token_retry_request = None;
+      self.token.disabled_retry_overdue_lag = None;
+      if let Some(mut retry) = self.token_retry_request.take() {
+        self.reject_token_waiters(
+          retry.drain_waiters(),
+          RefreshRejectionCode::SourceChanged,
+          Some("refresh source changed"),
+          &mut actions,
+        );
+      }
       self.token_retry_source_refresh = false;
       self.live.failure_streak = 0;
       self.live.retry_at = None;
+      self.live.disabled_retry_overdue_lag = None;
       self.live_retry_reasons = ReasonSet::default();
+      self.live_retry_planned_due_at = None;
 
-      let mut request = TokenRequest {
-        reasons: RefreshReason::SettingsChanged.into(),
-        kind: TokenScanKind::Full,
-        codex_home: self.config.codex_home.clone(),
-      };
+      let mut request = TokenRequest::for_reason(RefreshReason::SettingsChanged);
+      request.kind = TokenScanKind::Full;
+      request.bind_configured_source(self.source_generation, self.config.codex_home.clone());
       if let Some(previous_source_refresh) = self.token_source_refresh_pending.take() {
-        request.reasons.merge(previous_source_refresh.reasons);
+        self.retarget_automatic_reasons(
+          &mut request,
+          previous_source_refresh,
+          RefreshRejectionCode::SourceChanged,
+          &mut actions,
+        );
       }
       if let Some(pending) = self.token_pending_automatic.take() {
-        request.reasons.merge(pending.reasons);
+        self.retarget_automatic_reasons(
+          &mut request,
+          pending,
+          RefreshRejectionCode::SourceChanged,
+          &mut actions,
+        );
       }
-      if let Some(mut pending) = self.token_pending_manual.take() {
-        let manual_for_another_home = pending.reasons.contains(RefreshReason::Manual)
-          && pending.codex_home != self.config.codex_home;
-        if manual_for_another_home {
-          let mut automatic_reasons = pending.reasons;
+      if let Some(pending) = self.token_pending_manual.take() {
+        if pending.same_source_identity(&request) {
+          request
+            .try_merge(pending)
+            .expect("same source identity was checked before settings merge");
+        } else if pending.source_generation.is_none() {
+          let mut manual = pending;
+          let mut automatic_reasons = manual.reasons;
           automatic_reasons.remove(RefreshReason::Manual);
           request.reasons.merge(automatic_reasons);
-          pending.reasons = RefreshReason::Manual.into();
-          self.token_pending_manual = Some(pending);
+          request.planned_due_at =
+            earliest_planned_due(request.planned_due_at, manual.planned_due_at);
+          manual.reasons = RefreshReason::Manual.into();
+          manual.planned_due_at = None;
+          self.token_pending_manual = Some(manual);
         } else {
-          request.reasons.merge(pending.reasons);
+          self.retarget_automatic_reasons(
+            &mut request,
+            pending,
+            RefreshRejectionCode::SourceChanged,
+            &mut actions,
+          );
         }
       }
       token_request = Some(request);
       token_request_is_source_refresh = true;
       if self.config.auto_scan_enabled {
-        live_reasons.insert(RefreshReason::SettingsChanged);
+        live_request = Some(LiveRequest::for_reason(RefreshReason::SettingsChanged));
       }
     }
 
     if let Some((due, due_is_source_refresh)) =
       self.take_due_token_request(now, RefreshReason::SettingsChanged)
     {
-      merge_token_request(&mut token_request, due);
-      token_request_is_source_refresh |= due_is_source_refresh;
+      let merged_existing = token_request.is_some();
+      if let Err(due) = merge_token_request(&mut token_request, due) {
+        self.queue_token_pending_request(due, &mut actions);
+      } else {
+        if merged_existing {
+          self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+        }
+        token_request_is_source_refresh |= due_is_source_refresh;
+      }
     }
-    live_reasons.merge(self.take_due_live_reasons(now, RefreshReason::SettingsChanged));
+    if let Some(due) = self.take_due_live_request(now, RefreshReason::SettingsChanged) {
+      if live_request.is_some() {
+        self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
+      }
+      merge_live_request(&mut live_request, due);
+    }
 
-    let mut actions = Vec::with_capacity(2);
     if let Some(request) = token_request {
       if token_request_is_source_refresh {
         self.submit_source_refresh_request(request, &mut actions);
       } else {
-        self.submit_token_request(request, &mut actions);
+        self.submit_token_request(now, request, &mut actions);
       }
     }
-    if !live_reasons.is_empty() {
-      self.submit_live_request(
-        LiveRequest {
-          reasons: live_reasons,
-          waiter: None,
-        },
-        &mut actions,
-      );
+    if let Some(request) = live_request {
+      self.submit_live_request(now, request, &mut actions);
     }
     actions
   }
@@ -384,8 +710,10 @@ impl CoordinatorState {
           .is_some_and(|value| value.reasons.contains(RefreshReason::Manual));
       if retry_allowed {
         self.token.retry_at = None;
+        self.token.disabled_retry_overdue_lag = None;
         if let Some(retry) = self.token_retry_request.take() {
-          merge_token_request(&mut request, retry);
+          merge_token_request(&mut request, retry)
+            .expect("an empty due request accepts the retry source");
           source_refresh = self.token_retry_source_refresh;
           self.token_retry_source_refresh = false;
         }
@@ -393,87 +721,103 @@ impl CoordinatorState {
     }
 
     if self.config.auto_scan_enabled {
-      if let Some(reason) =
+      if let Some((reason, planned_due_at)) =
         self
           .token
           .take_normal_due(now, self.config.interval, trigger_reason)
       {
-        let automatic = TokenRequest {
-          reasons: reason.into(),
-          kind: TokenScanKind::Incremental,
-          codex_home: self.config.codex_home.clone(),
-        };
-        let retry_has_different_home = request
+        let mut automatic = TokenRequest::for_reason_at(reason, planned_due_at);
+        automatic.bind_configured_source(self.source_generation, self.config.codex_home.clone());
+        let retry_has_different_source = request
           .as_ref()
-          .is_some_and(|retry| retry.codex_home != automatic.codex_home);
-        if retry_has_different_home {
-          self.queue_token_pending_request(automatic);
+          .is_some_and(|retry| !retry.same_source_identity(&automatic));
+        if retry_has_different_source {
+          self.queue_token_pending_request(automatic, &mut Vec::new());
         } else {
-          merge_token_request(&mut request, automatic);
+          if request.is_some() {
+            self.token.coalesced_trigger_count =
+              self.token.coalesced_trigger_count.saturating_add(1);
+          }
+          merge_token_request(&mut request, automatic)
+            .expect("same configured source was checked before deadline merge");
         }
       }
     }
     request.map(|request| (request, source_refresh))
   }
 
-  fn take_due_live_reasons(
+  fn take_due_live_request(
     &mut self,
     now: Instant,
     trigger_reason: RefreshReason,
-  ) -> ReasonSet {
+  ) -> Option<LiveRequest> {
     let mut reasons = ReasonSet::default();
+    let mut planned_due_at = None;
     if self.live.retry_at.is_some_and(|retry_at| retry_at <= now) {
-      let retry_allowed = self.config.auto_scan_enabled
-        || self.live_retry_reasons.contains(RefreshReason::Manual);
+      let retry_allowed =
+        self.config.auto_scan_enabled || self.live_retry_reasons.contains(RefreshReason::Manual);
       if retry_allowed {
         self.live.retry_at = None;
+        self.live.disabled_retry_overdue_lag = None;
         reasons.merge(std::mem::take(&mut self.live_retry_reasons));
+        planned_due_at = self.live_retry_planned_due_at.take();
       }
     }
 
     if self.config.auto_scan_enabled {
-      if let Some(reason) =
+      if let Some((reason, normal_due_at)) =
         self
           .live
           .take_normal_due(now, self.config.interval, trigger_reason)
       {
+        if !reasons.is_empty() {
+          self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
+        }
         reasons.insert(reason);
+        planned_due_at = earliest_planned_due(planned_due_at, Some(normal_due_at));
       }
     }
-    reasons
+    (!reasons.is_empty()).then_some(LiveRequest {
+      reasons,
+      waiter: None,
+      planned_due_at,
+    })
   }
 
   fn submit_token_request(
     &mut self,
+    now: Instant,
     mut request: TokenRequest,
     actions: &mut Vec<CoordinatorAction>,
   ) {
     if request.reasons.is_empty() {
       return;
     }
-    if request.codex_home.is_none() {
-      request.codex_home = self.config.codex_home.clone();
-    }
+    request.bind_source_if_needed(self.source_generation, self.config.codex_home.clone());
 
     if self.token.running_generation.is_some() {
-      if !self.token_running_source_refresh {
-        if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
-          if source_refresh.codex_home == request.codex_home {
-            source_refresh.merge(request);
-            return;
-          }
+      if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
+        if source_refresh.same_source_identity(&request) {
+          source_refresh
+            .try_merge(request)
+            .expect("same source identity was checked before protected merge");
+          self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+          return;
         }
       }
-      self.queue_token_pending_request(request);
+      self.queue_token_pending_request(request, actions);
       return;
     }
 
     if self.token_retry_source_refresh {
       if let Some(source_retry) = self.token_retry_request.as_mut() {
-        if source_retry.codex_home == request.codex_home {
-          source_retry.merge(request);
+        if source_retry.same_source_identity(&request) {
+          source_retry
+            .try_merge(request)
+            .expect("same source identity was checked before protected retry merge");
+          self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
         } else {
-          self.queue_token_pending_request(request);
+          self.queue_token_pending_request(request, actions);
         }
         return;
       }
@@ -483,39 +827,80 @@ impl CoordinatorState {
     let preserves_manual_retry = self.token_retry_request.as_ref().is_some_and(|retry| {
       retry.reasons.contains(RefreshReason::Manual)
         && !request.reasons.contains(RefreshReason::Manual)
-        && retry.codex_home != request.codex_home
+        && !retry.same_source_identity(&request)
     });
     if preserves_manual_retry {
-      self.queue_token_pending_request(request);
+      self.queue_token_pending_request(request, actions);
       return;
     }
 
     if let Some(mut retry) = self.token_retry_request.take() {
-      if retry.codex_home == request.codex_home {
-        retry.merge(request);
+      if retry.same_source_identity(&request) {
+        let retry_was_manual = retry.reasons.contains(RefreshReason::Manual);
+        let retry_due_was_eligible = self.token.retry_at.is_some_and(|retry_at| retry_at <= now)
+          && (self.config.auto_scan_enabled || self.token_retry_source_refresh || retry_was_manual);
+        if !retry_due_was_eligible {
+          retry.planned_due_at = if !self.config.auto_scan_enabled && !retry_was_manual {
+            self
+              .token
+              .disabled_retry_overdue_lag
+              .and_then(|lag| now.checked_sub(lag))
+          } else {
+            None
+          };
+        }
+        retry
+          .try_merge(request)
+          .expect("same source identity was checked before retry merge");
         request = retry;
+        self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+      } else {
+        self.reject_token_waiters(
+          retry.drain_waiters(),
+          RefreshRejectionCode::Superseded,
+          Some("refresh request was superseded"),
+          actions,
+        );
       }
     }
     self.token.retry_at = None;
+    self.token.disabled_retry_overdue_lag = None;
     self.start_token_request(request, false, actions);
   }
 
-  fn queue_token_pending_request(&mut self, mut request: TokenRequest) {
+  fn queue_token_pending_request(
+    &mut self,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
     if request.reasons.contains(RefreshReason::Manual) {
       let automatic_matches = self
         .token_pending_automatic
         .as_ref()
-        .is_some_and(|pending| pending.codex_home == request.codex_home);
+        .is_some_and(|pending| pending.same_source_identity(&request));
       if automatic_matches {
         if let Some(automatic) = self.token_pending_automatic.take() {
-          request.merge(automatic);
+          request
+            .try_merge(automatic)
+            .expect("same source identity was checked before pending merge");
         }
       }
-      if let Some(manual) = self.token_pending_manual.as_mut() {
-        if manual.codex_home == request.codex_home {
-          manual.merge(request);
+      if let Some(mut manual) = self.token_pending_manual.take() {
+        if manual.same_source_identity(&request) {
+          manual
+            .try_merge(request)
+            .expect("same source identity was checked before manual merge");
+          self.token_pending_manual = Some(manual);
         } else {
-          *manual = request;
+          self.reject_token_waiters(
+            manual.drain_waiters(),
+            RefreshRejectionCode::Superseded,
+            Some("refresh request was superseded"),
+            actions,
+          );
+          self.retain_automatic_request(manual, actions);
+          self.token_pending_manual = Some(request);
         }
       } else {
         self.token_pending_manual = Some(request);
@@ -524,16 +909,27 @@ impl CoordinatorState {
     }
 
     if let Some(manual) = self.token_pending_manual.as_mut() {
-      if manual.codex_home == request.codex_home {
-        manual.merge(request);
+      if manual.same_source_identity(&request) {
+        manual
+          .try_merge(request)
+          .expect("same source identity was checked before automatic merge");
         return;
       }
     }
-    if let Some(automatic) = self.token_pending_automatic.as_mut() {
-      if automatic.codex_home == request.codex_home {
-        automatic.merge(request);
+    if let Some(mut automatic) = self.token_pending_automatic.take() {
+      if automatic.same_source_identity(&request) {
+        automatic
+          .try_merge(request)
+          .expect("same source identity was checked before automatic merge");
+        self.token_pending_automatic = Some(automatic);
       } else {
-        *automatic = request;
+        self.reject_token_waiters(
+          automatic.drain_waiters(),
+          RefreshRejectionCode::Superseded,
+          Some("refresh request was superseded"),
+          actions,
+        );
+        self.token_pending_automatic = Some(request);
       }
     } else {
       self.token_pending_automatic = Some(request);
@@ -542,10 +938,28 @@ impl CoordinatorState {
 
   fn start_token_request(
     &mut self,
-    request: TokenRequest,
+    mut request: TokenRequest,
     source_refresh: bool,
     actions: &mut Vec<CoordinatorAction>,
   ) {
+    if request
+      .source_generation
+      .is_some_and(|generation| generation != self.source_generation)
+    {
+      self.reject_token_waiters(
+        request.drain_waiters(),
+        RefreshRejectionCode::SourceChanged,
+        Some("refresh source changed"),
+        actions,
+      );
+      request.reasons.remove(RefreshReason::Manual);
+      if request.reasons.is_empty() {
+        return;
+      }
+      request.bind_configured_source(self.source_generation, self.config.codex_home.clone());
+      request.kind = TokenScanKind::Full;
+      request.reasons.insert(RefreshReason::SettingsChanged);
+    }
     let generation = self.token.start_generation();
     let execution = TokenExecutionRequest {
       generation,
@@ -567,25 +981,48 @@ impl CoordinatorState {
         && self
           .token_running
           .as_ref()
-          .is_some_and(|running| running.request.codex_home == request.codex_home);
+          .is_some_and(|running| running.request.same_source_identity(&request));
       if matches_running_source_refresh {
-        merge_token_request(&mut self.token_source_refresh_pending, request);
+        if let Err(request) = merge_token_request(&mut self.token_source_refresh_pending, request) {
+          self.token_source_refresh_pending = Some(request);
+        }
+        self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
         return;
       }
       if let Some(previous) = self.token_source_refresh_pending.take() {
-        request.reasons.merge(previous.reasons);
+        if request.same_source_identity(&previous) {
+          request
+            .try_merge(previous)
+            .expect("same source identity was checked before source-refresh merge");
+        } else {
+          self.retarget_automatic_reasons(
+            &mut request,
+            previous,
+            RefreshRejectionCode::SourceChanged,
+            actions,
+          );
+        }
       }
       self.token_source_refresh_pending = Some(request);
+      self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
       return;
     }
     self.token.retry_at = None;
-    self.token_retry_request = None;
+    if let Some(mut retry) = self.token_retry_request.take() {
+      self.reject_token_waiters(
+        retry.drain_waiters(),
+        RefreshRejectionCode::SourceChanged,
+        Some("refresh source changed"),
+        actions,
+      );
+    }
     self.token_retry_source_refresh = false;
     self.start_token_request(request, true, actions);
   }
 
   fn submit_live_request(
     &mut self,
+    now: Instant,
     mut request: LiveRequest,
     actions: &mut Vec<CoordinatorAction>,
   ) {
@@ -595,14 +1032,39 @@ impl CoordinatorState {
       }
       request.reasons.remove(RefreshReason::Manual);
       self.live_pending.merge(request.reasons);
+      self.live_pending_due_at =
+        earliest_planned_due(self.live_pending_due_at, request.planned_due_at);
+      self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
       return;
     }
 
     if let Some(waiter) = request.waiter {
       push_unique_waiter(&mut self.live_waiters, waiter);
     }
-    request.reasons.merge(std::mem::take(&mut self.live_retry_reasons));
+    let had_retry = !self.live_retry_reasons.is_empty();
+    let retry_was_manual = self.live_retry_reasons.contains(RefreshReason::Manual);
+    let retry_due_was_eligible = self.live.retry_at.is_some_and(|retry_at| retry_at <= now)
+      && (self.config.auto_scan_enabled || retry_was_manual);
+    request
+      .reasons
+      .merge(std::mem::take(&mut self.live_retry_reasons));
+    let retry_planned_due_at = self.live_retry_planned_due_at.take();
+    let retry_planned_due_at = if retry_due_was_eligible {
+      retry_planned_due_at
+    } else if !self.config.auto_scan_enabled && !retry_was_manual {
+      self
+        .live
+        .disabled_retry_overdue_lag
+        .and_then(|lag| now.checked_sub(lag))
+    } else {
+      None
+    };
+    request.planned_due_at = earliest_planned_due(request.planned_due_at, retry_planned_due_at);
     self.live.retry_at = None;
+    self.live.disabled_retry_overdue_lag = None;
+    if had_retry {
+      self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
+    }
     if request.reasons.is_empty() {
       return;
     }
@@ -612,6 +1074,7 @@ impl CoordinatorState {
       generation,
       source_generation: self.source_generation,
       reasons: request.reasons,
+      planned_due_at: request.planned_due_at,
     };
     self.live_running = Some(execution.clone());
     actions.push(CoordinatorAction::StartLive(execution));
@@ -619,6 +1082,7 @@ impl CoordinatorState {
 
   fn handle_token_prepared(
     &mut self,
+    now: Instant,
     generation: u64,
     source_generation: u64,
   ) -> Vec<CoordinatorAction> {
@@ -639,8 +1103,7 @@ impl CoordinatorState {
       return actions;
     }
 
-    if running.source_generation == source_generation
-      && source_generation == self.source_generation
+    if running.source_generation == source_generation && source_generation == self.source_generation
     {
       actions.push(CoordinatorAction::CommitToken {
         generation,
@@ -659,14 +1122,30 @@ impl CoordinatorState {
       generation,
       source_generation,
     });
-    if self.token_source_refresh_pending.is_none() {
-      let mut request = stale.request;
+    let mut stale_request = stale.request;
+    let stale_waiters = stale_request.drain_waiters();
+    self.complete_token_waiters(
+      stale_waiters,
+      generation,
+      false,
+      Some(RefreshFailureCode::SourceChanged),
+      Some("refresh source changed"),
+      &mut actions,
+    );
+    let mut replacement = self.token_source_refresh_pending.take().unwrap_or_else(|| {
+      let mut request = TokenRequest::for_reason(RefreshReason::SettingsChanged);
       request.kind = TokenScanKind::Full;
-      request.codex_home = self.config.codex_home.clone();
-      request.reasons.insert(RefreshReason::SettingsChanged);
-      self.token_source_refresh_pending = Some(request);
-    }
-    self.start_pending_token(&mut actions);
+      request.bind_configured_source(self.source_generation, self.config.codex_home.clone());
+      request
+    });
+    self.retarget_automatic_reasons(
+      &mut replacement,
+      stale_request,
+      RefreshRejectionCode::SourceChanged,
+      &mut actions,
+    );
+    self.token_source_refresh_pending = Some(replacement);
+    self.start_pending_token(now, &mut actions);
     actions
   }
 
@@ -682,7 +1161,7 @@ impl CoordinatorState {
       return Vec::new();
     }
 
-    let running = self
+    let mut running = self
       .token_running
       .take()
       .expect("matching token generation remains present");
@@ -692,31 +1171,88 @@ impl CoordinatorState {
     if running.source_generation != completion.source_generation
       || completion.source_generation != self.source_generation
     {
-      let mut actions = Vec::with_capacity(1);
-      self.start_pending_token(&mut actions);
+      let mut actions = Vec::with_capacity(3);
+      let waiters = running.request.drain_waiters();
+      self.complete_token_waiters(
+        waiters,
+        completion.generation,
+        false,
+        Some(RefreshFailureCode::SourceChanged),
+        Some("refresh source changed"),
+        &mut actions,
+      );
+      self.start_pending_token(now, &mut actions);
       return actions;
     }
 
     let completion = normalize_completion(completion);
-    let mut actions = Vec::with_capacity(3);
+    let waiters = running.request.drain_waiters();
+    let mut actions = Vec::with_capacity(4);
     if completion.succeeded {
       self.token.failure_streak = 0;
       self.token.retry_at = None;
+      self.token.disabled_retry_overdue_lag = None;
       self.token_retry_request = None;
       self.token_retry_source_refresh = false;
       self.usage_revision = self.usage_revision.saturating_add(1);
       actions.push(CoordinatorAction::PublishInvalidation(
-        self.invalidation(completion.commit.expect("normalized success has commit marker")),
+        self.invalidation(
+          completion
+            .commit
+            .expect("normalized success has commit marker"),
+        ),
       ));
     } else {
       self.token.failure_streak = self.token.failure_streak.saturating_add(1);
       let jitter = completion.retry_jitter.min(Duration::from_secs(1));
       let delay = retry_delay(self.token.failure_streak, self.config.interval, jitter);
-      self.token.retry_at = Some(now.checked_add(delay).unwrap_or(now));
+      let retry_at = now.checked_add(delay).unwrap_or(now);
+      self.token.retry_at = Some(retry_at);
+      self.token.disabled_retry_overdue_lag = None;
       let mut retry_request = running.request;
+      retry_request.planned_due_at = Some(retry_at);
       if running_source_refresh {
         if let Some(pending) = self.token_source_refresh_pending.take() {
-          retry_request.merge(pending);
+          if retry_request.same_source_identity(&pending) {
+            retry_request
+              .try_merge(pending)
+              .expect("same source identity was checked before protected retry merge");
+          } else {
+            self.retarget_automatic_reasons(
+              &mut retry_request,
+              pending,
+              RefreshRejectionCode::SourceChanged,
+              &mut actions,
+            );
+          }
+        }
+        let pending_manual_matches = self
+          .token_pending_manual
+          .as_ref()
+          .is_some_and(|pending| retry_request.same_source_identity(pending));
+        if pending_manual_matches {
+          retry_request
+            .try_merge(
+              self
+                .token_pending_manual
+                .take()
+                .expect("matching protected follow-up remains pending"),
+            )
+            .expect("same source identity was checked before protected follow-up merge");
+        }
+        let pending_automatic_matches = self
+          .token_pending_automatic
+          .as_ref()
+          .is_some_and(|pending| retry_request.same_source_identity(pending));
+        if pending_automatic_matches {
+          retry_request
+            .try_merge(
+              self
+                .token_pending_automatic
+                .take()
+                .expect("matching protected automatic follow-up remains pending"),
+            )
+            .expect("same source identity was checked before protected automatic merge");
         }
       }
       self.token_retry_request = Some(retry_request);
@@ -725,7 +1261,15 @@ impl CoordinatorState {
     actions.push(CoordinatorAction::PublishCompletion(
       self.completed_event(RefreshLane::Token, &completion),
     ));
-    self.start_pending_token(&mut actions);
+    self.complete_token_waiters(
+      waiters,
+      completion.generation,
+      completion.succeeded,
+      completion.failure_code,
+      completion.failure.as_deref(),
+      &mut actions,
+    );
+    self.start_pending_token(now, &mut actions);
     actions
   }
 
@@ -751,15 +1295,15 @@ impl CoordinatorState {
       || completion.source_generation != self.source_generation
     {
       let mut actions = Vec::with_capacity(2);
-      if !waiters.is_empty() {
-        actions.push(CoordinatorAction::ResolveLiveWaiters {
-          waiter_ids: waiters,
-          generation: completion.generation,
-          succeeded: false,
-          failure: Some("refresh source changed".to_string()),
-        });
-      }
-      self.start_pending_live(&mut actions);
+      self.complete_live_waiters(
+        waiters,
+        completion.generation,
+        false,
+        Some(RefreshFailureCode::SourceChanged),
+        Some("refresh source changed"),
+        &mut actions,
+      );
+      self.start_pending_live(now, &mut actions);
       return actions;
     }
 
@@ -768,34 +1312,42 @@ impl CoordinatorState {
     if completion.succeeded {
       self.live.failure_streak = 0;
       self.live.retry_at = None;
+      self.live.disabled_retry_overdue_lag = None;
       self.live_retry_reasons = ReasonSet::default();
       self.quota_revision = self.quota_revision.saturating_add(1);
       actions.push(CoordinatorAction::PublishInvalidation(
-        self.invalidation(completion.commit.expect("normalized success has commit marker")),
+        self.invalidation(
+          completion
+            .commit
+            .expect("normalized success has commit marker"),
+        ),
       ));
     } else {
       self.live.failure_streak = self.live.failure_streak.saturating_add(1);
       let jitter = completion.retry_jitter.min(Duration::from_secs(1));
       let delay = retry_delay(self.live.failure_streak, self.config.interval, jitter);
-      self.live.retry_at = Some(now.checked_add(delay).unwrap_or(now));
+      let retry_at = now.checked_add(delay).unwrap_or(now);
+      self.live.retry_at = Some(retry_at);
+      self.live.disabled_retry_overdue_lag = None;
       self.live_retry_reasons = running.reasons;
+      self.live_retry_planned_due_at = Some(retry_at);
     }
     actions.push(CoordinatorAction::PublishCompletion(
       self.completed_event(RefreshLane::Live, &completion),
     ));
-    if !waiters.is_empty() {
-      actions.push(CoordinatorAction::ResolveLiveWaiters {
-        waiter_ids: waiters,
-        generation: completion.generation,
-        succeeded: completion.succeeded,
-        failure: completion.failure.clone(),
-      });
-    }
-    self.start_pending_live(&mut actions);
+    self.complete_live_waiters(
+      waiters,
+      completion.generation,
+      completion.succeeded,
+      completion.failure_code,
+      completion.failure.as_deref(),
+      &mut actions,
+    );
+    self.start_pending_live(now, &mut actions);
     actions
   }
 
-  fn start_pending_token(&mut self, actions: &mut Vec<CoordinatorAction>) {
+  fn start_pending_token(&mut self, now: Instant, actions: &mut Vec<CoordinatorAction>) {
     if self.token_retry_source_refresh {
       return;
     }
@@ -804,12 +1356,12 @@ impl CoordinatorState {
       return;
     }
     if let Some(request) = self.token_pending_manual.take() {
-      self.submit_token_request(request, actions);
+      self.submit_token_request(now, request, actions);
       return;
     }
     if let Some(request) = self.token_pending_automatic.take() {
       if self.config.auto_scan_enabled {
-        self.submit_token_request(request, actions);
+        self.submit_token_request(now, request, actions);
       }
     }
   }
@@ -817,21 +1369,231 @@ impl CoordinatorState {
   fn prune_automatic_pending_work(&mut self) {
     if let Some(pending) = self.token_pending_manual.as_mut() {
       pending.reasons = RefreshReason::Manual.into();
+      pending.planned_due_at = None;
     }
     self.token_pending_automatic = None;
     self.live_pending = ReasonSet::default();
+    self.live_pending_due_at = None;
   }
 
-  fn start_pending_live(&mut self, actions: &mut Vec<CoordinatorAction>) {
+  fn start_pending_live(&mut self, now: Instant, actions: &mut Vec<CoordinatorAction>) {
     let reasons = std::mem::take(&mut self.live_pending);
+    let planned_due_at = self.live_pending_due_at.take();
     if !reasons.is_empty() {
       self.submit_live_request(
+        now,
         LiveRequest {
           reasons,
           waiter: None,
+          planned_due_at,
         },
         actions,
       );
+    }
+  }
+
+  fn prepare_token_intake(
+    &self,
+    request: &mut TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) -> bool {
+    request.bind_source_if_needed(self.source_generation, self.config.codex_home.clone());
+    let had_waiters = !request.waiter_ids.is_empty();
+    if !had_waiters {
+      return true;
+    }
+
+    if !request.reasons.contains(RefreshReason::Manual) {
+      self.reject_token_waiters(
+        request.drain_waiters(),
+        RefreshRejectionCode::InvalidRequest,
+        Some("token waiters require a manual refresh request"),
+        actions,
+      );
+      return false;
+    }
+
+    let incoming = request.drain_waiters();
+    let mut accepted = Vec::with_capacity(incoming.len());
+    let mut rejected = Vec::with_capacity(incoming.len());
+    let mut owned_count = self.token_waiter_count();
+    for waiter in incoming {
+      if accepted.contains(&waiter) || self.token_waiter_is_owned(waiter) {
+        continue;
+      }
+      if owned_count >= REFRESH_WAITER_CAPACITY {
+        rejected.push(waiter);
+      } else {
+        accepted.push(waiter);
+        owned_count += 1;
+      }
+    }
+    for waiter in accepted {
+      request
+        .try_add_waiter(waiter)
+        .expect("normalized token waiter input stays within the fixed capacity");
+    }
+    if !rejected.is_empty() {
+      actions.push(CoordinatorAction::ResolveTokenWaiters {
+        waiter_ids: rejected,
+        outcome: rejected_outcome(RefreshRejectionCode::Busy, None),
+      });
+    }
+    !request.waiter_ids.is_empty()
+  }
+
+  fn token_waiter_count(&self) -> usize {
+    self
+      .token_running
+      .as_ref()
+      .map_or(0, |request| request.request.waiter_ids.len())
+      .saturating_add(
+        self
+          .token_pending_manual
+          .as_ref()
+          .map_or(0, |request| request.waiter_ids.len()),
+      )
+      .saturating_add(
+        self
+          .token_pending_automatic
+          .as_ref()
+          .map_or(0, |request| request.waiter_ids.len()),
+      )
+      .saturating_add(
+        self
+          .token_source_refresh_pending
+          .as_ref()
+          .map_or(0, |request| request.waiter_ids.len()),
+      )
+      .saturating_add(
+        self
+          .token_retry_request
+          .as_ref()
+          .map_or(0, |request| request.waiter_ids.len()),
+      )
+  }
+
+  fn token_waiter_is_owned(&self, waiter: TokenWaiterId) -> bool {
+    self
+      .token_running
+      .as_ref()
+      .is_some_and(|request| request.request.waiter_ids.contains(&waiter))
+      || self
+        .token_pending_manual
+        .as_ref()
+        .is_some_and(|request| request.waiter_ids.contains(&waiter))
+      || self
+        .token_pending_automatic
+        .as_ref()
+        .is_some_and(|request| request.waiter_ids.contains(&waiter))
+      || self
+        .token_source_refresh_pending
+        .as_ref()
+        .is_some_and(|request| request.waiter_ids.contains(&waiter))
+      || self
+        .token_retry_request
+        .as_ref()
+        .is_some_and(|request| request.waiter_ids.contains(&waiter))
+  }
+
+  fn reject_token_waiters(
+    &self,
+    waiter_ids: Vec<TokenWaiterId>,
+    code: RefreshRejectionCode,
+    detail: Option<&str>,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if !waiter_ids.is_empty() {
+      actions.push(CoordinatorAction::ResolveTokenWaiters {
+        waiter_ids,
+        outcome: rejected_outcome(code, detail),
+      });
+    }
+  }
+
+  fn complete_token_waiters(
+    &self,
+    waiter_ids: Vec<TokenWaiterId>,
+    generation: u64,
+    succeeded: bool,
+    failure_code: Option<RefreshFailureCode>,
+    detail: Option<&str>,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if !waiter_ids.is_empty() {
+      actions.push(CoordinatorAction::ResolveTokenWaiters {
+        waiter_ids,
+        outcome: completed_outcome(generation, succeeded, failure_code, detail),
+      });
+    }
+  }
+
+  fn complete_live_waiters(
+    &self,
+    waiter_ids: Vec<LiveWaiterId>,
+    generation: u64,
+    succeeded: bool,
+    failure_code: Option<RefreshFailureCode>,
+    detail: Option<&str>,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if !waiter_ids.is_empty() {
+      actions.push(CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids,
+        outcome: completed_outcome(generation, succeeded, failure_code, detail),
+      });
+    }
+  }
+
+  fn retarget_automatic_reasons(
+    &self,
+    target: &mut TokenRequest,
+    mut displaced: TokenRequest,
+    rejection: RefreshRejectionCode,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    self.reject_token_waiters(
+      displaced.drain_waiters(),
+      rejection,
+      Some("refresh source changed"),
+      actions,
+    );
+    displaced.reasons.remove(RefreshReason::Manual);
+    if displaced.reasons.is_empty() {
+      return;
+    }
+    target.reasons.merge(displaced.reasons);
+    target.kind = target.kind.max(displaced.kind);
+    target.planned_due_at = earliest_planned_due(target.planned_due_at, displaced.planned_due_at);
+  }
+
+  fn retain_automatic_request(
+    &mut self,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    request.reasons.remove(RefreshReason::Manual);
+    request.waiter_ids.clear();
+    if request.reasons.is_empty() {
+      return;
+    }
+    if let Some(mut automatic) = self.token_pending_automatic.take() {
+      if automatic.same_source_identity(&request) {
+        automatic
+          .try_merge(request)
+          .expect("same source identity was checked before retained merge");
+        self.token_pending_automatic = Some(automatic);
+      } else {
+        self.reject_token_waiters(
+          automatic.drain_waiters(),
+          RefreshRejectionCode::Superseded,
+          Some("refresh request was superseded"),
+          actions,
+        );
+        self.token_pending_automatic = Some(request);
+      }
+    } else {
+      self.token_pending_automatic = Some(request);
     }
   }
 
@@ -889,13 +1651,157 @@ impl CoordinatorState {
   pub(crate) fn usage_revision(&self) -> u64 {
     self.usage_revision
   }
+
+  pub(crate) fn snapshot(&self) -> CoordinatorSnapshot {
+    let mut token_pending_reasons = ReasonSet::default();
+    for request in [
+      self.token_pending_manual.as_ref(),
+      self.token_pending_automatic.as_ref(),
+      self.token_source_refresh_pending.as_ref(),
+      self.token_retry_request.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+      token_pending_reasons.merge(request.reasons);
+    }
+    let mut live_pending_reasons = self.live_pending;
+    live_pending_reasons.merge(self.live_retry_reasons);
+
+    CoordinatorSnapshot {
+      token: LaneScheduleSnapshot {
+        running_generation: self.token.running_generation,
+        next_normal_deadline: self.token.next_deadline,
+        retry_deadline: self.token.retry_at,
+        failure_streak: self.token.failure_streak,
+        pending: !token_pending_reasons.is_empty(),
+        pending_reasons: token_pending_reasons,
+        missed_deadline_count: self.token.missed_deadline_count,
+        coalesced_trigger_count: self.token.coalesced_trigger_count,
+      },
+      live: LaneScheduleSnapshot {
+        running_generation: self.live.running_generation,
+        next_normal_deadline: self.live.next_deadline,
+        retry_deadline: self.live.retry_at,
+        failure_streak: self.live.failure_streak,
+        pending: !live_pending_reasons.is_empty(),
+        pending_reasons: live_pending_reasons,
+        missed_deadline_count: self.live.missed_deadline_count,
+        coalesced_trigger_count: self.live.coalesced_trigger_count,
+      },
+      source_generation: self.source_generation,
+      interval: self.config.interval,
+      auto_scan_enabled: self.config.auto_scan_enabled,
+    }
+  }
+
+  pub(crate) fn next_wait(&self, now: Instant) -> Option<Duration> {
+    let mut wait = None;
+    if self.config.auto_scan_enabled {
+      wait = Some(if self.token.immediate_due_at.is_some() {
+        Duration::ZERO
+      } else {
+        self.token.next_deadline.saturating_duration_since(now)
+      });
+      wait = earliest_wait(
+        wait,
+        Some(if self.live.immediate_due_at.is_some() {
+          Duration::ZERO
+        } else {
+          self.live.next_deadline.saturating_duration_since(now)
+        }),
+      );
+    }
+
+    let token_retry_is_eligible = self.config.auto_scan_enabled
+      || self.token_retry_source_refresh
+      || self
+        .token_retry_request
+        .as_ref()
+        .is_some_and(|request| request.reasons.contains(RefreshReason::Manual));
+    if token_retry_is_eligible {
+      wait = earliest_wait(
+        wait,
+        self
+          .token
+          .retry_at
+          .map(|deadline| deadline.saturating_duration_since(now)),
+      );
+    }
+
+    let live_retry_is_eligible =
+      self.config.auto_scan_enabled || self.live_retry_reasons.contains(RefreshReason::Manual);
+    if live_retry_is_eligible {
+      wait = earliest_wait(
+        wait,
+        self
+          .live
+          .retry_at
+          .map(|deadline| deadline.saturating_duration_since(now)),
+      );
+    }
+    wait
+  }
 }
 
-fn merge_token_request(target: &mut Option<TokenRequest>, request: TokenRequest) {
+fn merge_token_request(
+  target: &mut Option<TokenRequest>,
+  request: TokenRequest,
+) -> Result<(), TokenRequest> {
   if let Some(target) = target {
-    target.merge(request);
+    target.try_merge(request)
   } else {
     *target = Some(request);
+    Ok(())
+  }
+}
+
+fn merge_live_request(target: &mut Option<LiveRequest>, request: LiveRequest) {
+  if let Some(target) = target {
+    target.reasons.merge(request.reasons);
+    target.planned_due_at = earliest_planned_due(target.planned_due_at, request.planned_due_at);
+    if target.waiter.is_none() {
+      target.waiter = request.waiter;
+    }
+  } else {
+    *target = Some(request);
+  }
+}
+
+fn earliest_planned_due(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.min(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
+  }
+}
+
+fn earliest_wait(left: Option<Duration>, right: Option<Duration>) -> Option<Duration> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.min(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
+  }
+}
+
+fn completed_outcome(
+  generation: u64,
+  succeeded: bool,
+  failure_code: Option<RefreshFailureCode>,
+  detail: Option<&str>,
+) -> RefreshWaiterOutcome {
+  RefreshWaiterOutcome::Completed {
+    generation,
+    succeeded,
+    failure_code,
+    detail: detail.map(RefreshDetail::new),
+  }
+}
+
+fn rejected_outcome(code: RefreshRejectionCode, detail: Option<&str>) -> RefreshWaiterOutcome {
+  RefreshWaiterOutcome::Rejected {
+    code,
+    detail: detail.map(RefreshDetail::new),
   }
 }
 
@@ -908,9 +1814,18 @@ fn push_unique_waiter(waiters: &mut Vec<LiveWaiterId>, waiter: LiveWaiterId) {
 fn normalize_completion(mut completion: ExecutionCompletion) -> ExecutionCompletion {
   if completion.succeeded && completion.commit.is_none() {
     completion.succeeded = false;
+    completion.failure_code = Some(RefreshFailureCode::InvalidCompletion);
     completion.failure = Some("successful refresh completion missing commit marker".to_string());
-  } else if !completion.succeeded && completion.failure.is_none() {
-    completion.failure = Some("refresh failed without an error".to_string());
+  } else if !completion.succeeded {
+    if completion.failure_code.is_none() {
+      completion.failure_code = Some(RefreshFailureCode::ExecutionFailed);
+    }
+    if completion.failure.is_none() {
+      completion.failure = Some("refresh failed without an error".to_string());
+    }
+  } else {
+    completion.failure_code = None;
+    completion.failure = None;
   }
   completion
 }
@@ -924,17 +1839,56 @@ fn retry_delay(failure_streak: u32, interval: Duration, jitter: Duration) -> Dur
     .min(Duration::from_secs(300))
 }
 
-fn advance_fixed_deadline(
-  mut deadline: Instant,
-  interval: Duration,
-  now: Instant,
-) -> (Instant, u64) {
-  let mut elapsed_intervals = 0_u64;
-  while deadline <= now {
-    deadline += interval;
-    elapsed_intervals += 1;
+fn advance_fixed_deadline(deadline: Instant, interval: Duration, now: Instant) -> (Instant, u64) {
+  if deadline > now {
+    return (deadline, 0);
   }
-  (deadline, elapsed_intervals.saturating_sub(1))
+
+  let interval_nanos = interval.as_nanos();
+  debug_assert!(interval_nanos > 0);
+  let overdue_nanos = now.duration_since(deadline).as_nanos();
+  let elapsed_intervals = overdue_nanos / interval_nanos + 1;
+  let remainder_nanos = overdue_nanos % interval_nanos;
+  let remaining = duration_from_nanos(interval_nanos - remainder_nanos);
+  let next_deadline = saturating_instant_add(now, remaining);
+  let missed = elapsed_intervals.saturating_sub(1).min(u64::MAX as u128) as u64;
+  (next_deadline, missed)
+}
+
+fn duration_from_nanos(value: u128) -> Duration {
+  Duration::new(
+    (value / 1_000_000_000).min(u64::MAX as u128) as u64,
+    (value % 1_000_000_000) as u32,
+  )
+}
+
+fn saturating_instant_add(base: Instant, duration: Duration) -> Instant {
+  if let Some(value) = base.checked_add(duration) {
+    return value;
+  }
+
+  let mut accepted_nanos = 0_u128;
+  let mut rejected_nanos = duration.as_nanos();
+  let mut accepted = base;
+  while accepted_nanos.saturating_add(1) < rejected_nanos {
+    let candidate_nanos = accepted_nanos + (rejected_nanos - accepted_nanos) / 2;
+    if let Some(candidate) = base.checked_add(duration_from_nanos(candidate_nanos)) {
+      accepted_nanos = candidate_nanos;
+      accepted = candidate;
+    } else {
+      rejected_nanos = candidate_nanos;
+    }
+  }
+  accepted
+}
+
+fn effective_interval(base: Instant, requested: Duration) -> Duration {
+  let effective = saturating_instant_add(base, requested).duration_since(base);
+  if effective.is_zero() {
+    Duration::from_nanos(1)
+  } else {
+    effective
+  }
 }
 
 fn duration_remainder(value: Duration, modulus: Duration) -> Duration {
@@ -956,7 +1910,7 @@ fn initial_deadline(
   else {
     return monotonic_now;
   };
-  monotonic_now + interval.saturating_sub(age)
+  saturating_instant_add(monotonic_now, interval.saturating_sub(age))
 }
 
 #[cfg(test)]
@@ -1182,6 +2136,61 @@ mod tests {
   }
 
   #[test]
+  fn interval_shrink_preserves_original_planned_due() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(60),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(30), Some(wall))),
+    );
+
+    let token = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("shorter interval starts token catch-up");
+    let live = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("shorter interval starts live catch-up");
+    assert_eq!(
+      token.request.planned_due_at,
+      Some(base + Duration::from_secs(30))
+    );
+    assert_eq!(live.planned_due_at, Some(base + Duration::from_secs(30)));
+  }
+
+  #[test]
+  fn interval_shrink_counts_only_skipped_new_deadlines() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+
+    state.handle(
+      base + Duration::from_secs(60),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(30), Some(wall))),
+    );
+
+    assert_eq!(state.snapshot().token.missed_deadline_count, 1);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 1);
+  }
+
+  #[test]
   fn shorter_interval_preserves_unaligned_fixed_deadline() {
     let base = Instant::now();
     let wall = utc("2026-07-10T10:00:00Z");
@@ -1215,11 +2224,8 @@ mod tests {
     let old_interval = Duration::MAX;
     let old_next_deadline = base + Duration::from_secs(60);
     assert!(old_next_deadline.checked_sub(old_interval).is_none());
-    let mut state = CoordinatorState::new(
-      test_config(Duration::from_secs(60), Some(wall)),
-      base,
-      wall,
-    );
+    let mut state =
+      CoordinatorState::new(test_config(Duration::from_secs(60), Some(wall)), base, wall);
     state.config.interval = old_interval;
     state.token = LaneState::new(old_next_deadline, base);
     state.live = LaneState::new(old_next_deadline, base);
@@ -1351,6 +2357,7 @@ mod tests {
       generation,
       source_generation,
       succeeded: true,
+      failure_code: None,
       failure: None,
       completed_at: "2026-07-10T10:00:00Z".to_string(),
       commit: Some(CommitMarker {
@@ -1370,6 +2377,7 @@ mod tests {
       generation,
       source_generation,
       succeeded: false,
+      failure_code: Some(RefreshFailureCode::ExecutionFailed),
       failure: Some("test failure".to_string()),
       completed_at: "2026-07-10T10:00:00Z".to_string(),
       commit: None,
@@ -1393,16 +2401,43 @@ mod tests {
 
   fn start_live_generation(state: &mut CoordinatorState, now: Instant) -> LiveExecutionRequest {
     state
-      .handle(
-        now,
-        CoordinatorEvent::RequestLive(LiveRequest::scheduled()),
-      )
+      .handle(now, CoordinatorEvent::RequestLive(LiveRequest::scheduled()))
       .into_iter()
       .find_map(|action| match action {
         CoordinatorAction::StartLive(request) => Some(request),
         _ => None,
       })
       .expect("live generation starts")
+  }
+
+  fn manual_token_request(waiter: TokenWaiterId, codex_home: Option<&str>) -> TokenRequest {
+    TokenRequest::manual_full_with_waiter(codex_home.map(str::to_string), waiter)
+  }
+
+  fn token_waiter_outcome<'a>(
+    actions: &'a [CoordinatorAction],
+    waiter: TokenWaiterId,
+  ) -> Option<&'a RefreshWaiterOutcome> {
+    actions.iter().find_map(|action| match action {
+      CoordinatorAction::ResolveTokenWaiters {
+        waiter_ids,
+        outcome,
+      } if waiter_ids.contains(&waiter) => Some(outcome),
+      _ => None,
+    })
+  }
+
+  fn live_waiter_outcome<'a>(
+    actions: &'a [CoordinatorAction],
+    waiter: LiveWaiterId,
+  ) -> Option<&'a RefreshWaiterOutcome> {
+    actions.iter().find_map(|action| match action {
+      CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids,
+        outcome,
+      } if waiter_ids.contains(&waiter) => Some(outcome),
+      _ => None,
+    })
   }
 
   #[test]
@@ -1486,9 +2521,7 @@ mod tests {
     assert_eq!(starts.len(), 1);
     assert!(starts[0].reasons.contains(RefreshReason::Scheduled));
     assert!(starts[0].reasons.contains(RefreshReason::Wake));
-    assert!(starts[0]
-      .reasons
-      .contains(RefreshReason::SettingsChanged));
+    assert!(starts[0].reasons.contains(RefreshReason::SettingsChanged));
   }
 
   #[test]
@@ -1528,9 +2561,12 @@ mod tests {
       action,
       CoordinatorAction::ResolveLiveWaiters {
         waiter_ids,
-        generation,
-        succeeded: true,
-        failure: None,
+        outcome: RefreshWaiterOutcome::Completed {
+          generation,
+          succeeded: true,
+          failure_code: None,
+          detail: None,
+        },
       } if waiter_ids == &[waiter_id] && *generation == first.generation
     )));
   }
@@ -1720,6 +2756,7 @@ mod tests {
       generation: first.generation,
       source_generation: first.source_generation,
       succeeded: true,
+      failure_code: None,
       failure: None,
       completed_at: "2026-07-10T10:00:00Z".to_string(),
       commit: None,
@@ -1812,12 +2849,15 @@ mod tests {
       action,
       CoordinatorAction::ResolveLiveWaiters {
         waiter_ids,
-        generation,
-        succeeded: false,
-        failure: Some(failure),
+        outcome: RefreshWaiterOutcome::Completed {
+          generation,
+          succeeded: false,
+          failure_code: Some(RefreshFailureCode::SourceChanged),
+          detail,
+        },
       } if waiter_ids == &[waiter_id]
         && *generation == first.generation
-        && failure == "refresh source changed"
+        && detail.as_ref().is_some_and(|value| value.as_str() == "refresh source changed")
     )));
     assert_eq!(
       actions
@@ -2427,5 +3467,2037 @@ mod tests {
           && request.request.codex_home.as_deref()
             == Some("/normalized/configured-home-b")
     ));
+  }
+
+  #[test]
+  fn manual_token_waiter_binds_to_follow_up_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let running = start_token_generation(&mut state, base);
+    let waiter = TokenWaiterId(1);
+
+    let queued = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+    );
+    assert!(queued.is_empty());
+
+    let first_completion = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    assert!(token_waiter_outcome(&first_completion, waiter).is_none());
+    let follow_up = first_completion
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual waiter starts in one follow-up generation");
+    assert_ne!(follow_up.generation, running.generation);
+    assert_eq!(follow_up.request.waiter_ids(), &[waiter]);
+
+    let follow_up_completion = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        follow_up.generation,
+        follow_up.source_generation,
+        2,
+        base + Duration::from_secs(3),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&follow_up_completion, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: true,
+        failure_code: None,
+        detail: None,
+      }) if *generation == follow_up.generation
+    ));
+  }
+
+  #[test]
+  fn same_source_manual_waiters_coalesce() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut config = test_config(Duration::from_secs(300), Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let running = start_token_generation(&mut state, base);
+    let first_waiter = TokenWaiterId(10);
+    let second_waiter = TokenWaiterId(11);
+
+    for waiter in [first_waiter, second_waiter, first_waiter] {
+      assert!(state
+        .handle(
+          base + Duration::from_secs(1),
+          CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-a"),)),
+        )
+        .is_empty());
+    }
+
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let follow_up = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("coalesced manual request starts");
+    assert_eq!(
+      follow_up.request.waiter_ids(),
+      &[first_waiter, second_waiter]
+    );
+    assert_eq!(
+      follow_up.request.codex_home.as_deref(),
+      Some("/normalized/home-a")
+    );
+  }
+
+  #[test]
+  fn different_source_manual_waiter_is_rejected_without_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let running = start_token_generation(&mut state, base);
+    let displaced = TokenWaiterId(20);
+    let replacement = TokenWaiterId(21);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(manual_token_request(displaced, Some("/normalized/home-a"))),
+    );
+
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(manual_token_request(
+        replacement,
+        Some("/normalized/home-b"),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&replacement_actions, displaced),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::Superseded,
+        ..
+      })
+    ));
+
+    let completion_actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+    let follow_up = completion_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("replacement manual source starts");
+    assert_eq!(follow_up.request.waiter_ids(), &[replacement]);
+    assert_eq!(
+      follow_up.request.codex_home.as_deref(),
+      Some("/normalized/home-b")
+    );
+  }
+
+  #[test]
+  fn failed_manual_waiter_resolves_once_before_retry() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let waiter = TokenWaiterId(30);
+    let manual = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token generation starts");
+
+    let failure_actions = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual.generation,
+        manual.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&failure_actions, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: false,
+        failure_code: Some(RefreshFailureCode::ExecutionFailed),
+        ..
+      }) if *generation == manual.generation
+    ));
+    assert_eq!(
+      failure_actions
+        .iter()
+        .filter(|action| matches!(action, CoordinatorAction::ResolveTokenWaiters { .. }))
+        .count(),
+      1
+    );
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(6)));
+
+    let retry_actions = state.handle(base + Duration::from_secs(6), CoordinatorEvent::Timer);
+    let retry = retry_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("automatic retry starts");
+    assert!(retry.request.waiter_ids.is_empty());
+  }
+
+  #[test]
+  fn retry_never_reresolves_old_waiter() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let waiter = TokenWaiterId(31);
+    let manual = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token generation starts");
+    let failed = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual.generation,
+        manual.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(token_waiter_outcome(&failed, waiter).is_some());
+    let retry = state
+      .handle(base + Duration::from_secs(6), CoordinatorEvent::Timer)
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("retry starts");
+
+    let succeeded = state.handle(
+      base + Duration::from_secs(7),
+      CoordinatorEvent::TokenFinished(execution_success(
+        retry.generation,
+        retry.source_generation,
+        1,
+        base + Duration::from_secs(7),
+      )),
+    );
+    assert!(token_waiter_outcome(&succeeded, waiter).is_none());
+  }
+
+  #[test]
+  fn source_change_does_not_orphan_token_waiter() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let waiter = TokenWaiterId(40);
+    let running = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token generation starts");
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+
+    let stale = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&stale, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: false,
+        failure_code: Some(RefreshFailureCode::SourceChanged),
+        ..
+      }) if *generation == running.generation
+    ));
+  }
+
+  #[test]
+  fn protected_waiter_survives_or_rejects_second_source_change() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let running = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let protected_waiter = TokenWaiterId(41);
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(manual_token_request(
+        protected_waiter,
+        Some("/normalized/home-b"),
+      )),
+    );
+
+    let mut home_c = test_config(interval, Some(wall));
+    home_c.codex_home = Some("/normalized/home-c".to_string());
+    let second_change = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::SettingsChanged(home_c),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&second_change, protected_waiter),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::SourceChanged,
+        ..
+      })
+    ));
+
+    let stale = state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(4),
+      )),
+    );
+    let replacement = stale
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("latest protected source starts");
+    assert_eq!(
+      replacement.request.codex_home.as_deref(),
+      Some("/normalized/home-c")
+    );
+    assert!(replacement.request.waiter_ids.is_empty());
+  }
+
+  #[test]
+  fn stale_running_and_protected_waiters_are_drained_or_carried() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let stale_waiter = TokenWaiterId(50);
+    let stale_running = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(stale_waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("configured-source manual generation starts");
+
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let displaced_protected = TokenWaiterId(51);
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(manual_token_request(
+        displaced_protected,
+        Some("/normalized/home-b"),
+      )),
+    );
+
+    let mut home_a_again = test_config(interval, Some(wall));
+    home_a_again.codex_home = Some("/normalized/home-a".to_string());
+    let second_change = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::SettingsChanged(home_a_again),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&second_change, displaced_protected),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::SourceChanged,
+        ..
+      })
+    ));
+
+    let current_protected = TokenWaiterId(52);
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::RequestToken(manual_token_request(
+        current_protected,
+        Some("/normalized/home-a"),
+      )),
+    );
+    let discarded = state.handle(
+      base + Duration::from_secs(5),
+      CoordinatorEvent::TokenPrepared {
+        generation: stale_running.generation,
+        source_generation: stale_running.source_generation,
+      },
+    );
+    assert!(matches!(
+      token_waiter_outcome(&discarded, stale_waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: false,
+        failure_code: Some(RefreshFailureCode::SourceChanged),
+        ..
+      }) if *generation == stale_running.generation
+    ));
+    let protected = discarded
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("current protected source starts after stale discard");
+    assert_eq!(protected.request.waiter_ids(), &[current_protected]);
+  }
+
+  #[test]
+  fn protected_replacement_absorbs_same_source_waiter_behind_stale_source_refresh() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let home_b = state
+      .handle(
+        base + Duration::from_secs(2),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_a.generation,
+          home_a.source_generation,
+          1,
+          base + Duration::from_secs(2),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-b protected source refresh starts");
+
+    let mut home_c = test_config(interval, Some(wall));
+    home_c.codex_home = Some("/normalized/home-c".to_string());
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::SettingsChanged(home_c),
+    );
+    let waiter = TokenWaiterId(53);
+    assert!(state
+      .handle(
+        base + Duration::from_secs(4),
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-c"),)),
+      )
+      .is_empty());
+
+    let replacement = state
+      .handle(
+        base + Duration::from_secs(5),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_b.generation,
+          home_b.source_generation,
+          2,
+          base + Duration::from_secs(5),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-c protected replacement starts");
+    assert_eq!(replacement.request.waiter_ids(), &[waiter]);
+  }
+
+  #[test]
+  fn protected_retry_absorbs_same_source_follow_up_waiter() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let home_b = state
+      .handle(
+        base + Duration::from_secs(2),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_a.generation,
+          home_a.source_generation,
+          1,
+          base + Duration::from_secs(2),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-b protected source refresh starts");
+    let waiter = TokenWaiterId(54);
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-b"))),
+    );
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason(RefreshReason::Wake)),
+    );
+
+    let failed = state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        home_b.generation,
+        home_b.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(token_waiter_outcome(&failed, waiter).is_none());
+    let retry = state
+      .handle(base + Duration::from_secs(9), CoordinatorEvent::Timer)
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected retry starts at its deadline");
+    assert_eq!(retry.request.waiter_ids(), &[waiter]);
+    assert!(retry.request.reasons.contains(RefreshReason::Wake));
+
+    let completed = state.handle(
+      base + Duration::from_secs(10),
+      CoordinatorEvent::TokenFinished(execution_success(
+        retry.generation,
+        retry.source_generation,
+        2,
+        base + Duration::from_secs(10),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&completed, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: true,
+        ..
+      }) if *generation == retry.generation
+    ));
+  }
+
+  #[test]
+  fn protected_retry_absorbs_same_source_automatic_follow_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let home_b = state
+      .handle(
+        base + Duration::from_secs(2),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_a.generation,
+          home_a.source_generation,
+          1,
+          base + Duration::from_secs(2),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-b protected source refresh starts");
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason(RefreshReason::Wake)),
+    );
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        home_b.generation,
+        home_b.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let retry = state
+      .handle(base + Duration::from_secs(9), CoordinatorEvent::Timer)
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected retry starts at its deadline");
+    assert!(retry.request.reasons.contains(RefreshReason::Wake));
+    let completed = state.handle(
+      base + Duration::from_secs(10),
+      CoordinatorEvent::TokenFinished(execution_success(
+        retry.generation,
+        retry.source_generation,
+        2,
+        base + Duration::from_secs(10),
+      )),
+    );
+    assert_eq!(token_starts(&completed), 0);
+  }
+
+  #[test]
+  fn duplicate_completion_does_not_resolve_twice() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let waiter = TokenWaiterId(60);
+    let running = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual generation starts");
+    let completion = execution_success(
+      running.generation,
+      running.source_generation,
+      1,
+      base + Duration::from_secs(1),
+    );
+
+    let first = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(completion.clone()),
+    );
+    let duplicate = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(completion),
+    );
+    assert!(token_waiter_outcome(&first, waiter).is_some());
+    assert!(token_waiter_outcome(&duplicate, waiter).is_none());
+    assert!(duplicate.is_empty());
+  }
+
+  #[test]
+  fn waiter_cap_rejects_without_growth() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut token_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let token_running = start_token_generation(&mut token_state, base);
+    for raw in 0..REFRESH_WAITER_CAPACITY as u64 {
+      assert!(token_state
+        .handle(
+          base + Duration::from_secs(1),
+          CoordinatorEvent::RequestToken(manual_token_request(TokenWaiterId(raw), None)),
+        )
+        .is_empty());
+    }
+    let overflow = TokenWaiterId(REFRESH_WAITER_CAPACITY as u64);
+    let rejected = token_state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(manual_token_request(overflow, None)),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&rejected, overflow),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::Busy,
+        ..
+      })
+    ));
+    let token_follow_up = token_state
+      .handle(
+        base + Duration::from_secs(3),
+        CoordinatorEvent::TokenFinished(execution_success(
+          token_running.generation,
+          token_running.source_generation,
+          1,
+          base + Duration::from_secs(3),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("bounded token follow-up starts");
+    assert_eq!(
+      token_follow_up.request.waiter_ids.len(),
+      REFRESH_WAITER_CAPACITY
+    );
+
+    let mut live_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let live_running = start_live_generation(&mut live_state, base);
+    for raw in 0..REFRESH_WAITER_CAPACITY as u64 {
+      assert!(live_state
+        .handle(
+          base + Duration::from_secs(1),
+          CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(raw))),
+        )
+        .is_empty());
+    }
+    let live_overflow = LiveWaiterId(REFRESH_WAITER_CAPACITY as u64);
+    let live_rejected = live_state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestLive(LiveRequest::manual(live_overflow)),
+    );
+    assert!(matches!(
+      live_waiter_outcome(&live_rejected, live_overflow),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::Busy,
+        ..
+      })
+    ));
+    let live_completed = live_state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::LiveFinished(execution_success(
+        live_running.generation,
+        live_running.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+    let resolved_count = live_completed
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::ResolveLiveWaiters { waiter_ids, .. } => Some(waiter_ids.len()),
+        _ => None,
+      })
+      .expect("live waiters resolve");
+    assert_eq!(resolved_count, REFRESH_WAITER_CAPACITY);
+  }
+
+  #[test]
+  fn oversized_token_waiter_input_is_bounded_before_coordinator_intake() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut request = TokenRequest::manual_full(None);
+
+    for raw in 0..(REFRESH_WAITER_CAPACITY as u64 * 1_024) {
+      let result = request.try_add_waiter(TokenWaiterId(raw));
+      if raw < REFRESH_WAITER_CAPACITY as u64 {
+        assert_eq!(result, Ok(()));
+      } else {
+        assert_eq!(result, Err(RefreshRejectionCode::Busy));
+      }
+    }
+    assert_eq!(request.waiter_ids().len(), REFRESH_WAITER_CAPACITY);
+
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let actions = state.handle(base, CoordinatorEvent::RequestToken(request));
+    assert_eq!(actions.len(), 1);
+    assert!(matches!(
+      actions.as_slice(),
+      [CoordinatorAction::StartToken(execution)]
+        if execution.request.waiter_ids().len() == REFRESH_WAITER_CAPACITY
+    ));
+  }
+
+  #[test]
+  fn disabled_next_wait_returns_none_for_overdue_normal_deadline() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut disabled = test_config(Duration::from_secs(300), Some(wall));
+    disabled.auto_scan_enabled = false;
+    let state = CoordinatorState::new(disabled, base, wall);
+
+    assert_eq!(state.next_wait(base + Duration::from_secs(301)), None);
+
+    let immediate = CoordinatorState::new(test_config(Duration::from_secs(300), None), base, wall);
+    assert_eq!(immediate.next_wait(base), Some(Duration::ZERO));
+  }
+
+  #[test]
+  fn automatic_retry_is_ignored_while_disabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let automatic = start_token_generation(&mut state, base);
+    state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        automatic.generation,
+        automatic.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+
+    assert_eq!(state.next_wait(base + Duration::from_secs(5)), None);
+    assert!(state
+      .handle(base + Duration::from_secs(5), CoordinatorEvent::Timer)
+      .is_empty());
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(5)));
+  }
+
+  #[test]
+  fn manual_retry_controls_next_wait_while_disabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut token_state = CoordinatorState::new(disabled.clone(), base, wall);
+    let manual_token = token_state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(TokenWaiterId(70), None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token starts while disabled");
+    token_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual_token.generation,
+        manual_token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(
+      token_state.next_wait(base + Duration::from_secs(2)),
+      Some(Duration::from_secs(4))
+    );
+    assert_eq!(
+      token_starts(&token_state.handle(base + Duration::from_secs(6), CoordinatorEvent::Timer,)),
+      1
+    );
+
+    let mut live_state = CoordinatorState::new(disabled, base, wall);
+    let manual_live = live_state
+      .handle(
+        base,
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(71))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live starts while disabled");
+    live_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::LiveFinished(execution_failure(
+        manual_live.generation,
+        manual_live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(
+      live_state.next_wait(base + Duration::from_secs(2)),
+      Some(Duration::from_secs(4))
+    );
+  }
+
+  #[test]
+  fn next_wait_uses_earliest_lane_retry() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let token = start_token_generation(&mut state, base);
+    let live = start_live_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(7)));
+    assert_eq!(state.live_retry_at(), Some(base + Duration::from_secs(6)));
+    assert_eq!(
+      state.next_wait(base + Duration::from_secs(3)),
+      Some(Duration::from_secs(3))
+    );
+  }
+
+  #[test]
+  fn future_retry_preempted_by_manual_has_no_planned_due() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut token_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token = start_token_generation(&mut token_state, base);
+    token_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let token_manual = token_state
+      .handle(
+        base + Duration::from_secs(1),
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token request preempts future retry");
+    assert_eq!(token_manual.request.planned_due_at, None);
+    assert_eq!(token_state.snapshot().token.coalesced_trigger_count, 1);
+
+    let mut live_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let live = start_live_generation(&mut live_state, base);
+    live_state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let live_manual = live_state
+      .handle(
+        base + Duration::from_secs(1),
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(72))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live request preempts future retry");
+    assert_eq!(live_manual.planned_due_at, None);
+    assert_eq!(live_state.snapshot().live.coalesced_trigger_count, 1);
+  }
+
+  #[test]
+  fn overdue_retry_preempted_by_manual_keeps_original_planned_due() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let retry_due = base + Duration::from_secs(5);
+    let mut token_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token = start_token_generation(&mut token_state, base);
+    token_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let token_manual = token_state
+      .handle(
+        base + Duration::from_secs(10),
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token request starts overdue retry");
+    assert_eq!(token_manual.request.planned_due_at, Some(retry_due));
+
+    let mut live_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let live = start_live_generation(&mut live_state, base);
+    live_state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let live_manual = live_state
+      .handle(
+        base + Duration::from_secs(10),
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(73))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live request starts overdue retry");
+    assert_eq!(live_manual.planned_due_at, Some(retry_due));
+  }
+
+  #[test]
+  fn disabled_retry_preemption_preserves_only_pre_disable_lag() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+
+    let mut overdue_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let overdue = start_token_generation(&mut overdue_state, base);
+    overdue_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        overdue.generation,
+        overdue.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    overdue_state.handle(
+      base + Duration::from_secs(8),
+      CoordinatorEvent::SettingsChanged(disabled.clone()),
+    );
+    let frozen = overdue_state
+      .handle(
+        base + Duration::from_secs(20),
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual request starts frozen overdue retry");
+    assert_eq!(
+      frozen.request.planned_due_at,
+      Some(base + Duration::from_secs(17))
+    );
+
+    let mut disabled_due_state =
+      CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let future = start_token_generation(&mut disabled_due_state, base);
+    disabled_due_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        future.generation,
+        future.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    disabled_due_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(disabled.clone()),
+    );
+    let newly_eligible = disabled_due_state
+      .handle(
+        base + Duration::from_secs(20),
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual request starts retry that expired while disabled");
+    assert_eq!(newly_eligible.request.planned_due_at, None);
+
+    let mut overdue_live_state =
+      CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let overdue_live = start_live_generation(&mut overdue_live_state, base);
+    overdue_live_state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        overdue_live.generation,
+        overdue_live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    overdue_live_state.handle(
+      base + Duration::from_secs(8),
+      CoordinatorEvent::SettingsChanged(disabled.clone()),
+    );
+    let frozen_live = overdue_live_state
+      .handle(
+        base + Duration::from_secs(20),
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(76))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live request starts frozen overdue retry");
+    assert_eq!(
+      frozen_live.planned_due_at,
+      Some(base + Duration::from_secs(17))
+    );
+
+    let mut disabled_due_live_state =
+      CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let future_live = start_live_generation(&mut disabled_due_live_state, base);
+    disabled_due_live_state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        future_live.generation,
+        future_live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    disabled_due_live_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+    let newly_eligible_live = disabled_due_live_state
+      .handle(
+        base + Duration::from_secs(20),
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(77))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live request starts retry that expired while disabled");
+    assert_eq!(newly_eligible_live.planned_due_at, None);
+  }
+
+  #[test]
+  fn non_manual_waiters_are_rejected_before_disabled_pruning() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut disabled = test_config(Duration::from_secs(300), Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut token_state = CoordinatorState::new(disabled.clone(), base, wall);
+    let token_waiter = TokenWaiterId(74);
+    let mut token_request = TokenRequest::scheduled();
+    token_request
+      .try_add_waiter(token_waiter)
+      .expect("test request accepts waiter before coordinator validation");
+    let token_actions = token_state.handle(base, CoordinatorEvent::RequestToken(token_request));
+    assert!(matches!(
+      token_waiter_outcome(&token_actions, token_waiter),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::InvalidRequest,
+        ..
+      })
+    ));
+
+    let mut live_state = CoordinatorState::new(disabled, base, wall);
+    let live_waiter = LiveWaiterId(75);
+    let live_actions = live_state.handle(
+      base,
+      CoordinatorEvent::RequestLive(LiveRequest {
+        reasons: RefreshReason::Scheduled.into(),
+        waiter: Some(live_waiter),
+        planned_due_at: None,
+      }),
+    );
+    assert!(matches!(
+      live_waiter_outcome(&live_actions, live_waiter),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::InvalidRequest,
+        ..
+      })
+    ));
+  }
+
+  #[test]
+  fn retry_and_normal_due_coalescence_increments_fixed_counter() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(5);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token = start_token_generation(&mut state, base);
+    let live = start_live_generation(&mut state, base);
+    state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let actions = state.handle(base + interval, CoordinatorEvent::Timer);
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert_eq!(state.snapshot().token.coalesced_trigger_count, 1);
+    assert_eq!(state.snapshot().live.coalesced_trigger_count, 1);
+  }
+
+  #[test]
+  fn same_source_manual_at_normal_due_starts_one_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut token_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token_waiter = TokenWaiterId(78);
+
+    let token_actions = token_state.handle(
+      base + interval,
+      CoordinatorEvent::RequestToken(manual_token_request(token_waiter, None)),
+    );
+    assert_eq!(token_starts(&token_actions), 1);
+    let token = token_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("due manual token work starts");
+    assert!(token.request.reasons.contains(RefreshReason::Manual));
+    assert!(token.request.reasons.contains(RefreshReason::Scheduled));
+    assert_eq!(token.request.planned_due_at, Some(base + interval));
+    assert_eq!(token_state.token_next_deadline(), base + interval * 2);
+    assert_eq!(token_state.snapshot().token.coalesced_trigger_count, 1);
+    let token_completed = token_state.handle(
+      base + interval + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_success(
+        token.generation,
+        token.source_generation,
+        1,
+        base + interval + Duration::from_secs(1),
+      )),
+    );
+    assert_eq!(token_starts(&token_completed), 0);
+    assert!(token_waiter_outcome(&token_completed, token_waiter).is_some());
+    assert!(!token_state.snapshot().token.pending);
+
+    let mut live_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let live_waiter = LiveWaiterId(79);
+    let overdue = base + Duration::from_secs(950);
+    let live_actions = live_state.handle(
+      overdue,
+      CoordinatorEvent::RequestLive(LiveRequest::manual(live_waiter)),
+    );
+    assert_eq!(live_starts(&live_actions), 1);
+    let live = live_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("overdue manual live work starts");
+    assert!(live.reasons.contains(RefreshReason::Manual));
+    assert!(live.reasons.contains(RefreshReason::Scheduled));
+    assert_eq!(live.planned_due_at, Some(base + interval));
+    assert_eq!(
+      live_state.live_next_deadline(),
+      base + Duration::from_secs(1_200)
+    );
+    assert_eq!(live_state.snapshot().live.coalesced_trigger_count, 1);
+    let live_completed = live_state.handle(
+      overdue + Duration::from_secs(1),
+      CoordinatorEvent::LiveFinished(execution_success(
+        live.generation,
+        live.source_generation,
+        1,
+        overdue + Duration::from_secs(1),
+      )),
+    );
+    assert_eq!(live_starts(&live_completed), 0);
+    assert!(live_waiter_outcome(&live_completed, live_waiter).is_some());
+    assert!(!live_state.snapshot().live.pending);
+  }
+
+  #[test]
+  fn different_source_manual_at_normal_due_keeps_one_scheduled_follow_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let waiter = TokenWaiterId(80);
+
+    let actions = state.handle(
+      base + interval,
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-b"))),
+    );
+    assert_eq!(token_starts(&actions), 1);
+    let manual = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("different-source manual starts first");
+    assert_eq!(
+      manual.request.codex_home.as_deref(),
+      Some("/normalized/home-b")
+    );
+    assert_eq!(manual.request.waiter_ids(), &[waiter]);
+    assert!(!manual.request.reasons.contains(RefreshReason::Scheduled));
+    assert!(state
+      .snapshot()
+      .token
+      .pending_reasons
+      .contains(RefreshReason::Scheduled));
+    assert_eq!(state.snapshot().token.coalesced_trigger_count, 1);
+
+    let completed = state.handle(
+      base + interval + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual.generation,
+        manual.source_generation,
+        1,
+        base + interval + Duration::from_secs(1),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&completed, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: true,
+        ..
+      }) if *generation == manual.generation
+    ));
+    let scheduled = completed
+      .iter()
+      .filter_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(scheduled.len(), 1);
+    assert!(scheduled[0]
+      .request
+      .reasons
+      .contains(RefreshReason::Scheduled));
+    assert!(scheduled[0].request.waiter_ids().is_empty());
+    assert_eq!(
+      scheduled[0].request.codex_home.as_deref(),
+      Some("/normalized/home-a")
+    );
+  }
+
+  #[test]
+  fn due_work_merges_into_matching_protected_source_before_different_manual() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let waiter = TokenWaiterId(81);
+
+    let queued = state.handle(
+      base + interval,
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-c"))),
+    );
+    assert_eq!(token_starts(&queued), 0);
+    assert!(token_waiter_outcome(&queued, waiter).is_none());
+    assert_eq!(state.snapshot().token.coalesced_trigger_count, 3);
+
+    let protected_actions = state.handle(
+      base + interval + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_success(
+        home_a.generation,
+        home_a.source_generation,
+        1,
+        base + interval + Duration::from_secs(1),
+      )),
+    );
+    let protected = protected_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected home-b source refresh starts first");
+    assert_eq!(
+      protected.request.codex_home.as_deref(),
+      Some("/normalized/home-b")
+    );
+    assert!(protected
+      .request
+      .reasons
+      .contains(RefreshReason::SettingsChanged));
+    assert!(protected.request.reasons.contains(RefreshReason::Scheduled));
+    assert!(protected.request.waiter_ids().is_empty());
+
+    let manual_actions = state.handle(
+      base + interval + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        protected.generation,
+        protected.source_generation,
+        2,
+        base + interval + Duration::from_secs(2),
+      )),
+    );
+    let manual = manual_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("different-source manual starts after protected refresh");
+    assert_eq!(
+      manual.request.codex_home.as_deref(),
+      Some("/normalized/home-c")
+    );
+    assert_eq!(manual.request.waiter_ids(), &[waiter]);
+
+    let completed = state.handle(
+      base + interval + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual.generation,
+        manual.source_generation,
+        3,
+        base + interval + Duration::from_secs(3),
+      )),
+    );
+    assert_eq!(token_starts(&completed), 0);
+    assert!(matches!(
+      token_waiter_outcome(&completed, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: true,
+        ..
+      }) if *generation == manual.generation
+    ));
+    assert!(!state.snapshot().token.pending);
+  }
+
+  #[test]
+  fn due_work_merges_into_matching_future_protected_retry() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let home_b = state
+      .handle(
+        base + Duration::from_secs(2),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_a.generation,
+          home_a.source_generation,
+          1,
+          base + Duration::from_secs(2),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-b protected source refresh starts");
+    state.handle(
+      base + Duration::from_secs(298),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        home_b.generation,
+        home_b.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(
+      state.token_retry_at(),
+      Some(base + Duration::from_secs(303))
+    );
+    let waiter = TokenWaiterId(82);
+    state.handle(
+      base + interval,
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-c"))),
+    );
+    assert_eq!(state.snapshot().token.coalesced_trigger_count, 3);
+
+    let retry = state
+      .handle(base + Duration::from_secs(303), CoordinatorEvent::Timer)
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected home-b retry starts first");
+    assert_eq!(
+      retry.request.codex_home.as_deref(),
+      Some("/normalized/home-b")
+    );
+    assert!(retry.request.reasons.contains(RefreshReason::Scheduled));
+
+    let manual = state
+      .handle(
+        base + Duration::from_secs(304),
+        CoordinatorEvent::TokenFinished(execution_success(
+          retry.generation,
+          retry.source_generation,
+          2,
+          base + Duration::from_secs(304),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual home-c request starts after protected retry");
+    assert_eq!(manual.request.waiter_ids(), &[waiter]);
+    let completed = state.handle(
+      base + Duration::from_secs(305),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual.generation,
+        manual.source_generation,
+        3,
+        base + Duration::from_secs(305),
+      )),
+    );
+    assert_eq!(token_starts(&completed), 0);
+    assert!(token_waiter_outcome(&completed, waiter).is_some());
+    assert!(!state.snapshot().token.pending);
+  }
+
+  #[test]
+  fn merged_request_keeps_earliest_planned_due() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut token_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let token_running = start_token_generation(&mut token_state, base);
+    token_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason_at(
+        RefreshReason::Scheduled,
+        base + Duration::from_secs(40),
+      )),
+    );
+    token_state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason_at(
+        RefreshReason::Wake,
+        base + Duration::from_secs(20),
+      )),
+    );
+    token_state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+    );
+    let token_actions = token_state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::TokenFinished(execution_success(
+        token_running.generation,
+        token_running.source_generation,
+        1,
+        base + Duration::from_secs(4),
+      )),
+    );
+    let token_follow_up = token_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("merged token follow-up starts");
+    assert_eq!(
+      token_follow_up.request.planned_due_at,
+      Some(base + Duration::from_secs(20))
+    );
+
+    let mut live_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let live_running = start_live_generation(&mut live_state, base);
+    live_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestLive(LiveRequest::for_reason_at(
+        RefreshReason::Scheduled,
+        base + Duration::from_secs(30),
+      )),
+    );
+    live_state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestLive(LiveRequest::for_reason_at(
+        RefreshReason::Wake,
+        base + Duration::from_secs(10),
+      )),
+    );
+    let live_actions = live_state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::LiveFinished(execution_success(
+        live_running.generation,
+        live_running.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+    let live_follow_up = live_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("merged live follow-up starts");
+    assert_eq!(
+      live_follow_up.planned_due_at,
+      Some(base + Duration::from_secs(10))
+    );
+  }
+
+  #[test]
+  fn snapshot_reports_running_and_pending_state() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let token = start_token_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason(RefreshReason::Wake)),
+    );
+    let live = start_live_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let snapshot = state.snapshot();
+    assert_eq!(snapshot.token.running_generation, Some(token.generation));
+    assert_eq!(snapshot.token.next_normal_deadline, base + interval);
+    assert_eq!(snapshot.token.retry_deadline, None);
+    assert_eq!(snapshot.token.failure_streak, 0);
+    assert!(snapshot.token.pending);
+    assert!(snapshot.token.pending_reasons.contains(RefreshReason::Wake));
+    assert_eq!(snapshot.live.running_generation, None);
+    assert_eq!(
+      snapshot.live.retry_deadline,
+      Some(base + Duration::from_secs(7))
+    );
+    assert_eq!(snapshot.live.failure_streak, 1);
+    assert!(snapshot.live.pending);
+    assert!(snapshot
+      .live
+      .pending_reasons
+      .contains(RefreshReason::Scheduled));
+    assert_eq!(snapshot.source_generation, 0);
+    assert_eq!(snapshot.interval, interval);
+    assert!(snapshot.auto_scan_enabled);
+    assert_eq!(std::mem::size_of::<ReasonSet>(), 1);
+    assert_eq!(
+      RefreshReason::Wake as u8,
+      snapshot.token.pending_reasons.bits().trailing_zeros() as u8
+    );
+  }
+
+  #[test]
+  fn missed_deadline_counter_is_saturating_and_fixed() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(10);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    state.token.missed_deadline_count = u64::MAX;
+
+    state.handle(base + Duration::from_secs(35), CoordinatorEvent::Timer);
+
+    let snapshot = state.snapshot();
+    assert_eq!(snapshot.token.missed_deadline_count, u64::MAX);
+    assert_eq!(snapshot.live.missed_deadline_count, 2);
+  }
+
+  #[test]
+  fn many_missed_intervals_advance_in_constant_work() {
+    let base = Instant::now();
+    let interval = Duration::from_nanos(10);
+    let now = base + Duration::from_secs(100);
+
+    let (next, missed) = advance_fixed_deadline(base + interval, interval, now);
+
+    assert_eq!(next, now + interval);
+    assert_eq!(missed, 9_999_999_999);
+  }
+
+  #[test]
+  fn huge_interval_never_overflows_monotonic_deadlines() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let huge = Duration::MAX;
+    let mut state = CoordinatorState::new(test_config(huge, Some(wall)), base, wall);
+    assert!(state.token_next_deadline() > base);
+    assert!(state.live_next_deadline() > base);
+    assert!(state.snapshot().interval < huge);
+    assert!(base.checked_add(state.snapshot().interval).is_some());
+
+    let shortened = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(60), Some(wall))),
+    );
+    assert!(shortened.is_empty());
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(60));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(60));
+
+    let (advanced, missed) = advance_fixed_deadline(base, huge, base);
+    assert!(advanced > base);
+    assert_eq!(missed, 0);
+
+    let mut changed =
+      CoordinatorState::new(test_config(Duration::from_secs(60), Some(wall)), base, wall);
+    let actions = changed.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(test_config(huge, Some(wall))),
+    );
+    assert!(actions.is_empty());
+    assert!(changed.token_next_deadline() > base + Duration::from_secs(1));
+    assert!(changed.live_next_deadline() > base + Duration::from_secs(1));
+  }
+
+  #[test]
+  fn disabled_intervals_do_not_count_as_missed() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(disabled, base, wall);
+
+    assert!(state
+      .handle(base + Duration::from_secs(1_800), CoordinatorEvent::Timer)
+      .is_empty());
+    assert_eq!(state.snapshot().token.missed_deadline_count, 0);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 0);
+
+    let reenabled = state.handle(
+      base + Duration::from_secs(1_800),
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    assert_eq!(token_starts(&reenabled), 1);
+    assert_eq!(live_starts(&reenabled), 1);
+    assert_eq!(state.snapshot().token.missed_deadline_count, 0);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 0);
+  }
+
+  #[test]
+  fn enabled_overdue_misses_survive_disable_and_reenable() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+
+    let disabling = state.handle(
+      base + Duration::from_secs(950),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+    assert!(disabling.is_empty());
+    assert_eq!(state.snapshot().token.missed_deadline_count, 2);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 2);
+
+    let reenabled = state.handle(
+      base + Duration::from_secs(1_850),
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    assert_eq!(token_starts(&reenabled), 1);
+    assert_eq!(live_starts(&reenabled), 1);
+    assert_eq!(state.snapshot().token.missed_deadline_count, 2);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 2);
+  }
+
+  #[test]
+  fn disabled_deadline_catch_up_is_planned_when_reenabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(disabled, base, wall);
+    let reenabled_at = base + Duration::from_secs(1_800);
+
+    let actions = state.handle(
+      reenabled_at,
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+
+    let token = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartToken(request) => Some(request),
+      _ => None,
+    });
+    let live = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartLive(request) => Some(request),
+      _ => None,
+    });
+    assert_eq!(
+      token.and_then(|value| value.request.planned_due_at),
+      Some(reenabled_at)
+    );
+    assert_eq!(
+      live.and_then(|value| value.planned_due_at),
+      Some(reenabled_at)
+    );
+  }
+
+  #[test]
+  fn disabled_time_does_not_inflate_preexisting_normal_start_lag() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let disabled_at = base + Duration::from_secs(950);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(disabled_at, CoordinatorEvent::SettingsChanged(disabled));
+    let reenabled_at = base + Duration::from_secs(1_850);
+
+    let actions = state.handle(
+      reenabled_at,
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    let expected_due = reenabled_at - disabled_at.duration_since(base + interval);
+    let token = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartToken(request) => Some(request),
+      _ => None,
+    });
+    let live = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartLive(request) => Some(request),
+      _ => None,
+    });
+    assert_eq!(
+      token.and_then(|value| value.request.planned_due_at),
+      Some(expected_due)
+    );
+    assert_eq!(
+      live.and_then(|value| value.planned_due_at),
+      Some(expected_due)
+    );
+    assert_eq!(state.snapshot().token.missed_deadline_count, 2);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 2);
+  }
+
+  #[test]
+  fn automatic_retry_due_while_disabled_is_planned_when_reenabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token = start_token_generation(&mut state, base);
+    state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+    let reenabled_at = base + Duration::from_secs(100);
+
+    let actions = state.handle(
+      reenabled_at,
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    let retry = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartToken(request) => Some(request),
+      _ => None,
+    });
+    assert_eq!(
+      retry.and_then(|value| value.request.planned_due_at),
+      Some(reenabled_at)
+    );
+  }
+
+  #[test]
+  fn reenable_before_deadline_does_not_suppress_future_misses() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(disabled, base, wall);
+    let reenabled = state.handle(
+      base + Duration::from_secs(100),
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    assert!(reenabled.is_empty());
+
+    state.handle(base + Duration::from_secs(950), CoordinatorEvent::Timer);
+
+    assert_eq!(state.snapshot().token.missed_deadline_count, 2);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 2);
+  }
+
+  #[test]
+  fn coalesced_trigger_counter_tracks_merged_work() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    start_token_generation(&mut state, base);
+    start_live_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason(RefreshReason::Wake)),
+    );
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestLive(LiveRequest::scheduled()),
+    );
+
+    let snapshot = state.snapshot();
+    assert_eq!(snapshot.token.coalesced_trigger_count, 2);
+    assert_eq!(snapshot.live.coalesced_trigger_count, 1);
   }
 }

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -139,9 +139,11 @@ pub(crate) struct CoordinatorState {
   token: LaneState,
   live: LaneState,
   token_running: Option<TokenExecutionRequest>,
+  token_running_source_refresh: bool,
   token_pending: Option<TokenRequest>,
   token_source_refresh_pending: Option<TokenRequest>,
   token_retry_request: Option<TokenRequest>,
+  token_retry_source_refresh: bool,
   live_running: Option<LiveExecutionRequest>,
   live_pending: ReasonSet,
   live_retry_reasons: ReasonSet,
@@ -181,9 +183,11 @@ impl CoordinatorState {
       token: LaneState::new(token_next_deadline, monotonic_now),
       live: LaneState::new(live_next_deadline, monotonic_now),
       token_running: None,
+      token_running_source_refresh: false,
       token_pending: None,
       token_source_refresh_pending: None,
       token_retry_request: None,
+      token_retry_source_refresh: false,
       live_running: None,
       live_pending: ReasonSet::default(),
       live_retry_reasons: ReasonSet::default(),
@@ -235,8 +239,12 @@ impl CoordinatorState {
     let mut live_reasons = self.take_due_live_reasons(now, trigger_reason);
     let mut actions = Vec::with_capacity(2);
 
-    if let Some(request) = token_request.take() {
-      self.submit_token_request(request, &mut actions);
+    if let Some((request, source_refresh)) = token_request.take() {
+      if source_refresh {
+        self.submit_source_refresh_request(request, &mut actions);
+      } else {
+        self.submit_token_request(request, &mut actions);
+      }
     }
     if !live_reasons.is_empty() {
       self.submit_live_request(
@@ -284,6 +292,7 @@ impl CoordinatorState {
     }
 
     let mut token_request = None;
+    let mut token_request_is_source_refresh = false;
     let mut live_reasons = ReasonSet::default();
     if source_changed {
       self.source_generation = self
@@ -293,6 +302,7 @@ impl CoordinatorState {
       self.token.failure_streak = 0;
       self.token.retry_at = None;
       self.token_retry_request = None;
+      self.token_retry_source_refresh = false;
       self.live.failure_streak = 0;
       self.live.retry_at = None;
       self.live_retry_reasons = ReasonSet::default();
@@ -319,19 +329,23 @@ impl CoordinatorState {
         }
       }
       token_request = Some(request);
+      token_request_is_source_refresh = true;
       if self.config.auto_scan_enabled {
         live_reasons.insert(RefreshReason::SettingsChanged);
       }
     }
 
-    if let Some(due) = self.take_due_token_request(now, RefreshReason::SettingsChanged) {
+    if let Some((due, due_is_source_refresh)) =
+      self.take_due_token_request(now, RefreshReason::SettingsChanged)
+    {
       merge_token_request(&mut token_request, due);
+      token_request_is_source_refresh |= due_is_source_refresh;
     }
     live_reasons.merge(self.take_due_live_reasons(now, RefreshReason::SettingsChanged));
 
     let mut actions = Vec::with_capacity(2);
     if let Some(request) = token_request {
-      if source_changed {
+      if token_request_is_source_refresh {
         self.submit_source_refresh_request(request, &mut actions);
       } else {
         self.submit_token_request(request, &mut actions);
@@ -353,10 +367,12 @@ impl CoordinatorState {
     &mut self,
     now: Instant,
     trigger_reason: RefreshReason,
-  ) -> Option<TokenRequest> {
+  ) -> Option<(TokenRequest, bool)> {
     let mut request = None;
+    let mut source_refresh = false;
     if self.token.retry_at.is_some_and(|retry_at| retry_at <= now) {
       let retry_allowed = self.config.auto_scan_enabled
+        || self.token_retry_source_refresh
         || self
           .token_retry_request
           .as_ref()
@@ -365,6 +381,8 @@ impl CoordinatorState {
         self.token.retry_at = None;
         if let Some(retry) = self.token_retry_request.take() {
           merge_token_request(&mut request, retry);
+          source_refresh = self.token_retry_source_refresh;
+          self.token_retry_source_refresh = false;
         }
       }
     }
@@ -385,7 +403,7 @@ impl CoordinatorState {
         );
       }
     }
-    request
+    request.map(|request| (request, source_refresh))
   }
 
   fn take_due_live_reasons(
@@ -428,6 +446,15 @@ impl CoordinatorState {
     }
 
     if self.token.running_generation.is_some() {
+      let matches_running_source_refresh = self.token_running_source_refresh
+        && self
+          .token_running
+          .as_ref()
+          .is_some_and(|running| running.request.codex_home == request.codex_home);
+      if matches_running_source_refresh {
+        merge_token_request(&mut self.token_source_refresh_pending, request);
+        return;
+      }
       if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
         if source_refresh.codex_home == request.codex_home {
           source_refresh.merge(request);
@@ -438,11 +465,32 @@ impl CoordinatorState {
       return;
     }
 
+    if self.token_retry_source_refresh {
+      if let Some(source_retry) = self.token_retry_request.as_mut() {
+        if source_retry.codex_home == request.codex_home {
+          source_retry.merge(request);
+        } else {
+          merge_token_request(&mut self.token_pending, request);
+        }
+        return;
+      }
+      self.token_retry_source_refresh = false;
+    }
+
     if let Some(mut retry) = self.token_retry_request.take() {
       retry.merge(request);
       request = retry;
     }
     self.token.retry_at = None;
+    self.start_token_request(request, false, actions);
+  }
+
+  fn start_token_request(
+    &mut self,
+    request: TokenRequest,
+    source_refresh: bool,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
     let generation = self.token.start_generation();
     let execution = TokenExecutionRequest {
       generation,
@@ -450,6 +498,7 @@ impl CoordinatorState {
       request,
     };
     self.token_running = Some(execution.clone());
+    self.token_running_source_refresh = source_refresh;
     actions.push(CoordinatorAction::StartToken(execution));
   }
 
@@ -459,13 +508,25 @@ impl CoordinatorState {
     actions: &mut Vec<CoordinatorAction>,
   ) {
     if self.token.running_generation.is_some() {
+      let matches_running_source_refresh = self.token_running_source_refresh
+        && self
+          .token_running
+          .as_ref()
+          .is_some_and(|running| running.request.codex_home == request.codex_home);
+      if matches_running_source_refresh {
+        merge_token_request(&mut self.token_source_refresh_pending, request);
+        return;
+      }
       if let Some(previous) = self.token_source_refresh_pending.take() {
         request.reasons.merge(previous.reasons);
       }
       self.token_source_refresh_pending = Some(request);
       return;
     }
-    self.submit_token_request(request, actions);
+    self.token.retry_at = None;
+    self.token_retry_request = None;
+    self.token_retry_source_refresh = false;
+    self.start_token_request(request, true, actions);
   }
 
   fn submit_live_request(
@@ -538,6 +599,7 @@ impl CoordinatorState {
       .take()
       .expect("matching token generation remains present");
     self.token.clear_running();
+    self.token_running_source_refresh = false;
     actions.push(CoordinatorAction::DiscardToken {
       generation,
       source_generation,
@@ -569,7 +631,9 @@ impl CoordinatorState {
       .token_running
       .take()
       .expect("matching token generation remains present");
+    let running_source_refresh = self.token_running_source_refresh;
     self.token.clear_running();
+    self.token_running_source_refresh = false;
     if running.source_generation != completion.source_generation
       || completion.source_generation != self.source_generation
     {
@@ -584,6 +648,7 @@ impl CoordinatorState {
       self.token.failure_streak = 0;
       self.token.retry_at = None;
       self.token_retry_request = None;
+      self.token_retry_source_refresh = false;
       self.usage_revision = self.usage_revision.saturating_add(1);
       actions.push(CoordinatorAction::PublishInvalidation(
         self.invalidation(completion.commit.expect("normalized success has commit marker")),
@@ -593,7 +658,14 @@ impl CoordinatorState {
       let jitter = completion.retry_jitter.min(Duration::from_secs(1));
       let delay = retry_delay(self.token.failure_streak, self.config.interval, jitter);
       self.token.retry_at = Some(now.checked_add(delay).unwrap_or(now));
-      self.token_retry_request = Some(running.request);
+      let mut retry_request = running.request;
+      if running_source_refresh {
+        if let Some(pending) = self.token_source_refresh_pending.take() {
+          retry_request.merge(pending);
+        }
+      }
+      self.token_retry_request = Some(retry_request);
+      self.token_retry_source_refresh = running_source_refresh;
     }
     actions.push(CoordinatorAction::PublishCompletion(
       self.completed_event(RefreshLane::Token, &completion),
@@ -669,8 +741,11 @@ impl CoordinatorState {
   }
 
   fn start_pending_token(&mut self, actions: &mut Vec<CoordinatorAction>) {
+    if self.token_retry_source_refresh {
+      return;
+    }
     if let Some(request) = self.token_source_refresh_pending.take() {
-      self.submit_token_request(request, actions);
+      self.submit_source_refresh_request(request, actions);
       return;
     }
     if let Some(request) = self.token_pending.take() {
@@ -719,7 +794,9 @@ impl CoordinatorState {
     lane: RefreshLane,
     completion: &ExecutionCompletion,
   ) -> RefreshCompletedEvent {
-    self.refresh_revision = self.refresh_revision.saturating_add(1);
+    if completion.succeeded {
+      self.refresh_revision = self.refresh_revision.saturating_add(1);
+    }
     RefreshCompletedEvent {
       refresh_revision: self.refresh_revision,
       lane,
@@ -1574,7 +1651,7 @@ mod tests {
   }
 
   #[test]
-  fn success_without_commit_marker_is_rejected() {
+  fn success_without_commit_marker_does_not_advance_refresh_revision() {
     let base = Instant::now();
     let wall = utc("2026-07-10T10:00:00Z");
     let mut state = CoordinatorState::new(
@@ -1600,12 +1677,45 @@ mod tests {
     assert!(actions
       .iter()
       .all(|action| !matches!(action, CoordinatorAction::PublishInvalidation(_))));
-    assert!(actions.iter().any(|action| matches!(
+    let published = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::PublishCompletion(event) => Some(event),
+        _ => None,
+      })
+      .expect("invalid success publishes a failed attempt");
+    assert!(!published.succeeded);
+    assert_eq!(
+      published.failure.as_deref(),
+      Some("successful refresh completion missing commit marker")
+    );
+    assert_eq!(published.refresh_revision, 0);
+    assert_eq!(published.usage_revision, 0);
+    assert_eq!(published.quota_revision, 0);
+    assert_eq!(published.generation, first.generation);
+
+    let mut failure_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let failed = start_token_generation(&mut failure_state, base);
+    let failed_actions = failure_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        failed.generation,
+        failed.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(failed_actions.iter().any(|action| matches!(
       action,
       CoordinatorAction::PublishCompletion(event)
-        if !event.succeeded
-          && event.failure.as_deref()
-            == Some("successful refresh completion missing commit marker")
+        if event.refresh_revision == 0
+          && event.usage_revision == 0
+          && event.quota_revision == 0
+          && event.generation == failed.generation
+          && !event.succeeded
     )));
   }
 
@@ -1804,5 +1914,147 @@ mod tests {
       starts[0].request.codex_home.as_deref(),
       Some("/normalized/new-home")
     );
+  }
+
+  #[test]
+  fn protected_source_refresh_failure_retries_while_auto_scan_disabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.auto_scan_enabled = false;
+    changed.codex_home = Some("/normalized/configured-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("new source Full refresh starts");
+    assert_eq!(protected.request.kind, TokenScanKind::Full);
+    assert_eq!(
+      protected.request.codex_home.as_deref(),
+      Some("/normalized/configured-home")
+    );
+
+    let failure_actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        protected.generation,
+        protected.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(failure_actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(8)));
+
+    let early = state.handle(base + Duration::from_secs(7), CoordinatorEvent::Timer);
+    let retry_actions = state.handle(base + Duration::from_secs(8), CoordinatorEvent::Timer);
+    assert_eq!(token_starts(&early), 0);
+    assert!(matches!(
+      retry_actions.as_slice(),
+      [CoordinatorAction::StartToken(request)]
+        if request.request.kind == TokenScanKind::Full
+          && request.request.codex_home.as_deref()
+            == Some("/normalized/configured-home")
+    ));
+  }
+
+  #[test]
+  fn protected_source_retry_is_not_retargeted_by_different_home_manual_request() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.auto_scan_enabled = false;
+    changed.codex_home = Some("/normalized/configured-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("new source Full refresh starts");
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        protected.generation,
+        protected.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let manual_actions = state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home".to_string(),
+      ))),
+    );
+    assert!(manual_actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+
+    let retry_actions = state.handle(base + Duration::from_secs(8), CoordinatorEvent::Timer);
+    let retry = retry_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected retry starts first");
+    assert_eq!(retry.request.kind, TokenScanKind::Full);
+    assert_eq!(
+      retry.request.codex_home.as_deref(),
+      Some("/normalized/configured-home")
+    );
+
+    let success_actions = state.handle(
+      base + Duration::from_secs(9),
+      CoordinatorEvent::TokenFinished(execution_success(
+        retry.generation,
+        retry.source_generation,
+        2,
+        base + Duration::from_secs(9),
+      )),
+    );
+    assert!(matches!(
+      success_actions.last(),
+      Some(CoordinatorAction::StartToken(request))
+        if request.request.kind == TokenScanKind::Full
+          && request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref() == Some("/normalized/manual-home")
+    ));
   }
 }

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -63,7 +63,7 @@ impl LaneState {
       }
     };
     self.next_deadline = now + remaining;
-    self.immediate_due |= elapsed >= new_interval;
+    self.immediate_due = elapsed >= new_interval;
   }
 
   fn take_due(
@@ -515,6 +515,77 @@ mod tests {
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(40));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(40));
+  }
+
+  #[test]
+  fn shorten_then_lengthen_while_disabled_does_not_refresh_on_reenable() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut initial = test_config(Duration::from_secs(300), Some(wall));
+    initial.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(initial, base, wall);
+    let mut shorter = test_config(Duration::from_secs(30), Some(wall));
+    shorter.auto_scan_enabled = false;
+    let mut longer = test_config(Duration::from_secs(300), Some(wall));
+    longer.auto_scan_enabled = false;
+
+    let shortened = state.handle(
+      base + Duration::from_secs(45),
+      CoordinatorEvent::SettingsChanged(shorter),
+    );
+    let lengthened = state.handle(
+      base + Duration::from_secs(50),
+      CoordinatorEvent::SettingsChanged(longer),
+    );
+    let reenabled = state.handle(
+      base + Duration::from_secs(50),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(300), Some(wall))),
+    );
+
+    assert!(shortened.is_empty());
+    assert!(lengthened.is_empty());
+    assert_eq!(
+      state.token_next_deadline().duration_since(base),
+      Duration::from_secs(330)
+    );
+    assert_eq!(
+      state.live_next_deadline().duration_since(base),
+      Duration::from_secs(330)
+    );
+    assert_eq!(token_starts(&reenabled), 0);
+    assert_eq!(live_starts(&reenabled), 0);
+  }
+
+  #[test]
+  fn same_interval_reenable_preserves_due_disabled_refresh() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut initial = test_config(Duration::from_secs(300), Some(wall));
+    initial.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(initial, base, wall);
+    let mut shorter = test_config(Duration::from_secs(30), Some(wall));
+    shorter.auto_scan_enabled = false;
+
+    let shortened = state.handle(
+      base + Duration::from_secs(45),
+      CoordinatorEvent::SettingsChanged(shorter),
+    );
+    let reenabled = state.handle(
+      base + Duration::from_secs(50),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(30), Some(wall))),
+    );
+
+    assert!(shortened.is_empty());
+    assert_eq!(token_starts(&reenabled), 1);
+    assert_eq!(live_starts(&reenabled), 1);
+    assert_eq!(
+      state.token_next_deadline().duration_since(base),
+      Duration::from_secs(60)
+    );
+    assert_eq!(
+      state.live_next_deadline().duration_since(base),
+      Duration::from_secs(60)
+    );
   }
 
   #[test]

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -1,4 +1,8 @@
-use super::{RefreshConfig, RefreshReason, TokenScanKind};
+use super::{
+  CommitMarker, DisplayInvalidation, ExecutionCompletion, LiveExecutionRequest, LiveRequest,
+  LiveWaiterId, ReasonSet, RefreshCompletedEvent, RefreshConfig, RefreshLane, RefreshReason,
+  TokenExecutionRequest, TokenRequest, TokenScanKind,
+};
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};
 
@@ -7,33 +11,58 @@ pub(crate) enum CoordinatorEvent {
   Timer,
   Wake,
   SettingsChanged(RefreshConfig),
+  RequestToken(TokenRequest),
+  RequestLive(LiveRequest),
+  TokenPrepared {
+    generation: u64,
+    source_generation: u64,
+  },
+  TokenFinished(ExecutionCompletion),
+  LiveFinished(ExecutionCompletion),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) enum CoordinatorAction {
-  StartToken {
-    kind: TokenScanKind,
-    reason: RefreshReason,
+  StartToken(TokenExecutionRequest),
+  StartLive(LiveExecutionRequest),
+  CommitToken {
+    generation: u64,
+    source_generation: u64,
   },
-  StartLive {
-    reason: RefreshReason,
+  DiscardToken {
+    generation: u64,
+    source_generation: u64,
+  },
+  PublishInvalidation(DisplayInvalidation),
+  PublishCompletion(RefreshCompletedEvent),
+  ResolveLiveWaiters {
+    waiter_ids: Vec<LiveWaiterId>,
+    generation: u64,
+    succeeded: bool,
+    failure: Option<String>,
   },
 }
 
 struct LaneState {
   next_deadline: Instant,
-  running: bool,
   startup_due: bool,
   immediate_due: bool,
+  last_generation: u64,
+  running_generation: Option<u64>,
+  failure_streak: u32,
+  retry_at: Option<Instant>,
 }
 
 impl LaneState {
   fn new(next_deadline: Instant, monotonic_now: Instant) -> Self {
     Self {
       next_deadline,
-      running: false,
       startup_due: next_deadline <= monotonic_now,
       immediate_due: false,
+      last_generation: 0,
+      running_generation: None,
+      failure_streak: 0,
+      retry_at: None,
     }
   }
 
@@ -66,7 +95,7 @@ impl LaneState {
     self.immediate_due = elapsed >= new_interval;
   }
 
-  fn take_due(
+  fn take_normal_due(
     &mut self,
     now: Instant,
     interval: Duration,
@@ -87,13 +116,21 @@ impl LaneState {
       trigger_reason
     };
     self.startup_due = false;
-
-    if self.running {
-      return None;
-    }
-
-    self.running = true;
     Some(reason)
+  }
+
+  fn start_generation(&mut self) -> u64 {
+    let generation = self
+      .last_generation
+      .checked_add(1)
+      .expect("refresh generation overflowed");
+    self.last_generation = generation;
+    self.running_generation = Some(generation);
+    generation
+  }
+
+  fn clear_running(&mut self) {
+    self.running_generation = None;
   }
 }
 
@@ -101,6 +138,19 @@ pub(crate) struct CoordinatorState {
   config: RefreshConfig,
   token: LaneState,
   live: LaneState,
+  token_running: Option<TokenExecutionRequest>,
+  token_pending: Option<TokenRequest>,
+  token_source_refresh_pending: Option<TokenRequest>,
+  token_retry_request: Option<TokenRequest>,
+  live_running: Option<LiveExecutionRequest>,
+  live_pending: ReasonSet,
+  live_retry_reasons: ReasonSet,
+  live_waiters: Vec<LiveWaiterId>,
+  source_generation: u64,
+  refresh_revision: u64,
+  usage_revision: u64,
+  quota_revision: u64,
+  settings_revision: u64,
 }
 
 impl CoordinatorState {
@@ -130,51 +180,557 @@ impl CoordinatorState {
       config,
       token: LaneState::new(token_next_deadline, monotonic_now),
       live: LaneState::new(live_next_deadline, monotonic_now),
+      token_running: None,
+      token_pending: None,
+      token_source_refresh_pending: None,
+      token_retry_request: None,
+      live_running: None,
+      live_pending: ReasonSet::default(),
+      live_retry_reasons: ReasonSet::default(),
+      live_waiters: Vec::new(),
+      source_generation: 0,
+      refresh_revision: 0,
+      usage_revision: 0,
+      quota_revision: 0,
+      settings_revision: 0,
     }
   }
 
   pub(crate) fn handle(&mut self, now: Instant, event: CoordinatorEvent) -> Vec<CoordinatorAction> {
-    let trigger_reason = match event {
-      CoordinatorEvent::Timer => RefreshReason::Scheduled,
-      CoordinatorEvent::Wake => RefreshReason::Wake,
-      CoordinatorEvent::SettingsChanged(config) => {
-        assert!(
-          !config.interval.is_zero(),
-          "refresh interval must be positive"
-        );
-        let old_interval = self.config.interval;
+    match event {
+      CoordinatorEvent::Timer => self.handle_due(now, RefreshReason::Scheduled),
+      CoordinatorEvent::Wake => self.handle_due(now, RefreshReason::Wake),
+      CoordinatorEvent::SettingsChanged(config) => self.handle_settings_changed(now, config),
+      CoordinatorEvent::RequestToken(request) => {
+        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+          return Vec::new();
+        }
+        let mut actions = Vec::with_capacity(1);
+        self.submit_token_request(request, &mut actions);
+        actions
+      }
+      CoordinatorEvent::RequestLive(request) => {
+        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+          return Vec::new();
+        }
+        let mut actions = Vec::with_capacity(1);
+        self.submit_live_request(request, &mut actions);
+        actions
+      }
+      CoordinatorEvent::TokenPrepared {
+        generation,
+        source_generation,
+      } => self.handle_token_prepared(generation, source_generation),
+      CoordinatorEvent::TokenFinished(completion) => {
+        self.handle_token_finished(now, completion)
+      }
+      CoordinatorEvent::LiveFinished(completion) => {
+        self.handle_live_finished(now, completion)
+      }
+    }
+  }
+
+  fn handle_due(&mut self, now: Instant, trigger_reason: RefreshReason) -> Vec<CoordinatorAction> {
+    let mut token_request = self.take_due_token_request(now, trigger_reason);
+    let mut live_reasons = self.take_due_live_reasons(now, trigger_reason);
+    let mut actions = Vec::with_capacity(2);
+
+    if let Some(request) = token_request.take() {
+      self.submit_token_request(request, &mut actions);
+    }
+    if !live_reasons.is_empty() {
+      self.submit_live_request(
+        LiveRequest {
+          reasons: std::mem::take(&mut live_reasons),
+          waiter: None,
+        },
+        &mut actions,
+      );
+    }
+
+    actions
+  }
+
+  fn handle_settings_changed(
+    &mut self,
+    now: Instant,
+    config: RefreshConfig,
+  ) -> Vec<CoordinatorAction> {
+    assert!(
+      !config.interval.is_zero(),
+      "refresh interval must be positive"
+    );
+    let old_interval = self.config.interval;
+    let source_changed = self.config.codex_home != config.codex_home;
+    let disabling_auto_scan = self.config.auto_scan_enabled && !config.auto_scan_enabled;
+    let settings_changed = self.config.auto_scan_enabled != config.auto_scan_enabled
+      || old_interval != config.interval
+      || source_changed;
+
+    self
+      .token
+      .recalculate_interval(now, old_interval, config.interval);
+    self
+      .live
+      .recalculate_interval(now, old_interval, config.interval);
+    self.config = config;
+
+    if disabling_auto_scan {
+      self.prune_automatic_pending_work();
+    }
+
+    if settings_changed {
+      self.settings_revision = self.settings_revision.saturating_add(1);
+    }
+
+    let mut token_request = None;
+    let mut live_reasons = ReasonSet::default();
+    if source_changed {
+      self.source_generation = self
+        .source_generation
+        .checked_add(1)
+        .expect("refresh source generation overflowed");
+      self.token.failure_streak = 0;
+      self.token.retry_at = None;
+      self.token_retry_request = None;
+      self.live.failure_streak = 0;
+      self.live.retry_at = None;
+      self.live_retry_reasons = ReasonSet::default();
+
+      let mut request = TokenRequest {
+        reasons: RefreshReason::SettingsChanged.into(),
+        kind: TokenScanKind::Full,
+        codex_home: self.config.codex_home.clone(),
+      };
+      if let Some(previous_source_refresh) = self.token_source_refresh_pending.take() {
+        request.reasons.merge(previous_source_refresh.reasons);
+      }
+      if let Some(mut pending) = self.token_pending.take() {
+        let manual_for_another_home = pending.reasons.contains(RefreshReason::Manual)
+          && pending.codex_home != self.config.codex_home;
+        if manual_for_another_home {
+          let mut automatic_reasons = pending.reasons;
+          automatic_reasons.remove(RefreshReason::Manual);
+          request.reasons.merge(automatic_reasons);
+          pending.reasons = RefreshReason::Manual.into();
+          self.token_pending = Some(pending);
+        } else {
+          request.reasons.merge(pending.reasons);
+        }
+      }
+      token_request = Some(request);
+      if self.config.auto_scan_enabled {
+        live_reasons.insert(RefreshReason::SettingsChanged);
+      }
+    }
+
+    if let Some(due) = self.take_due_token_request(now, RefreshReason::SettingsChanged) {
+      merge_token_request(&mut token_request, due);
+    }
+    live_reasons.merge(self.take_due_live_reasons(now, RefreshReason::SettingsChanged));
+
+    let mut actions = Vec::with_capacity(2);
+    if let Some(request) = token_request {
+      if source_changed {
+        self.submit_source_refresh_request(request, &mut actions);
+      } else {
+        self.submit_token_request(request, &mut actions);
+      }
+    }
+    if !live_reasons.is_empty() {
+      self.submit_live_request(
+        LiveRequest {
+          reasons: live_reasons,
+          waiter: None,
+        },
+        &mut actions,
+      );
+    }
+    actions
+  }
+
+  fn take_due_token_request(
+    &mut self,
+    now: Instant,
+    trigger_reason: RefreshReason,
+  ) -> Option<TokenRequest> {
+    let mut request = None;
+    if self.token.retry_at.is_some_and(|retry_at| retry_at <= now) {
+      let retry_allowed = self.config.auto_scan_enabled
+        || self
+          .token_retry_request
+          .as_ref()
+          .is_some_and(|value| value.reasons.contains(RefreshReason::Manual));
+      if retry_allowed {
+        self.token.retry_at = None;
+        if let Some(retry) = self.token_retry_request.take() {
+          merge_token_request(&mut request, retry);
+        }
+      }
+    }
+
+    if self.config.auto_scan_enabled {
+      if let Some(reason) =
         self
           .token
-          .recalculate_interval(now, old_interval, config.interval);
+          .take_normal_due(now, self.config.interval, trigger_reason)
+      {
+        merge_token_request(
+          &mut request,
+          TokenRequest {
+            reasons: reason.into(),
+            kind: TokenScanKind::Incremental,
+            codex_home: self.config.codex_home.clone(),
+          },
+        );
+      }
+    }
+    request
+  }
+
+  fn take_due_live_reasons(
+    &mut self,
+    now: Instant,
+    trigger_reason: RefreshReason,
+  ) -> ReasonSet {
+    let mut reasons = ReasonSet::default();
+    if self.live.retry_at.is_some_and(|retry_at| retry_at <= now) {
+      let retry_allowed = self.config.auto_scan_enabled
+        || self.live_retry_reasons.contains(RefreshReason::Manual);
+      if retry_allowed {
+        self.live.retry_at = None;
+        reasons.merge(std::mem::take(&mut self.live_retry_reasons));
+      }
+    }
+
+    if self.config.auto_scan_enabled {
+      if let Some(reason) =
         self
           .live
-          .recalculate_interval(now, old_interval, config.interval);
-        self.config = config;
-        RefreshReason::SettingsChanged
+          .take_normal_due(now, self.config.interval, trigger_reason)
+      {
+        reasons.insert(reason);
       }
+    }
+    reasons
+  }
+
+  fn submit_token_request(
+    &mut self,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if request.reasons.is_empty() {
+      return;
+    }
+    if request.codex_home.is_none() {
+      request.codex_home = self.config.codex_home.clone();
+    }
+
+    if self.token.running_generation.is_some() {
+      if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
+        if source_refresh.codex_home == request.codex_home {
+          source_refresh.merge(request);
+          return;
+        }
+      }
+      merge_token_request(&mut self.token_pending, request);
+      return;
+    }
+
+    if let Some(mut retry) = self.token_retry_request.take() {
+      retry.merge(request);
+      request = retry;
+    }
+    self.token.retry_at = None;
+    let generation = self.token.start_generation();
+    let execution = TokenExecutionRequest {
+      generation,
+      source_generation: self.source_generation,
+      request,
+    };
+    self.token_running = Some(execution.clone());
+    actions.push(CoordinatorAction::StartToken(execution));
+  }
+
+  fn submit_source_refresh_request(
+    &mut self,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if self.token.running_generation.is_some() {
+      if let Some(previous) = self.token_source_refresh_pending.take() {
+        request.reasons.merge(previous.reasons);
+      }
+      self.token_source_refresh_pending = Some(request);
+      return;
+    }
+    self.submit_token_request(request, actions);
+  }
+
+  fn submit_live_request(
+    &mut self,
+    mut request: LiveRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if self.live.running_generation.is_some() {
+      if let Some(waiter) = request.waiter {
+        push_unique_waiter(&mut self.live_waiters, waiter);
+      }
+      request.reasons.remove(RefreshReason::Manual);
+      self.live_pending.merge(request.reasons);
+      return;
+    }
+
+    if let Some(waiter) = request.waiter {
+      push_unique_waiter(&mut self.live_waiters, waiter);
+    }
+    request.reasons.merge(std::mem::take(&mut self.live_retry_reasons));
+    self.live.retry_at = None;
+    if request.reasons.is_empty() {
+      return;
+    }
+
+    let generation = self.live.start_generation();
+    let execution = LiveExecutionRequest {
+      generation,
+      source_generation: self.source_generation,
+      reasons: request.reasons,
+    };
+    self.live_running = Some(execution.clone());
+    actions.push(CoordinatorAction::StartLive(execution));
+  }
+
+  fn handle_token_prepared(
+    &mut self,
+    generation: u64,
+    source_generation: u64,
+  ) -> Vec<CoordinatorAction> {
+    let mut actions = Vec::with_capacity(2);
+    let Some(running) = self.token_running.as_ref() else {
+      actions.push(CoordinatorAction::DiscardToken {
+        generation,
+        source_generation,
+      });
+      return actions;
     };
 
-    if !self.config.auto_scan_enabled {
+    if running.generation != generation {
+      actions.push(CoordinatorAction::DiscardToken {
+        generation,
+        source_generation,
+      });
+      return actions;
+    }
+
+    if running.source_generation == source_generation
+      && source_generation == self.source_generation
+    {
+      actions.push(CoordinatorAction::CommitToken {
+        generation,
+        source_generation,
+      });
+      return actions;
+    }
+
+    let stale = self
+      .token_running
+      .take()
+      .expect("matching token generation remains present");
+    self.token.clear_running();
+    actions.push(CoordinatorAction::DiscardToken {
+      generation,
+      source_generation,
+    });
+    if self.token_source_refresh_pending.is_none() {
+      let mut request = stale.request;
+      request.kind = TokenScanKind::Full;
+      request.codex_home = self.config.codex_home.clone();
+      request.reasons.insert(RefreshReason::SettingsChanged);
+      self.token_source_refresh_pending = Some(request);
+    }
+    self.start_pending_token(&mut actions);
+    actions
+  }
+
+  fn handle_token_finished(
+    &mut self,
+    now: Instant,
+    completion: ExecutionCompletion,
+  ) -> Vec<CoordinatorAction> {
+    let Some(running) = self.token_running.as_ref() else {
+      return Vec::new();
+    };
+    if running.generation != completion.generation {
       return Vec::new();
     }
 
-    let mut actions = Vec::with_capacity(2);
-    if let Some(reason) = self
-      .token
-      .take_due(now, self.config.interval, trigger_reason)
+    let running = self
+      .token_running
+      .take()
+      .expect("matching token generation remains present");
+    self.token.clear_running();
+    if running.source_generation != completion.source_generation
+      || completion.source_generation != self.source_generation
     {
-      actions.push(CoordinatorAction::StartToken {
-        kind: TokenScanKind::Incremental,
-        reason,
+      let mut actions = Vec::with_capacity(1);
+      self.start_pending_token(&mut actions);
+      return actions;
+    }
+
+    let completion = normalize_completion(completion);
+    let mut actions = Vec::with_capacity(3);
+    if completion.succeeded {
+      self.token.failure_streak = 0;
+      self.token.retry_at = None;
+      self.token_retry_request = None;
+      self.usage_revision = self.usage_revision.saturating_add(1);
+      actions.push(CoordinatorAction::PublishInvalidation(
+        self.invalidation(completion.commit.expect("normalized success has commit marker")),
+      ));
+    } else {
+      self.token.failure_streak = self.token.failure_streak.saturating_add(1);
+      let jitter = completion.retry_jitter.min(Duration::from_secs(1));
+      let delay = retry_delay(self.token.failure_streak, self.config.interval, jitter);
+      self.token.retry_at = Some(now.checked_add(delay).unwrap_or(now));
+      self.token_retry_request = Some(running.request);
+    }
+    actions.push(CoordinatorAction::PublishCompletion(
+      self.completed_event(RefreshLane::Token, &completion),
+    ));
+    self.start_pending_token(&mut actions);
+    actions
+  }
+
+  fn handle_live_finished(
+    &mut self,
+    now: Instant,
+    completion: ExecutionCompletion,
+  ) -> Vec<CoordinatorAction> {
+    let Some(running) = self.live_running.as_ref() else {
+      return Vec::new();
+    };
+    if running.generation != completion.generation {
+      return Vec::new();
+    }
+
+    let running = self
+      .live_running
+      .take()
+      .expect("matching live generation remains present");
+    self.live.clear_running();
+    let waiters = std::mem::take(&mut self.live_waiters);
+    if running.source_generation != completion.source_generation
+      || completion.source_generation != self.source_generation
+    {
+      let mut actions = Vec::with_capacity(2);
+      if !waiters.is_empty() {
+        actions.push(CoordinatorAction::ResolveLiveWaiters {
+          waiter_ids: waiters,
+          generation: completion.generation,
+          succeeded: false,
+          failure: Some("refresh source changed".to_string()),
+        });
+      }
+      self.start_pending_live(&mut actions);
+      return actions;
+    }
+
+    let completion = normalize_completion(completion);
+    let mut actions = Vec::with_capacity(4);
+    if completion.succeeded {
+      self.live.failure_streak = 0;
+      self.live.retry_at = None;
+      self.live_retry_reasons = ReasonSet::default();
+      self.quota_revision = self.quota_revision.saturating_add(1);
+      actions.push(CoordinatorAction::PublishInvalidation(
+        self.invalidation(completion.commit.expect("normalized success has commit marker")),
+      ));
+    } else {
+      self.live.failure_streak = self.live.failure_streak.saturating_add(1);
+      let jitter = completion.retry_jitter.min(Duration::from_secs(1));
+      let delay = retry_delay(self.live.failure_streak, self.config.interval, jitter);
+      self.live.retry_at = Some(now.checked_add(delay).unwrap_or(now));
+      self.live_retry_reasons = running.reasons;
+    }
+    actions.push(CoordinatorAction::PublishCompletion(
+      self.completed_event(RefreshLane::Live, &completion),
+    ));
+    if !waiters.is_empty() {
+      actions.push(CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids: waiters,
+        generation: completion.generation,
+        succeeded: completion.succeeded,
+        failure: completion.failure.clone(),
       });
     }
-    if let Some(reason) = self
-      .live
-      .take_due(now, self.config.interval, trigger_reason)
-    {
-      actions.push(CoordinatorAction::StartLive { reason });
-    }
+    self.start_pending_live(&mut actions);
     actions
+  }
+
+  fn start_pending_token(&mut self, actions: &mut Vec<CoordinatorAction>) {
+    if let Some(request) = self.token_source_refresh_pending.take() {
+      self.submit_token_request(request, actions);
+      return;
+    }
+    if let Some(request) = self.token_pending.take() {
+      if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+        return;
+      }
+      self.submit_token_request(request, actions);
+    }
+  }
+
+  fn prune_automatic_pending_work(&mut self) {
+    if let Some(mut pending) = self.token_pending.take() {
+      if pending.reasons.contains(RefreshReason::Manual) {
+        pending.reasons = RefreshReason::Manual.into();
+        self.token_pending = Some(pending);
+      }
+    }
+    self.live_pending = ReasonSet::default();
+  }
+
+  fn start_pending_live(&mut self, actions: &mut Vec<CoordinatorAction>) {
+    let reasons = std::mem::take(&mut self.live_pending);
+    if !reasons.is_empty() {
+      self.submit_live_request(
+        LiveRequest {
+          reasons,
+          waiter: None,
+        },
+        actions,
+      );
+    }
+  }
+
+  fn invalidation(&self, commit: CommitMarker) -> DisplayInvalidation {
+    DisplayInvalidation {
+      usage_revision: self.usage_revision,
+      quota_revision: self.quota_revision,
+      settings_revision: self.settings_revision,
+      source_generation: self.source_generation,
+      commit,
+    }
+  }
+
+  fn completed_event(
+    &mut self,
+    lane: RefreshLane,
+    completion: &ExecutionCompletion,
+  ) -> RefreshCompletedEvent {
+    self.refresh_revision = self.refresh_revision.saturating_add(1);
+    RefreshCompletedEvent {
+      refresh_revision: self.refresh_revision,
+      lane,
+      generation: completion.generation,
+      usage_revision: self.usage_revision,
+      quota_revision: self.quota_revision,
+      source_generation: self.source_generation,
+      succeeded: completion.succeeded,
+      failure: completion.failure.clone(),
+      completed_at: completion.completed_at.clone(),
+    }
   }
 
   pub(crate) fn token_next_deadline(&self) -> Instant {
@@ -184,6 +740,55 @@ impl CoordinatorState {
   pub(crate) fn live_next_deadline(&self) -> Instant {
     self.live.next_deadline
   }
+
+  pub(crate) fn token_retry_at(&self) -> Option<Instant> {
+    self.token.retry_at
+  }
+
+  pub(crate) fn live_retry_at(&self) -> Option<Instant> {
+    self.live.retry_at
+  }
+
+  pub(crate) fn source_generation(&self) -> u64 {
+    self.source_generation
+  }
+
+  pub(crate) fn usage_revision(&self) -> u64 {
+    self.usage_revision
+  }
+}
+
+fn merge_token_request(target: &mut Option<TokenRequest>, request: TokenRequest) {
+  if let Some(target) = target {
+    target.merge(request);
+  } else {
+    *target = Some(request);
+  }
+}
+
+fn push_unique_waiter(waiters: &mut Vec<LiveWaiterId>, waiter: LiveWaiterId) {
+  if !waiters.contains(&waiter) {
+    waiters.push(waiter);
+  }
+}
+
+fn normalize_completion(mut completion: ExecutionCompletion) -> ExecutionCompletion {
+  if completion.succeeded && completion.commit.is_none() {
+    completion.succeeded = false;
+    completion.failure = Some("successful refresh completion missing commit marker".to_string());
+  } else if !completion.succeeded && completion.failure.is_none() {
+    completion.failure = Some("refresh failed without an error".to_string());
+  }
+  completion
+}
+
+fn retry_delay(failure_streak: u32, interval: Duration, jitter: Duration) -> Duration {
+  const STEPS: [u64; 6] = [5, 15, 30, 60, 120, 300];
+  let index = failure_streak.saturating_sub(1) as usize;
+  Duration::from_secs(STEPS[index.min(STEPS.len() - 1)])
+    .saturating_add(jitter)
+    .min(interval)
+    .min(Duration::from_secs(300))
 }
 
 fn advance_fixed_deadline(
@@ -246,14 +851,14 @@ mod tests {
   fn token_starts(actions: &[CoordinatorAction]) -> usize {
     actions
       .iter()
-      .filter(|value| matches!(value, CoordinatorAction::StartToken { .. }))
+      .filter(|value| matches!(value, CoordinatorAction::StartToken(_)))
       .count()
   }
 
   fn live_starts(actions: &[CoordinatorAction]) -> usize {
     actions
       .iter()
-      .filter(|value| matches!(value, CoordinatorAction::StartLive { .. }))
+      .filter(|value| matches!(value, CoordinatorAction::StartLive(_)))
       .count()
   }
 
@@ -286,14 +891,11 @@ mod tests {
     assert!(matches!(
       first.as_slice(),
       [
-        CoordinatorAction::StartToken {
-          kind: TokenScanKind::Incremental,
-          reason: RefreshReason::Startup,
-        },
-        CoordinatorAction::StartLive {
-          reason: RefreshReason::Startup,
-        },
-      ]
+        CoordinatorAction::StartToken(token),
+        CoordinatorAction::StartLive(live),
+      ] if token.request.kind == TokenScanKind::Incremental
+        && token.request.reasons.contains(RefreshReason::Startup)
+        && live.reasons.contains(RefreshReason::Startup)
     ));
     assert!(duplicate.is_empty());
   }
@@ -352,10 +954,10 @@ mod tests {
 
     assert!(actions
       .iter()
-      .any(|value| matches!(value, CoordinatorAction::StartToken { .. })));
+      .any(|value| matches!(value, CoordinatorAction::StartToken(_))));
     assert!(actions
       .iter()
-      .any(|value| matches!(value, CoordinatorAction::StartLive { .. })));
+      .any(|value| matches!(value, CoordinatorAction::StartLive(_))));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
   }
@@ -382,9 +984,8 @@ mod tests {
     assert_eq!(live_starts(&live_due), 1);
     assert!(matches!(
       live_due.as_slice(),
-      [CoordinatorAction::StartLive {
-        reason: RefreshReason::Scheduled,
-      }]
+      [CoordinatorAction::StartLive(request)]
+        if request.reasons.contains(RefreshReason::Scheduled)
     ));
   }
 
@@ -402,14 +1003,10 @@ mod tests {
     assert!(matches!(
       actions.as_slice(),
       [
-        CoordinatorAction::StartToken {
-          reason: RefreshReason::Wake,
-          ..
-        },
-        CoordinatorAction::StartLive {
-          reason: RefreshReason::Wake,
-        },
-      ]
+        CoordinatorAction::StartToken(token),
+        CoordinatorAction::StartLive(live),
+      ] if token.request.reasons.contains(RefreshReason::Wake)
+        && live.reasons.contains(RefreshReason::Wake)
     ));
     assert_eq!(
       state.token_next_deadline(),
@@ -442,14 +1039,10 @@ mod tests {
     assert!(matches!(
       actions.as_slice(),
       [
-        CoordinatorAction::StartToken {
-          reason: RefreshReason::SettingsChanged,
-          ..
-        },
-        CoordinatorAction::StartLive {
-          reason: RefreshReason::SettingsChanged,
-        },
-      ]
+        CoordinatorAction::StartToken(token),
+        CoordinatorAction::StartLive(live),
+      ] if token.request.reasons.contains(RefreshReason::SettingsChanged)
+        && live.reasons.contains(RefreshReason::SettingsChanged)
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(90));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(90));
@@ -485,14 +1078,18 @@ mod tests {
   #[test]
   fn shorter_interval_recalculates_when_prior_anchor_predates_monotonic_epoch() {
     let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
     let old_interval = Duration::MAX;
     let old_next_deadline = base + Duration::from_secs(60);
     assert!(old_next_deadline.checked_sub(old_interval).is_none());
-    let mut state = CoordinatorState {
-      config: test_config(old_interval, None),
-      token: LaneState::new(old_next_deadline, base),
-      live: LaneState::new(old_next_deadline, base),
-    };
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(60), Some(wall)),
+      base,
+      wall,
+    );
+    state.config.interval = old_interval;
+    state.token = LaneState::new(old_next_deadline, base);
+    state.live = LaneState::new(old_next_deadline, base);
 
     let actions = state.handle(
       base + Duration::from_secs(30),
@@ -504,14 +1101,10 @@ mod tests {
     assert!(matches!(
       actions.as_slice(),
       [
-        CoordinatorAction::StartToken {
-          reason: RefreshReason::SettingsChanged,
-          ..
-        },
-        CoordinatorAction::StartLive {
-          reason: RefreshReason::SettingsChanged,
-        },
-      ]
+        CoordinatorAction::StartToken(token),
+        CoordinatorAction::StartLive(live),
+      ] if token.request.reasons.contains(RefreshReason::SettingsChanged)
+        && live.reasons.contains(RefreshReason::SettingsChanged)
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(40));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(40));
@@ -613,5 +1206,603 @@ mod tests {
     assert_eq!(live_starts(&due), 1);
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
+  }
+
+  fn execution_success(
+    generation: u64,
+    source_generation: u64,
+    sequence: u64,
+    committed_at: Instant,
+  ) -> ExecutionCompletion {
+    ExecutionCompletion {
+      generation,
+      source_generation,
+      succeeded: true,
+      failure: None,
+      completed_at: "2026-07-10T10:00:00Z".to_string(),
+      commit: Some(CommitMarker {
+        sequence,
+        committed_at,
+      }),
+      retry_jitter: Duration::ZERO,
+    }
+  }
+
+  fn execution_failure(
+    generation: u64,
+    source_generation: u64,
+    retry_jitter: Duration,
+  ) -> ExecutionCompletion {
+    ExecutionCompletion {
+      generation,
+      source_generation,
+      succeeded: false,
+      failure: Some("test failure".to_string()),
+      completed_at: "2026-07-10T10:00:00Z".to_string(),
+      commit: None,
+      retry_jitter,
+    }
+  }
+
+  fn start_token_generation(state: &mut CoordinatorState, now: Instant) -> TokenExecutionRequest {
+    state
+      .handle(
+        now,
+        CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("token generation starts")
+  }
+
+  fn start_live_generation(state: &mut CoordinatorState, now: Instant) -> LiveExecutionRequest {
+    state
+      .handle(
+        now,
+        CoordinatorEvent::RequestLive(LiveRequest::scheduled()),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("live generation starts")
+  }
+
+  #[test]
+  fn triggers_during_run_create_one_follow_up_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let first = start_token_generation(&mut state, base);
+
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+    );
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    let starts = actions
+      .iter()
+      .filter_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(starts.len(), 1);
+    assert_eq!(starts[0].request.kind, TokenScanKind::Full);
+  }
+
+  #[test]
+  fn multiple_triggers_merge_reason_bits() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let first = start_live_generation(&mut state, base);
+
+    for reason in [
+      RefreshReason::Scheduled,
+      RefreshReason::Wake,
+      RefreshReason::SettingsChanged,
+    ] {
+      state.handle(
+        base + Duration::from_secs(1),
+        CoordinatorEvent::RequestLive(LiveRequest::for_reason(reason)),
+      );
+    }
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::LiveFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+
+    let starts = actions
+      .iter()
+      .filter_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(starts.len(), 1);
+    assert!(starts[0].reasons.contains(RefreshReason::Scheduled));
+    assert!(starts[0].reasons.contains(RefreshReason::Wake));
+    assert!(starts[0]
+      .reasons
+      .contains(RefreshReason::SettingsChanged));
+  }
+
+  #[test]
+  fn manual_live_waiter_joins_running_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let first = start_live_generation(&mut state, base);
+    let waiter_id = LiveWaiterId(41);
+
+    let joined = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestLive(LiveRequest::manual(waiter_id)),
+    );
+    assert!(joined
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartLive(_))));
+
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::LiveFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+
+    assert!(actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartLive(_))));
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids,
+        generation,
+        succeeded: true,
+        failure: None,
+      } if waiter_ids == &[waiter_id] && *generation == first.generation
+    )));
+  }
+
+  #[test]
+  fn failed_lanes_back_off_independently() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first_token = start_token_generation(&mut state, base);
+    let first_live = start_live_generation(&mut state, base);
+
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        first_token.generation,
+        first_token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::LiveFinished(execution_failure(
+        first_live.generation,
+        first_live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(6)));
+    assert_eq!(state.live_retry_at(), Some(base + Duration::from_secs(7)));
+    assert_eq!(state.token_next_deadline(), base + interval);
+    assert_eq!(state.live_next_deadline(), base + interval);
+
+    let token_retry = state.handle(base + Duration::from_secs(6), CoordinatorEvent::Timer);
+    assert_eq!(token_starts(&token_retry), 1);
+    assert_eq!(live_starts(&token_retry), 0);
+    let second_token = token_retry
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("token retry starts");
+    state.handle(
+      base + Duration::from_secs(6),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        second_token.generation,
+        second_token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(21)));
+    assert_eq!(state.live_retry_at(), Some(base + Duration::from_secs(7)));
+    assert_eq!(
+      retry_delay(6, Duration::from_secs(600), Duration::ZERO),
+      Duration::from_secs(300)
+    );
+    assert_eq!(
+      retry_delay(1, Duration::from_secs(3), Duration::ZERO),
+      Duration::from_secs(3)
+    );
+
+    let mut jitter_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let jittered = start_token_generation(&mut jitter_state, base);
+    jitter_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        jittered.generation,
+        jittered.source_generation,
+        Duration::from_secs(2),
+      )),
+    );
+    assert_eq!(
+      jitter_state.token_retry_at(),
+      Some(base + Duration::from_secs(6))
+    );
+  }
+
+  #[test]
+  fn source_change_rejects_old_completion() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/new-home".to_string());
+
+    let settings_actions = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    assert!(settings_actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+
+    assert_eq!(state.source_generation(), first.source_generation + 1);
+    assert_eq!(state.usage_revision(), 0);
+    assert!(actions.iter().all(|action| !matches!(
+      action,
+      CoordinatorAction::PublishCompletion(_) | CoordinatorAction::PublishInvalidation(_)
+    )));
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::StartToken(request)
+        if request.source_generation == first.source_generation + 1
+          && request.request.kind == TokenScanKind::Full
+          && request.request.codex_home.as_deref() == Some("/normalized/new-home")
+    )));
+  }
+
+  #[test]
+  fn source_change_discards_prepared_token_before_commit() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/new-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenPrepared {
+        generation: first.generation,
+        source_generation: first.source_generation,
+      },
+    );
+
+    assert_eq!(state.usage_revision(), 0);
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::DiscardToken {
+        generation,
+        source_generation,
+      } if *generation == first.generation && *source_generation == first.source_generation
+    )));
+    assert!(actions.iter().all(|action| !matches!(
+      action,
+      CoordinatorAction::CommitToken { .. }
+        | CoordinatorAction::PublishCompletion(_)
+        | CoordinatorAction::PublishInvalidation(_)
+    )));
+    assert_eq!(
+      actions
+        .iter()
+        .filter(|action| matches!(action, CoordinatorAction::StartToken(_)))
+        .count(),
+      1
+    );
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::StartToken(request)
+        if request.source_generation == first.source_generation + 1
+          && request.request.kind == TokenScanKind::Full
+    )));
+  }
+
+  #[test]
+  fn success_without_commit_marker_is_rejected() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let first = start_token_generation(&mut state, base);
+    let completion = ExecutionCompletion {
+      generation: first.generation,
+      source_generation: first.source_generation,
+      succeeded: true,
+      failure: None,
+      completed_at: "2026-07-10T10:00:00Z".to_string(),
+      commit: None,
+      retry_jitter: Duration::ZERO,
+    };
+
+    let actions = state.handle(base, CoordinatorEvent::TokenFinished(completion));
+
+    assert_eq!(state.usage_revision(), 0);
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(5)));
+    assert!(actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::PublishInvalidation(_))));
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::PublishCompletion(event)
+        if !event.succeeded
+          && event.failure.as_deref()
+            == Some("successful refresh completion missing commit marker")
+    )));
+  }
+
+  #[test]
+  fn stale_live_completion_resolves_waiters_without_publishing() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_live_generation(&mut state, base);
+    let waiter_id = LiveWaiterId(73);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestLive(LiveRequest::manual(waiter_id)),
+    );
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/new-home".to_string());
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::LiveFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    assert!(actions.iter().all(|action| !matches!(
+      action,
+      CoordinatorAction::PublishCompletion(_) | CoordinatorAction::PublishInvalidation(_)
+    )));
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids,
+        generation,
+        succeeded: false,
+        failure: Some(failure),
+      } if waiter_ids == &[waiter_id]
+        && *generation == first.generation
+        && failure == "refresh source changed"
+    )));
+    assert_eq!(
+      actions
+        .iter()
+        .filter(|action| matches!(action, CoordinatorAction::StartLive(_)))
+        .count(),
+      1
+    );
+  }
+
+  #[test]
+  fn manual_full_request_supersedes_pending_retry_source() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut config = test_config(Duration::from_secs(300), Some(wall));
+    config.codex_home = Some("/normalized/configured-home".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let first = start_token_generation(&mut state, base);
+    state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        first.generation,
+        first.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home".to_string(),
+      ))),
+    );
+
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::StartToken(request)
+        if request.request.kind == TokenScanKind::Full
+          && request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref() == Some("/normalized/manual-home")
+    )));
+  }
+
+  #[test]
+  fn disabling_auto_scan_cancels_queued_automatic_token_follow_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_token_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    assert!(actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+  }
+
+  #[test]
+  fn disabling_auto_scan_cancels_queued_automatic_live_follow_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_live_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestLive(LiveRequest::scheduled()),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::LiveFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    assert!(actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartLive(_))));
+  }
+
+  #[test]
+  fn source_refresh_precedes_manual_request_for_another_home() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/new-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home".to_string(),
+      ))),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    let starts = actions
+      .iter()
+      .filter_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(starts.len(), 1);
+    assert_eq!(starts[0].request.kind, TokenScanKind::Full);
+    assert_eq!(
+      starts[0].request.codex_home.as_deref(),
+      Some("/normalized/new-home")
+    );
   }
 }

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -446,19 +446,12 @@ impl CoordinatorState {
     }
 
     if self.token.running_generation.is_some() {
-      let matches_running_source_refresh = self.token_running_source_refresh
-        && self
-          .token_running
-          .as_ref()
-          .is_some_and(|running| running.request.codex_home == request.codex_home);
-      if matches_running_source_refresh {
-        merge_token_request(&mut self.token_source_refresh_pending, request);
-        return;
-      }
-      if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
-        if source_refresh.codex_home == request.codex_home {
-          source_refresh.merge(request);
-          return;
+      if !self.token_running_source_refresh {
+        if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
+          if source_refresh.codex_home == request.codex_home {
+            source_refresh.merge(request);
+            return;
+          }
         }
       }
       merge_token_request(&mut self.token_pending, request);
@@ -2056,5 +2049,64 @@ mod tests {
           && request.request.reasons.contains(RefreshReason::Manual)
           && request.request.codex_home.as_deref() == Some("/normalized/manual-home")
     ));
+  }
+
+  #[test]
+  fn automatic_follow_up_during_protected_run_is_pruned_when_disabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/configured-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed.clone()),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("configured-source Full refresh starts");
+    assert_eq!(protected.request.kind, TokenScanKind::Full);
+    assert_eq!(
+      protected.request.codex_home.as_deref(),
+      Some("/normalized/configured-home")
+    );
+
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    changed.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let completion_actions = state.handle(
+      base + Duration::from_secs(5),
+      CoordinatorEvent::TokenFinished(execution_success(
+        protected.generation,
+        protected.source_generation,
+        2,
+        base + Duration::from_secs(5),
+      )),
+    );
+
+    assert!(completion_actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,12 @@
-import { startTransition, useCallback, useDeferredValue, useEffect, useRef, useState } from 'react'
+import {
+  startTransition,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import { isTauri } from '@tauri-apps/api/core'
 import { emitTo, listen } from '@tauri-apps/api/event'
 import { getCurrentWindow } from '@tauri-apps/api/window'
@@ -234,7 +242,7 @@ function App() {
     bucket === 'five_hour' || bucket === 'seven_day' ? liveWindowOffset : 0,
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     loadShellRef.current = loadShell
   }, [loadShell])
 
@@ -288,7 +296,7 @@ function App() {
     void emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_LANGUAGE_EVENT, { language }).catch(() => {})
   }, [language])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isTauri()) return
 
     let cancelled = false
@@ -450,7 +458,7 @@ function App() {
         () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
       )
       if (shouldLoadDashboardAfterManualRefresh(listenerReady)) {
-        await loadShell(true)
+        await loadShellRef.current(true)
       }
       setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
     } catch (error) {
@@ -503,7 +511,7 @@ function App() {
     setSyncSettings(saved.syncSettings)
     setSubscriptionProfile(saved.subscriptionProfile)
     if (shouldLoadDashboardAfterSettingsSave(saved.codexHomeChanged, listenerReady)) {
-      await loadShell(true)
+      await loadShellRef.current(true)
     }
     if (isTauri()) {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { startTransition, useCallback, useDeferredValue, useEffect, useRef, useState } from 'react'
 import { isTauri } from '@tauri-apps/api/core'
 import { emitTo, listen } from '@tauri-apps/api/event'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import {
   BadgeDollarSign,
   ChartNoAxesCombined,
@@ -15,9 +16,7 @@ import {
 import {
   getScanInProgress,
   getConversationDetail,
-  getLiveRateLimits,
   loadDashboard,
-  refreshBackgroundData,
   refreshPricing,
   scanCodexUsage,
   updateSubscriptionProfile,
@@ -25,11 +24,10 @@ import {
 } from './app/api'
 import {
   loadConversationDetailForGeneration,
-  refreshDashboardAfterBackgroundScan,
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
-  waitForScanToSettleUntilCancelled,
 } from './app/dataFreshness'
+import { SurfaceRevisionGate } from './app/refreshEvents'
 import { saveSettingsWithCodexHomeRollback } from './app/settingsSave'
 import {
   formatCompactDateTime,
@@ -54,6 +52,7 @@ import type {
   ModelShare,
   OverviewBucket,
   OverviewResponse,
+  RefreshCompletedEvent,
   ShareDimension,
   ShareMode,
   ShareSlice,
@@ -82,10 +81,6 @@ const BUCKETS: OverviewBucket[] = [
   'total',
 ]
 
-function unifiedRefreshIntervalMs(autoScanIntervalMinutes: number | null | undefined) {
-  return Math.max(60000, (autoScanIntervalMinutes ?? 5) * 60 * 1000)
-}
-
 function App() {
   const { language, setLanguage, t } = useI18n()
   const [view, setView] = useState<AppView>('overview')
@@ -111,11 +106,12 @@ function App() {
   const [search, setSearch] = useState('')
   const deferredSearch = useDeferredValue(search)
   const syncSettingsRef = useRef<SyncSettings | null>(null)
-  const loadShellRef = useRef<(requestScan?: boolean) => Promise<void>>(async () => {})
+  const loadShellRef = useRef<(quiet?: boolean) => Promise<void>>(async () => {})
   const lastRequestedQueryKeyRef = useRef<string | null>(null)
   const latestLoadRequestIdRef = useRef(0)
   const detailCacheRef = useRef(new Map<string, ConversationDetail>())
   const latestDetailRequestIdRef = useRef(0)
+  const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
   const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
@@ -133,7 +129,7 @@ function App() {
     syncSettingsRef.current = syncSettings
   }, [syncSettings])
 
-  const loadShell = useCallback(async (requestScan = false) => {
+  const loadShell = useCallback(async (quiet = false) => {
     const requestId = latestLoadRequestIdRef.current + 1
     latestLoadRequestIdRef.current = requestId
     const requestBucket = bucket
@@ -150,21 +146,14 @@ function App() {
       requestSearch,
       requestLiveWindowOffset,
     )
-    setIsBusy(true)
-    if ((requestBucket === 'five_hour' || requestBucket === 'seven_day') && requestLiveWindowOffset === 0) {
+    if (
+      !quiet &&
+      (requestBucket === 'five_hour' || requestBucket === 'seven_day') &&
+      requestLiveWindowOffset === 0
+    ) {
       setStatusMessage(t.status.fetchingLiveQuotaWindow)
     }
     try {
-      if (requestScan) {
-        const scan = await runScanWithOverlapRetry(
-          () => scanCodexUsage(syncSettingsRef.current?.codexHome ?? null),
-          (error) => String(error).includes('already running'),
-          waitForScanToSettle,
-          () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
-        )
-        setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
-      }
-
       const snapshot = await loadDashboard(
         requestBucket,
         requestAnchor,
@@ -225,16 +214,11 @@ function App() {
       if (requestId !== latestLoadRequestIdRef.current) {
         return
       }
-      startTransition(() => {
-        setLoadedQueryKey(null)
-      })
-      setStatusMessage(t.status.failedToLoad(t.buckets[requestBucket], String(error)))
-    } finally {
-      if (requestId === latestLoadRequestIdRef.current) {
-        setIsBusy(false)
+      if (!quiet) {
+        setStatusMessage(t.status.failedToLoad(t.buckets[requestBucket], String(error)))
       }
     }
-  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t, waitForScanToSettle])
+  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t])
 
   const currentQueryKey = buildQueryKey(
     bucket,
@@ -272,14 +256,24 @@ function App() {
   useEffect(() => {
     if (!isTauri()) return
 
+    let cancelled = false
     let dispose: (() => void) | undefined
     void listen('codex-counter://open-settings', () => {
-      setSettingsOpen(true)
-    }).then((unlisten) => {
-      dispose = unlisten
+      if (!cancelled) {
+        setSettingsOpen(true)
+      }
     })
+      .then((unlisten) => {
+        if (cancelled) {
+          unlisten()
+        } else {
+          dispose = unlisten
+        }
+      })
+      .catch(() => {})
 
     return () => {
+      cancelled = true
       dispose?.()
     }
   }, [])
@@ -288,6 +282,85 @@ function App() {
     if (!isTauri()) return
     void emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_LANGUAGE_EVENT, { language }).catch(() => {})
   }, [language])
+
+  useEffect(() => {
+    if (!isTauri()) return
+
+    let cancelled = false
+    const disposers = new Set<() => void>()
+    const appWindow = getCurrentWindow()
+    const trackRegistration = (registration: Promise<() => void>) => {
+      void registration
+        .then((dispose) => {
+          if (cancelled) {
+            dispose()
+          } else {
+            disposers.add(dispose)
+          }
+        })
+        .catch(() => {})
+    }
+    const reloadDashboard = () => {
+      void loadShellRef.current(true)
+    }
+    const handleCompletion = async (event: RefreshCompletedEvent) => {
+      let visible: boolean
+      try {
+        visible = await getCurrentWindow().isVisible()
+      } catch {
+        return
+      }
+      if (cancelled) return
+      if (refreshRevisionGateRef.current.accept(event, visible) === 'reload') {
+        reloadDashboard()
+      }
+    }
+    const handleVisible = async () => {
+      let visible: boolean
+      try {
+        visible = await getCurrentWindow().isVisible()
+      } catch {
+        return
+      }
+      if (cancelled || !visible) return
+      if (refreshRevisionGateRef.current.onVisible() === 'reload') {
+        reloadDashboard()
+      }
+    }
+    const handleDocumentVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        void handleVisible()
+      }
+    }
+    const handleWindowFocus = () => {
+      void handleVisible()
+    }
+
+    trackRegistration(
+      listen<RefreshCompletedEvent>('codex-counter://refresh-completed', (event) => {
+        void handleCompletion(event.payload)
+      }),
+    )
+    trackRegistration(
+      appWindow.onFocusChanged(({ payload: focused }) => {
+        if (focused) {
+          void handleVisible()
+        }
+      }),
+    )
+    document.addEventListener('visibilitychange', handleDocumentVisibility)
+    window.addEventListener('focus', handleWindowFocus)
+
+    return () => {
+      cancelled = true
+      document.removeEventListener('visibilitychange', handleDocumentVisibility)
+      window.removeEventListener('focus', handleWindowFocus)
+      for (const dispose of disposers) {
+        dispose()
+      }
+      disposers.clear()
+    }
+  }, [])
 
   const loadDetail = useCallback(async (rootSessionId: string | null) => {
     const requestId = latestDetailRequestIdRef.current + 1
@@ -327,27 +400,16 @@ function App() {
 
   useEffect(() => {
     let cancelled = false
-
-    const bootstrap = async () => {
-      const settled = await waitForScanToSettleUntilCancelled(
-        () => waitForScanToSettle(60000),
-        () => cancelled,
-      )
-      if (!settled || cancelled) {
-        return
-      }
-      await loadShellRef.current(false)
+    void loadShellRef.current(false).then(() => {
       if (!cancelled) {
         setHasBootstrapped(true)
       }
-    }
-
-    void bootstrap()
+    })
 
     return () => {
       cancelled = true
     }
-  }, [waitForScanToSettle])
+  }, [])
 
   useEffect(() => {
     if (!hasBootstrapped) return
@@ -360,46 +422,21 @@ function App() {
     void loadDetail(selectedRootSessionId)
   }, [dashboardRevision, loadDetail, loadedQueryKey, selectedRootSessionId])
 
-  useEffect(() => {
-    if (!hasBootstrapped || !syncSettings?.autoScanEnabled) return
-    let cancelled = false
-    const refresh = () => {
-      void refreshDashboardAfterBackgroundScan(
-        refreshBackgroundData,
-        getScanInProgress,
-        waitForScanToSettle,
-        () => loadShell(false),
-        () => cancelled,
-      )
-    }
-    const interval = window.setInterval(refresh, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-    }
-  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes, waitForScanToSettle])
-
-  useEffect(() => {
-    if (!settingsOpen || !syncSettings?.autoScanEnabled) return
-    let cancelled = false
-    const refresh = () =>
-      void getLiveRateLimits()
-        .then((snapshot) => {
-          if (!cancelled) {
-            setLiveRateLimits(snapshot)
-          }
-        })
-        .catch(() => {})
-    refresh()
-    const interval = window.setInterval(refresh, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-    }
-  }, [settingsOpen, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes])
-
   async function handleRescan() {
-    await loadShell(true)
+    setIsBusy(true)
+    try {
+      const scan = await runScanWithOverlapRetry(
+        () => scanCodexUsage(syncSettingsRef.current?.codexHome ?? null),
+        (error) => String(error).includes('already running'),
+        waitForScanToSettle,
+        () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
+      )
+      setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
+    } catch (error) {
+      setStatusMessage(String(error))
+    } finally {
+      setIsBusy(false)
+    }
   }
 
   async function handleRefreshPricing() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,11 @@ import {
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
 } from './app/dataFreshness'
-import { SurfaceRevisionGate } from './app/refreshEvents'
+import {
+  shouldLoadDashboardAfterManualRefresh,
+  shouldLoadDashboardAfterSettingsSave,
+  SurfaceRevisionGate,
+} from './app/refreshEvents'
 import { saveSettingsWithCodexHomeRollback } from './app/settingsSave'
 import {
   formatCompactDateTime,
@@ -112,6 +116,7 @@ function App() {
   const detailCacheRef = useRef(new Map<string, ConversationDetail>())
   const latestDetailRequestIdRef = useRef(0)
   const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
+  const refreshCompletionListenerReadyRef = useRef<Promise<boolean>>(Promise.resolve(false))
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
   const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
@@ -336,11 +341,22 @@ function App() {
       void handleVisible()
     }
 
-    trackRegistration(
-      listen<RefreshCompletedEvent>('codex-counter://refresh-completed', (event) => {
+    const completionRegistration = listen<RefreshCompletedEvent>(
+      'codex-counter://refresh-completed',
+      (event) => {
         void handleCompletion(event.payload)
-      }),
+      },
     )
+    refreshCompletionListenerReadyRef.current = completionRegistration
+      .then((dispose) => {
+        if (cancelled) {
+          dispose()
+          return false
+        }
+        disposers.add(dispose)
+        return true
+      })
+      .catch(() => false)
     trackRegistration(
       appWindow.onFocusChanged(({ payload: focused }) => {
         if (focused) {
@@ -353,6 +369,7 @@ function App() {
 
     return () => {
       cancelled = true
+      refreshCompletionListenerReadyRef.current = Promise.resolve(false)
       document.removeEventListener('visibilitychange', handleDocumentVisibility)
       window.removeEventListener('focus', handleWindowFocus)
       for (const dispose of disposers) {
@@ -425,12 +442,16 @@ function App() {
   async function handleRescan() {
     setIsBusy(true)
     try {
+      const listenerReady = await refreshCompletionListenerReadyRef.current
       const scan = await runScanWithOverlapRetry(
         () => scanCodexUsage(syncSettingsRef.current?.codexHome ?? null),
         (error) => String(error).includes('already running'),
         waitForScanToSettle,
         () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
       )
+      if (shouldLoadDashboardAfterManualRefresh(listenerReady)) {
+        await loadShell(true)
+      }
       setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
     } catch (error) {
       setStatusMessage(String(error))
@@ -462,6 +483,7 @@ function App() {
       throw new Error(t.status.settingsStillLoading)
     }
 
+    const listenerReady = await refreshCompletionListenerReadyRef.current
     const saved = await saveSettingsWithCodexHomeRollback({
       previousSyncSettings,
       nextSyncSettings: payload.syncSettings,
@@ -480,7 +502,9 @@ function App() {
     syncSettingsRef.current = saved.syncSettings
     setSyncSettings(saved.syncSettings)
     setSubscriptionProfile(saved.subscriptionProfile)
-    await loadShell(false)
+    if (shouldLoadDashboardAfterSettingsSave(saved.codexHomeChanged, listenerReady)) {
+      await loadShell(true)
+    }
     if (isTauri()) {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
     }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -214,10 +214,6 @@ export async function getScanInProgress() {
   return invokeOrMock('getScanInProgress', {}, () => false)
 }
 
-export async function refreshBackgroundData(): Promise<import('./types').ScanResult | null> {
-  return invokeOrMock('refreshBackgroundData', {}, () => null)
-}
-
 export async function refreshPricing() {
   return invokeOrMock('refreshPricing', {}, () => [])
 }

--- a/src/app/dataFreshness.ts
+++ b/src/app/dataFreshness.ts
@@ -54,16 +54,6 @@ export async function loadConversationDetailForGeneration<T>(
   return requestGeneration === getCurrentGeneration() ? detail : null
 }
 
-export async function waitForOverlappingScan(
-  getScanInProgress: () => Promise<boolean>,
-  waitForScanToSettle: () => Promise<boolean>,
-): Promise<boolean> {
-  if (await getScanInProgress()) {
-    return waitForScanToSettle()
-  }
-  return true
-}
-
 export async function runScanWithOverlapRetry<T>(
   runScan: () => Promise<T>,
   isOverlappingScanError: (error: unknown) => boolean,
@@ -82,47 +72,4 @@ export async function runScanWithOverlapRetry<T>(
     }
     return runScan()
   }
-}
-
-export async function refreshDashboardAfterBackgroundScan(
-  refreshBackgroundData: () => Promise<unknown>,
-  getScanInProgress: () => Promise<boolean>,
-  waitForScanToSettle: () => Promise<boolean>,
-  loadDashboard: () => Promise<void>,
-  isCancelled: () => boolean = () => false,
-): Promise<void> {
-  if (isCancelled()) {
-    return
-  }
-  try {
-    await refreshBackgroundData()
-  } catch {
-    // Keep loading persisted data when the background refresh itself fails.
-  }
-  if (isCancelled()) {
-    return
-  }
-
-  let settled: boolean
-  try {
-    settled = await waitForOverlappingScan(getScanInProgress, waitForScanToSettle)
-  } catch {
-    return
-  }
-  if (!settled || isCancelled()) {
-    return
-  }
-  await loadDashboard()
-}
-
-export async function waitForScanToSettleUntilCancelled(
-  waitForScanToSettle: () => Promise<boolean>,
-  isCancelled: () => boolean,
-): Promise<boolean> {
-  while (!isCancelled()) {
-    if (await waitForScanToSettle()) {
-      return true
-    }
-  }
-  return false
 }

--- a/src/app/refreshEvents.ts
+++ b/src/app/refreshEvents.ts
@@ -1,0 +1,50 @@
+import type { RefreshCompletedEvent } from './types.ts'
+
+export type SurfaceRevisionDecision = 'reload' | 'defer' | 'ignore'
+
+export class SurfaceRevisionGate {
+  private appliedRevision = 0
+  private pendingRevision = 0
+
+  accept(event: RefreshCompletedEvent, visible: boolean): SurfaceRevisionDecision {
+    if (
+      !event.succeeded ||
+      event.refreshRevision <= Math.max(this.appliedRevision, this.pendingRevision)
+    ) {
+      return 'ignore'
+    }
+    if (!visible) {
+      this.pendingRevision = event.refreshRevision
+      return 'defer'
+    }
+    this.appliedRevision = event.refreshRevision
+    return 'reload'
+  }
+
+  onVisible(): 'reload' | 'ignore' {
+    if (this.pendingRevision <= this.appliedRevision) {
+      return 'ignore'
+    }
+    this.appliedRevision = this.pendingRevision
+    return 'reload'
+  }
+}
+
+export interface RefreshSurfaceState<T> {
+  data: T | null
+  loading: boolean
+  refreshing: boolean
+  error: string | null
+}
+
+export function settleRefreshFailure<T>(
+  state: RefreshSurfaceState<T>,
+  error: unknown,
+): RefreshSurfaceState<T> {
+  return {
+    ...state,
+    loading: false,
+    refreshing: false,
+    error: state.data === null ? String(error) : null,
+  }
+}

--- a/src/app/refreshEvents.ts
+++ b/src/app/refreshEvents.ts
@@ -30,6 +30,55 @@ export class SurfaceRevisionGate {
   }
 }
 
+export function shouldLoadDashboardAfterManualRefresh(listenerReady: boolean): boolean {
+  return !listenerReady
+}
+
+export function shouldLoadDashboardAfterSettingsSave(
+  codexHomeChanged: boolean,
+  listenerReady: boolean,
+): boolean {
+  return !codexHomeChanged || !listenerReady
+}
+
+export type SurfaceRequestKind = 'passive' | 'manual'
+
+export interface SurfaceRequestClaim {
+  readonly id: number
+  readonly kind: SurfaceRequestKind
+}
+
+export class SurfaceRequestController {
+  private latestRequestId = 0
+  private manualRequestId: number | null = null
+
+  get manualInFlight(): boolean {
+    return this.manualRequestId !== null
+  }
+
+  claim(kind: SurfaceRequestKind): SurfaceRequestClaim | null {
+    if (kind === 'manual' && this.manualRequestId !== null) {
+      return null
+    }
+    const claim = { id: this.latestRequestId + 1, kind }
+    this.latestRequestId = claim.id
+    if (kind === 'manual') {
+      this.manualRequestId = claim.id
+    }
+    return claim
+  }
+
+  isLatest(claim: SurfaceRequestClaim): boolean {
+    return claim.id === this.latestRequestId
+  }
+
+  finish(claim: SurfaceRequestClaim): void {
+    if (claim.kind === 'manual' && claim.id === this.manualRequestId) {
+      this.manualRequestId = null
+    }
+  }
+}
+
 export interface RefreshSurfaceState<T> {
   data: T | null
   loading: boolean

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -64,6 +64,18 @@ export interface ScanResult {
   lastCompletedAt: string
 }
 
+export interface RefreshCompletedEvent {
+  refreshRevision: number
+  lane: 'token' | 'live'
+  generation: number
+  usageRevision: number
+  quotaRevision: number
+  sourceGeneration: number
+  succeeded: boolean
+  failure: string | null
+  completedAt: string
+}
+
 export interface OverviewStats {
   apiValueUsd: number
   subscriptionCostUsd: number

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -13,6 +13,7 @@ import {
   formatTokenCount,
   formatUsd,
 } from '../app/format'
+import { settleRefreshFailure, type RefreshSurfaceState } from '../app/refreshEvents'
 import type { MenuBarPopupModuleId, MenuBarPopupSnapshot } from '../app/types'
 import { useI18n } from '../app/useI18n'
 import { PopupStatModuleGrid } from '../components/PopupStatModuleGrid'
@@ -46,42 +47,51 @@ export function MenuBarPopup() {
   const panelRef = useRef<HTMLDivElement | null>(null)
   const lastMeasuredHeightRef = useRef<number | null>(null)
   const resizeFrameRef = useRef(0)
-  const [snapshot, setSnapshot] = useState<MenuBarPopupSnapshot | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [refreshing, setRefreshing] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [loadState, setLoadState] = useState<RefreshSurfaceState<MenuBarPopupSnapshot>>({
+    data: null,
+    loading: true,
+    refreshing: false,
+    error: null,
+  })
+  const { data: snapshot, loading, refreshing, error } = loadState
 
   const loadSnapshot = useCallback(async (forceRefresh = false) => {
-    if (forceRefresh) {
-      setRefreshing(true)
-    } else {
-      setLoading(true)
-    }
+    setLoadState((current) => {
+      if (forceRefresh) {
+        return { ...current, refreshing: true }
+      }
+      return current.data === null ? { ...current, loading: true } : current
+    })
 
+    let failed = false
+    let failure: unknown
     try {
       const nextSnapshot = await getMenuBarPopupSnapshot(forceRefresh)
-      setSnapshot(nextSnapshot)
-      setError(null)
+      setLoadState((current) => ({
+        ...current,
+        data: nextSnapshot,
+        loading: false,
+        error: null,
+      }))
     } catch (loadError) {
-      setError(String(loadError))
+      failed = true
+      failure = loadError
     } finally {
-      setLoading(false)
-      setRefreshing(false)
+      setLoadState((current) => {
+        if (failed) {
+          const settled = settleRefreshFailure(current, failure)
+          return forceRefresh ? settled : { ...settled, refreshing: current.refreshing }
+        }
+        return forceRefresh
+          ? { ...current, refreshing: false }
+          : { ...current, loading: false }
+      })
     }
   }, [])
 
   useEffect(() => {
     void loadSnapshot(false)
   }, [loadSnapshot])
-
-  useEffect(() => {
-    const intervalSeconds = snapshot?.refreshIntervalSeconds ?? 300
-    const interval = window.setInterval(() => {
-      void loadSnapshot(false)
-    }, Math.max(60000, intervalSeconds * 1000))
-
-    return () => window.clearInterval(interval)
-  }, [loadSnapshot, snapshot?.refreshIntervalSeconds])
 
   const schedulePopupResize = useCallback(() => {
     if (!isTauri()) return
@@ -113,8 +123,19 @@ export function MenuBarPopup() {
   useEffect(() => {
     if (!isTauri()) return
 
-    let refreshDispose: (() => void) | undefined
-    let languageDispose: (() => void) | undefined
+    let cancelled = false
+    const disposers = new Set<() => void>()
+    const trackRegistration = (registration: Promise<() => void>) => {
+      void registration
+        .then((dispose) => {
+          if (cancelled) {
+            dispose()
+          } else {
+            disposers.add(dispose)
+          }
+        })
+        .catch(() => {})
+    }
     const resizeObserver = new ResizeObserver(() => {
       schedulePopupResize()
     })
@@ -125,26 +146,31 @@ export function MenuBarPopup() {
     window.addEventListener('resize', schedulePopupResize)
     schedulePopupResize()
 
-    void listen('codex-counter://menu-bar-popup-refresh', () => {
-      void loadSnapshot(false)
-    }).then((unlisten) => {
-      refreshDispose = unlisten
-    })
+    trackRegistration(
+      listen('codex-counter://menu-bar-popup-refresh', () => {
+        if (!cancelled) {
+          void loadSnapshot(false)
+        }
+      }),
+    )
 
-    void listen<{ language?: 'zh-CN' | 'en' }>('codex-counter://language-changed', (event) => {
-      if (event.payload?.language) {
-        setLanguage(event.payload.language)
-      }
-    }).then((unlisten) => {
-      languageDispose = unlisten
-    })
+    trackRegistration(
+      listen<{ language?: 'zh-CN' | 'en' }>('codex-counter://language-changed', (event) => {
+        if (!cancelled && event.payload?.language) {
+          setLanguage(event.payload.language)
+        }
+      }),
+    )
 
     return () => {
+      cancelled = true
       window.cancelAnimationFrame(resizeFrameRef.current)
       window.removeEventListener('resize', schedulePopupResize)
       resizeObserver.disconnect()
-      refreshDispose?.()
-      languageDispose?.()
+      for (const dispose of disposers) {
+        dispose()
+      }
+      disposers.clear()
     }
   }, [loadSnapshot, schedulePopupResize, setLanguage])
 

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -13,7 +13,11 @@ import {
   formatTokenCount,
   formatUsd,
 } from '../app/format'
-import { settleRefreshFailure, type RefreshSurfaceState } from '../app/refreshEvents'
+import {
+  settleRefreshFailure,
+  SurfaceRequestController,
+  type RefreshSurfaceState,
+} from '../app/refreshEvents'
 import type { MenuBarPopupModuleId, MenuBarPopupSnapshot } from '../app/types'
 import { useI18n } from '../app/useI18n'
 import { PopupStatModuleGrid } from '../components/PopupStatModuleGrid'
@@ -47,6 +51,7 @@ export function MenuBarPopup() {
   const panelRef = useRef<HTMLDivElement | null>(null)
   const lastMeasuredHeightRef = useRef<number | null>(null)
   const resizeFrameRef = useRef(0)
+  const requestControllerRef = useRef(new SurfaceRequestController())
   const [loadState, setLoadState] = useState<RefreshSurfaceState<MenuBarPopupSnapshot>>({
     data: null,
     loading: true,
@@ -56,35 +61,45 @@ export function MenuBarPopup() {
   const { data: snapshot, loading, refreshing, error } = loadState
 
   const loadSnapshot = useCallback(async (forceRefresh = false) => {
+    const claim = requestControllerRef.current.claim(forceRefresh ? 'manual' : 'passive')
+    if (claim === null) return
+    const manualInFlight = requestControllerRef.current.manualInFlight
     setLoadState((current) => {
-      if (forceRefresh) {
-        return { ...current, refreshing: true }
+      return {
+        ...current,
+        loading: forceRefresh ? current.loading : current.data === null,
+        refreshing: manualInFlight,
       }
-      return current.data === null ? { ...current, loading: true } : current
     })
 
     let failed = false
     let failure: unknown
+    let nextSnapshot: MenuBarPopupSnapshot | null = null
     try {
-      const nextSnapshot = await getMenuBarPopupSnapshot(forceRefresh)
-      setLoadState((current) => ({
-        ...current,
-        data: nextSnapshot,
-        loading: false,
-        error: null,
-      }))
+      nextSnapshot = await getMenuBarPopupSnapshot(forceRefresh)
     } catch (loadError) {
       failed = true
       failure = loadError
     } finally {
+      requestControllerRef.current.finish(claim)
       setLoadState((current) => {
-        if (failed) {
-          const settled = settleRefreshFailure(current, failure)
-          return forceRefresh ? settled : { ...settled, refreshing: current.refreshing }
+        let nextState = current
+        if (requestControllerRef.current.isLatest(claim)) {
+          if (failed) {
+            nextState = settleRefreshFailure(current, failure)
+          } else if (nextSnapshot !== null) {
+            nextState = {
+              ...current,
+              data: nextSnapshot,
+              loading: false,
+              error: null,
+            }
+          }
         }
-        return forceRefresh
-          ? { ...current, refreshing: false }
-          : { ...current, loading: false }
+        return {
+          ...nextState,
+          refreshing: requestControllerRef.current.manualInFlight,
+        }
       })
     }
   }, [])
@@ -249,6 +264,7 @@ export function MenuBarPopup() {
               <button
                 aria-label={t.popup.actions.refresh}
                 className="ghost-button popup-icon-button"
+                disabled={refreshing}
                 onClick={() => void loadSnapshot(true)}
                 type="button"
               >


### PR DESCRIPTION
## What changed

- Reworked background refresh scheduling so token usage and online quota refresh independently, while coalescing duplicate work and preserving retries.
- Replaced full-file rescans with durable parser checkpoints and tail-only parsing for growing session logs.
- Changed usage and quota persistence to append or reconcile in place instead of deleting and rebuilding unchanged history.
- Moved menu bar totals into bounded SQLite aggregates and added the indexes needed by the hot queries.
- Reduced refresh scratch allocations and write amplification through compressed temporary spools, macOS pressure relief, and mimalloc for Rust-owned allocations.

## Why

The old refresh path repeatedly reread active session files, rebuilt quota and usage history, and loaded large result sets just to render the menu bar. A normal one-minute refresh could write roughly 53 MiB, and reopening the app repeated much of that work. Refresh lanes could also interfere with one another, which made token and online quota freshness less reliable.

## User impact

Background refresh now continues updating token statistics and online quota without the previous full rescan and rewrite cycle. Menu bar updates do less database and allocation work, and refresh memory peaks return toward the idle footprint instead of accumulating after every interval.

## Validation

- Rust test suite: 384/384 passed.
- The previously intermittent epoch backfill test passed 10 consecutive focused runs.
- Frontend lint and production build passed.
- Signed macOS release build completed and passed signature verification.
- Two restart samples and one clean-cache launch sample confirmed database progress with `PRAGMA quick_check = ok`.
- Clean-cache launch: 75 seconds, 0.074 MiB read, 1.676 MiB written; the startup write burst dropped from roughly 53 MiB to 0.203 MiB.
- Four-minute sample: mean CPU 1.53% of one core, 0.18 MiB read, 5.30 MiB written. Physical footprint returned to roughly 136–142 MiB after refresh peaks.

## Notes

The local release was Developer ID signed for testing. Notarization was not part of this change.
