### PR TITLE
Handle accounts without a five-hour quota

### DIFF
--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3172,7 +3172,7 @@ fn extract_rate_limit_samples(timestamp: &str, payload: &Value) -> Vec<RateLimit
     .map(ToString::to_string);
 
   let mut samples = Vec::new();
-  for (bucket, window_key) in [("five_hour", "primary"), ("seven_day", "secondary")] {
+  for (default_bucket, window_key) in [("five_hour", "primary"), ("seven_day", "secondary")] {
     let Some(rate_window) = rate_limits.get(window_key) else {
       continue;
     };
@@ -3185,6 +3185,11 @@ fn extract_rate_limit_samples(timestamp: &str, payload: &Value) -> Vec<RateLimit
       .or_else(|| rate_window.get("window_minutes").and_then(Value::as_i64))
     else {
       continue;
+    };
+    let bucket = if window_duration_mins == 7 * 24 * 60 {
+      "seven_day"
+    } else {
+      default_bucket
     };
     let Some(resets_at_seconds) = rate_window.get("resets_at").and_then(Value::as_i64) else {
       continue;
@@ -5669,6 +5674,26 @@ mod tests {
     assert_eq!(samples.2, "seven_day".to_string());
     assert_eq!(samples.3, 79);
     assert_eq!(samples.4, 88);
+  }
+
+  #[test]
+  fn primary_only_seven_day_rate_limit_is_imported_into_the_seven_day_bucket() {
+    let payload = serde_json::json!({
+      "rate_limits": {
+        "plan_type": "pro",
+        "primary": {
+          "used_percent": 21,
+          "window_duration_mins": 10_080,
+          "resets_at": 1_774_589_128
+        }
+      }
+    });
+
+    let samples = extract_rate_limit_samples("2026-03-26T11:45:00+08:00", &payload);
+
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].bucket, "seven_day");
+    assert_eq!(samples[0].remaining_percent, 79);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1555,8 +1555,9 @@ fn build_passive_menu_bar_popup_snapshot(
   drop(conn);
   let live_rate_limits = live_cache
     .rate_limits()
-    .map(|snapshot| snapshot.as_ref().clone());
-  let selected_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+    .map(|snapshot| normalize_live_rate_limit_snapshot(snapshot.as_ref().clone()));
+  let configured_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  let selected_bucket = effective_menu_bar_api_bucket(&configured_bucket, live_rate_limits.as_ref());
   let anchor = bucket_uses_anchor(&selected_bucket).then(|| Local::now().format("%Y-%m-%d").to_string());
   let overview = get_overview(
     db_path,
@@ -2890,6 +2891,48 @@ mod tests {
     assert!(!status_after.token.running && !status_after.token.pending);
     assert!(!status_after.live.running && !status_after.live.pending);
     runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn popup_snapshot_uses_seven_day_bucket_when_five_hour_quota_is_absent() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.menu_bar_bucket = "five_hour".to_string();
+    save_sync_settings(&conn, &settings).expect("save menu bar bucket");
+    drop(conn);
+
+    let cache = refresh::LiveQuotaCache::new();
+    cache.publish_fallback(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: None,
+        secondary: Some(RateLimitWindowSnapshot {
+          used_percent: 21,
+          remaining_percent: 79,
+          window_duration_mins: Some(10_080),
+          resets_at: Some("2026-07-20T00:00:00+08:00".to_string()),
+          window_start: Some("2026-07-13T00:00:00+08:00".to_string()),
+        }),
+        fetched_at: "2026-07-13T10:00:00+08:00".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+
+    let snapshot = build_passive_menu_bar_popup_snapshot(&db_path, &cache)
+      .expect("build popup snapshot");
+
+    assert_eq!(snapshot.selected_bucket, "seven_day");
+    assert!(snapshot.quota_5h.is_none());
+    assert_eq!(
+      snapshot.quota_7d.map(|window| window.remaining_percent),
+      Some(79)
+    );
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -956,15 +956,16 @@ fn current_menu_bar_title_parts(
   settings: &SyncSettings,
   cached_live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<(Option<String>, Option<String>), String> {
-  let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  let configured_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let anchor = Local::now().format("%Y-%m-%d").to_string();
   let live_rate_limits = if settings.show_menu_bar_live_quota_percent
-    || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&bucket))
+    || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&configured_bucket))
   {
     cached_live_rate_limits
   } else {
     None
   };
+  let bucket = effective_menu_bar_api_bucket(&configured_bucket, live_rate_limits);
   let api_value_title = if settings.show_menu_bar_daily_api_value {
     let api_value_usd = get_window_api_value(
       &state.db_path,
@@ -1017,6 +1018,19 @@ fn normalize_menu_bar_bucket(bucket: &str) -> String {
   }
 }
 
+fn effective_menu_bar_api_bucket(
+  configured_bucket: &str,
+  live_rate_limits: Option<&LiveRateLimitSnapshot>,
+) -> String {
+  if configured_bucket == "five_hour"
+    && live_rate_limits.is_some_and(|snapshot| snapshot.primary.is_none() && snapshot.secondary.is_some())
+  {
+    "seven_day".to_string()
+  } else {
+    configured_bucket.to_string()
+  }
+}
+
 fn normalize_menu_bar_live_quota_bucket(bucket: &str) -> String {
   match bucket {
     "five_hour" | "seven_day" => bucket.to_string(),
@@ -1065,7 +1079,8 @@ fn menu_bar_tooltip(
   api_value_title: Option<&str>,
   cached_live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<String, String> {
-  let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  let configured_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  let bucket = effective_menu_bar_api_bucket(&configured_bucket, cached_live_rate_limits);
   let mut fragments = Vec::new();
   if let Some(title) = api_value_title.filter(|value| !value.trim().is_empty()) {
     fragments.push(format!("{}累计 API 价值：{title}", menu_bar_bucket_label(&bucket)));
@@ -4067,6 +4082,52 @@ mod tests {
     assert_eq!(
       menu_bar_title(Some("$12.4"), Some("67%")),
       Some("$12.4 67%".to_string())
+    );
+  }
+
+  #[test]
+  fn menu_bar_api_value_falls_back_to_seven_days_when_five_hour_quota_is_absent() {
+    let snapshot = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: Some(RateLimitWindowSnapshot {
+        used_percent: 21,
+        remaining_percent: 79,
+        window_duration_mins: Some(10_080),
+        resets_at: Some("2026-04-02T00:00:00+08:00".to_string()),
+        window_start: Some("2026-03-26T00:00:00+08:00".to_string()),
+      }),
+      fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
+    };
+
+    assert_eq!(
+      effective_menu_bar_api_bucket("five_hour", Some(&snapshot)),
+      "seven_day"
+    );
+  }
+
+  #[test]
+  fn menu_bar_api_value_keeps_five_hours_when_that_quota_exists() {
+    let snapshot = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: Some(RateLimitWindowSnapshot {
+        used_percent: 12,
+        remaining_percent: 88,
+        window_duration_mins: Some(300),
+        resets_at: Some("2026-03-27T05:00:00+08:00".to_string()),
+        window_start: Some("2026-03-27T00:00:00+08:00".to_string()),
+      }),
+      secondary: None,
+      fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
+    };
+
+    assert_eq!(
+      effective_menu_bar_api_bucket("five_hour", Some(&snapshot)),
+      "five_hour"
     );
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1387,7 +1387,7 @@ fn load_persisted_live_rate_limits_from_connection(
   source_kind: Option<&str>,
 ) -> Option<LiveRateLimitSnapshot> {
   if let Ok(Some(snapshot)) = load_latest_rate_limits(conn, source_kind) {
-    return Some(snapshot);
+    return Some(normalize_live_rate_limit_snapshot(snapshot));
   }
   let mut primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
     .ok()
@@ -1422,7 +1422,7 @@ fn load_persisted_live_rate_limits_from_connection(
     .map(|window| window.fetched_at.clone())
     .or_else(|| secondary.as_ref().map(|window| window.fetched_at.clone()))?;
 
-  Some(LiveRateLimitSnapshot {
+  Some(normalize_live_rate_limit_snapshot(LiveRateLimitSnapshot {
     limit_id: primary
       .as_ref()
       .and_then(|window| window.limit_id.clone())
@@ -1438,7 +1438,21 @@ fn load_persisted_live_rate_limits_from_connection(
     primary: primary.map(|window| window.snapshot),
     secondary: secondary.map(|window| window.snapshot),
     fetched_at,
-  })
+  }))
+}
+
+fn normalize_live_rate_limit_snapshot(
+  mut snapshot: LiveRateLimitSnapshot,
+) -> LiveRateLimitSnapshot {
+  if snapshot.secondary.is_none()
+    && snapshot
+      .primary
+      .as_ref()
+      .is_some_and(|window| window.window_duration_mins == Some(7 * 24 * 60))
+  {
+    snapshot.secondary = snapshot.primary.take();
+  }
+  snapshot
 }
 
 fn load_preferred_persisted_live_rate_limits(
@@ -1487,7 +1501,7 @@ fn load_display_live_rate_limit_fallback(
 ) -> Option<LiveRateLimitSnapshot> {
   let memory = live_cache
     .rate_limits()
-    .map(|snapshot| snapshot.as_ref().clone());
+    .map(|snapshot| normalize_live_rate_limit_snapshot(snapshot.as_ref().clone()));
   let memory_is_live = live_cache.state().last_live_success_at.is_some();
   let Ok(conn) = open_connection(db_path) else {
     return memory;
@@ -3768,6 +3782,45 @@ mod tests {
     assert_eq!(
       memory.primary.as_ref().map(|window| window.remaining_percent),
       Some(77)
+    );
+  }
+
+  #[test]
+  fn persisted_primary_only_seven_day_snapshot_is_normalized_for_offline_fallback() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 21,
+          remaining_percent: 79,
+          window_duration_mins: Some(10_080),
+          resets_at: Some("2026-04-02T00:00:00+08:00".to_string()),
+          window_start: Some("2026-03-26T00:00:00+08:00".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
+      },
+    )
+    .expect("insert legacy live sample");
+    drop(conn);
+
+    let snapshot = load_display_live_rate_limit_fallback(
+      &db_path,
+      &refresh::LiveQuotaCache::new(),
+    )
+    .expect("load offline fallback");
+
+    assert!(snapshot.primary.is_none());
+    assert_eq!(
+      snapshot.secondary.map(|window| window.remaining_percent),
+      Some(79)
     );
   }
 

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -362,13 +362,26 @@ fn send_app_server_request(
 }
 
 fn convert_live_rate_limits(snapshot: AppServerRateLimitSnapshot) -> LiveRateLimitSnapshot {
+  let (primary, secondary) = normalize_rate_limit_windows(snapshot.primary, snapshot.secondary);
   LiveRateLimitSnapshot {
     limit_id: snapshot.limit_id,
     limit_name: snapshot.limit_name,
     plan_type: snapshot.plan_type,
-    primary: snapshot.primary.map(convert_window),
-    secondary: snapshot.secondary.map(convert_window),
+    primary: primary.map(convert_window),
+    secondary: secondary.map(convert_window),
     fetched_at: Local::now().to_rfc3339(),
+  }
+}
+
+fn normalize_rate_limit_windows(
+  primary: Option<AppServerRateLimitWindow>,
+  secondary: Option<AppServerRateLimitWindow>,
+) -> (Option<AppServerRateLimitWindow>, Option<AppServerRateLimitWindow>) {
+  match (primary, secondary) {
+    (Some(primary), None) if primary.window_duration_mins == Some(7 * 24 * 60) => {
+      (None, Some(primary))
+    }
+    windows => windows,
   }
 }
 
@@ -620,6 +633,28 @@ mod tests {
     assert_eq!(converted.window_duration_mins, Some(300));
     assert!(converted.resets_at.is_some());
     assert!(converted.window_start.is_some());
+  }
+
+  #[test]
+  fn convert_live_rate_limits_keeps_a_primary_only_seven_day_window_in_the_seven_day_slot() {
+    let converted = super::convert_live_rate_limits(super::AppServerRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: Some(super::AppServerRateLimitWindow {
+        used_percent: 21,
+        window_duration_mins: Some(10_080),
+        resets_at: Some(1_774_589_128),
+      }),
+      secondary: None,
+    });
+
+    assert!(converted.primary.is_none());
+    assert_eq!(
+      converted.secondary.as_ref().and_then(|window| window.window_duration_mins),
+      Some(10_080)
+    );
+    assert_eq!(converted.secondary.map(|window| window.remaining_percent), Some(79));
   }
 
   #[test]


### PR DESCRIPTION
## What changed

Codex Pacer now identifies a seven-day quota by its window duration when Codex returns it in the primary slot without a five-hour quota. The same classification applies to live app-server responses and quota samples imported from local sessions.

When the menu bar is configured to show the five-hour API value but the account only has a seven-day quota, it now uses the active seven-day window. The tooltip also labels the value as the last seven days. Accounts that still have a five-hour quota keep the existing behavior.

## Why

Codex may omit the five-hour quota for some accounts. In that response shape, the seven-day quota moves into the primary slot. The previous positional mapping treated it as a five-hour quota, left the seven-day quota empty, and could leave the menu bar using stale five-hour history.

## Validation

- `cargo test`: 393 tests passed
- `npm test`: passed
- `npm run lint`: passed
- `npm run build`: passed
- Signed macOS app and DMG verification: passed
- DMG image verification: passed

The production build still reports the existing Vite chunk-size warning. No new build warnings were introduced.