### PR TITLE
Reduce routine scan I/O and paginate conversation history

### DIFF
--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -310,3 +310,14 @@ test('popup_wires_latest_request_controller_and_disables_duplicate_manual_refres
     /aria-label=\{t\.popup\.actions\.refresh\}[\s\S]{0,220}disabled=\{refreshing\}/,
   )
 })
+
+test('dashboard_startup_does_not_open_and_parse_the_first_conversation_implicitly', () => {
+  assert.match(
+    appSource,
+    /setSelectedRootSessionId\(\(current\) =>[\s\S]{0,260}\? current[\s\S]{0,80}: null,/,
+  )
+  assert.doesNotMatch(
+    appSource,
+    /setSelectedRootSessionId\([\s\S]{0,320}conversationPage\.items\[0\]/,
+  )
+})

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -7358,6 +7358,32 @@ mod tests {
   }
 
   #[test]
+  #[ignore = "resource profiling helper; requires database and Codex home copies"]
+  fn profile_real_incremental_scan() {
+    let db_path = std::env::var_os("CODEX_PACER_PROFILE_DB")
+      .map(PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_DB to a database copy");
+    let codex_home = std::env::var_os("CODEX_PACER_PROFILE_CODEX_HOME")
+      .map(PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_CODEX_HOME");
+    let started = std::time::Instant::now();
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental scan");
+    eprintln!(
+      "profile incremental elapsed_ms={} visited={} read_bytes={} tail={} full={}",
+      started.elapsed().as_millis(),
+      prepared.stats().files_visited,
+      prepared.stats().source_bytes_read,
+      prepared.stats().tail_parsed_files,
+      prepared.stats().fully_parsed_files
+    );
+  }
+
+  #[test]
   fn changed_checkpoint_suffix_falls_back_to_full_session_parse() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -162,6 +162,8 @@ pub(crate) enum ScanKind {
 pub(crate) struct PreparedScanStats {
   pub files_visited: usize,
   pub source_bytes_read: u64,
+  pub tail_parsed_files: usize,
+  pub fully_parsed_files: usize,
   pub full_rebuild: bool,
   pub used_spool: bool,
   pub parent_replay_cache_evictions: usize,
@@ -883,6 +885,8 @@ pub(crate) fn prepare_scan(
   let stats = PreparedScanStats {
     files_visited: session_files.len(),
     source_bytes_read: 0,
+    tail_parsed_files: 0,
+    fully_parsed_files: 0,
     full_rebuild: effective_kind == ScanKind::Full,
     used_spool: false,
     parent_replay_cache_evictions: 0,
@@ -955,6 +959,8 @@ pub(crate) fn prepare_scan(
   let mut storage = PreparedStorageBuilder::new();
   let mut updated_sessions = 0usize;
   let mut source_bytes_read = 0u64;
+  let mut tail_parsed_files = 0usize;
+  let mut fully_parsed_files = 0usize;
 
   for session_file in changed_files {
     let source_path = session_file.path.to_string_lossy().to_string();
@@ -986,8 +992,14 @@ pub(crate) fn prepare_scan(
       Ok(None)
     };
     let parsed_result = match tail_candidate {
-      Ok(Some(result)) => Ok(result),
-      Ok(None) => parse_session_file_counted(&session_file, &titles),
+      Ok(Some(result)) => {
+        tail_parsed_files += 1;
+        Ok(result)
+      }
+      Ok(None) => {
+        fully_parsed_files += 1;
+        parse_session_file_counted(&session_file, &titles)
+      }
       Err(error) => Err(error),
     };
     let (mut parsed, bytes_read) = match parsed_result {
@@ -1090,6 +1102,8 @@ pub(crate) fn prepare_scan(
   let storage = storage.finish()?;
   let stats = PreparedScanStats {
     source_bytes_read,
+    tail_parsed_files,
+    fully_parsed_files,
     used_spool: matches!(&storage, PreparedStorage::Spool { .. }),
     parent_replay_cache_evictions,
     parent_replay_cache_oversized_bypasses,
@@ -1325,6 +1339,15 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
     imported_sessions,
     updated_sessions,
     missing_sessions,
+    scan_kind: match effective_kind {
+      ScanKind::Full => "full",
+      ScanKind::Reconcile => "reconcile",
+      ScanKind::Incremental => "incremental",
+    }
+    .to_string(),
+    source_bytes_read: stats.source_bytes_read,
+    tail_parsed_files: stats.tail_parsed_files,
+    fully_parsed_files: stats.fully_parsed_files,
     last_completed_at: completed_at,
   })
 }
@@ -7227,6 +7250,110 @@ mod tests {
     assert_eq!(
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn reconcile_scan_reads_only_completed_tail_after_checkpoint() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "56565656-5656-5656-5656-565656565656";
+    let session_path = sessions_dir.join("reconciled-growing.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let filler = "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"ignored\",\"payload\":{}}\n";
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open initial session for append");
+    for _ in 0..4_096 {
+      file.write_all(filler.as_bytes()).expect("append filler");
+    }
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial full scan");
+
+    let appended = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (180, 40, 45, 225),
+      last: (80, 20, 20, 100),
+    });
+    std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open growing session")
+      .write_all(appended.as_bytes())
+      .expect("append completed token line");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Reconcile,
+    )
+    .expect("prepare reconcile tail");
+    assert_eq!(prepared.stats().tail_parsed_files, 1);
+    assert_eq!(prepared.stats().fully_parsed_files, 0);
+    assert!(
+      prepared.stats().source_bytes_read < appended.len() as u64 * 4,
+      "reconcile should avoid rereading the historical prefix; read {} bytes",
+      prepared.stats().source_bytes_read
+    );
+    commit_prepared_scan(prepared).expect("commit reconcile tail");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn reconcile_scan_discovers_new_archived_session() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archives_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archives_dir).expect("archives dir");
+
+    let initial_id = "67676767-6767-6767-6767-676767676767";
+    write_session_file(
+      &sessions_dir.join("initial.jsonl"),
+      initial_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial full scan");
+
+    let archived_id = "78787878-7878-7878-7878-787878787878";
+    write_session_file(
+      &archives_dir.join("new-archive.jsonl"),
+      archived_id,
+      &[("2026-03-24T01:00:01Z", 200, 40, 50, 250)],
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Reconcile,
+    )
+    .expect("prepare reconcile scan");
+    assert_eq!(prepared.stats().fully_parsed_files, 1);
+    commit_prepared_scan(prepared).expect("commit reconcile scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, archived_id),
+      (200, 40, 50, 250, 1)
     );
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -154,6 +154,7 @@ pub(crate) fn release_unused_process_memory() {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScanKind {
   Full,
+  Reconcile,
   Incremental,
 }
 
@@ -874,6 +875,7 @@ pub(crate) fn prepare_scan(
 
   let (session_files, active_paths_kept_for_archive_retry) = match effective_kind {
     ScanKind::Full => (collect_session_files(&codex_home), HashSet::new()),
+    ScanKind::Reconcile => (collect_session_files(&codex_home), HashSet::new()),
     ScanKind::Incremental => {
       collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
     }
@@ -939,7 +941,7 @@ pub(crate) fn prepare_scan(
     changed_files.push(session_file.clone());
   }
 
-  let titles = if effective_kind == ScanKind::Full || !changed_files.is_empty() {
+  let titles = if effective_kind != ScanKind::Incremental || !changed_files.is_empty() {
     load_session_index(&codex_home)
   } else {
     HashMap::new()
@@ -962,7 +964,7 @@ pub(crate) fn prepare_scan(
       needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
     let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
       || pending_fork_replay_v3_repair_paths.contains(&source_path);
-    let tail_candidate = if effective_kind == ScanKind::Incremental
+    let tail_candidate = if effective_kind != ScanKind::Full
       && !file_needs_rate_limit_repair
       && !file_needs_token_v2_repair
       && !file_needs_fork_replay_v3_repair
@@ -1066,7 +1068,7 @@ pub(crate) fn prepare_scan(
     updated_sessions += 1;
   }
 
-  let titles = if effective_kind == ScanKind::Full {
+  let titles = if effective_kind != ScanKind::Incremental {
     titles
   } else {
     HashMap::new()
@@ -1254,7 +1256,7 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
     }
   }
 
-  if effective_kind == ScanKind::Full {
+  if effective_kind != ScanKind::Incremental {
     refresh_session_titles(&tx, &titles).map_err(|error| error.to_string())?;
   }
   apply_missing_source_plan(&tx, missing_plan).map_err(|error| error.to_string())?;
@@ -1295,8 +1297,8 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
       &completed_at,
       source_identity.key.selector.as_deref(),
       &resolved_codex_home,
-      effective_kind == ScanKind::Full && !skipped_session_files,
-      effective_kind == ScanKind::Full && skipped_session_files,
+      effective_kind != ScanKind::Incremental && !skipped_session_files,
+      effective_kind != ScanKind::Incremental && skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
@@ -1500,7 +1502,7 @@ fn prepare_missing_source_plan(
   let mut plan = MissingSourcePlan::default();
 
   match scan_kind {
-    ScanKind::Full => {
+    ScanKind::Full | ScanKind::Reconcile => {
       for source in existing_sources {
         if !present_paths.contains(&source.source_path)
           && (reconcile_existing_absent_sources || !Path::new(&source.source_path).exists())
@@ -1631,7 +1633,7 @@ fn effective_scan_scope(
   {
     ScanKind::Full
   } else {
-    ScanKind::Incremental
+    requested_scope
   }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ use database::{
 };
 use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
 use models::{
-  ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
+  ConversationDetail, ConversationFilters, ConversationPage, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
   ScanResult, SubscriptionProfile, SyncSettings,
@@ -451,7 +451,7 @@ fn getOverview(
 fn listConversations(
   state: State<'_, AppState>,
   filters: Option<ConversationFilters>,
-) -> Result<Vec<ConversationListItem>, String> {
+) -> Result<ConversationPage, String> {
   let live_rate_limits = maybe_live_rate_limits_for_bucket(
     state.inner(),
     filters.as_ref().and_then(|value| value.bucket.as_deref()),
@@ -520,7 +520,7 @@ async fn loadDashboard(
 ) -> Result<DashboardSnapshot, String> {
   let state = state.inner().clone();
   tauri::async_runtime::spawn_blocking(move || {
-    let normalized_bucket = bucket.clone().unwrap_or_else(|| "subscription_month".to_string());
+    let normalized_bucket = bucket.clone().unwrap_or_else(|| "seven_day".to_string());
     let live_rate_limits =
       maybe_live_rate_limits_for_bucket(&state, Some(&normalized_bucket), live_window_offset)?;
     let snapshot = load_dashboard_data(
@@ -538,7 +538,7 @@ async fn loadDashboard(
 
     Ok(DashboardSnapshot {
       overview: snapshot.overview,
-      conversations: snapshot.conversations,
+      conversation_page: snapshot.conversation_page,
       sync_settings,
       subscription_profile: snapshot.subscription_profile,
       live_rate_limits,
@@ -553,8 +553,9 @@ async fn loadDashboard(
 fn getConversationDetail(
   state: State<'_, AppState>,
   root_session_id: String,
+  turn_cursor: Option<usize>,
 ) -> Result<ConversationDetail, String> {
-  get_conversation_detail(&state.db_path, &root_session_id)
+  get_conversation_detail(&state.db_path, &root_session_id, turn_cursor)
 }
 
 #[allow(non_snake_case)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2144,7 +2144,7 @@ fn effective_token_scan_kind(
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let last_full = get_last_full_scan_completed(&conn).map_err(|error| error.to_string())?;
   Ok(if full_maintenance_due(last_full.as_deref(), now) {
-    ScanKind::Full
+    ScanKind::Reconcile
   } else {
     ScanKind::Incremental
   })
@@ -3052,7 +3052,7 @@ mod tests {
     assert!(parsed_generation > 0);
     assert_eq!(parsed_generation, committed_generation);
     assert_eq!(source_generation, handle.status().source_generation);
-    assert_eq!(kind, refresh::TokenScanKind::Full);
+    assert_eq!(kind, refresh::TokenScanKind::Incremental);
     assert_eq!(result.codex_home, codex_home.to_string_lossy());
     assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
     runtime.shutdown_and_join().expect("shutdown runtime");
@@ -3214,7 +3214,7 @@ mod tests {
         utc_time("2026-07-11T00:00:00Z"),
       )
       .expect("select scan kind"),
-      ScanKind::Full
+      ScanKind::Reconcile
     );
     assert_eq!(
       effective_token_scan_kind(

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -165,6 +165,8 @@ pub struct ConversationFilters {
   pub custom_end: Option<String>,
   pub search: Option<String>,
   pub live_window_offset: Option<i64>,
+  pub cursor: Option<String>,
+  pub limit: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -333,10 +335,18 @@ pub struct OverviewResponse {
 #[serde(rename_all = "camelCase")]
 pub struct DashboardSnapshot {
   pub overview: OverviewResponse,
-  pub conversations: Vec<ConversationListItem>,
+  pub conversation_page: ConversationPage,
   pub sync_settings: SyncSettings,
   pub subscription_profile: SubscriptionProfile,
   pub live_rate_limits: Option<LiveRateLimitSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationPage {
+  pub items: Vec<ConversationListItem>,
+  pub next_cursor: Option<String>,
+  pub has_more: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -423,6 +433,8 @@ pub struct ConversationDetail {
   pub source_states: Vec<String>,
   pub sessions: Vec<ConversationSessionSummary>,
   pub turns: Vec<ConversationTurnPoint>,
+  pub next_turn_cursor: Option<usize>,
+  pub has_more_turns: bool,
   pub model_breakdown: Vec<ModelShare>,
   pub composition_breakdown: Vec<CompositionShare>,
 }
@@ -435,5 +447,9 @@ pub struct ScanResult {
   pub imported_sessions: usize,
   pub updated_sessions: usize,
   pub missing_sessions: usize,
+  pub scan_kind: String,
+  pub source_bytes_read: u64,
+  pub tail_parsed_files: usize,
+  pub fully_parsed_files: usize,
   pub last_completed_at: String,
 }

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::database::{get_subscription_profile, open_connection};
 use crate::models::{
-  CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem,
+  CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem, ConversationPage,
   ConversationSessionSummary, ConversationTurnPoint, LiveRateLimitSnapshot, ModelShare,
   OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SubscriptionProfile, TokenUsage,
   TrendPoint,
@@ -24,10 +24,8 @@ use crate::pricing::{
 
 const SQL_SESSIONS: &str = include_str!("../sql/queries/sessions.sql");
 const SQL_SESSIONS_FOR_ROOT: &str = include_str!("../sql/queries/sessions_for_root.sql");
-const SQL_USAGE_EVENTS: &str = include_str!("../sql/queries/usage_events.sql");
 const SQL_USAGE_EVENTS_FOR_ROOT: &str = include_str!("../sql/queries/usage_events_for_root.sql");
 const SQL_RATE_LIMIT_WINDOWS: &str = include_str!("../sql/queries/rate_limit_windows.sql");
-const SQL_QUOTA_SAMPLES: &str = include_str!("../sql/queries/quota_samples.sql");
 
 #[derive(Debug, Clone)]
 struct SessionRow {
@@ -95,7 +93,7 @@ struct RateLimitWindowSummary {
 
 pub struct DashboardData {
   pub overview: OverviewResponse,
-  pub conversations: Vec<ConversationListItem>,
+  pub conversation_page: ConversationPage,
   pub subscription_profile: SubscriptionProfile,
 }
 
@@ -109,9 +107,20 @@ pub fn get_overview(
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let resolved_window = resolve_window(
+    &conn,
+    bucket.clone(),
+    anchor.clone(),
+    custom_start.clone(),
+    custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
   build_overview(
     &conn,
@@ -134,7 +143,6 @@ pub fn get_quota_trend(
   live_rate_limits: Option<LiveRateLimitSnapshot>,
 ) -> Result<Vec<QuotaTrendPoint>, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let resolved_window = resolve_window(
     &conn,
@@ -142,17 +150,13 @@ pub fn get_quota_trend(
     None,
     None,
     None,
-    &events,
+    &[],
     profile.billing_anchor_day,
     live_rate_limits.as_ref(),
     None,
   )?;
   let window = &resolved_window.window;
-  let filtered_events: Vec<_> = events
-    .iter()
-    .filter(|event| event_in_window(event, window))
-    .cloned()
-    .collect();
+  let filtered_events = load_events_in_window(&conn, window).map_err(|error| error.to_string())?;
 
   Ok(build_quota_trend(
     &conn,
@@ -195,12 +199,27 @@ pub fn list_conversations(
   db_path: &Path,
   filters: Option<ConversationFilters>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
-) -> Result<Vec<ConversationListItem>, String> {
+) -> Result<ConversationPage, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
-  build_conversation_list(&conn, &sessions, &events, &profile, filters, live_rate_limits.as_ref())
+  let filters = filters.unwrap_or_default();
+  let resolved_window = resolve_window(
+    &conn,
+    filters.bucket.clone(),
+    filters.anchor.clone(),
+    filters.custom_start.clone(),
+    filters.custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    filters.live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
+  let cursor = filters.cursor.clone();
+  let limit = filters.limit.unwrap_or(50).clamp(1, 100);
+  let items = build_conversation_list(&conn, &sessions, &events, &profile, Some(filters), live_rate_limits.as_ref())?;
+  Ok(paginate_conversations(items, cursor.as_deref(), limit))
 }
 
 pub fn load_dashboard_data(
@@ -214,9 +233,20 @@ pub fn load_dashboard_data(
   live_window_offset: Option<i64>,
 ) -> Result<DashboardData, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let resolved_window = resolve_window(
+    &conn,
+    bucket.clone(),
+    anchor.clone(),
+    custom_start.clone(),
+    custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
 
   let overview = build_overview(
@@ -244,15 +274,39 @@ pub fn load_dashboard_data(
       custom_end,
       search,
       live_window_offset,
+      cursor: None,
+      limit: Some(50),
     }),
     live_rate_limits.as_ref(),
   )?;
 
   Ok(DashboardData {
     overview,
-    conversations,
+    conversation_page: paginate_conversations(conversations, None, 50),
     subscription_profile: profile,
   })
+}
+
+fn paginate_conversations(
+  items: Vec<ConversationListItem>,
+  cursor: Option<&str>,
+  limit: usize,
+) -> ConversationPage {
+  let start = cursor
+    .and_then(|cursor| items.iter().position(|item| item.root_session_id == cursor))
+    .map(|index| index.saturating_add(1))
+    .unwrap_or(0);
+  let end = start.saturating_add(limit).min(items.len());
+  let page_items = items[start..end].to_vec();
+  let has_more = end < items.len();
+  let next_cursor = has_more
+    .then(|| page_items.last().map(|item| item.root_session_id.clone()))
+    .flatten();
+  ConversationPage {
+    items: page_items,
+    next_cursor,
+    has_more,
+  }
 }
 
 fn build_overview(
@@ -479,7 +533,11 @@ fn build_conversation_list(
   Ok(items)
 }
 
-pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<ConversationDetail, String> {
+pub fn get_conversation_detail(
+  db_path: &Path,
+  root_session_id: &str,
+  turn_cursor: Option<usize>,
+) -> Result<ConversationDetail, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let sessions = load_sessions_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
   let events = load_events_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
@@ -584,6 +642,12 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
       .then_with(|| left.session_id.cmp(&right.session_id))
       .then_with(|| left.turn_id.cmp(&right.turn_id))
   });
+  let already_loaded = turn_cursor.unwrap_or(0);
+  let page_end = detail_turns.len().saturating_sub(already_loaded);
+  let page_start = page_end.saturating_sub(40);
+  let turn_page = detail_turns[page_start..page_end].to_vec();
+  let has_more_turns = page_start > 0;
+  let next_turn_cursor = has_more_turns.then_some(already_loaded.saturating_add(turn_page.len()));
 
   let mut session_summaries = Vec::new();
   for session in conversation_sessions {
@@ -647,7 +711,9 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     multiple_agent: session_summaries.len() > 1,
     source_states: sorted_strings(source_states),
     sessions: session_summaries,
-    turns: detail_turns,
+    turns: turn_page,
+    next_turn_cursor,
+    has_more_turns,
     model_breakdown,
     composition_breakdown,
   })
@@ -1149,23 +1215,43 @@ fn load_sessions_for_root_session(
   Ok(sessions)
 }
 
-fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
-  let mut stmt = conn.prepare(SQL_USAGE_EVENTS)?;
-  let rows = stmt.query_map([], |row| {
-    Ok(EventRow {
-      session_id: row.get(0)?,
-      timestamp: row.get(1)?,
-      model_id: row.get(2)?,
-      input_tokens: row.get(3)?,
-      cached_input_tokens: row.get(4)?,
-      output_tokens: row.get(5)?,
-      reasoning_output_tokens: row.get(6)?,
-      total_tokens: row.get(7)?,
-      value_usd: row.get(8)?,
-      fast_mode_auto: row.get::<_, i64>(9)? != 0,
-      fast_mode_effective: row.get::<_, i64>(10)? != 0,
-    })
-  })?;
+fn load_events_in_window(conn: &Connection, window: &Window) -> rusqlite::Result<Vec<EventRow>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
+    UNION ALL
+    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE timestamp_ms IS NULL
+      AND unixepoch(timestamp) * 1000 >= ?1
+      AND unixepoch(timestamp) * 1000 < ?2
+    ORDER BY timestamp ASC
+    ",
+  )?;
+  let rows = stmt.query_map(
+    rusqlite::params![window.start.timestamp_millis(), window.end.timestamp_millis()],
+    |row| {
+      Ok(EventRow {
+        session_id: row.get(0)?,
+        timestamp: row.get(1)?,
+        model_id: row.get(2)?,
+        input_tokens: row.get(3)?,
+        cached_input_tokens: row.get(4)?,
+        output_tokens: row.get(5)?,
+        reasoning_output_tokens: row.get(6)?,
+        total_tokens: row.get(7)?,
+        value_usd: row.get(8)?,
+        fast_mode_auto: row.get::<_, i64>(9)? != 0,
+        fast_mode_effective: row.get::<_, i64>(10)? != 0,
+      })
+    },
+  )?;
 
   rows.collect()
 }
@@ -1227,7 +1313,7 @@ fn resolve_window(
   anchor: Option<String>,
   custom_start: Option<String>,
   custom_end: Option<String>,
-  events: &[EventRow],
+  _events: &[EventRow],
   billing_anchor_day: i64,
   live_rate_limits: Option<&LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
@@ -1295,20 +1381,30 @@ fn resolve_window(
       (start, end, start_date, 0, 0)
     }
     "total" => {
-      if events.is_empty() {
+      let bounds = conn
+        .query_row(
+          "
+          SELECT
+            MIN(COALESCE(timestamp_ms, unixepoch(timestamp) * 1000)),
+            MAX(COALESCE(timestamp_ms, unixepoch(timestamp) * 1000))
+          FROM usage_events
+          ",
+          [],
+          |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, Option<i64>>(1)?)),
+        )
+        .map_err(|error| error.to_string())?;
+      if bounds.0.is_none() || bounds.1.is_none() {
         let start = local_midnight(anchor_date)?;
         (start, start + chrono::Duration::days(1), anchor_date, 0, 0)
       } else {
-        let first = events
-          .iter()
-          .filter_map(|event| parse_rfc3339_local(&event.timestamp))
-          .min()
-          .ok_or_else(|| "No valid event timestamps found.".to_string())?;
-        let last = events
-          .iter()
-          .filter_map(|event| parse_rfc3339_local(&event.timestamp))
-          .max()
-          .ok_or_else(|| "No valid event timestamps found.".to_string())?;
+        let first = Local
+          .timestamp_millis_opt(bounds.0.unwrap_or_default())
+          .single()
+          .ok_or_else(|| "No valid first usage timestamp found.".to_string())?;
+        let last = Local
+          .timestamp_millis_opt(bounds.1.unwrap_or_default())
+          .single()
+          .ok_or_else(|| "No valid last usage timestamp found.".to_string())?;
         let start_date = first.date_naive();
         let end_date = last.date_naive().checked_add_days(Days::new(1)).unwrap_or(last.date_naive());
         let start = local_midnight(start_date)?;
@@ -1647,34 +1743,46 @@ fn live_sample(live_rate_limits: &LiveRateLimitSnapshot, bucket: &str) -> Option
 }
 
 fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
-  let mut stmt = match conn.prepare(SQL_QUOTA_SAMPLES) {
+  let target_start = normalize_local_timestamp(window.start);
+  let target_end = normalize_local_timestamp(window.end);
+  let mut stmt = match conn.prepare(
+    "
+    SELECT sample_timestamp, used_percent
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND window_start_ms = ?2
+      AND resets_at_ms = ?3
+    UNION ALL
+    SELECT sample_timestamp, used_percent
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND (window_start_ms IS NULL OR resets_at_ms IS NULL)
+      AND window_start = ?4
+      AND resets_at = ?5
+    ORDER BY sample_timestamp ASC
+    ",
+  ) {
     Ok(stmt) => stmt,
     Err(_) => return Vec::new(),
   };
 
-  let rows = match stmt.query_map(rusqlite::params![window.bucket], |row| {
-    Ok((
-      row.get::<_, String>(0)?,
-      row.get::<_, i64>(1)?,
-      row.get::<_, String>(2)?,
-      row.get::<_, String>(3)?,
-    ))
-  }) {
+  let rows = match stmt.query_map(
+    rusqlite::params![
+      window.bucket,
+      target_start.timestamp_millis(),
+      target_end.timestamp_millis(),
+      target_start.to_rfc3339(),
+      target_end.to_rfc3339(),
+    ],
+    |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+  ) {
     Ok(rows) => rows,
     Err(_) => return Vec::new(),
   };
 
-  let target_start = normalize_local_timestamp(window.start);
-  let target_end = normalize_local_timestamp(window.end);
-
   rows
     .filter_map(Result::ok)
-    .filter_map(|(timestamp, used_percent, window_start, resets_at)| {
-      let sample_window_start = parse_rfc3339_local(&window_start).map(normalize_local_timestamp)?;
-      let sample_window_end = parse_rfc3339_local(&resets_at).map(normalize_local_timestamp)?;
-      if sample_window_start != target_start || sample_window_end != target_end {
-        return None;
-      }
+    .filter_map(|(timestamp, used_percent)| {
       parse_rfc3339_local(&timestamp).map(|timestamp| QuotaSample {
         timestamp,
         used_percent,
@@ -1898,6 +2006,69 @@ mod tests {
   use super::*;
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
+
+  fn conversation_item(id: &str) -> ConversationListItem {
+    ConversationListItem {
+      root_session_id: id.to_string(),
+      title: id.to_string(),
+      started_at: None,
+      updated_at: None,
+      model_ids: Vec::new(),
+      input_tokens: 0,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: 0,
+      session_count: 1,
+      subagent_count: 0,
+      has_fast_mode: false,
+      api_value_usd: 0.0,
+      subscription_share: 0.0,
+      source_states: Vec::new(),
+    }
+  }
+
+  #[test]
+  fn conversation_pages_are_bounded_and_resume_after_the_cursor() {
+    let items = (0..120)
+      .map(|index| conversation_item(&format!("root-{index:03}")))
+      .collect::<Vec<_>>();
+
+    let first = paginate_conversations(items.clone(), None, 50);
+    assert_eq!(first.items.len(), 50);
+    assert!(first.has_more);
+    assert_eq!(first.next_cursor.as_deref(), Some("root-049"));
+
+    let second = paginate_conversations(items, first.next_cursor.as_deref(), 50);
+    assert_eq!(second.items.len(), 50);
+    assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("root-050"));
+    assert_eq!(second.next_cursor.as_deref(), Some("root-099"));
+  }
+
+  #[test]
+  fn window_event_loader_does_not_return_rows_outside_the_requested_range() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    for timestamp in ["2026-07-01T00:00:00Z", "2026-07-10T00:00:00Z"] {
+      let timestamp_ms = parse_rfc3339_local(timestamp).expect("timestamp").timestamp_millis();
+      conn.execute(
+        "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES ('session', ?1, ?2, 'gpt-5.4', 1, 0, 1, 0, 2, 0.0, 0, 0)",
+        rusqlite::params![timestamp, timestamp_ms],
+      )
+      .expect("insert event");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-10".to_string(),
+      start: parse_rfc3339_local("2026-07-09T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-11T00:00:00Z").expect("end"),
+    };
+
+    let events = load_events_in_window(&conn, &window).expect("load window events");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].timestamp, "2026-07-10T00:00:00Z");
+  }
 
   #[test]
   fn groups_modern_snapshots_into_one_turn() {

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -334,18 +334,13 @@ fn build_overview(
     live_window_offset,
   )?;
   let window = &resolved_window.window;
-  let filtered_events: Vec<_> = events
-    .iter()
-    .filter(|event| event_in_window(event, window))
-    .cloned()
-    .collect();
 
   let mut conversation_ids = HashSet::new();
   let mut total_value_usd = 0.0;
   let mut total_tokens = 0i64;
   let mut model_shares: HashMap<String, ModelShareAccumulator> = HashMap::new();
 
-  for event in &filtered_events {
+  for event in events {
     total_value_usd += event.value_usd;
     total_tokens += event.total_tokens;
     if let Some(session) = sessions.get(&event.session_id) {
@@ -365,9 +360,9 @@ fn build_overview(
     0.0
   };
 
-  let trend = build_trend(window, &filtered_events);
-  let quota_trend = build_quota_trend(conn, window, &filtered_events, live_rate_limits.as_ref());
-  let composition_breakdown = build_composition_breakdown(&filtered_events, catalog);
+  let trend = build_trend(window, events);
+  let quota_trend = build_quota_trend(conn, window, events, live_rate_limits.as_ref());
+  let composition_breakdown = build_composition_breakdown(events, catalog);
   let mut model_breakdown = model_shares
     .into_iter()
     .map(|(model_id, value)| ModelShare {
@@ -457,9 +452,6 @@ fn build_conversation_list(
   }
 
   for event in events {
-    if !event_in_window(event, &window) {
-      continue;
-    }
     let Some(session) = sessions.get(&event.session_id) else {
       continue;
     };
@@ -1514,35 +1506,31 @@ fn load_live_rate_limit_windows(
   Ok(ordered)
 }
 
-fn event_in_window(event: &EventRow, window: &Window) -> bool {
-  parse_rfc3339_local(&event.timestamp)
-    .map(|timestamp| timestamp >= window.start && timestamp < window.end)
-    .unwrap_or(false)
-}
-
 fn build_trend(window: &Window, events: &[EventRow]) -> Vec<TrendPoint> {
   let bins = build_bins(window);
-  let mut trend = Vec::new();
-  for bin in bins {
-    let mut api_value_usd = 0.0;
-    let mut total_tokens = 0i64;
-    for event in events {
-      let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
-        continue;
-      };
-      if timestamp >= bin.start && timestamp < bin.end {
-        api_value_usd += event.value_usd;
-        total_tokens += event.total_tokens;
-      }
+  let mut totals = vec![(0.0, 0i64); bins.len()];
+  for event in events {
+    let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
+      continue;
+    };
+    if let Some(index) = bins
+      .iter()
+      .position(|bin| timestamp >= bin.start && timestamp < bin.end)
+    {
+      totals[index].0 += event.value_usd;
+      totals[index].1 += event.total_tokens;
     }
-    trend.push(TrendPoint {
+  }
+  bins
+    .into_iter()
+    .zip(totals)
+    .map(|(bin, (api_value_usd, total_tokens))| TrendPoint {
       label: bin.label,
       timestamp: bin.timestamp,
       api_value_usd,
       total_tokens,
-    });
-  }
-  trend
+    })
+    .collect()
 }
 
 fn build_quota_trend(
@@ -1570,22 +1558,24 @@ fn build_quota_trend(
   samples.dedup_by(|right, left| right.timestamp == left.timestamp && right.used_percent == left.used_percent);
 
   let bins = build_elapsed_bins(window, window.end);
+  let mut bin_totals = vec![(0.0, 0i64); bins.len()];
+  for event in events {
+    let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
+      continue;
+    };
+    if let Some(index) = bins
+      .iter()
+      .position(|bin| timestamp >= bin.start && timestamp < bin.end)
+    {
+      bin_totals[index].0 += event.value_usd;
+      bin_totals[index].1 += event.total_tokens;
+    }
+  }
   let mut trend = Vec::new();
   let mut cumulative_api_value_usd = 0.0;
   let mut cumulative_tokens = 0i64;
 
-  for bin in bins {
-    let mut api_value_usd = 0.0;
-    let mut total_tokens = 0i64;
-    for event in events {
-      let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
-        continue;
-      };
-      if timestamp >= bin.start && timestamp < bin.end {
-        api_value_usd += event.value_usd;
-        total_tokens += event.total_tokens;
-      }
-    }
+  for (bin, (api_value_usd, total_tokens)) in bins.into_iter().zip(bin_totals) {
 
     cumulative_api_value_usd += api_value_usd;
     cumulative_tokens += total_tokens;
@@ -2043,6 +2033,32 @@ mod tests {
     assert_eq!(second.items.len(), 50);
     assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("root-050"));
     assert_eq!(second.next_cursor.as_deref(), Some("root-099"));
+  }
+
+  #[test]
+  #[ignore = "resource profiling helper; requires CODEX_PACER_PROFILE_DB"]
+  fn profile_real_seven_day_dashboard_load() {
+    let db_path = std::env::var_os("CODEX_PACER_PROFILE_DB")
+      .map(std::path::PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_DB to a database copy");
+    let started = std::time::Instant::now();
+    let data = load_dashboard_data(
+      &db_path,
+      Some("seven_day".to_string()),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+    )
+    .expect("load seven-day dashboard");
+    eprintln!(
+      "profile seven_day elapsed_ms={} first_page={} has_more={}",
+      started.elapsed().as_millis(),
+      data.conversation_page.items.len(),
+      data.conversation_page.has_more
+    );
   }
 
   #[test]

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -181,6 +181,24 @@ impl TokenRequest {
     }
   }
 
+  pub(crate) fn manual_incremental_with_waiter(
+    codex_home: Option<String>,
+    waiter: TokenWaiterId,
+  ) -> Self {
+    let mut request = Self {
+      reasons: RefreshReason::Manual.into(),
+      kind: TokenScanKind::Incremental,
+      codex_home,
+      waiter_ids: TokenWaiterIds::default(),
+      planned_due_at: None,
+      source_generation: None,
+    };
+    request
+      .try_add_waiter(waiter)
+      .expect("an empty token request accepts one waiter");
+    request
+  }
+
   pub(crate) fn manual_full_with_waiter(codex_home: Option<String>, waiter: TokenWaiterId) -> Self {
     let mut request = Self::manual_full(codex_home);
     request

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -2203,7 +2203,7 @@ impl RefreshCoordinatorHandle {
       }
       waiters.token.insert(waiter, reply_tx);
     }
-    let request = TokenRequest::manual_full_with_waiter(codex_home, waiter);
+    let request = TokenRequest::manual_incremental_with_waiter(codex_home, waiter);
     if let Err(error) = try_send_public(&intake.sender, RuntimeMessage::RequestToken(request)) {
       lock(&self.inner.waiters).token.remove(&waiter);
       return Err(error);

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -5448,6 +5448,10 @@ impl TokenRefreshExecutor for TestTokenExecutor {
       imported_sessions: generation as usize,
       updated_sessions: generation as usize,
       missing_sessions: 0,
+      scan_kind: "incremental".to_string(),
+      source_bytes_read: 0,
+      tail_parsed_files: 0,
+      fully_parsed_files: 0,
       last_completed_at: "2026-07-11T00:00:00Z".to_string(),
     })
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import {
 import {
   getScanInProgress,
   getConversationDetail,
+  listConversations,
   loadDashboard,
   refreshPricing,
   scanCodexUsage,
@@ -105,8 +106,12 @@ function App() {
   const [shareDimension, setShareDimension] = useState<ShareDimension>('model')
   const [overview, setOverview] = useState<OverviewResponse | null>(null)
   const [conversations, setConversations] = useState<ConversationListItem[]>([])
+  const [conversationCursor, setConversationCursor] = useState<string | null>(null)
+  const [hasMoreConversations, setHasMoreConversations] = useState(false)
+  const [loadingMoreConversations, setLoadingMoreConversations] = useState(false)
   const [selectedRootSessionId, setSelectedRootSessionId] = useState<string | null>(null)
   const [detail, setDetail] = useState<ConversationDetail | null>(null)
+  const [loadingEarlierTurns, setLoadingEarlierTurns] = useState(false)
   const [syncSettings, setSyncSettings] = useState<SyncSettings | null>(null)
   const [subscriptionProfile, setSubscriptionProfile] = useState<SubscriptionProfile | null>(null)
   const [liveRateLimits, setLiveRateLimits] = useState<LiveRateLimitSnapshot | null>(null)
@@ -125,6 +130,7 @@ function App() {
   const latestDetailRequestIdRef = useRef(0)
   const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
   const refreshCompletionListenerReadyRef = useRef<Promise<boolean>>(Promise.resolve(false))
+  const refreshReloadTimerRef = useRef<number | null>(null)
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
   const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
@@ -181,7 +187,7 @@ function App() {
 
       startTransition(() => {
         const nextDetailCache = new Map<string, ConversationDetail>()
-        for (const conversation of snapshot.conversations) {
+        for (const conversation of snapshot.conversationPage.items) {
           const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
           if (
             cachedDetail &&
@@ -197,7 +203,9 @@ function App() {
 
         latestDetailRequestIdRef.current += 1
         setOverview(snapshot.overview)
-        setConversations(snapshot.conversations)
+        setConversations(snapshot.conversationPage.items)
+        setConversationCursor(snapshot.conversationPage.nextCursor)
+        setHasMoreConversations(snapshot.conversationPage.hasMore)
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
         setLiveRateLimits(snapshot.liveRateLimits)
@@ -218,9 +226,9 @@ function App() {
           ),
         )
         setSelectedRootSessionId((current) =>
-          current && snapshot.conversations.some((item) => item.rootSessionId === current)
+          current && snapshot.conversationPage.items.some((item) => item.rootSessionId === current)
             ? current
-            : snapshot.conversations[0]?.rootSessionId ?? null,
+            : snapshot.conversationPage.items[0]?.rootSessionId ?? null,
         )
       })
     } catch (error) {
@@ -232,6 +240,43 @@ function App() {
       }
     }
   }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t])
+
+  const loadMoreConversations = useCallback(async () => {
+    if (!conversationCursor || !hasMoreConversations || loadingMoreConversations) return
+    const requestId = latestLoadRequestIdRef.current
+    setLoadingMoreConversations(true)
+    try {
+      const page = await listConversations({
+        bucket,
+        anchor: bucketUsesAnchor(bucket) ? anchor : null,
+        customStart: bucket === 'custom' ? customStart : null,
+        customEnd: bucket === 'custom' ? customEnd : null,
+        search: deferredSearch || null,
+        liveWindowOffset: bucket === 'five_hour' || bucket === 'seven_day' ? liveWindowOffset : 0,
+        cursor: conversationCursor,
+        limit: 50,
+      })
+      if (requestId !== latestLoadRequestIdRef.current) return
+      setConversations((current) => {
+        const seen = new Set(current.map((item) => item.rootSessionId))
+        return [...current, ...page.items.filter((item) => !seen.has(item.rootSessionId))]
+      })
+      setConversationCursor(page.nextCursor)
+      setHasMoreConversations(page.hasMore)
+    } finally {
+      setLoadingMoreConversations(false)
+    }
+  }, [
+    anchor,
+    bucket,
+    conversationCursor,
+    customEnd,
+    customStart,
+    deferredSearch,
+    hasMoreConversations,
+    liveWindowOffset,
+    loadingMoreConversations,
+  ])
 
   const currentQueryKey = buildQueryKey(
     bucket,
@@ -314,7 +359,13 @@ function App() {
         .catch(() => {})
     }
     const reloadDashboard = () => {
-      void loadShellRef.current(true)
+      if (refreshReloadTimerRef.current !== null) {
+        window.clearTimeout(refreshReloadTimerRef.current)
+      }
+      refreshReloadTimerRef.current = window.setTimeout(() => {
+        refreshReloadTimerRef.current = null
+        void loadShellRef.current(true)
+      }, 200)
     }
     const handleCompletion = async (event: RefreshCompletedEvent) => {
       let visible: boolean
@@ -378,6 +429,10 @@ function App() {
     return () => {
       cancelled = true
       refreshCompletionListenerReadyRef.current = Promise.resolve(false)
+      if (refreshReloadTimerRef.current !== null) {
+        window.clearTimeout(refreshReloadTimerRef.current)
+        refreshReloadTimerRef.current = null
+      }
       document.removeEventListener('visibilitychange', handleDocumentVisibility)
       window.removeEventListener('focus', handleWindowFocus)
       for (const dispose of disposers) {
@@ -422,6 +477,30 @@ function App() {
       setStatusMessage(String(error))
     }
   }, [])
+
+  const loadEarlierTurns = useCallback(async () => {
+    if (!detail?.hasMoreTurns || detail.nextTurnCursor === null || loadingEarlierTurns) return
+    const requestId = latestDetailRequestIdRef.current
+    const rootSessionId = detail.rootSessionId
+    setLoadingEarlierTurns(true)
+    try {
+      const page = await getConversationDetail(rootSessionId, detail.nextTurnCursor)
+      if (requestId !== latestDetailRequestIdRef.current) return
+      setDetail((current) => {
+        if (!current || current.rootSessionId !== rootSessionId) return current
+        const merged = {
+          ...current,
+          turns: [...page.turns, ...current.turns],
+          nextTurnCursor: page.nextTurnCursor,
+          hasMoreTurns: page.hasMoreTurns,
+        }
+        detailCacheRef.current.set(rootSessionId, merged)
+        return merged
+      })
+    } finally {
+      setLoadingEarlierTurns(false)
+    }
+  }, [detail, loadingEarlierTurns])
 
   useEffect(() => {
     let cancelled = false
@@ -871,8 +950,9 @@ function App() {
                   {activeConversations.length === 0 ? (
                     <div className="empty-state">{t.conversationList.empty}</div>
                   ) : (
-                    activeConversations.map((conversation) => (
-                      <button
+                    <>
+                      {activeConversations.map((conversation) => (
+                        <button
                         key={conversation.rootSessionId}
                         className={`conversation-card ${
                           conversation.rootSessionId === selectedRootSessionId ? 'active' : ''
@@ -904,8 +984,21 @@ function App() {
                           <span>{formatShortDate(conversation.updatedAt, language)}</span>
                           <span>{formatPercent(conversation.subscriptionShare, language)}</span>
                         </div>
-                      </button>
-                    ))
+                        </button>
+                      ))}
+                      {hasMoreConversations ? (
+                        <button
+                          className="ghost-button"
+                          disabled={loadingMoreConversations}
+                          onClick={() => void loadMoreConversations()}
+                          type="button"
+                        >
+                          {loadingMoreConversations
+                            ? t.conversationList.loadingMore
+                            : t.conversationList.loadMore}
+                        </button>
+                      ) : null}
+                    </>
                   )}
                 </div>
               </aside>
@@ -967,14 +1060,26 @@ function App() {
                           <h3>{t.detail.turnUsage}</h3>
                         </div>
                         <p className="chart-note">
-                          {t.detail.latestTurns(Math.min(activeDetail.turns.length, 40))}
+                          {t.detail.latestTurns(activeDetail.turns.length)}
                         </p>
                       </div>
+                      {activeDetail.hasMoreTurns ? (
+                        <button
+                          className="ghost-button"
+                          disabled={loadingEarlierTurns}
+                          onClick={() => void loadEarlierTurns()}
+                          type="button"
+                        >
+                          {loadingEarlierTurns
+                            ? t.detail.loadingEarlierTurns
+                            : t.detail.loadEarlierTurns}
+                        </button>
+                      ) : null}
                       <div className="timeline-grid">
                         {activeDetail.turns.length === 0 ? (
                           <div className="empty-state">{t.detail.emptyTurns}</div>
                         ) : (
-                          activeDetail.turns.slice(-40).reverse().map((turn) => {
+                          [...activeDetail.turns].reverse().map((turn) => {
                             const session = sessionSummariesById.get(turn.sessionId)
                             const modelSummary = formatModelSummary(turn.modelIds, t)
                             const sessionLabel = formatSessionLabel(session, turn.sessionId, t)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -228,7 +228,7 @@ function App() {
         setSelectedRootSessionId((current) =>
           current && snapshot.conversationPage.items.some((item) => item.rootSessionId === current)
             ? current
-            : snapshot.conversationPage.items[0]?.rootSessionId ?? null,
+            : null,
         )
       })
     } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,7 +96,7 @@ const BUCKETS: OverviewBucket[] = [
 function App() {
   const { language, setLanguage, t } = useI18n()
   const [view, setView] = useState<AppView>('overview')
-  const [bucket, setBucket] = useState<OverviewBucket>('subscription_month')
+  const [bucket, setBucket] = useState<OverviewBucket>('seven_day')
   const [liveWindowOffset, setLiveWindowOffset] = useState(0)
   const [anchor, setAnchor] = useState(todayInputValue())
   const [customStart, setCustomStart] = useState(todayInputValue())

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2,7 +2,7 @@ import { invoke, isTauri } from '@tauri-apps/api/core'
 
 import type {
   ConversationFilters,
-  ConversationListItem,
+  ConversationPage,
   LiveRateLimitSnapshot,
   MenuBarPopupSnapshot,
   OverviewBucket,
@@ -206,6 +206,10 @@ export async function scanCodexUsage(codexHome?: string | null): Promise<import(
     importedSessions: 0,
     updatedSessions: 0,
     missingSessions: 0,
+    scanKind: 'incremental',
+    sourceBytesRead: 0,
+    tailParsedFiles: 0,
+    fullyParsedFiles: 0,
     lastCompletedAt: nowIso(),
   }))
 }
@@ -257,7 +261,7 @@ export async function loadDashboard(
     },
     () => ({
       overview: createMockOverview(bucket, anchor, customStart, customEnd),
-      conversations: [] as ConversationListItem[],
+      conversationPage: { items: [], nextCursor: null, hasMore: false } satisfies ConversationPage,
       syncSettings: createMockSyncSettings(),
       subscriptionProfile: createMockSubscriptionProfile(),
       liveRateLimits: createMockLiveRateLimits(),
@@ -265,8 +269,12 @@ export async function loadDashboard(
   )
 }
 
-export async function listConversations(filters: ConversationFilters) {
-  return invokeOrMock('listConversations', { filters }, () => [] satisfies ConversationListItem[])
+export async function listConversations(filters: ConversationFilters): Promise<ConversationPage> {
+  return invokeOrMock(
+    'listConversations',
+    { filters },
+    () => ({ items: [], nextCursor: null, hasMore: false }) satisfies ConversationPage,
+  )
 }
 
 export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {
@@ -275,8 +283,9 @@ export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {
 
 export async function getConversationDetail(
   rootSessionId: string,
+  turnCursor?: number | null,
 ): Promise<import('./types').ConversationDetail> {
-  return invokeOrMock('getConversationDetail', { rootSessionId }, () => {
+  return invokeOrMock('getConversationDetail', { rootSessionId, turnCursor: turnCursor ?? null }, () => {
     throw new Error(`Conversation ${rootSessionId} is unavailable in browser preview mode.`)
   })
 }

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -96,6 +96,8 @@ export type TranslationSet = {
     title: string
     shown: (count: number) => string
     empty: string
+    loadMore: string
+    loadingMore: string
   }
   detail: {
     eyebrow: string
@@ -105,6 +107,8 @@ export type TranslationSet = {
     turnTimelineEyebrow: string
     turnUsage: string
     latestTurns: (count: number) => string
+    loadEarlierTurns: string
+    loadingEarlierTurns: string
     emptyTurns: string
     emptySelection: string
     untitledTurn: string
@@ -345,6 +349,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       title: '根会话',
       shown: (count) => `显示 ${count} 条`,
       empty: '当前筛选条件下没有匹配对话。',
+      loadMore: '加载更多',
+      loadingMore: '正在加载…',
     },
     detail: {
       eyebrow: '对话详情',
@@ -353,6 +359,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       conversationCostBreakdown: '对话成本结构',
       turnTimelineEyebrow: 'Turn 时间线',
       turnUsage: 'Turn 用量',
+      loadEarlierTurns: '加载更早记录',
+      loadingEarlierTurns: '正在加载…',
       latestTurns: (count) => `最近 ${count} 个 turn`,
       emptyTurns: '该对话暂无 turn 级来源数据。',
       emptySelection: '选择一个对话以查看详细账本。',
@@ -587,6 +595,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       title: 'Root sessions',
       shown: (count) => `${count} shown`,
       empty: 'No conversations matched the current filter.',
+      loadMore: 'Load more',
+      loadingMore: 'Loading…',
     },
     detail: {
       eyebrow: 'Conversation detail',
@@ -596,6 +606,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       turnTimelineEyebrow: 'Turn timeline',
       turnUsage: 'Turn usage',
       latestTurns: (count) => `Latest ${count} turns`,
+      loadEarlierTurns: 'Load earlier turns',
+      loadingEarlierTurns: 'Loading…',
       emptyTurns: 'No turn-level source data is available for this conversation.',
       emptySelection: 'Select a conversation to inspect its detailed ledger.',
       untitledTurn: 'Untitled turn',

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -61,6 +61,10 @@ export interface ScanResult {
   importedSessions: number
   updatedSessions: number
   missingSessions: number
+  scanKind: 'incremental' | 'reconcile' | 'full'
+  sourceBytesRead: number
+  tailParsedFiles: number
+  fullyParsedFiles: number
   lastCompletedAt: string
 }
 
@@ -200,7 +204,7 @@ export interface OverviewResponse {
 
 export interface DashboardSnapshot {
   overview: OverviewResponse
-  conversations: ConversationListItem[]
+  conversationPage: ConversationPage
   syncSettings: SyncSettings
   subscriptionProfile: SubscriptionProfile
   liveRateLimits: LiveRateLimitSnapshot | null
@@ -213,6 +217,14 @@ export interface ConversationFilters {
   customEnd?: string | null
   search?: string | null
   liveWindowOffset?: number | null
+  cursor?: string | null
+  limit?: number | null
+}
+
+export interface ConversationPage {
+  items: ConversationListItem[]
+  nextCursor: string | null
+  hasMore: boolean
 }
 
 export interface ConversationListItem {
@@ -291,6 +303,8 @@ export interface ConversationDetail {
   sourceStates: string[]
   sessions: ConversationSessionSummary[]
   turns: ConversationTurnPoint[]
+  nextTurnCursor: number | null
+  hasMoreTurns: boolean
   modelBreakdown: ModelShare[]
   compositionBreakdown: CompositionShare[]
 }


### PR DESCRIPTION
## What changed

- Routine automatic and manual refreshes now use incremental scanning. A daily reconciliation still checks active and archived sessions, but unchanged files are not reparsed and growing files use their tail checkpoints.
- The main window opens on the current 7-day quota window. Dashboard queries read only the selected time range, and chart data is aggregated in one pass.
- Conversation lists and turn history are paginated. The app no longer opens the first conversation automatically, so source history is read only after the user selects a conversation.
- Refresh completions are coalesced before reloading the dashboard, and scan results now expose source bytes read plus tail/full parse counts.

## Why

Routine refreshes could walk and parse far more session history than the visible dashboard needed. Startup also selected the first conversation automatically, which caused an unrelated JSONL file to be parsed before the user opened the conversation view. Together these paths caused avoidable disk reads, CPU work, and temporary memory growth.

## Validation

- `cargo test --no-fail-fast`: 399 passed, 2 ignored profiling helpers
- `npm test`: passed
- `npm run build`: passed
- `npm run lint`: passed
- Tauri release build and arm64 DMG packaging: passed
- Real-data incremental refresh: about 240 KB read and 680 KB written, with about 0.66 seconds of process CPU time
- Idle packaged app: 0.0% CPU, roughly 61–69 MB physical memory, and 0 bytes read or written during a 10-second sample
