### PR TITLE
fix: prevent stale quota fallback from overriding live data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-11
+
 ### Added
 - GPT-5.6 Sol, Terra, and Luna model recognition with bundled Standard API pricing; the `gpt-5.6` alias uses Sol pricing
 - automatic discovery of the Codex CLI bundled with the ChatGPT desktop app on macOS, while retaining standalone CLI and `CODEX_BIN` support
+- independent background refresh lanes for local token usage and online quota data, with bounded retries and missed-refresh recovery
 
 ### Changed
-- changing a custom Codex home now starts a full refresh without reusing scan times from the previous directory
-- dashboard refreshes now wait for an active scan to finish and reload conversation details when their source values have changed
+- active session logs are parsed from durable checkpoints instead of being reread from the beginning on every refresh
+- usage and quota records are appended or reconciled in place instead of deleting and rebuilding unchanged history
+- menu bar totals are calculated with bounded SQLite aggregates, and frontend refresh polling has been replaced with backend events
+- database timestamp migration now runs in small resumable batches so startup remains responsive on larger histories
+- changing a custom Codex home starts a full refresh without reusing scan times from the previous directory
 
 ### Fixed
 - GPT-5.6 API-equivalent values now recalculate at startup, including rows that were zero or used a cache-write price as the output price
 - incremental imports now capture final snapshots moved into `archived_sessions`, refresh titles from `session_index.jsonl`, avoid saving partial results from unreadable files, and repair missing conversation links
 - persisted quota fallback now chooses the latest timestamp by its actual instant and never combines windows from different samples
+- forked and nested sessions no longer rebill usage inherited from their parent, including single-snapshot and temporarily missing-parent cases
+- token and quota refreshes no longer overwrite newer results, block one another, or lose a scheduled retry when settings change
+- complete JSONL records without a trailing newline are imported instead of being skipped permanently
+- refresh scratch memory and temporary spool files are released promptly after commits and menu bar updates
+
+### Upgrade notes
+- macOS users can install 1.2.0 over 1.1.1 or 1.1.2 without uninstalling the previous version
+- the existing local database is migrated in place; session history, token usage, quota samples, subscription settings, menu bar preferences, and custom Codex paths are retained
+- the first launch may perform a bounded background timestamp backfill, but token and online quota refresh continue independently while it runs
 
 ## [1.1.2] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ English | [简体中文](./README.zh-CN.md)
 
 **Codex Pacer** is a local-first desktop app for understanding Codex usage as pace, value, and session-level activity. It helps you see how quickly you are consuming quota, what that usage is worth in API-equivalent terms, and which conversations or subagents are driving it.
 
-> Current stable release: **v1.1.2**
-> Official download: signed **macOS Apple Silicon DMG** via GitHub Releases. Windows installer publishing is paused for this release.
+> Current stable release: **v1.2.0**
+> Official download: signed and notarized **macOS Apple Silicon DMG** via GitHub Releases. Windows installer publishing is paused for this release.
 
 ## Highlights
 
@@ -40,13 +40,13 @@ Codex Pacer is local-first:
 
 ## Getting started
 
-The documentation set for installation, packaging, and release notes is maintained for the public `v1.1.2` release. Start with:
+The documentation set for installation, packaging, and release notes is maintained for the public `v1.2.0` release. Start with:
 
 - [Getting started](./docs/en/getting-started.md)
 - [Installing on macOS](./docs/en/installing-on-macos.md)
 - [Installing on Windows](./docs/en/installing-on-windows.md)
 - [Packaging and release](./docs/en/packaging-and-release.md)
-- [Release notes for v1.1.2](./docs/en/release-notes-v1.1.2.md)
+- [Release notes for v1.2.0](./docs/en/release-notes-v1.2.0.md)
 
 On macOS, Codex Pacer can use the Codex CLI bundled with the ChatGPT desktop app for live quota reads. It discovers `/Applications/ChatGPT.app/Contents/Resources/codex` automatically. A standalone Codex CLI and the `CODEX_BIN` override remain supported.
 
@@ -83,7 +83,7 @@ npm run tauri build
 
 ## Project status
 
-`v1.1.2` is the current stable release line.
+`v1.2.0` is the current stable release line.
 
 Current release packaging focus:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,8 +8,8 @@
 
 **Codex Pacer** 是一个本地优先的桌面应用，用来把 Codex 使用情况转换成更容易行动的视角：额度节奏、API 等价价值，以及会话级别的使用分析。你可以更快看清自己消耗额度的速度、订阅回报，以及哪些对话或 subagent 正在驱动这些使用量。
 
-> 当前稳定版本：**v1.1.2**
-> 官方下载：通过 GitHub Releases 获取已签名的 **macOS Apple Silicon DMG**。本版本暂缓发布 Windows 安装包。
+> 当前稳定版本：**v1.2.0**
+> 官方下载：通过 GitHub Releases 获取已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**。本版本暂缓发布 Windows 安装包。
 
 ## 核心能力
 
@@ -40,13 +40,13 @@ Codex Pacer 是本地优先的：
 
 ## 开始使用
 
-安装、打包和发布说明已按公开 `v1.1.2` 版本维护。可以从这些文档入口开始：
+安装、打包和发布说明已按公开 `v1.2.0` 版本维护。可以从这些文档入口开始：
 
 - [快速开始](./docs/zh-CN/getting-started.md)
 - [在 macOS 上安装](./docs/zh-CN/installing-on-macos.md)
 - [在 Windows 上安装](./docs/zh-CN/installing-on-windows.md)
 - [打包与发布](./docs/zh-CN/packaging-and-release.md)
-- [v1.1.2 发布说明](./docs/zh-CN/release-notes-v1.1.2.md)
+- [v1.2.0 发布说明](./docs/zh-CN/release-notes-v1.2.0.md)
 
 在 macOS 上，Codex Pacer 可以使用 ChatGPT 桌面应用内置的 Codex CLI 读取实时额度。应用会自动发现 `/Applications/ChatGPT.app/Contents/Resources/codex`。独立安装的 Codex CLI 和 `CODEX_BIN` 覆盖配置仍然可用。
 
@@ -83,7 +83,7 @@ npm run tauri build
 
 ## 项目状态
 
-`v1.1.2` 是当前稳定发布线。
+`v1.2.0` 是当前稳定发布线。
 
 当前发布重点：
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -12,7 +12,7 @@ It is built to help you answer practical questions such as:
 
 ## Requirements
 
-- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.1.2`.
+- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.2.0`.
 - Local Codex data under `~/.codex` or a custom `CODEX_HOME`
 
 For development from source, you will also need:
@@ -25,8 +25,8 @@ For development from source, you will also need:
 
 Official public downloads are published through GitHub Releases:
 
-- signed **macOS Apple Silicon DMG**
-- no Windows installer is attached to `v1.1.2`; use the Windows guide only for source validation
+- signed and notarized **macOS Apple Silicon DMG**
+- no Windows installer is attached to `v1.2.0`; use the Windows guide only for source validation
 
 Start here:
 
@@ -106,4 +106,4 @@ npm run tauri build
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Packaging and release](./packaging-and-release.md)
-- [Release notes for v1.1.2](./release-notes-v1.1.2.md)
+- [Release notes for v1.2.0](./release-notes-v1.2.0.md)

--- a/docs/en/installing-on-macos.md
+++ b/docs/en/installing-on-macos.md
@@ -2,7 +2,7 @@
 
 ## macOS install path
 
-The macOS public installer for **Codex Pacer** is the signed **Apple Silicon DMG** published through GitHub Releases.
+The macOS public installer for **Codex Pacer** is the signed and notarized **Apple Silicon DMG** published through GitHub Releases.
 
 ## Happy path
 

--- a/docs/en/installing-on-windows.md
+++ b/docs/en/installing-on-windows.md
@@ -2,7 +2,7 @@
 
 ## Windows test-stage status
 
-Windows installer publishing is paused for `v1.1.2`. No Windows setup `.exe` is attached to the current stable GitHub Release.
+Windows installer publishing is paused for `v1.2.0`. No Windows setup `.exe` is attached to the current stable GitHub Release.
 
 Windows support is currently in a test stage. When a future release includes a Windows installer, it is unsigned unless Windows code signing is separately configured for that release, and Windows SmartScreen may warn that the publisher is unknown.
 
@@ -12,7 +12,7 @@ Windows support is currently in a test stage. When a future release includes a W
 2. Install the Windows Tauri prerequisites.
 3. Run `npm ci`.
 4. Run `npm run lint`, `npm run build`, and `cargo test --manifest-path src-tauri/Cargo.toml --locked`.
-5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.1.2` on Windows.
+5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.2.0` on Windows.
 
 ## After installation
 
@@ -27,7 +27,7 @@ When testing a local Windows build:
 ## Notes
 
 - GitHub Releases is the official distribution channel.
-- `v1.1.2` only publishes the macOS Apple Silicon DMG asset.
+- `v1.2.0` only publishes the macOS Apple Silicon DMG asset.
 - Any locally built Windows setup `.exe` remains a test-stage NSIS installer.
 - A Windows installer does not install the Codex CLI and does not create Codex usage history.
 - Stable Windows support, Windows code signing, and auto-update delivery are not currently promised.

--- a/docs/en/packaging-and-release.md
+++ b/docs/en/packaging-and-release.md
@@ -6,9 +6,9 @@ The stable public release of **Codex Pacer** is distributed through **GitHub Rel
 
 The stable packaged asset is:
 
-- signed **macOS Apple Silicon DMG**
+- signed and notarized **macOS Apple Silicon DMG**
 
-Windows installer publishing is paused for `v1.1.2`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
+Windows installer publishing is paused for `v1.2.0`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
 
 - unsigned **Windows NSIS setup EXE** for local compatibility testing and early validation only
 
@@ -28,8 +28,8 @@ Keep release messaging aligned with this scope so the project does not over-prom
 The intended public release flow is:
 
 1. Confirm public branding and documentation are ready for release.
-2. Build the signed macOS Apple Silicon DMG.
-3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.1.2`.
+2. Build, notarize, and staple the macOS Apple Silicon DMG.
+3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.2.0`.
 4. Publish the release assets through GitHub Releases.
 5. Attach or include release notes for the tagged version.
 
@@ -39,15 +39,15 @@ Public release preparation is driven by the release scripts below:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.2
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
-Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.1.2`.
+Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, submits it for notarization, staples the ticket, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.2.0`.
 
 ## Platform isolation rules
 
@@ -76,8 +76,8 @@ Windows-specific tray popup placement, hidden child-process windows, and unsigne
 
 - Create the Git tag for the stable release version.
 - Create the GitHub Release from that tag.
-- Upload the signed Apple Silicon DMG.
-- Do not upload a Windows NSIS setup EXE for `v1.1.2`.
+- Upload the signed, notarized, and stapled Apple Silicon DMG.
+- Do not upload a Windows NSIS setup EXE for `v1.2.0`.
 - Add the matching release notes document for the version being published.
 - Verify the download and install flow after publication.
 
@@ -88,9 +88,9 @@ GitHub Releases is more than a file host in the current workflow. It is the publ
 For public docs and announcements, use this message consistently:
 
 - official distribution channel: GitHub Releases
-- stable release asset: signed macOS Apple Silicon DMG
-- Windows installer: paused for `v1.1.2`
-- current stable line: `v1.1.2`
+- stable release asset: signed and notarized macOS Apple Silicon DMG
+- Windows installer: paused for `v1.2.0`
+- current stable line: `v1.2.0`
 
 ## Related docs
 
@@ -98,4 +98,4 @@ For public docs and announcements, use this message consistently:
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Release runbook](./release-runbook.md)
-- [Release notes for v1.1.2](./release-notes-v1.1.2.md)
+- [Release notes for v1.2.0](./release-notes-v1.2.0.md)

--- a/docs/en/release-notes-v1.2.0.md
+++ b/docs/en/release-notes-v1.2.0.md
@@ -1,0 +1,41 @@
+# Codex Pacer v1.2.0
+
+## Summary
+
+Version 1.2.0 focuses on reliable background refresh and lower resource use. Token statistics and online quota now refresh through independent workers, so a slow local scan does not hold up live quota updates and a live request does not delay token imports.
+
+The importer now reads only the completed tail of growing session files. It also updates usage and quota history in place instead of rebuilding unchanged rows. Menu bar totals are calculated inside SQLite, which avoids loading a large usage history just to render a value.
+
+## What changed
+
+- added GPT-5.6 Sol, Terra, and Luna recognition with bundled Standard API-equivalent pricing
+- added automatic discovery of the Codex CLI bundled with the ChatGPT desktop app on macOS
+- separated token and online quota refresh scheduling, retries, and freshness tracking
+- replaced frontend refresh polling with backend events
+- added durable parser checkpoints for growing JSONL session files
+- reduced database write amplification for usage and quota history
+- moved timestamp migration into bounded, resumable background batches
+- corrected forked-session accounting, including nested forks and temporarily unavailable parent files
+- fixed stale refresh overwrites, listener startup races, shutdown races, and lost retry work
+- fixed complete final JSONL records being skipped when the file has no trailing newline
+- reduced refresh allocation retention and temporary spool size on macOS
+
+## Upgrading from 1.1.1 or 1.1.2
+
+Install 1.2.0 over the existing application. You do not need to uninstall the previous version or remove its database.
+
+Codex Pacer keeps the same app name, bundle identifier, and local data location. On first launch, it adds the new schema fields and indexes in place. Existing conversations, token usage, quota samples, subscription settings, menu bar preferences, and custom Codex paths are preserved.
+
+Older timestamp rows are filled in by a small resumable background job. Normal token and online quota refresh continue independently while that work runs. Compatibility tests build databases from the exact 1.1.1 and 1.1.2 schemas, populate user data, upgrade them to 1.2.0, and verify the stored values and database integrity.
+
+## Performance notes
+
+Local restart testing on the release build no longer showed the previous roughly 53 MiB startup and per-refresh write bursts. A clean-cache launch wrote 1.68 MiB over 75 seconds, including one background refresh. A four-minute sample averaged 1.53% of one CPU core, read 0.18 MiB, and wrote 5.30 MiB. Refresh memory peaks returned to roughly 136–142 MiB of physical footprint after the work completed.
+
+These figures describe the release test machine and dataset; actual use depends on session history and refresh activity.
+
+## Packaging
+
+The public macOS asset is an Apple Silicon DMG distributed through GitHub Releases with a SHA-256 checksum. The release is Developer ID signed, notarized by Apple, stapled, and checked with Gatekeeper before publication.
+
+Windows installer publishing remains paused for this release.

--- a/docs/en/release-runbook.md
+++ b/docs/en/release-runbook.md
@@ -4,20 +4,20 @@
 
 This runbook is for maintainers producing public **Codex Pacer** release assets:
 
-- signed Apple Silicon DMG
-- Windows compatibility checks, with Windows installer publishing paused for `v1.1.2`
+- signed, notarized, and stapled Apple Silicon DMG
+- Windows compatibility checks, with Windows installer publishing paused for `v1.2.0`
 - published through GitHub Releases
 
 The local release entry points are:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.2
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
 The macOS release scripts default `CARGO_TARGET_DIR` to `~/Library/Caches/CodexPacer/cargo-target` so signed macOS bundles are produced outside cloud-synced folders such as iCloud Drive. This avoids `codesign` failures caused by Finder and file-provider metadata on `.app` bundles.
@@ -101,7 +101,7 @@ GitHub Releases is the handoff point between maintainer workflow and user instal
 ## Build the signed DMG
 
 ```bash
-./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
 ```
 
 What the build script does:
@@ -129,7 +129,7 @@ What the build script does:
 Run this on Windows:
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
 What the Windows build script does:
@@ -152,7 +152,7 @@ If you need to override the Windows build output location, set `CARGO_TARGET_DIR
 
 ```powershell
 $env:CARGO_TARGET_DIR = "C:\Users\you\AppData\Local\CodexPacer\cargo-target"
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
 ### Optional target override
@@ -161,7 +161,7 @@ If you need to pass a specific Tauri target triple, set `TAURI_TARGET` before ru
 
 ```bash
 export TAURI_TARGET="aarch64-apple-darwin"
-./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
 ```
 
 `TAURI_TARGET` stays on the Tauri CLI side of the command, before the final `--` that introduces Cargo runner args such as `--locked`.
@@ -174,8 +174,8 @@ If you need to override the build output location, export `CARGO_TARGET_DIR` bef
 
 ```bash
 export CARGO_TARGET_DIR="$HOME/Library/Caches/CodexPacer/custom-target"
-./scripts/release/build-macos-release.sh 1.1.2
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other cloud/file-provider folders. Signed `.app` bundles created there can pick up `com.apple.FinderInfo` metadata and fail during `codesign`.
@@ -184,8 +184,8 @@ Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other clo
 
 ```bash
 git status --short
-git tag v1.1.2
-git push origin v1.1.2
+git tag v1.2.0
+git push origin v1.2.0
 ```
 
 The publish script expects:
@@ -198,18 +198,18 @@ The publish script expects:
 ## Publish the GitHub Release
 
 ```bash
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 The publish script uses:
 
-- the built DMG for `v1.1.2`
+- the built DMG for `v1.2.0`
 - the sibling `.sha256` checksum file
-- `docs/en/release-notes-v1.1.2.md`
+- `docs/en/release-notes-v1.2.0.md`
 
 It publishes those assets with `gh release create`.
 
-For `v1.1.2`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
+For `v1.2.0`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
 
 ## macOS manual smoke test
 
@@ -255,7 +255,7 @@ Run this before announcing Windows availability publicly:
 Useful spot check:
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.1.2_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.0_x64-setup.exe"
 ```
 
 ## Troubleshooting

--- a/docs/superpowers/plans/2026-07-11-release-1.2.0.md
+++ b/docs/superpowers/plans/2026-07-11-release-1.2.0.md
@@ -164,4 +164,3 @@
 - [ ] **Step 5: Merge, tag, publish, and clean up**
 
   Merge the release PR, create tag `v1.2.0` at the merged `main` commit, publish the GitHub Release with the verified artifacts, then delete the local and remote release branch.
-

--- a/docs/superpowers/plans/2026-07-11-release-1.2.0.md
+++ b/docs/superpowers/plans/2026-07-11-release-1.2.0.md
@@ -1,0 +1,167 @@
+# Codex Pacer 1.2.0 Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare, verify, sign, notarize, and publish Codex Pacer 1.2.0 without exposing private credentials and without breaking upgrades from 1.1.1 or 1.1.2.
+
+**Architecture:** The release branch starts at the latest `develop` merge and targets `main`. Compatibility is verified at the SQLite schema and persisted-settings boundaries before building. The existing macOS release script remains the only build path so signing, notarization, stapling, Gatekeeper checks, checksums, and release artifact naming stay reproducible.
+
+**Tech Stack:** Tauri 2, Rust, SQLite, React, TypeScript, npm, Apple `codesign`, `notarytool`, `stapler`, `spctl`, GitHub CLI.
+
+## Global Constraints
+
+- Release version is exactly `1.2.0` in `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`.
+- Never write Apple credentials, Apple ID values, passwords, private home paths, or signing secrets into the repository, shell history, logs, PR text, checksums, or release artifacts.
+- Use `scripts/release/build-macos-release.sh 1.2.0` as the release build entrypoint.
+- The public release must be Developer ID signed, notarized, stapled, and accepted by Gatekeeper.
+- Existing databases and preferences created by 1.1.1 and 1.1.2 must open and migrate in place without losing usage, quota, settings, subscription, or conversation data.
+- The release PR targets `main` and remains unmerged until Codex review passes and the user explicitly confirms the merge.
+
+---
+
+### Task 1: Verify version and upgrade boundaries
+
+**Files:**
+- Inspect: `package.json`
+- Inspect: `package-lock.json`
+- Inspect: `src-tauri/Cargo.toml`
+- Inspect: `src-tauri/Cargo.lock`
+- Inspect: `src-tauri/tauri.conf.json`
+- Inspect: `src-tauri/sql/schema.sql`
+- Inspect: `src-tauri/src/database.rs`
+- Test: `src-tauri/src/database.rs`
+
+**Interfaces:**
+- Consumes: databases and settings produced by tags `v1.1.1` and `v1.1.2`.
+- Produces: evidence that `init_db` upgrades both versions to the 1.2.0 schema without destructive resets.
+
+- [ ] **Step 1: Compare all committed version declarations with `1.2.0`**
+
+  Run a script that reads each manifest and fails on any mismatch.
+
+- [ ] **Step 2: Diff schema and migration behavior against `v1.1.1` and `v1.1.2`**
+
+  Review every new table, column, index, repair marker, and startup migration. Confirm migrations use additive DDL or transactional repair paths.
+
+- [ ] **Step 3: Add or extend legacy database tests only if an upgrade boundary lacks coverage**
+
+  Build representative 1.1.1 and 1.1.2 databases, call the current `init_db`, and assert preserved row counts and values plus the new schema objects.
+
+- [ ] **Step 4: Run the focused compatibility tests**
+
+  Run: `cargo test --manifest-path src-tauri/Cargo.toml legacy -- --nocapture`
+
+  Expected: every legacy migration test passes with no data-loss assertion failure.
+
+### Task 2: Write release notes and changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Create: `docs/en/release-notes-v1.2.0.md`
+- Create: `docs/zh-CN/release-notes-v1.2.0.md`
+
+**Interfaces:**
+- Consumes: commit history from `v1.1.2` through the release branch.
+- Produces: concise English and Chinese notes suitable for the repository and GitHub Release.
+
+- [ ] **Step 1: Group user-visible changes by behavior**
+
+  Cover ChatGPT/Codex discovery, GPT-5.6 pricing, fork accounting, refresh correctness, lower resource use, menu bar rendering, and database migration behavior.
+
+- [ ] **Step 2: State upgrade compatibility plainly**
+
+  Tell 1.1.1 and 1.1.2 users that the existing local database is migrated in place and that uninstalling the old version is unnecessary.
+
+- [ ] **Step 3: Humanize the final English and Chinese copy**
+
+  Remove promotional wording, repetitive summaries, vague claims, and implementation-heavy phrasing while preserving technical accuracy.
+
+- [ ] **Step 4: Verify links, headings, version numbers, and dates**
+
+  Run repository text searches for stale versions and broken local release-note references.
+
+### Task 3: Audit private information and public packaging
+
+**Files:**
+- Inspect: all tracked files changed since `v1.1.2`
+- Inspect: macOS `.app` and `.dmg` contents after build
+- Run: `scripts/release/audit-public-branding.sh`
+
+**Interfaces:**
+- Consumes: tracked release diff and generated artifacts.
+- Produces: a clean scan with no credentials, private paths, personal email addresses, temporary measurements, or local backup files.
+
+- [ ] **Step 1: Scan tracked text and Git diff for credential patterns**
+
+  Search for password assignments, Apple credential values, private home paths, tokens, signing key material, and local measurement paths.
+
+- [ ] **Step 2: Run the repository public-branding audit**
+
+  Expected: exit code 0.
+
+- [ ] **Step 3: Inspect built app and DMG file lists**
+
+  Confirm only expected runtime resources are packaged and no `.env`, database, log, backup, plan output, or measurement file is present.
+
+- [ ] **Step 4: Scan extracted strings and metadata without printing secrets**
+
+  Report only matched file names and pattern categories. Do not print secret values.
+
+### Task 4: Run release validation and macOS signing workflow
+
+**Files:**
+- Execute: `scripts/release/build-macos-release.sh`
+- Inspect: generated `.app`, `.dmg`, and `.sha256`
+
+**Interfaces:**
+- Consumes: a clean release branch and credentials supplied outside the repository.
+- Produces: signed, notarized, stapled, Gatekeeper-approved 1.2.0 macOS artifacts.
+
+- [ ] **Step 1: Confirm signing identity and secure notarization configuration**
+
+  Use environment variables or an existing keychain profile without echoing their values. Stop if notarization cannot be configured without exposing credentials.
+
+- [ ] **Step 2: Run the full macOS release build**
+
+  Run: `scripts/release/build-macos-release.sh 1.2.0`
+
+  Expected: npm install, branding audit, lint, frontend build, Rust tests, Tauri build, Developer ID signature verification, notarization, staple validation, Gatekeeper assessment, DMG integrity check, and checksum generation all pass.
+
+- [ ] **Step 3: Verify signatures and notarization independently**
+
+  Run `codesign --verify --deep --strict`, `spctl --assess`, `xcrun stapler validate`, `hdiutil verify`, and `shasum -a 256 -c` against the final artifacts.
+
+- [ ] **Step 4: Install the built app over the existing local installation and smoke-test startup**
+
+  Preserve a rollback copy, replace `/Applications/Codex Pacer.app`, launch it, and confirm the existing database opens with current token and quota data.
+
+### Task 5: Publish the release PR and GitHub Release
+
+**Files:**
+- Commit: release notes and any compatibility tests required by Task 1.
+- Upload after merge: final `.dmg` and `.sha256` artifacts.
+
+**Interfaces:**
+- Consumes: verified release commit and macOS artifacts built from that exact commit.
+- Produces: a ready-for-review PR to `main`, followed by tag `v1.2.0` and a public GitHub Release after explicit merge approval.
+
+- [ ] **Step 1: Commit and push `codex/release-1.2.0`**
+
+  Stage only reviewed release files, commit with a release-specific message, and push with upstream tracking.
+
+- [ ] **Step 2: Create a ready-for-review PR targeting `main`**
+
+  Include the user-visible changes, compatibility evidence, privacy audit, build commands, signature/notarization results, and remaining limitations.
+
+- [ ] **Step 3: Wait for Codex review using PR reaction groups**
+
+  Poll for Codex `EYES`, `THUMBS_UP`, P1, or P2 without posting `@codex review`.
+
+- [ ] **Step 4: Request explicit merge confirmation after Codex `THUMBS_UP`**
+
+  Do not merge until the user confirms after seeing the final diff and validation summary.
+
+- [ ] **Step 5: Merge, tag, publish, and clean up**
+
+  Merge the release PR, create tag `v1.2.0` at the merged `main` commit, publish the GitHub Release with the verified artifacts, then delete the local and remote release branch.
+

--- a/docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
+++ b/docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
@@ -1,0 +1,353 @@
+# Auto refresh quota fallback implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent a newer session history timestamp from replacing a valid online quota value during a failed background refresh.
+
+**Architecture:** Keep source precedence separate from timestamp ordering. A live value confirmed in the current process wins first, followed by persisted live data, then an existing display fallback, and finally session history. Compare timestamps only within the live source group. The change stays in the Rust fallback loader and its tests. The frontend and database schema do not change.
+
+**Tech Stack:** Rust 2021, Tauri 2, rusqlite, chrono, Cargo tests, npm scripts, TypeScript, Vite, ESLint.
+
+## Global Constraints
+
+- A session timestamp must never outrank an online value merely because it is later.
+- A live fallback remains eligible for another live refresh and must not be treated as a fresh success.
+- Startup fallback loading must prefer persisted live data before session history.
+- Passive reads must not start a fetch or a scan.
+- Use the current codex/release-1.2.0 branch as explicitly requested by the user.
+- Do not change the frontend or database schema for this fix.
+
+---
+
+### Task 1: Add failing mixed-source fallback tests
+
+**Files:**
+
+- Modify: src-tauri/src/lib.rs in the existing test module, near background_live_rate_limit_fallback_prefers_newest_persisted_sample
+
+**Interfaces:**
+
+- Consumes: prepare_app_database, database::replace_session_rate_limit_samples, insert_live_rate_limit_snapshot, LiveQuotaCache, and load_display_live_rate_limit_fallback.
+- Produces: Regression tests that fail against the current mixed-source timestamp selection and preserve the existing history fallback contract.
+
+- [ ] **Step 1: Add small test builders for live and session samples**
+
+Add test-only helpers beside the existing quota fallback tests. Use a fixed five-hour window so each fixture has a coherent bucket and a distinct value:
+
+~~~rust
+fn test_live_quota_snapshot(fetched_at: &str, remaining_percent: i64) -> LiveRateLimitSnapshot {
+  LiveRateLimitSnapshot {
+    limit_id: Some("codex".to_string()),
+    limit_name: Some("Codex".to_string()),
+    plan_type: Some("pro".to_string()),
+    primary: Some(RateLimitWindowSnapshot {
+      used_percent: 100 - remaining_percent,
+      remaining_percent,
+      window_duration_mins: Some(300),
+      resets_at: Some("2026-07-12T05:00:00+08:00".to_string()),
+      window_start: Some("2026-07-12T00:00:00+08:00".to_string()),
+    }),
+    secondary: None,
+    fetched_at: fetched_at.to_string(),
+  }
+}
+
+fn test_session_quota_sample(
+  session_id: &str,
+  sample_timestamp: &str,
+  remaining_percent: i64,
+) -> crate::models::RateLimitSampleRecord {
+  crate::models::RateLimitSampleRecord {
+    source_kind: "session".to_string(),
+    source_session_id: Some(session_id.to_string()),
+    bucket: "five_hour".to_string(),
+    sample_timestamp: sample_timestamp.to_string(),
+    limit_id: Some("codex".to_string()),
+    limit_name: Some("Codex".to_string()),
+    plan_type: Some("pro".to_string()),
+    window_start: "2026-07-12T00:00:00+08:00".to_string(),
+    resets_at: "2026-07-12T05:00:00+08:00".to_string(),
+    used_percent: 100 - remaining_percent,
+    remaining_percent,
+  }
+}
+~~~
+
+- [ ] **Step 2: Add the current-process live value regression test**
+
+Add background_live_fallback_keeps_current_live_over_newer_session. Insert a session sample at 2026-07-12T00:10:00+08:00, put a live snapshot at 2026-07-12T00:05:00+08:00 into the cache with publish_live, then call load_display_live_rate_limit_fallback. Assert that the returned timestamp is 2026-07-12T00:05:00+08:00 and the returned remaining value is the live value, not the session value:
+
+~~~rust
+#[test]
+fn background_live_fallback_keeps_current_live_over_newer_session() {
+  let directory = tempdir().expect("tempdir");
+  let db_path = directory.path().join("usage.sqlite");
+  prepare_app_database(&db_path).expect("prepare app database");
+  let conn = open_connection(&db_path).expect("open database");
+  database::replace_session_rate_limit_samples(
+    &conn,
+    "session-late",
+    &[test_session_quota_sample(
+      "session-late",
+      "2026-07-12T00:10:00+08:00",
+      20,
+    )],
+  )
+  .expect("insert newer session sample");
+  drop(conn);
+
+  let live_cache = refresh::LiveQuotaCache::new();
+  live_cache.publish_live(
+    Arc::new(test_live_quota_snapshot(
+      "2026-07-12T00:05:00+08:00",
+      88,
+    )),
+    Instant::now(),
+    Utc::now(),
+  );
+
+  let snapshot = load_display_live_rate_limit_fallback(&db_path, &live_cache)
+    .expect("load fallback");
+
+  assert_eq!(snapshot.fetched_at, "2026-07-12T00:05:00+08:00");
+  assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(88));
+}
+~~~
+
+- [ ] **Step 3: Add the persisted live precedence test**
+
+Add background_live_fallback_prefers_persisted_live_over_newer_session. Insert a persisted live snapshot at 2026-07-12T00:05:00+08:00 with 88 percent remaining and a session sample at 2026-07-12T00:10:00+08:00 with 20 percent remaining. Use an empty cache and assert that the fallback returns the persisted live snapshot:
+
+~~~rust
+#[test]
+fn background_live_fallback_prefers_persisted_live_over_newer_session() {
+  let directory = tempdir().expect("tempdir");
+  let db_path = directory.path().join("usage.sqlite");
+  prepare_app_database(&db_path).expect("prepare app database");
+  let conn = open_connection(&db_path).expect("open database");
+  insert_live_rate_limit_snapshot(
+    &conn,
+    &test_live_quota_snapshot("2026-07-12T00:05:00+08:00", 88),
+  )
+  .expect("insert persisted live sample");
+  database::replace_session_rate_limit_samples(
+    &conn,
+    "session-late",
+    &[test_session_quota_sample(
+      "session-late",
+      "2026-07-12T00:10:00+08:00",
+      20,
+    )],
+  )
+  .expect("insert newer session sample");
+  drop(conn);
+
+  let snapshot = load_display_live_rate_limit_fallback(
+    &db_path,
+    &refresh::LiveQuotaCache::new(),
+  )
+  .expect("load fallback");
+
+  assert_eq!(snapshot.fetched_at, "2026-07-12T00:05:00+08:00");
+  assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(88));
+}
+~~~
+
+- [ ] **Step 4: Add the no-live history fallback test**
+
+Add background_live_fallback_uses_session_when_no_live_data_exists. Insert only the session sample, use an empty cache, and assert that the session timestamp and remaining value are returned. This protects the last-resort behavior.
+
+~~~rust
+#[test]
+fn background_live_fallback_uses_session_when_no_live_data_exists() {
+  let directory = tempdir().expect("tempdir");
+  let db_path = directory.path().join("usage.sqlite");
+  prepare_app_database(&db_path).expect("prepare app database");
+  let conn = open_connection(&db_path).expect("open database");
+  database::replace_session_rate_limit_samples(
+    &conn,
+    "session-only",
+    &[test_session_quota_sample(
+      "session-only",
+      "2026-07-12T00:10:00+08:00",
+      20,
+    )],
+  )
+  .expect("insert session sample");
+  drop(conn);
+
+  let snapshot = load_display_live_rate_limit_fallback(
+    &db_path,
+    &refresh::LiveQuotaCache::new(),
+  )
+  .expect("load history fallback");
+
+  assert_eq!(snapshot.fetched_at, "2026-07-12T00:10:00+08:00");
+  assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(20));
+}
+~~~
+
+- [ ] **Step 5: Run the focused tests and verify the failure**
+
+Run:
+
+~~~bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked background_live_rate_limit_fallback -- --nocapture
+~~~
+
+Expected result: the new current-process and persisted-live tests fail because load_display_live_rate_limit_fallback currently calls load_persisted_live_rate_limits_from_connection with no source filter and compares session rows with live rows. The session-only test may pass before the production change.
+
+- [ ] **Step 6: Commit the failing regression tests**
+
+~~~bash
+git add src-tauri/src/lib.rs
+git commit -m "test: cover mixed-source quota fallback"
+~~~
+
+### Task 2: Implement source-prioritized fallback loading
+
+**Files:**
+
+- Modify: src-tauri/src/lib.rs in load_display_live_rate_limit_fallback and app setup fallback initialization
+
+**Interfaces:**
+
+- Consumes: the failing tests from Task 1, LiveQuotaCache::state, LiveQuotaCache::rate_limits, load_persisted_live_rate_limits_from_connection, and newest_live_rate_limit_snapshot.
+- Produces: a fallback loader that compares only live candidates before considering session history.
+
+- [ ] **Step 1: Add a source-priority helper for startup data**
+
+Add this helper near load_persisted_live_rate_limits_from_connection:
+
+~~~rust
+fn load_preferred_persisted_live_rate_limits(
+  conn: &rusqlite::Connection,
+) -> Option<LiveRateLimitSnapshot> {
+  load_persisted_live_rate_limits_from_connection(conn, Some("live"))
+    .or_else(|| load_persisted_live_rate_limits_from_connection(conn, Some("session")))
+}
+~~~
+
+Change app setup so display_fallback calls this helper instead of loading with no source filter and then trying session again:
+
+~~~rust
+let display_fallback = load_preferred_persisted_live_rate_limits(&conn);
+~~~
+
+Keep live_last_success_at sourced from Some("live") so the scheduler still restores the live deadline from online data only.
+
+- [ ] **Step 2: Replace mixed-source fallback selection**
+
+Update load_display_live_rate_limit_fallback to use the following order:
+
+~~~rust
+fn load_display_live_rate_limit_fallback(
+  db_path: &Path,
+  live_cache: &refresh::LiveQuotaCache,
+) -> Option<LiveRateLimitSnapshot> {
+  let memory = live_cache
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone());
+  let memory_is_live = live_cache.state().last_live_success_at.is_some();
+  let Ok(conn) = open_connection(db_path) else {
+    return memory;
+  };
+
+  let persisted_live = load_persisted_live_rate_limits_from_connection(&conn, Some("live"));
+  if memory_is_live {
+    return newest_live_rate_limit_snapshot([memory, persisted_live]);
+  }
+  if persisted_live.is_some() {
+    return persisted_live;
+  }
+  memory.or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")))
+}
+~~~
+
+This preserves timestamp comparison for two live candidates. It prevents a session row from entering that comparison. A live value published by this process remains the display value even when the database contains a later session timestamp. A startup cache that has only a historical value gives persisted live data the next chance before keeping history.
+
+- [ ] **Step 3: Run the focused regression tests**
+
+Run:
+
+~~~bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked background_live_rate_limit_fallback -- --nocapture
+~~~
+
+Expected result: all fallback tests pass, including the existing test that chooses a newer persisted live sample and the new tests from Task 1.
+
+- [ ] **Step 4: Run formatter and focused neighboring tests**
+
+Run:
+
+~~~bash
+cargo fmt --all -- --check
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::live_cache::tests -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests -- --nocapture
+~~~
+
+Expected result: formatting and all focused Rust tests pass. The runtime tests must still show that a failed live request triggers a retry and a fallback token intent.
+
+- [ ] **Step 5: Commit the production fix**
+
+~~~bash
+git add src-tauri/src/lib.rs
+git commit -m "fix: prioritize live quota fallback sources"
+~~~
+
+### Task 3: Run full verification and prepare the branch
+
+**Files:**
+
+- Inspect: src-tauri/src/lib.rs
+- Inspect: docs/superpowers/specs/2026-07-12-auto-quota-fallback-design.md
+- Inspect: docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
+
+**Interfaces:**
+
+- Consumes: the committed regression tests and source-priority implementation from Tasks 1 and 2.
+- Produces: evidence that the fix does not break refresh runtime behavior, frontend checks, formatting, or build output.
+
+- [ ] **Step 1: Run the complete Rust test suite**
+
+Run:
+
+~~~bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+~~~
+
+Expected result: every Rust test passes. Intentional panic messages from existing worker recovery tests are acceptable only when the tests finish successfully.
+
+- [ ] **Step 2: Run frontend tests, lint, and build**
+
+Run:
+
+~~~bash
+npm test
+npm run lint
+npm run build
+~~~
+
+Expected result: all Node test scripts pass, ESLint exits successfully, and TypeScript plus Vite produce a successful build.
+
+- [ ] **Step 3: Inspect the final diff for scope and formatting**
+
+Run:
+
+~~~bash
+git diff --check HEAD~2..HEAD
+git diff --stat HEAD~2..HEAD
+git status --short --branch
+~~~
+
+Expected result: only the fallback tests and source-priority loader changed in the implementation commits, the design and plan documents are present, and the working tree is clean.
+
+- [ ] **Step 4: Push the current branch after verification**
+
+Run:
+
+~~~bash
+git push origin codex/release-1.2.0
+~~~
+
+Do not create or merge a pull request in this plan. The project workflow requires the user to test the pushed branch and explicitly approve entering the PR process.

--- a/docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
+++ b/docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
@@ -281,12 +281,12 @@ Expected result: all fallback tests pass, including the existing test that choos
 Run:
 
 ~~~bash
-cargo fmt --all -- --check
+cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
 cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::live_cache::tests -- --nocapture
 cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests -- --nocapture
 ~~~
 
-Expected result: formatting and all focused Rust tests pass. The runtime tests must still show that a failed live request triggers a retry and a fallback token intent.
+Expected result: the focused Rust tests pass. The repository currently contains formatting differences outside this change, so do not reformat the whole crate. The runtime tests must still show that a failed live request triggers a retry and a fallback token intent.
 
 - [ ] **Step 5: Commit the production fix**
 

--- a/docs/superpowers/specs/2026-07-12-auto-quota-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-12-auto-quota-fallback-design.md
@@ -1,0 +1,50 @@
+# Auto refresh quota fallback source precedence
+
+## Context
+
+The application has two refresh paths for online quota data. A manual refresh usually succeeds because it waits for a live app-server request. The background scheduler can occasionally fail that request and ask the live worker for a fallback value.
+
+The fallback loader currently combines in-memory data, persisted `live` samples, and `session` history. It then selects the candidate with the greatest timestamp. That comparison treats an observation from an old session as equivalent to a successful online fetch. A later historical timestamp can therefore replace a valid online value.
+
+## Decision
+
+Fallback selection will respect source precedence before comparing timestamps:
+
+1. A live value already confirmed by the current process remains the preferred value.
+2. If the process has no confirmed live value, use the newest persisted `live` sample.
+3. If no persisted live sample exists, keep an available display fallback.
+4. Use `session` history only when no live value is available.
+
+Timestamp ordering will apply only between values from the same source class. A `session` timestamp will never outrank an online value merely because it is later.
+
+The existing cache field `last_live_success_at` identifies whether the current in-memory value has been produced by a live request in this process. Startup loading will also prefer persisted `live` data before loading `session` history, so the cache does not begin with a historical value when an online value is available.
+
+## Data flow
+
+When a live request fails, `AppLiveQuotaFetcher::fallback` will use the source-prioritized loader. If the cache contains a live value from the current process, the loader returns it without consulting session history. Otherwise it checks the database for `source_kind = 'live'`, then falls back to the existing display value or `source_kind = 'session'` history.
+
+The runtime will continue to mark the live lane as needing refresh after a fallback. This change affects which value is displayed while the retry is pending. It does not suppress retries, change refresh intervals, or turn a fallback into a fresh live success.
+
+## Implementation scope
+
+- Update `src-tauri/src/lib.rs` so automatic fallback loading separates persisted live samples from session history.
+- Update startup fallback selection to use the same source precedence.
+- Keep existing timestamp comparison helpers for candidates that share the same source class.
+- Add regression tests for a later session timestamp failing to replace a current in-memory live value.
+- Add regression coverage showing that persisted live data wins over a newer session record and that session history remains available when no live data exists.
+
+No frontend behavior or database schema changes are required.
+
+## Error handling
+
+If the database cannot be opened, the loader returns the available in-memory value. If no in-memory or persisted live value exists, the loader may return a session fallback as it does today. A fallback never updates the live success timestamp and remains eligible for another live refresh.
+
+## Verification
+
+The implementation will follow a red, green, refactor cycle:
+
+1. Add the regression tests and run them to confirm the current mixed-source selection fails.
+2. Implement the smallest source-priority change.
+3. Run the focused Rust tests, the existing refresh event tests, the full Rust test suite, lint, and the frontend build.
+
+Acceptance requires that a newer session timestamp cannot replace a current live value during a failed background refresh, while the existing historical fallback behavior still works when no live data is available.

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -12,7 +12,7 @@
 
 ## 环境要求
 
-- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.1.2` 暂缓发布 Windows 安装包
+- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.2.0` 暂缓发布 Windows 安装包
 - 本地 Codex 数据位于 `~/.codex` 或自定义 `CODEX_HOME`
 
 如果你要从源码开发，还需要：
@@ -25,8 +25,8 @@
 
 官方公开下载方式均通过 GitHub Releases 提供：
 
-- 已签名的 **macOS Apple Silicon DMG**
-- `v1.1.2` 不附加 Windows 安装包；Windows 文档仅用于源码验证
+- 已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**
+- `v1.2.0` 不附加 Windows 安装包；Windows 文档仅用于源码验证
 
 请先阅读：
 
@@ -106,4 +106,4 @@ npm run tauri build
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [打包与发布](./packaging-and-release.md)
-- [v1.1.2 发布说明](./release-notes-v1.1.2.md)
+- [v1.2.0 发布说明](./release-notes-v1.2.0.md)

--- a/docs/zh-CN/installing-on-macos.md
+++ b/docs/zh-CN/installing-on-macos.md
@@ -2,7 +2,7 @@
 
 ## macOS 安装路径
 
-**Codex Pacer** 的 macOS 公开安装包，是通过 GitHub Releases 发布的、已签名的 **Apple Silicon DMG**。
+**Codex Pacer** 的 macOS 公开安装包，是通过 GitHub Releases 发布的、已签名并完成 Apple notarization 的 **Apple Silicon DMG**。
 
 ## 标准安装流程
 

--- a/docs/zh-CN/installing-on-windows.md
+++ b/docs/zh-CN/installing-on-windows.md
@@ -2,7 +2,7 @@
 
 ## Windows 测试阶段状态
 
-`v1.1.2` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
+`v1.2.0` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
 
 Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windows 安装包，除非该版本单独配置了 Windows code signing，否则安装包默认未签名，Windows SmartScreen 可能会提示发布者未知。
 
@@ -12,7 +12,7 @@ Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windo
 2. 安装 Windows Tauri 前置依赖。
 3. 运行 `npm ci`。
 4. 运行 `npm run lint`、`npm run build` 和 `cargo test --manifest-path src-tauri/Cargo.toml --locked`。
-5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.1.2`。
+5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.2.0`。
 
 ## 安装后
 
@@ -27,7 +27,7 @@ Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windo
 ## 说明
 
 - GitHub Releases 是官方分发渠道。
-- `v1.1.2` 只发布 macOS Apple Silicon DMG 资产。
+- `v1.2.0` 只发布 macOS Apple Silicon DMG 资产。
 - 任何本地构建的 Windows setup `.exe` 仍是测试阶段的 NSIS 安装包。
 - Windows 安装包不会安装 Codex CLI，也不会创建 Codex 使用历史。
 - Windows 稳定支持、Windows code signing 和自动更新交付目前都不承诺。

--- a/docs/zh-CN/packaging-and-release.md
+++ b/docs/zh-CN/packaging-and-release.md
@@ -6,9 +6,9 @@
 
 当前稳定公开打包资产为：
 
-- 已签名的 **macOS Apple Silicon DMG**
+- 已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**
 
-`v1.1.2` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
+`v1.2.0` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
 
 - 未签名的 **Windows NSIS setup EXE**，仅用于本地兼容性测试和早期验证
 
@@ -28,8 +28,8 @@
 当前面向公开发布的目标流程是：
 
 1. 确认公开品牌文案和文档已经准备完成。
-2. 构建已签名的 macOS Apple Silicon DMG。
-3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.1.2` 不发布 Windows 安装包。
+2. 构建并完成 macOS Apple Silicon DMG 的 notarization 与 staple。
+3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.2.0` 不发布 Windows 安装包。
 4. 通过 GitHub Releases 发布这些安装资产。
 5. 附上对应版本的发布说明。
 
@@ -39,15 +39,15 @@
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.2
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
-这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.1.2` 不上传 Windows EXE 资产。
+这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，提交 Apple notarization，执行 staple，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.2.0` 不上传 Windows EXE 资产。
 
 ## 平台隔离规则
 
@@ -76,8 +76,8 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 
 - 为稳定版本创建 Git tag
 - 基于该 tag 创建 GitHub Release
-- 上传已签名的 Apple Silicon DMG
-- `v1.1.2` 不上传 Windows NSIS setup EXE
+- 上传已签名、完成 notarization 并已 staple 的 Apple Silicon DMG
+- `v1.2.0` 不上传 Windows NSIS setup EXE
 - 附上该版本对应的发布说明
 - 发布后再次验证下载与安装流程
 
@@ -88,9 +88,9 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 面向外部文档和公告时，请保持以下表述一致：
 
 - 官方分发渠道：GitHub Releases
-- 稳定发布资产：已签名的 macOS Apple Silicon DMG
-- Windows 安装包：`v1.1.2` 暂缓发布
-- 当前稳定版本线：`v1.1.2`
+- 稳定发布资产：已签名并完成 Apple notarization 的 macOS Apple Silicon DMG
+- Windows 安装包：`v1.2.0` 暂缓发布
+- 当前稳定版本线：`v1.2.0`
 
 ## 相关文档
 
@@ -98,4 +98,4 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [发布 Runbook](./release-runbook.md)
-- [v1.1.2 发布说明](./release-notes-v1.1.2.md)
+- [v1.2.0 发布说明](./release-notes-v1.2.0.md)

--- a/docs/zh-CN/release-notes-v1.2.0.md
+++ b/docs/zh-CN/release-notes-v1.2.0.md
@@ -1,0 +1,41 @@
+# Codex Pacer v1.2.0
+
+## 概要
+
+1.2.0 主要改善后台刷新稳定性和资源占用。token 统计与在线额度现在由独立 worker 刷新：本地扫描变慢时不会阻塞在线额度，请求在线额度时也不会延迟 token 导入。
+
+导入器现在只读取增长中 session 文件已经写完整的尾部内容。usage 与 quota 历史改为原位追加或校正，不再反复重建未变化的数据。菜单栏数值直接通过 SQLite 聚合计算，渲染时不必把大量历史记录加载到内存。
+
+## 本次更新
+
+- 新增 GPT-5.6 Sol、Terra 和 Luna 识别及内置 Standard API 等价值 pricing
+- macOS 可以自动发现 ChatGPT 桌面应用内置的 Codex CLI
+- token 与在线额度分别调度刷新、重试和 freshness 状态
+- 前端不再轮询刷新状态，改为接收后端事件
+- 增长中的 JSONL session 文件使用持久化解析检查点
+- 减少 usage 与 quota 历史的数据库重复写入
+- 时间戳迁移改为小批量、可续跑的后台任务
+- 修复 fork 和嵌套 fork 的 token 归属，包括单快照和父文件暂时不可用的情况
+- 修复旧刷新结果覆盖新结果、listener 启动竞态、退出竞态和重试丢失
+- 修复 JSONL 最后一条记录完整但没有换行符时被永久跳过的问题
+- 减少 macOS 刷新后的临时内存滞留和 spool 文件体积
+
+## 从 1.1.1 或 1.1.2 升级
+
+直接覆盖安装 1.2.0 即可，不需要先卸载旧版本，也不要删除旧数据库。
+
+Codex Pacer 的应用名称、bundle identifier 和本地数据位置保持不变。首次启动时，应用会在原数据库上增加新字段和索引。已有 conversation、token usage、quota 样本、订阅设置、菜单栏偏好和自定义 Codex 路径都会保留。
+
+旧记录的时间戳会由一个小批量、可续跑的后台任务补齐。这个任务运行期间，token 与在线额度仍会分别刷新。兼容性测试使用 1.1.1 和 1.1.2 的原始 schema 建库并写入用户数据，再升级到 1.2.0，检查保存值和数据库完整性。
+
+## 性能验证
+
+release 构建的本地重启测试中，没有再出现此前启动和每次刷新约 53 MiB 的写入突发。清空开发缓存后启动 75 秒（包含一次后台刷新）共写入 1.68 MiB。四分钟采样平均占用约 1.53% 单核 CPU，读取 0.18 MiB、写入 5.30 MiB；刷新结束后的物理内存回落到约 136–142 MiB。
+
+这些数字来自本次 release 测试机器和数据集，实际结果会随 session 历史和刷新活动变化。
+
+## 发布形式
+
+公开 macOS 资产是通过 GitHub Releases 分发的 Apple Silicon DMG，并附带 SHA-256 checksum。发布前会完成 Developer ID 签名、Apple notarization、staple 和 Gatekeeper 检查。
+
+本版本仍暂缓发布 Windows 安装包。

--- a/docs/zh-CN/release-runbook.md
+++ b/docs/zh-CN/release-runbook.md
@@ -4,22 +4,22 @@
 
 本文面向维护者，说明如何生成 **Codex Pacer** 的公开发布资产：
 
-- 已签名的 Apple Silicon DMG
-- Windows 兼容性检查，且 `v1.1.2` 暂缓发布 Windows 安装包
+- 已签名、完成 notarization 并已 staple 的 Apple Silicon DMG
+- Windows 兼容性检查，且 `v1.2.0` 暂缓发布 Windows 安装包
 - 通过 GitHub Releases 分发
 
 本地发布入口：
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
-macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.2` 上传 DMG 与 checksum。`v1.1.2` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
+macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.0` 上传 DMG 与 checksum。`v1.2.0` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
 
 ## macOS 发布要求
 
@@ -44,7 +44,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 ## macOS 构建
 
 ```bash
-./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
 ```
 
 脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，构建 app/dmg，执行 codesign，并写入 `<artifact>.dmg.sha256`。如果配置了 notarization 凭据，脚本还会执行 notarytool、stapling、Gatekeeper 与 stapler 校验；如果未配置，则跳过这些 notarization 专属步骤。
@@ -52,7 +52,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 ## Windows 构建
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
 脚本会校验版本，运行 `npm ci`、lint、前端构建和 Rust 测试，执行 `npm run tauri build -- --ci --bundles nsis -- --locked`，定位生成的 NSIS setup `.exe`，并写入 `<installer>.exe.sha256`。
@@ -98,7 +98,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 10. 刷新 live quota 数据，确认不会弹出黑色命令行窗口。
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.1.2_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.0_x64-setup.exe"
 ```
 
 ## 相关文档

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,13 +36,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -61,21 +61,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -92,14 +92,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -109,14 +109,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -136,29 +136,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -198,27 +198,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -228,33 +228,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -262,35 +262,35 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -569,26 +569,28 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -632,9 +634,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -649,9 +651,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -666,9 +668,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -683,9 +685,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -700,9 +702,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
-      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -717,9 +719,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -734,9 +736,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
-      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -751,9 +753,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -768,9 +770,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -785,9 +787,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -802,9 +804,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
-      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -819,9 +821,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -836,9 +838,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
-      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -846,16 +848,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
-      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -870,9 +874,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
-      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -1133,9 +1137,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1455,9 +1459,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1648,9 +1652,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1661,9 +1665,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1672,9 +1676,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -1692,11 +1696,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1716,9 +1720,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true,
       "funding": [
         {
@@ -1991,9 +1995,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2482,10 +2486,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2889,9 +2903,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -2915,11 +2929,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3012,9 +3029,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3025,9 +3042,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -3045,7 +3062,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3186,14 +3203,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
-      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.11"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3202,27 +3219,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
-      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3308,14 +3325,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3476,17 +3493,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
-      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.11",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3502,8 +3519,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -873,6 +873,183 @@ mod tests {
         assert_eq!(settings.live_quota_refresh_interval_seconds, 600);
     }
 
+    fn assert_release_upgrade_preserves_user_data(legacy_schema: &str) {
+        let conn = Connection::open_in_memory().expect("open legacy release database");
+        conn.execute_batch(legacy_schema)
+            .expect("install historical release schema");
+        conn.execute_batch(
+            "
+            INSERT INTO sessions (
+              session_id, root_session_id, title, source_state,
+              created_at, imported_at
+            ) VALUES (
+              'legacy-session', 'legacy-session', 'Legacy conversation', 'active',
+              '2026-04-01T00:00:00Z', '2026-04-01T00:01:00Z'
+            );
+            INSERT INTO conversation_links (
+              session_id, root_session_id, parent_session_id, depth
+            ) VALUES ('legacy-session', 'legacy-session', NULL, 0);
+            INSERT INTO usage_events (
+              session_id, timestamp, model_id,
+              input_tokens, cached_input_tokens, output_tokens,
+              reasoning_output_tokens, total_tokens, value_usd,
+              fast_mode_auto, fast_mode_effective
+            ) VALUES (
+              'legacy-session', '2026-04-01T00:02:00Z', 'gpt-5.4',
+              100, 20, 25, 0, 125, 0.42, 0, 0
+            );
+            INSERT INTO pricing_catalog (
+              model_id, display_name,
+              input_price_per_million, cached_input_price_per_million,
+              output_price_per_million, effective_model_id,
+              is_official, note, source_url, updated_at
+            ) VALUES (
+              'legacy-model', 'Legacy model', 1.0, 0.1, 2.0,
+              'legacy-model', 1, 'release fixture',
+              'https://example.invalid/pricing', '2026-04-01T00:00:00Z'
+            );
+            INSERT INTO subscription_profile (
+              singleton_id, plan_type, currency,
+              monthly_price, billing_anchor_day, updated_at
+            ) VALUES (1, 'pro', 'USD', 42.0, 9, '2026-04-01T00:00:00Z');
+            INSERT INTO session_overrides (
+              session_id, fast_mode_override, updated_at
+            ) VALUES ('legacy-session', 1, '2026-04-01T00:00:00Z');
+            INSERT INTO sync_settings (
+              singleton_id, codex_home, auto_scan_enabled,
+              auto_scan_interval_minutes, last_scan_started_at,
+              last_scan_completed_at, updated_at
+            ) VALUES (
+              1, '/legacy/codex-home', 1, 17,
+              '2026-04-01T00:03:00Z', '2026-04-01T00:04:00Z',
+              '2026-04-01T00:05:00Z'
+            );
+            INSERT INTO import_state (
+              source_path, session_id, source_bucket,
+              file_size, file_mtime_ms, last_imported_at
+            ) VALUES (
+              '/legacy/session.jsonl', 'legacy-session', 'active',
+              512, 1775000000000, '2026-04-01T00:05:00Z'
+            );
+            INSERT INTO rate_limit_samples (
+              source_kind, source_session_id, bucket,
+              sample_timestamp, limit_id, limit_name, plan_type,
+              window_start, resets_at, used_percent,
+              remaining_percent, created_at
+            ) VALUES (
+              'session', 'legacy-session', 'five_hour',
+              '2026-04-01T00:06:00Z', 'legacy-limit', 'Legacy limit', 'pro',
+              '2026-04-01T00:00:00Z', '2026-04-01T05:00:00Z',
+              25, 75, '2026-04-01T00:06:00Z'
+            );
+            ",
+        )
+        .expect("seed historical user data");
+
+        init_db(&conn).expect("upgrade historical release database");
+        let progress = backfill_epoch_batch(&conn, 1_000)
+            .expect("backfill historical epoch values");
+        assert!(progress.complete);
+        init_db(&conn).expect("repeat upgrade idempotently");
+
+        let session: (String, String) = conn
+            .query_row(
+                "SELECT title, source_state FROM sessions WHERE session_id = 'legacy-session'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("load preserved session");
+        assert_eq!(session, ("Legacy conversation".to_string(), "active".to_string()));
+
+        let usage: (i64, i64, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT COUNT(*), total_tokens, timestamp_ms
+                FROM usage_events
+                WHERE session_id = 'legacy-session'
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load preserved usage");
+        assert_eq!(usage.0, 1);
+        assert_eq!(usage.1, 125);
+        assert!(usage.2.is_some());
+
+        let quota: (i64, i64, i64, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT COUNT(*), used_percent, remaining_percent, sample_timestamp_ms
+                FROM rate_limit_samples
+                WHERE source_session_id = 'legacy-session'
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("load preserved quota");
+        assert_eq!((quota.0, quota.1, quota.2), (1, 25, 75));
+        assert!(quota.3.is_some());
+
+        let profile = get_subscription_profile(&conn).expect("load preserved subscription");
+        assert_eq!(profile.plan_type, "pro");
+        assert_eq!(profile.monthly_price, 42.0);
+        assert_eq!(profile.billing_anchor_day, 9);
+
+        let settings = get_sync_settings(&conn).expect("load preserved settings");
+        assert_eq!(settings.codex_home.as_deref(), Some("/legacy/codex-home"));
+        assert_eq!(settings.auto_scan_interval_minutes, 17);
+
+        let import_state: (i64, Option<String>) = conn
+            .query_row(
+                "
+                SELECT file_size, parser_checkpoint
+                FROM import_state
+                WHERE source_path = '/legacy/session.jsonl'
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("load preserved import state");
+        assert_eq!(import_state, (512, None));
+
+        let repair_tables: i64 = conn
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM sqlite_master
+                WHERE type = 'table'
+                  AND name IN (
+                    'data_repair_progress',
+                    'data_repair_quarantine',
+                    'latest_rate_limits'
+                  )
+                ",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load upgraded tables");
+        assert_eq!(repair_tables, 3);
+
+        let integrity: String = conn
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .expect("check upgraded database integrity");
+        assert_eq!(integrity, "ok");
+    }
+
+    #[test]
+    fn upgrades_v1_1_1_database_without_losing_user_data() {
+        assert_release_upgrade_preserves_user_data(include_str!(
+            "../tests/fixtures/v1.1.1-schema.sql"
+        ));
+    }
+
+    #[test]
+    fn upgrades_v1_1_2_database_without_losing_user_data() {
+        assert_release_upgrade_preserves_user_data(include_str!(
+            "../tests/fixtures/v1.1.2-schema.sql"
+        ));
+    }
+
     #[test]
     fn subscription_profile_is_normalized_to_usd() {
         let conn = Connection::open_in_memory().expect("open in-memory database");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3630,6 +3630,43 @@ mod tests {
     assert!(!pricing_value_resolution_repair_pending(&conn).expect("load repair marker"));
   }
 
+  fn test_live_quota_snapshot(fetched_at: &str, remaining_percent: i64) -> LiveRateLimitSnapshot {
+    LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: Some(RateLimitWindowSnapshot {
+        used_percent: 100 - remaining_percent,
+        remaining_percent,
+        window_duration_mins: Some(300),
+        resets_at: Some("2026-07-12T05:00:00+08:00".to_string()),
+        window_start: Some("2026-07-12T00:00:00+08:00".to_string()),
+      }),
+      secondary: None,
+      fetched_at: fetched_at.to_string(),
+    }
+  }
+
+  fn test_session_quota_sample(
+    session_id: &str,
+    sample_timestamp: &str,
+    remaining_percent: i64,
+  ) -> crate::models::RateLimitSampleRecord {
+    crate::models::RateLimitSampleRecord {
+      source_kind: "session".to_string(),
+      source_session_id: Some(session_id.to_string()),
+      bucket: "five_hour".to_string(),
+      sample_timestamp: sample_timestamp.to_string(),
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      window_start: "2026-07-12T00:00:00+08:00".to_string(),
+      resets_at: "2026-07-12T05:00:00+08:00".to_string(),
+      used_percent: 100 - remaining_percent,
+      remaining_percent,
+    }
+  }
+
   #[test]
   fn background_live_rate_limit_fallback_prefers_newest_persisted_sample() {
     let directory = tempdir().expect("tempdir");
@@ -3709,6 +3746,102 @@ mod tests {
       memory.primary.as_ref().map(|window| window.remaining_percent),
       Some(77)
     );
+  }
+
+  #[test]
+  fn background_live_fallback_keeps_current_live_over_newer_session() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    database::replace_session_rate_limit_samples(
+      &conn,
+      "session-late",
+      &[test_session_quota_sample(
+        "session-late",
+        "2026-07-12T00:10:00+08:00",
+        20,
+      )],
+    )
+    .expect("insert newer session sample");
+    drop(conn);
+
+    let live_cache = refresh::LiveQuotaCache::new();
+    live_cache.publish_live(
+      Arc::new(test_live_quota_snapshot(
+        "2026-07-12T00:05:00+08:00",
+        88,
+      )),
+      Instant::now(),
+      Utc::now(),
+    );
+
+    let snapshot = load_display_live_rate_limit_fallback(&db_path, &live_cache)
+      .expect("load fallback");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-12T00:05:00+08:00");
+    assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(88));
+  }
+
+  #[test]
+  fn background_live_fallback_prefers_persisted_live_over_newer_session() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &test_live_quota_snapshot("2026-07-12T00:05:00+08:00", 88),
+    )
+    .expect("insert persisted live sample");
+    database::replace_session_rate_limit_samples(
+      &conn,
+      "session-late",
+      &[test_session_quota_sample(
+        "session-late",
+        "2026-07-12T00:10:00+08:00",
+        20,
+      )],
+    )
+    .expect("insert newer session sample");
+    drop(conn);
+
+    let snapshot = load_display_live_rate_limit_fallback(
+      &db_path,
+      &refresh::LiveQuotaCache::new(),
+    )
+    .expect("load fallback");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-12T00:05:00+08:00");
+    assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(88));
+  }
+
+  #[test]
+  fn background_live_fallback_uses_session_when_no_live_data_exists() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    database::replace_session_rate_limit_samples(
+      &conn,
+      "session-only",
+      &[test_session_quota_sample(
+        "session-only",
+        "2026-07-12T00:10:00+08:00",
+        20,
+      )],
+    )
+    .expect("insert session sample");
+    drop(conn);
+
+    let snapshot = load_display_live_rate_limit_fallback(
+      &db_path,
+      &refresh::LiveQuotaCache::new(),
+    )
+    .expect("load history fallback");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-12T00:10:00+08:00");
+    assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(20));
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1426,6 +1426,13 @@ fn load_persisted_live_rate_limits_from_connection(
   })
 }
 
+fn load_preferred_persisted_live_rate_limits(
+  conn: &rusqlite::Connection,
+) -> Option<LiveRateLimitSnapshot> {
+  load_persisted_live_rate_limits_from_connection(conn, Some("live"))
+    .or_else(|| load_persisted_live_rate_limits_from_connection(conn, Some("session")))
+}
+
 fn persisted_window_is_newer(
   candidate: &PersistedRateLimitWindow,
   current: &PersistedRateLimitWindow,
@@ -1466,16 +1473,18 @@ fn load_display_live_rate_limit_fallback(
   let memory = live_cache
     .rate_limits()
     .map(|snapshot| snapshot.as_ref().clone());
+  let memory_is_live = live_cache.state().last_live_success_at.is_some();
   let Ok(conn) = open_connection(db_path) else {
     return memory;
   };
-  let persisted = load_persisted_live_rate_limits_from_connection(&conn, None);
-  let session_only = if persisted.is_none() {
-    load_persisted_live_rate_limits_from_connection(&conn, Some("session"))
-  } else {
-    None
-  };
-  newest_live_rate_limit_snapshot([memory, persisted, session_only])
+  let persisted_live = load_persisted_live_rate_limits_from_connection(&conn, Some("live"));
+  if memory_is_live {
+    return newest_live_rate_limit_snapshot([memory, persisted_live]);
+  }
+  if persisted_live.is_some() {
+    return persisted_live;
+  }
+  memory.or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")))
 }
 
 fn newest_live_rate_limit_snapshot(
@@ -2178,8 +2187,7 @@ pub fn run() {
       prepare_app_database(&db_path)?;
       let conn = open_connection(&db_path).map_err(|error| error.to_string())?;
       let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
-      let display_fallback = load_persisted_live_rate_limits_from_connection(&conn, None)
-        .or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")));
+      let display_fallback = load_preferred_persisted_live_rate_limits(&conn);
       let live_last_success_at = load_persisted_live_rate_limits_from_connection(&conn, Some("live"))
         .map(|snapshot| snapshot.fetched_at);
       let epoch_backfill_is_pending =

--- a/src-tauri/tests/fixtures/v1.1.1-schema.sql
+++ b/src-tauri/tests/fixtures/v1.1.1-schema.sql
@@ -1,0 +1,138 @@
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id TEXT PRIMARY KEY,
+      root_session_id TEXT NOT NULL,
+      parent_session_id TEXT,
+      title TEXT,
+      source_state TEXT NOT NULL DEFAULT 'missing',
+      source_path TEXT,
+      source_bucket TEXT,
+      started_at TEXT,
+      updated_at TEXT,
+      agent_nickname TEXT,
+      agent_role TEXT,
+      explicit_fast_mode INTEGER,
+      fast_mode_default INTEGER NOT NULL DEFAULT 0,
+      latest_plan_type TEXT,
+      last_model_id TEXT,
+      contains_subagents INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      imported_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS conversation_links (
+      session_id TEXT PRIMARY KEY,
+      root_session_id TEXT NOT NULL,
+      parent_session_id TEXT,
+      depth INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS usage_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL,
+      cached_input_tokens INTEGER NOT NULL,
+      output_tokens INTEGER NOT NULL,
+      reasoning_output_tokens INTEGER NOT NULL,
+      total_tokens INTEGER NOT NULL,
+      value_usd REAL NOT NULL,
+      fast_mode_auto INTEGER NOT NULL,
+      fast_mode_effective INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS pricing_catalog (
+      model_id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      input_price_per_million REAL NOT NULL,
+      cached_input_price_per_million REAL NOT NULL,
+      output_price_per_million REAL NOT NULL,
+      effective_model_id TEXT NOT NULL,
+      is_official INTEGER NOT NULL,
+      note TEXT,
+      source_url TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS subscription_profile (
+      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+      plan_type TEXT NOT NULL,
+      currency TEXT NOT NULL,
+      monthly_price REAL NOT NULL,
+      billing_anchor_day INTEGER NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS session_overrides (
+      session_id TEXT PRIMARY KEY,
+      fast_mode_override INTEGER,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS sync_settings (
+      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+      sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
+      codex_home TEXT,
+      auto_scan_enabled INTEGER NOT NULL,
+      auto_scan_interval_minutes INTEGER NOT NULL,
+      live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
+      default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0,
+      hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0,
+      show_menu_bar_logo INTEGER NOT NULL DEFAULT 1,
+      show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1,
+      show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0,
+      menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent',
+      menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour',
+      menu_bar_bucket TEXT NOT NULL DEFAULT 'day',
+      menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1,
+      menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85,
+      menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115,
+      menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢',
+      menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥',
+      menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢',
+      menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1,
+      menu_bar_popup_modules TEXT NOT NULL DEFAULT '["api_value","scan_freshness"]',
+      menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1,
+      menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
+      last_scan_started_at TEXT,
+      last_scan_completed_at TEXT,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS import_state (
+      source_path TEXT PRIMARY KEY,
+      session_id TEXT,
+      source_bucket TEXT NOT NULL,
+      file_size INTEGER NOT NULL,
+      file_mtime_ms INTEGER NOT NULL,
+      last_imported_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS rate_limit_samples (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_kind TEXT NOT NULL,
+      source_session_id TEXT NOT NULL DEFAULT '',
+      bucket TEXT NOT NULL,
+      sample_timestamp TEXT NOT NULL,
+      limit_id TEXT NOT NULL DEFAULT '',
+      limit_name TEXT NOT NULL DEFAULT '',
+      plan_type TEXT NOT NULL DEFAULT '',
+      window_start TEXT NOT NULL,
+      resets_at TEXT NOT NULL,
+      used_percent INTEGER NOT NULL,
+      remaining_percent INTEGER NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_usage_events_session_id ON usage_events(session_id);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp);
+    CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
+    CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
+    CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
+    CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
+    CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
+      ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
+      ON rate_limit_samples(
+        bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
+      );

--- a/src-tauri/tests/fixtures/v1.1.2-schema.sql
+++ b/src-tauri/tests/fixtures/v1.1.2-schema.sql
@@ -1,0 +1,138 @@
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT PRIMARY KEY,
+  root_session_id TEXT NOT NULL,
+  parent_session_id TEXT,
+  title TEXT,
+  source_state TEXT NOT NULL DEFAULT 'missing',
+  source_path TEXT,
+  source_bucket TEXT,
+  started_at TEXT,
+  updated_at TEXT,
+  agent_nickname TEXT,
+  agent_role TEXT,
+  explicit_fast_mode INTEGER,
+  fast_mode_default INTEGER NOT NULL DEFAULT 0,
+  latest_plan_type TEXT,
+  last_model_id TEXT,
+  contains_subagents INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  imported_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS conversation_links (
+  session_id TEXT PRIMARY KEY,
+  root_session_id TEXT NOT NULL,
+  parent_session_id TEXT,
+  depth INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL,
+  cached_input_tokens INTEGER NOT NULL,
+  output_tokens INTEGER NOT NULL,
+  reasoning_output_tokens INTEGER NOT NULL,
+  total_tokens INTEGER NOT NULL,
+  value_usd REAL NOT NULL,
+  fast_mode_auto INTEGER NOT NULL,
+  fast_mode_effective INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pricing_catalog (
+  model_id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  input_price_per_million REAL NOT NULL,
+  cached_input_price_per_million REAL NOT NULL,
+  output_price_per_million REAL NOT NULL,
+  effective_model_id TEXT NOT NULL,
+  is_official INTEGER NOT NULL,
+  note TEXT,
+  source_url TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subscription_profile (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  plan_type TEXT NOT NULL,
+  currency TEXT NOT NULL,
+  monthly_price REAL NOT NULL,
+  billing_anchor_day INTEGER NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_overrides (
+  session_id TEXT PRIMARY KEY,
+  fast_mode_override INTEGER,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sync_settings (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
+  codex_home TEXT,
+  auto_scan_enabled INTEGER NOT NULL,
+  auto_scan_interval_minutes INTEGER NOT NULL,
+  live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
+  default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0,
+  hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0,
+  show_menu_bar_logo INTEGER NOT NULL DEFAULT 1,
+  show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1,
+  show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0,
+  menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent',
+  menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour',
+  menu_bar_bucket TEXT NOT NULL DEFAULT 'day',
+  menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1,
+  menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85,
+  menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115,
+  menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢',
+  menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥',
+  menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢',
+  menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1,
+  menu_bar_popup_modules TEXT NOT NULL DEFAULT '["api_value","scan_freshness"]',
+  menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1,
+  menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
+  last_scan_started_at TEXT,
+  last_scan_completed_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS import_state (
+  source_path TEXT PRIMARY KEY,
+  session_id TEXT,
+  source_bucket TEXT NOT NULL,
+  file_size INTEGER NOT NULL,
+  file_mtime_ms INTEGER NOT NULL,
+  last_imported_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS data_repairs (
+  repair_key TEXT PRIMARY KEY,
+  completed_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS data_repair_pending_files (
+  repair_key TEXT NOT NULL,
+  source_path TEXT NOT NULL,
+  last_error TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (repair_key, source_path)
+);
+
+CREATE TABLE IF NOT EXISTS rate_limit_samples (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_kind TEXT NOT NULL,
+  source_session_id TEXT NOT NULL DEFAULT '',
+  bucket TEXT NOT NULL,
+  sample_timestamp TEXT NOT NULL,
+  limit_id TEXT NOT NULL DEFAULT '',
+  limit_name TEXT NOT NULL DEFAULT '',
+  plan_type TEXT NOT NULL DEFAULT '',
+  window_start TEXT NOT NULL,
+  resets_at TEXT NOT NULL,
+  used_percent INTEGER NOT NULL,
+  remaining_percent INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary

This PR targets `develop` and brings the current `codex/release-1.2.0` branch up to date. It includes the existing v1.2.0 release preparation changes and fixes the intermittent online quota rollback.

## What changed

- Give current-process live data priority over persisted fallback data.
- Prefer persisted live snapshots over session-history snapshots.
- Keep timestamp comparisons within the same source type, so a historical session timestamp cannot outrank a valid online fetch.
- Add regression coverage for mixed live/session data and session-only fallback.
- Keep startup fallback selection consistent with background refresh fallback behavior.

## Root cause and user impact

Manual refresh succeeds because it uses the fresh response directly. When a background refresh failed, the fallback path compared live-fetch timestamps with session-history timestamps as if they represented the same kind of event. A newer historical observation could therefore replace the most recent live quota. The fallback now preserves the latest valid live quota and only uses session history when no live snapshot exists.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --locked`: 389 passed, 0 failed.
- Focused Rust fallback tests: 3 passed.
- `npm test`: passed.
- `npm run lint`: passed.
- `npm run build`: passed; Vite reported the repository's existing large-chunk warning.
- `git diff --check origin/develop...HEAD`: passed.
- Rust format check was not clean because of pre-existing repository-wide formatting differences; no unrelated mass reformatting was applied.