### PR TITLE
Fix recurring background reads and seven-day quota fallback

### DIFF
--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -320,6 +320,17 @@ test('dashboard_startup_does_not_open_and_parse_the_first_conversation_implicitl
   )
 })
 
+test('conversation_entry_load_does_not_repeat_for_query_changes', () => {
+  assert.match(
+    appSource,
+    /if \(!hasBootstrapped \|\| view !== 'conversations'\) return\s+void loadShellRef\.current\(false\)\s+}, \[hasBootstrapped, view\]\)/,
+  )
+  assert.doesNotMatch(
+    appSource,
+    /if \(!hasBootstrapped \|\| view !== 'conversations'\) return\s+void loadShell\(false\)/,
+  )
+})
+
 test('dashboard_reload_preserves_a_later-page_selection_for_the_same_query', () => {
   assert.equal(
     refreshEvents.selectionAfterDashboardReload('root-page-2', 'seven-day-query', 'seven-day-query'),

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -312,12 +312,20 @@ test('popup_wires_latest_request_controller_and_disables_duplicate_manual_refres
 })
 
 test('dashboard_startup_does_not_open_and_parse_the_first_conversation_implicitly', () => {
-  assert.match(
-    appSource,
-    /setSelectedRootSessionId\(\(current\) =>[\s\S]{0,260}\? current[\s\S]{0,80}: null,/,
-  )
+  assert.equal(refreshEvents.selectionAfterDashboardReload(null, null, 'seven-day-query'), null)
   assert.doesNotMatch(
     appSource,
     /setSelectedRootSessionId\([\s\S]{0,320}conversationPage\.items\[0\]/,
+  )
+})
+
+test('dashboard_reload_preserves_a_later-page_selection_for_the_same_query', () => {
+  assert.equal(
+    refreshEvents.selectionAfterDashboardReload('root-page-2', 'seven-day-query', 'seven-day-query'),
+    'root-page-2',
+  )
+  assert.equal(
+    refreshEvents.selectionAfterDashboardReload('root-page-2', 'seven-day-query', 'month-query'),
+    null,
   )
 })

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -310,3 +310,14 @@ test('popup_wires_latest_request_controller_and_disables_duplicate_manual_refres
     /aria-label=\{t\.popup\.actions\.refresh\}[\s\S]{0,220}disabled=\{refreshing\}/,
   )
 })
+
+test('dashboard_startup_does_not_open_and_parse_the_first_conversation_implicitly', () => {
+  assert.match(
+    appSource,
+    /setSelectedRootSessionId\(\(current\) =>[\s\S]{0,260}\? current[\s\S]{0,80}: null,/,
+  )
+  assert.doesNotMatch(
+    appSource,
+    /setSelectedRootSessionId\([\s\S]{0,320}conversationPage\.items\[0\]/,
+  )
+})

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -132,7 +132,8 @@ test('frontend_refresh_sources_are_event_driven_without_automatic_polling', () =
 
   assert.match(appSource, /codex-counter:\/\/refresh-completed/)
   assert.match(appSource, /SurfaceRevisionGate/)
-  assert.match(appSource, /getCurrentWindow\(\)\.isVisible\(\)/)
+  assert.match(appSource, /appWindow\.isVisible\(\)/)
+  assert.match(appSource, /appWindow\.isFocused\(\)/)
   assert.match(appSource, /onFocusChanged/)
   assert.match(appSource, /visibilitychange/)
 

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -3,6 +3,9 @@ CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp)
 CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_ms
   ON usage_events(timestamp_ms, id)
   WHERE timestamp_ms IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_value
+  ON usage_events(timestamp_ms, value_usd)
+  WHERE timestamp_ms IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_usage_events_missing_timestamp_ms
   ON usage_events(id)
   WHERE timestamp_ms IS NULL;
@@ -10,6 +13,11 @@ CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
 CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
+CREATE INDEX IF NOT EXISTS idx_import_state_source_bucket ON import_state(source_bucket);
+CREATE INDEX IF NOT EXISTS idx_import_state_incomplete_archived_tail
+  ON import_state(source_path)
+  WHERE source_bucket = 'archived'
+    AND parser_completed_offset < file_size;
 CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
   ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
 CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_window_ms

--- a/src-tauri/sql/queries/rate_limit_windows.sql
+++ b/src-tauri/sql/queries/rate_limit_windows.sql
@@ -1,5 +1,0 @@
-SELECT window_start, resets_at
-FROM rate_limit_samples
-WHERE bucket = ?1
-GROUP BY window_start, resets_at
-ORDER BY window_start DESC, resets_at DESC

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -110,6 +110,7 @@ CREATE TABLE IF NOT EXISTS import_state (
   file_size INTEGER NOT NULL,
   file_mtime_ms INTEGER NOT NULL,
   parser_checkpoint TEXT,
+  parser_completed_offset INTEGER,
   last_imported_at TEXT NOT NULL
 );
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -93,6 +93,25 @@ fn ensure_import_state_schema(conn: &Connection) -> rusqlite::Result<()> {
     if !columns.iter().any(|column| column == "parser_checkpoint") {
         conn.execute("ALTER TABLE import_state ADD COLUMN parser_checkpoint TEXT", [])?;
     }
+    if !columns
+        .iter()
+        .any(|column| column == "parser_completed_offset")
+    {
+        conn.execute(
+            "ALTER TABLE import_state ADD COLUMN parser_completed_offset INTEGER",
+            [],
+        )?;
+        conn.execute(
+            "
+            UPDATE import_state
+            SET parser_completed_offset = CAST(
+              json_extract(parser_checkpoint, '$.completed_offset') AS INTEGER
+            )
+            WHERE parser_checkpoint IS NOT NULL
+            ",
+            [],
+        )?;
+    }
     Ok(())
 }
 
@@ -194,6 +213,9 @@ mod tests {
             .collect::<rusqlite::Result<Vec<_>>>()
             .expect("collect columns");
         assert!(columns.iter().any(|column| column == "parser_checkpoint"));
+        assert!(columns
+            .iter()
+            .any(|column| column == "parser_completed_offset"));
     }
 
     #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -7358,6 +7358,32 @@ mod tests {
   }
 
   #[test]
+  #[ignore = "resource profiling helper; requires database and Codex home copies"]
+  fn profile_real_incremental_scan() {
+    let db_path = std::env::var_os("CODEX_PACER_PROFILE_DB")
+      .map(PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_DB to a database copy");
+    let codex_home = std::env::var_os("CODEX_PACER_PROFILE_CODEX_HOME")
+      .map(PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_CODEX_HOME");
+    let started = std::time::Instant::now();
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental scan");
+    eprintln!(
+      "profile incremental elapsed_ms={} visited={} read_bytes={} tail={} full={}",
+      started.elapsed().as_millis(),
+      prepared.stats().files_visited,
+      prepared.stats().source_bytes_read,
+      prepared.stats().tail_parsed_files,
+      prepared.stats().fully_parsed_files
+    );
+  }
+
+  #[test]
   fn changed_checkpoint_suffix_falls_back_to_full_session_parse() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -807,14 +807,65 @@ fn perform_scan_with_kind(
   commit_prepared_scan(prepared)
 }
 
+#[cfg(test)]
 pub(crate) fn prepare_scan(
   db_path: &Path,
   codex_home_override: Option<String>,
   requested_kind: ScanKind,
 ) -> Result<PreparedScan, String> {
+  let database_snapshot = load_preparation_database_snapshot(
+    db_path,
+    codex_home_override.as_deref(),
+    requested_kind,
+  )
+  .map_err(|error| error.to_string())?;
+  prepare_scan_from_snapshot(
+    db_path,
+    codex_home_override,
+    requested_kind,
+    database_snapshot,
+  )
+}
+
+pub(crate) fn prepare_scan_with_cached_snapshot_connection(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_kind: ScanKind,
+  cached_connection: &mut Option<Connection>,
+) -> Result<PreparedScan, String> {
+  if cached_connection.is_none() {
+    let connection = open_scan_snapshot(db_path).map_err(|error| error.to_string())?;
+    connection
+      .pragma_update(None, "cache_size", -16_384)
+      .map_err(|error| error.to_string())?;
+    *cached_connection = Some(connection);
+  }
+  let database_snapshot = match load_preparation_database_snapshot_from_connection(
+    cached_connection.as_mut().expect("cached connection initialized"),
+    codex_home_override.as_deref(),
+    requested_kind,
+  ) {
+    Ok(snapshot) => snapshot,
+    Err(error) => {
+      *cached_connection = None;
+      return Err(error.to_string());
+    }
+  };
+  prepare_scan_from_snapshot(
+    db_path,
+    codex_home_override,
+    requested_kind,
+    database_snapshot,
+  )
+}
+
+fn prepare_scan_from_snapshot(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_kind: ScanKind,
+  database_snapshot: PreparationDatabaseSnapshot,
+) -> Result<PreparedScan, String> {
   let scan_started_at = now_utc_string();
-  let database_snapshot =
-    load_preparation_database_snapshot(db_path).map_err(|error| error.to_string())?;
   let PreparationDatabaseSnapshot {
     scan_source_selector,
     scan_commit_revision,
@@ -830,7 +881,7 @@ pub(crate) fn prepare_scan(
     needs_fork_replay_v3_repair_sweep,
     pending_fork_replay_v3_repair_paths,
     mut session_source_paths,
-    existing_relations,
+    mut existing_relations,
     existing_session_sources,
     topology_needs_repair,
   } = database_snapshot;
@@ -865,6 +916,9 @@ pub(crate) fn prepare_scan(
     pending_repair_session_ids(&import_state, &pending_rate_limit_repair_paths);
   pending_repair_session_ids.extend(pending_token_v2_repair_session_ids.iter().cloned());
   pending_repair_session_ids.extend(pending_fork_replay_v3_repair_session_ids.iter().cloned());
+  let mut pending_repair_paths = pending_rate_limit_repair_paths.clone();
+  pending_repair_paths.extend(pending_token_v2_repair_paths.iter().cloned());
+  pending_repair_paths.extend(pending_fork_replay_v3_repair_paths.iter().cloned());
   let needs_token_usage_repair_sweep =
     needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
   let effective_kind = effective_scan_scope(
@@ -879,7 +933,12 @@ pub(crate) fn prepare_scan(
     ScanKind::Full => (collect_session_files(&codex_home), HashSet::new()),
     ScanKind::Reconcile => (collect_session_files(&codex_home), HashSet::new()),
     ScanKind::Incremental => {
-      collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
+      collect_incremental_session_files(
+        &codex_home,
+        &import_state,
+        &pending_repair_session_ids,
+        &pending_repair_paths,
+      )
     }
   };
   let stats = PreparedScanStats {
@@ -932,8 +991,9 @@ pub(crate) fn prepare_scan(
     if let Some(state) = import_state.get(&source_path) {
       let session_id_mismatch = import_state_session_id_mismatch(state, session_file);
       if state.file_size == session_file.file_size
-        && state.file_mtime_ms == session_file.file_mtime_ms
         && !session_id_mismatch
+        && (state.file_mtime_ms == session_file.file_mtime_ms
+          || parser_checkpoint_prefix_matches(state, session_file))
       {
         if let Some(session_id) = &state.session_id {
           imported_session_ids.insert(session_id.clone());
@@ -1024,6 +1084,7 @@ pub(crate) fn prepare_scan(
     };
     source_bytes_read = source_bytes_read.saturating_add(bytes_read);
 
+    ensure_replay_parent_source_path(db_path, &parsed, &mut session_source_paths)?;
     let (replay_parent_unavailable, parent_replay_bytes_read) =
       if matches!(parsed.mode, ParsedSessionMode::Full) {
         assign_inherited_token_snapshot_cutoff(
@@ -1050,6 +1111,11 @@ pub(crate) fn prepare_scan(
       replay_parent_unavailable || !related_pending_fork_replay_v3_paths.is_empty();
     imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
+    ensure_existing_relation_context(
+      db_path,
+      &parsed.raw_session.session_id,
+      &mut existing_relations,
+    )?;
     match classify_topology_maintenance(
       existing_relations.get(&parsed.raw_session.session_id),
       existing_relations
@@ -1276,7 +1342,8 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
   apply_missing_source_plan(&tx, missing_plan).map_err(|error| error.to_string())?;
 
   let topology_needs_repair = topology_needs_repair
-    || conversation_links_need_repair(&tx).map_err(|error| error.to_string())?;
+    || (effective_kind != ScanKind::Incremental
+      && conversation_links_need_repair(&tx).map_err(|error| error.to_string())?);
   if topology_dirty || topology_needs_repair {
     recompute_conversation_links(&tx).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
@@ -1359,10 +1426,25 @@ fn open_scan_snapshot(db_path: &Path) -> rusqlite::Result<Connection> {
   Ok(conn)
 }
 
+#[cfg(test)]
 fn load_preparation_database_snapshot(
   db_path: &Path,
+  codex_home_override: Option<&str>,
+  requested_kind: ScanKind,
 ) -> rusqlite::Result<PreparationDatabaseSnapshot> {
   let mut conn = open_scan_snapshot(db_path)?;
+  load_preparation_database_snapshot_from_connection(
+    &mut conn,
+    codex_home_override,
+    requested_kind,
+  )
+}
+
+fn load_preparation_database_snapshot_from_connection(
+  conn: &mut Connection,
+  codex_home_override: Option<&str>,
+  requested_kind: ScanKind,
+) -> rusqlite::Result<PreparationDatabaseSnapshot> {
   let tx = conn.transaction()?;
   let (
     scan_source_selector,
@@ -1397,7 +1479,6 @@ fn load_preparation_database_snapshot(
       ))
     },
   )?;
-  let import_state = load_import_state(&tx)?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&tx)?;
   let pending_rate_limit_repair_paths =
     load_pending_data_repair_paths(&tx, RATE_LIMIT_SAMPLE_BACKFILL_KEY)?;
@@ -1409,29 +1490,72 @@ fn load_preparation_database_snapshot(
     data_repair_is_pending(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY)?;
   let pending_fork_replay_v3_repair_paths =
     load_pending_data_repair_paths(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY)?;
-  let session_source_paths = load_session_source_paths(&tx, &import_state, &[])?;
-  let existing_relations = load_existing_session_relations(&tx)?;
-  let existing_session_sources = {
-    let mut stmt = tx.prepare(
+  let mut pending_repair_paths = pending_rate_limit_repair_paths.clone();
+  pending_repair_paths.extend(pending_token_v2_repair_paths.iter().cloned());
+  pending_repair_paths.extend(pending_fork_replay_v3_repair_paths.iter().cloned());
+  let import_state_is_empty = tx.query_row(
+    "SELECT NOT EXISTS (SELECT 1 FROM import_state LIMIT 1)",
+    [],
+    |row| Ok(row.get::<_, i64>(0)? != 0),
+  )?;
+  let home_dir = dirs::home_dir();
+  let resolved_requested_home = resolve_codex_home(
+    scan_source_selector.as_deref(),
+    codex_home_override.map(ToString::to_string),
+    home_dir.as_deref(),
+  )
+  .and_then(|path| expand_home_prefix(path, home_dir.as_deref()));
+  let use_incremental_snapshot = requested_kind == ScanKind::Incremental
+    && !import_state_is_empty
+    && !needs_rate_limit_backfill
+    && !needs_token_usage_v2_repair_sweep
+    && !needs_fork_replay_v3_repair_sweep
+    && last_full_scan_completed_at.is_some()
+    && resolved_requested_home.as_ref().is_ok_and(|path| {
+      last_scan_codex_home.as_deref() == Some(path.to_string_lossy().as_ref())
+    });
+  let import_state = if use_incremental_snapshot {
+    load_incremental_import_state(&tx, &pending_repair_paths)?
+  } else {
+    load_import_state(&tx)?
+  };
+  let session_source_paths = if use_incremental_snapshot {
+    import_state
+      .values()
+      .filter_map(|state| {
+        state
+          .session_id
+          .as_ref()
+          .map(|session_id| (session_id.clone(), PathBuf::from(&state.source_path)))
+      })
+      .collect()
+  } else {
+    load_session_source_paths(&tx, &import_state, &[])?
+  };
+  let existing_relations = if use_incremental_snapshot {
+    load_incremental_session_relations(&tx, &import_state)?
+  } else {
+    load_existing_session_relations(&tx)?
+  };
+  let existing_session_sources = if use_incremental_snapshot {
+    load_incremental_session_sources(&tx, &import_state)?
+  } else {
+    {
+      let mut stmt = tx.prepare(
       "
       SELECT session_id, source_path, source_state, source_bucket
       FROM sessions
       WHERE source_path IS NOT NULL
       ",
-    )?;
-    let rows = stmt
-      .query_map([], |row| {
-        Ok(ExistingSessionSource {
-          session_id: row.get(0)?,
-          source_path: row.get(1)?,
-          source_state: row.get(2)?,
-          source_bucket: row.get(3)?,
-        })
-      })?
-      .collect::<rusqlite::Result<Vec<_>>>()?;
-    rows
+      )?;
+      let sources = stmt
+        .query_map([], existing_session_source_from_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+      sources
+    }
   };
-  let topology_needs_repair = conversation_links_need_repair(&tx)?;
+  let topology_needs_repair =
+    !use_incremental_snapshot && conversation_links_need_repair(&tx)?;
   tx.commit()?;
 
   Ok(PreparationDatabaseSnapshot {
@@ -1874,20 +1998,31 @@ fn collect_session_files(codex_home: &Path) -> Vec<SessionFile> {
   files
 }
 
-fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
+fn collect_recent_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
   let sessions_root = codex_home.join("sessions");
-  if !sessions_root.exists() {
-    return Vec::new();
-  }
-
   let mut files = Vec::new();
-  for entry in WalkDir::new(sessions_root)
-    .into_iter()
-    .filter_map(Result::ok)
-  {
-    if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), "active") {
-      files.push(session_file);
+  let mut collect_directory = |directory: &Path| {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+      return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+      if let Some(session_file) = session_file_from_path(entry.path(), "active") {
+        files.push(session_file);
+      }
     }
+  };
+
+  // Legacy clients may place session files directly under `sessions`.
+  collect_directory(&sessions_root);
+  let today = Local::now().date_naive();
+  for days_ago in 0..=2 {
+    let date = today - chrono::Duration::days(days_ago);
+    collect_directory(
+      &sessions_root
+        .join(date.format("%Y").to_string())
+        .join(date.format("%m").to_string())
+        .join(date.format("%d").to_string()),
+    );
   }
   files.sort_by(|left, right| left.path.cmp(&right.path));
   files
@@ -1897,25 +2032,47 @@ fn collect_incremental_session_files(
   codex_home: &Path,
   import_state: &HashMap<String, ImportState>,
   pending_repair_session_ids: &HashSet<String>,
+  pending_repair_paths: &HashSet<String>,
 ) -> (Vec<SessionFile>, HashSet<String>) {
-  let mut files = collect_active_session_files(codex_home);
+  let mut files = collect_recent_active_session_files(codex_home);
   let mut collected_paths = files
     .iter()
     .map(|session_file| session_file.path.to_string_lossy().to_string())
     .collect::<HashSet<_>>();
   let mut active_paths_kept_for_archive_retry = HashSet::new();
 
+  for state in import_state.values().filter(|state| state.source_bucket == "active") {
+    if collected_paths.contains(&state.source_path) {
+      continue;
+    }
+    let Some(session_file) = session_file_from_path(PathBuf::from(&state.source_path), "active") else {
+      continue;
+    };
+    collected_paths.insert(state.source_path.clone());
+    files.push(session_file);
+  }
+
   for state in import_state.values() {
     if state.source_bucket == "archived" {
+      let session_has_pending_repair = state
+        .session_id
+        .as_ref()
+        .is_some_and(|session_id| pending_repair_session_ids.contains(session_id));
+      let needs_tail_retry = state
+        .parser_checkpoint
+        .as_ref()
+        .is_some_and(|checkpoint| checkpoint.completed_offset < state.file_size.max(0) as u64);
+      if !session_has_pending_repair
+        && !pending_repair_paths.contains(&state.source_path)
+        && !needs_tail_retry
+      {
+        continue;
+      }
       let Some(session_file) =
         session_file_from_path(PathBuf::from(&state.source_path), "archived")
       else {
         continue;
       };
-      let session_has_pending_repair = state
-        .session_id
-        .as_ref()
-        .is_some_and(|session_id| pending_repair_session_ids.contains(session_id));
       if state.file_size == session_file.file_size
         && state.file_mtime_ms == session_file.file_mtime_ms
         && !session_has_pending_repair
@@ -1971,6 +2128,15 @@ fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
     file_size,
     file_mtime_ms,
   })
+}
+
+fn parser_checkpoint_prefix_matches(state: &ImportState, session_file: &SessionFile) -> bool {
+  let Some(checkpoint) = state.parser_checkpoint.as_ref() else {
+    return false;
+  };
+  checkpoint.completed_offset == session_file.file_size.max(0) as u64
+    && read_prefix_signature(&session_file.path, checkpoint.completed_offset)
+      .is_ok_and(|signature| signature == checkpoint.prefix_signature)
 }
 
 fn parse_session_file_counted(
@@ -2838,6 +3004,76 @@ impl ReplayParentTokenUsage {
   }
 }
 
+fn ensure_replay_parent_source_path(
+  db_path: &Path,
+  parsed: &ParsedSession,
+  session_source_paths: &mut HashMap<String, PathBuf>,
+) -> Result<(), String> {
+  if !matches!(parsed.mode, ParsedSessionMode::Full) {
+    return Ok(());
+  }
+  let Some(parent_session_id) = parsed
+    .explicit_forked_from_id
+    .as_deref()
+    .filter(|session_id| !session_id.trim().is_empty())
+  else {
+    return Ok(());
+  };
+  if session_source_paths.contains_key(parent_session_id) {
+    return Ok(());
+  }
+
+  let conn = open_scan_snapshot(db_path).map_err(|error| error.to_string())?;
+  let source_path = conn
+    .query_row(
+      "SELECT source_path FROM sessions WHERE session_id = ?1 AND source_path IS NOT NULL",
+      params![parent_session_id],
+      |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(|error| error.to_string())?;
+  if let Some(source_path) = source_path {
+    session_source_paths.insert(parent_session_id.to_string(), PathBuf::from(source_path));
+  }
+  Ok(())
+}
+
+fn ensure_existing_relation_context(
+  db_path: &Path,
+  session_id: &str,
+  existing_relations: &mut HashMap<String, ExistingSessionRelation>,
+) -> Result<(), String> {
+  if existing_relations.contains_key(session_id) {
+    return Ok(());
+  }
+  let conn = open_scan_snapshot(db_path).map_err(|error| error.to_string())?;
+  let existing_parent = conn
+    .query_row(
+      "SELECT parent_session_id FROM sessions WHERE session_id = ?1",
+      params![session_id],
+      |row| row.get::<_, Option<String>>(0),
+    )
+    .optional()
+    .map_err(|error| error.to_string())?;
+  let child_count = conn
+    .query_row(
+      "SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?1",
+      params![session_id],
+      |row| row.get::<_, i64>(0),
+    )
+    .map_err(|error| error.to_string())?
+    .max(0) as usize;
+  existing_relations.insert(
+    session_id.to_string(),
+    ExistingSessionRelation {
+      exists: existing_parent.is_some(),
+      parent_session_id: existing_parent.flatten(),
+      child_count,
+    },
+  );
+  Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ReplayKey {
   total_token_usage: TokenUsage,
@@ -3116,15 +3352,16 @@ fn persist_session(
     "
     INSERT INTO import_state (
       source_path, session_id, source_bucket, file_size, file_mtime_ms,
-      parser_checkpoint, last_imported_at
+      parser_checkpoint, parser_completed_offset, last_imported_at
     )
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
     ON CONFLICT(source_path) DO UPDATE SET
       session_id = excluded.session_id,
       source_bucket = excluded.source_bucket,
       file_size = excluded.file_size,
       file_mtime_ms = excluded.file_mtime_ms,
       parser_checkpoint = excluded.parser_checkpoint,
+      parser_completed_offset = excluded.parser_completed_offset,
       last_imported_at = excluded.last_imported_at
     ",
     params![
@@ -3134,6 +3371,7 @@ fn persist_session(
       session_file.file_size,
       session_file.file_mtime_ms,
       parser_checkpoint,
+      parsed.checkpoint.completed_offset as i64,
       now_utc_string(),
     ],
   )?;
@@ -3294,6 +3532,62 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
   Ok(result)
 }
 
+fn load_incremental_import_state(
+  conn: &Connection,
+  pending_repair_paths: &HashSet<String>,
+) -> rusqlite::Result<HashMap<String, ImportState>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms, parser_checkpoint
+    FROM import_state
+    WHERE source_bucket = 'active'
+    UNION ALL
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms, parser_checkpoint
+    FROM import_state INDEXED BY idx_import_state_incomplete_archived_tail
+    WHERE source_bucket = 'archived'
+      AND parser_completed_offset < file_size
+    ",
+  )?;
+  let rows = stmt.query_map([], import_state_from_row)?;
+
+  let mut result = HashMap::new();
+  for row in rows {
+    let state = row?;
+    result.insert(state.source_path.clone(), state);
+  }
+  drop(stmt);
+  for source_path in pending_repair_paths {
+    let state = conn
+      .query_row(
+        "
+        SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms, parser_checkpoint
+        FROM import_state
+        WHERE source_path = ?1
+        ",
+        params![source_path],
+        import_state_from_row,
+      )
+      .optional()?;
+    if let Some(state) = state {
+      result.insert(state.source_path.clone(), state);
+    }
+  }
+  Ok(result)
+}
+
+fn import_state_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ImportState> {
+  Ok(ImportState {
+    source_path: row.get(0)?,
+    session_id: row.get(1)?,
+    source_bucket: row.get(2)?,
+    file_size: row.get(3)?,
+    file_mtime_ms: row.get(4)?,
+    parser_checkpoint: row
+      .get::<_, Option<String>>(5)?
+      .and_then(|checkpoint| serde_json::from_str(&checkpoint).ok()),
+  })
+}
+
 fn needs_rate_limit_sample_backfill(conn: &Connection) -> rusqlite::Result<bool> {
   data_repair_is_pending(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY)
 }
@@ -3434,6 +3728,112 @@ fn load_existing_session_relations(
   }
 
   Ok(relations)
+}
+
+fn load_incremental_session_relations(
+  conn: &Connection,
+  import_state: &HashMap<String, ImportState>,
+) -> rusqlite::Result<HashMap<String, ExistingSessionRelation>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, parent_session_id
+    FROM sessions
+    WHERE source_state = 'active'
+    ",
+  )?;
+  let rows = stmt.query_map([], |row| {
+    Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+  })?;
+
+  let mut relations = HashMap::new();
+  for row in rows {
+    let (session_id, parent_session_id) = row?;
+    relations.insert(
+      session_id,
+      ExistingSessionRelation {
+        exists: true,
+        parent_session_id,
+        child_count: 0,
+      },
+    );
+  }
+  drop(stmt);
+  for state in import_state
+    .values()
+    .filter(|state| state.source_bucket != "active")
+  {
+    let Some(session_id) = state.session_id.as_deref() else {
+      continue;
+    };
+    let parent_session_id = conn
+      .query_row(
+        "SELECT parent_session_id FROM sessions WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get::<_, Option<String>>(0),
+      )
+      .optional()?;
+    if let Some(parent_session_id) = parent_session_id {
+      relations.insert(
+        session_id.to_string(),
+        ExistingSessionRelation {
+          exists: true,
+          parent_session_id,
+          child_count: 0,
+        },
+      );
+    }
+  }
+  Ok(relations)
+}
+
+fn existing_session_source_from_row(
+  row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<ExistingSessionSource> {
+  Ok(ExistingSessionSource {
+    session_id: row.get(0)?,
+    source_path: row.get(1)?,
+    source_state: row.get(2)?,
+    source_bucket: row.get(3)?,
+  })
+}
+
+fn load_incremental_session_sources(
+  conn: &Connection,
+  import_state: &HashMap<String, ImportState>,
+) -> rusqlite::Result<Vec<ExistingSessionSource>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, source_path, source_state, source_bucket
+    FROM sessions
+    WHERE source_path IS NOT NULL AND source_state = 'active'
+    ",
+  )?;
+  let rows = stmt.query_map([], existing_session_source_from_row)?;
+  let mut sources = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+  drop(stmt);
+  for state in import_state
+    .values()
+    .filter(|state| state.source_bucket != "active")
+  {
+    let Some(session_id) = state.session_id.as_deref() else {
+      continue;
+    };
+    let source = conn
+      .query_row(
+        "
+        SELECT session_id, source_path, source_state, source_bucket
+        FROM sessions
+        WHERE session_id = ?1 AND source_path IS NOT NULL
+        ",
+        params![session_id],
+        existing_session_source_from_row,
+      )
+      .optional()?;
+    if let Some(source) = source {
+      sources.push(source);
+    }
+  }
+  Ok(sources)
 }
 
 fn upsert_root_conversation_links(
@@ -6061,7 +6461,16 @@ mod tests {
     );
 
     let db_path = directory.path().join("usage.sqlite");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "UPDATE sync_settings SET codex_home = ?1 WHERE singleton_id = 1",
+        params![codex_home.to_string_lossy().to_string()],
+      )
+      .expect("configure source home");
+    drop(conn);
+    perform_scan(&db_path, None).expect("first scan");
 
     write_session_file_with_parent(
       &sessions_dir.join("child.jsonl"),
@@ -6072,7 +6481,7 @@ mod tests {
         ("2026-03-24T00:10:02Z", 160, 20, 25, 185),
       ],
     );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+    perform_incremental_scan(&db_path, None).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(
@@ -6110,14 +6519,23 @@ mod tests {
     );
 
     let db_path = directory.path().join("usage.sqlite");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "UPDATE sync_settings SET codex_home = ?1 WHERE singleton_id = 1",
+        params![codex_home.to_string_lossy().to_string()],
+      )
+      .expect("configure source home");
+    drop(conn);
+    perform_scan(&db_path, None).expect("first scan");
 
     write_session_file(
       &sessions_dir.join("parent.jsonl"),
       parent_session_id,
       &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)],
     );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+    perform_incremental_scan(&db_path, None).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(
@@ -6226,6 +6644,52 @@ mod tests {
   }
 
   #[test]
+  fn incremental_snapshot_does_not_load_archived_database_rows() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archived_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_dir).expect("archived dir");
+
+    write_session_file(
+      &sessions_dir.join("active.jsonl"),
+      "12121212-0000-0000-0000-000000000001",
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    for index in 2..=32 {
+      write_session_file(
+        &archived_dir.join(format!("archived-{index}.jsonl")),
+        &format!("12121212-0000-0000-0000-{index:012}"),
+        &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+      );
+    }
+
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "UPDATE sync_settings SET codex_home = ?1 WHERE singleton_id = 1",
+        params![codex_home.to_string_lossy().to_string()],
+      )
+      .expect("configure source home");
+    drop(conn);
+    perform_scan(&db_path, None).expect("full scan");
+
+    let snapshot = load_preparation_database_snapshot(
+      &db_path,
+      None,
+      ScanKind::Incremental,
+    )
+    .expect("incremental snapshot");
+    assert_eq!(snapshot.import_state.len(), 1);
+    assert_eq!(snapshot.session_source_paths.len(), 1);
+    assert_eq!(snapshot.existing_relations.len(), 1);
+    assert_eq!(snapshot.existing_session_sources.len(), 1);
+  }
+
+  #[test]
   fn incremental_scan_discovers_new_recent_active_session() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
@@ -6271,7 +6735,7 @@ mod tests {
   }
 
   #[test]
-  fn incremental_scan_discovers_new_old_dated_active_session() {
+  fn reconcile_scan_discovers_new_old_dated_active_session() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions_dir = codex_home.join("sessions");
@@ -6296,8 +6760,18 @@ mod tests {
       &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
     );
 
-    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
-      .expect("incremental scan");
+    let incremental = perform_incremental_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+    )
+    .expect("incremental scan");
+    assert_eq!(incremental.updated_sessions, 0);
+    let result = perform_scan_with_kind(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Reconcile,
+    )
+    .expect("reconcile scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
@@ -7251,6 +7725,38 @@ mod tests {
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)
     );
+  }
+
+  #[test]
+  fn unchanged_size_with_new_mtime_uses_checkpoint_instead_of_full_parse() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_id = "45454545-aaaa-bbbb-cccc-454545454545";
+    let session_path = sessions_dir.join("touched.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial scan");
+
+    let unchanged = std::fs::read(&session_path).expect("read source");
+    std::thread::sleep(Duration::from_millis(5));
+    std::fs::write(&session_path, unchanged).expect("rewrite identical source");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare touched source");
+    assert_eq!(prepared.stats().source_bytes_read, 0);
+    assert_eq!(prepared.stats().fully_parsed_files, 0);
+    assert_eq!(prepared.updated_sessions, 0);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2052,6 +2052,27 @@ fn collect_incremental_session_files(
     files.push(session_file);
   }
 
+  let active_root = codex_home.join("sessions");
+  let archived_root = codex_home.join("archived_sessions");
+  for source_path in pending_repair_paths {
+    if collected_paths.contains(source_path) {
+      continue;
+    }
+    let path = PathBuf::from(source_path);
+    let bucket = if path.starts_with(&archived_root) {
+      "archived"
+    } else if path.starts_with(&active_root) {
+      "active"
+    } else {
+      continue;
+    };
+    let Some(session_file) = session_file_from_path(path, bucket) else {
+      continue;
+    };
+    collected_paths.insert(source_path.clone());
+    files.push(session_file);
+  }
+
   for state in import_state.values() {
     if state.source_bucket == "archived" {
       let session_has_pending_repair = state
@@ -6824,7 +6845,9 @@ mod tests {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions_dir = codex_home.join("sessions");
+    let archived_dir = codex_home.join("archived_sessions");
     std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_dir).expect("archived sessions dir");
 
     let existing_session_id = "77777777-8888-9999-aaaa-bbbbbbbbbbbb";
     write_session_file(
@@ -6832,7 +6855,7 @@ mod tests {
       existing_session_id,
       &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
-    let pending_path = sessions_dir.join("unparseable.jsonl");
+    let pending_path = archived_dir.join("unparseable.jsonl");
     std::fs::write(&pending_path, "not json\n").expect("write bad session");
 
     let db_path = directory.path().join("usage.sqlite");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -162,6 +162,8 @@ pub(crate) enum ScanKind {
 pub(crate) struct PreparedScanStats {
   pub files_visited: usize,
   pub source_bytes_read: u64,
+  pub tail_parsed_files: usize,
+  pub fully_parsed_files: usize,
   pub full_rebuild: bool,
   pub used_spool: bool,
   pub parent_replay_cache_evictions: usize,
@@ -883,6 +885,8 @@ pub(crate) fn prepare_scan(
   let stats = PreparedScanStats {
     files_visited: session_files.len(),
     source_bytes_read: 0,
+    tail_parsed_files: 0,
+    fully_parsed_files: 0,
     full_rebuild: effective_kind == ScanKind::Full,
     used_spool: false,
     parent_replay_cache_evictions: 0,
@@ -955,6 +959,8 @@ pub(crate) fn prepare_scan(
   let mut storage = PreparedStorageBuilder::new();
   let mut updated_sessions = 0usize;
   let mut source_bytes_read = 0u64;
+  let mut tail_parsed_files = 0usize;
+  let mut fully_parsed_files = 0usize;
 
   for session_file in changed_files {
     let source_path = session_file.path.to_string_lossy().to_string();
@@ -986,8 +992,14 @@ pub(crate) fn prepare_scan(
       Ok(None)
     };
     let parsed_result = match tail_candidate {
-      Ok(Some(result)) => Ok(result),
-      Ok(None) => parse_session_file_counted(&session_file, &titles),
+      Ok(Some(result)) => {
+        tail_parsed_files += 1;
+        Ok(result)
+      }
+      Ok(None) => {
+        fully_parsed_files += 1;
+        parse_session_file_counted(&session_file, &titles)
+      }
       Err(error) => Err(error),
     };
     let (mut parsed, bytes_read) = match parsed_result {
@@ -1090,6 +1102,8 @@ pub(crate) fn prepare_scan(
   let storage = storage.finish()?;
   let stats = PreparedScanStats {
     source_bytes_read,
+    tail_parsed_files,
+    fully_parsed_files,
     used_spool: matches!(&storage, PreparedStorage::Spool { .. }),
     parent_replay_cache_evictions,
     parent_replay_cache_oversized_bypasses,
@@ -1325,6 +1339,15 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
     imported_sessions,
     updated_sessions,
     missing_sessions,
+    scan_kind: match effective_kind {
+      ScanKind::Full => "full",
+      ScanKind::Reconcile => "reconcile",
+      ScanKind::Incremental => "incremental",
+    }
+    .to_string(),
+    source_bytes_read: stats.source_bytes_read,
+    tail_parsed_files: stats.tail_parsed_files,
+    fully_parsed_files: stats.fully_parsed_files,
     last_completed_at: completed_at,
   })
 }
@@ -7227,6 +7250,110 @@ mod tests {
     assert_eq!(
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn reconcile_scan_reads_only_completed_tail_after_checkpoint() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "56565656-5656-5656-5656-565656565656";
+    let session_path = sessions_dir.join("reconciled-growing.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let filler = "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"ignored\",\"payload\":{}}\n";
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open initial session for append");
+    for _ in 0..4_096 {
+      file.write_all(filler.as_bytes()).expect("append filler");
+    }
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial full scan");
+
+    let appended = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (180, 40, 45, 225),
+      last: (80, 20, 20, 100),
+    });
+    std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open growing session")
+      .write_all(appended.as_bytes())
+      .expect("append completed token line");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Reconcile,
+    )
+    .expect("prepare reconcile tail");
+    assert_eq!(prepared.stats().tail_parsed_files, 1);
+    assert_eq!(prepared.stats().fully_parsed_files, 0);
+    assert!(
+      prepared.stats().source_bytes_read < appended.len() as u64 * 4,
+      "reconcile should avoid rereading the historical prefix; read {} bytes",
+      prepared.stats().source_bytes_read
+    );
+    commit_prepared_scan(prepared).expect("commit reconcile tail");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn reconcile_scan_discovers_new_archived_session() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archives_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archives_dir).expect("archives dir");
+
+    let initial_id = "67676767-6767-6767-6767-676767676767";
+    write_session_file(
+      &sessions_dir.join("initial.jsonl"),
+      initial_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial full scan");
+
+    let archived_id = "78787878-7878-7878-7878-787878787878";
+    write_session_file(
+      &archives_dir.join("new-archive.jsonl"),
+      archived_id,
+      &[("2026-03-24T01:00:01Z", 200, 40, 50, 250)],
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Reconcile,
+    )
+    .expect("prepare reconcile scan");
+    assert_eq!(prepared.stats().fully_parsed_files, 1);
+    commit_prepared_scan(prepared).expect("commit reconcile scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, archived_id),
+      (200, 40, 50, 250, 1)
     );
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -154,6 +154,7 @@ pub(crate) fn release_unused_process_memory() {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScanKind {
   Full,
+  Reconcile,
   Incremental,
 }
 
@@ -874,6 +875,7 @@ pub(crate) fn prepare_scan(
 
   let (session_files, active_paths_kept_for_archive_retry) = match effective_kind {
     ScanKind::Full => (collect_session_files(&codex_home), HashSet::new()),
+    ScanKind::Reconcile => (collect_session_files(&codex_home), HashSet::new()),
     ScanKind::Incremental => {
       collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
     }
@@ -939,7 +941,7 @@ pub(crate) fn prepare_scan(
     changed_files.push(session_file.clone());
   }
 
-  let titles = if effective_kind == ScanKind::Full || !changed_files.is_empty() {
+  let titles = if effective_kind != ScanKind::Incremental || !changed_files.is_empty() {
     load_session_index(&codex_home)
   } else {
     HashMap::new()
@@ -962,7 +964,7 @@ pub(crate) fn prepare_scan(
       needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
     let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
       || pending_fork_replay_v3_repair_paths.contains(&source_path);
-    let tail_candidate = if effective_kind == ScanKind::Incremental
+    let tail_candidate = if effective_kind != ScanKind::Full
       && !file_needs_rate_limit_repair
       && !file_needs_token_v2_repair
       && !file_needs_fork_replay_v3_repair
@@ -1066,7 +1068,7 @@ pub(crate) fn prepare_scan(
     updated_sessions += 1;
   }
 
-  let titles = if effective_kind == ScanKind::Full {
+  let titles = if effective_kind != ScanKind::Incremental {
     titles
   } else {
     HashMap::new()
@@ -1254,7 +1256,7 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
     }
   }
 
-  if effective_kind == ScanKind::Full {
+  if effective_kind != ScanKind::Incremental {
     refresh_session_titles(&tx, &titles).map_err(|error| error.to_string())?;
   }
   apply_missing_source_plan(&tx, missing_plan).map_err(|error| error.to_string())?;
@@ -1295,8 +1297,8 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
       &completed_at,
       source_identity.key.selector.as_deref(),
       &resolved_codex_home,
-      effective_kind == ScanKind::Full && !skipped_session_files,
-      effective_kind == ScanKind::Full && skipped_session_files,
+      effective_kind != ScanKind::Incremental && !skipped_session_files,
+      effective_kind != ScanKind::Incremental && skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
@@ -1500,7 +1502,7 @@ fn prepare_missing_source_plan(
   let mut plan = MissingSourcePlan::default();
 
   match scan_kind {
-    ScanKind::Full => {
+    ScanKind::Full | ScanKind::Reconcile => {
       for source in existing_sources {
         if !present_paths.contains(&source.source_path)
           && (reconcile_existing_absent_sources || !Path::new(&source.source_path).exists())
@@ -1631,7 +1633,7 @@ fn effective_scan_scope(
   {
     ScanKind::Full
   } else {
-    ScanKind::Incremental
+    requested_scope
   }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ use database::{
 };
 use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
 use models::{
-  ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
+  ConversationDetail, ConversationFilters, ConversationPage, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
   ScanResult, SubscriptionProfile, SyncSettings,
@@ -451,7 +451,7 @@ fn getOverview(
 fn listConversations(
   state: State<'_, AppState>,
   filters: Option<ConversationFilters>,
-) -> Result<Vec<ConversationListItem>, String> {
+) -> Result<ConversationPage, String> {
   let live_rate_limits = maybe_live_rate_limits_for_bucket(
     state.inner(),
     filters.as_ref().and_then(|value| value.bucket.as_deref()),
@@ -520,7 +520,7 @@ async fn loadDashboard(
 ) -> Result<DashboardSnapshot, String> {
   let state = state.inner().clone();
   tauri::async_runtime::spawn_blocking(move || {
-    let normalized_bucket = bucket.clone().unwrap_or_else(|| "subscription_month".to_string());
+    let normalized_bucket = bucket.clone().unwrap_or_else(|| "seven_day".to_string());
     let live_rate_limits =
       maybe_live_rate_limits_for_bucket(&state, Some(&normalized_bucket), live_window_offset)?;
     let snapshot = load_dashboard_data(
@@ -538,7 +538,7 @@ async fn loadDashboard(
 
     Ok(DashboardSnapshot {
       overview: snapshot.overview,
-      conversations: snapshot.conversations,
+      conversation_page: snapshot.conversation_page,
       sync_settings,
       subscription_profile: snapshot.subscription_profile,
       live_rate_limits,
@@ -553,8 +553,9 @@ async fn loadDashboard(
 fn getConversationDetail(
   state: State<'_, AppState>,
   root_session_id: String,
+  turn_cursor: Option<usize>,
 ) -> Result<ConversationDetail, String> {
-  get_conversation_detail(&state.db_path, &root_session_id)
+  get_conversation_detail(&state.db_path, &root_session_id, turn_cursor)
 }
 
 #[allow(non_snake_case)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -766,6 +766,13 @@ fn updateSubscriptionProfile(
   state: State<'_, AppState>,
   payload: SubscriptionProfile,
 ) -> Result<SubscriptionProfile, String> {
+  update_subscription_profile_for_state(state.inner(), payload)
+}
+
+fn update_subscription_profile_for_state(
+  state: &AppState,
+  payload: SubscriptionProfile,
+) -> Result<SubscriptionProfile, String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let updated = SubscriptionProfile {
     plan_type: payload.plan_type,
@@ -774,7 +781,13 @@ fn updateSubscriptionProfile(
     billing_anchor_day: payload.billing_anchor_day.clamp(1, 28),
     updated_at: payload.updated_at,
   };
-  save_subscription_profile(&conn, &updated).map_err(|error| error.to_string())
+  let saved = save_subscription_profile(&conn, &updated).map_err(|error| error.to_string())?;
+  state.settings_revision.fetch_add(1, Ordering::AcqRel);
+  *state
+    .overview_cache
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+  Ok(saved)
 }
 
 fn prepare_app_database(db_path: &Path) -> Result<(), String> {
@@ -3134,6 +3147,53 @@ mod tests {
       snapshot.quota_7d.map(|window| window.remaining_percent),
       Some(79)
     );
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn subscription_profile_update_invalidates_cached_overview() {
+    let (runtime, _, _) = start_recording_runtime(disabled_refresh_config(None));
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let state = test_app_state(
+      db_path,
+      runtime.handle(),
+      refresh::UsageMutationCoordinator::new(),
+      refresh::LiveQuotaCache::new(),
+    );
+    cached_overview(
+      &state,
+      Some("seven_day".to_string()),
+      None,
+      None,
+      None,
+      None,
+      None,
+    )
+    .expect("populate overview cache");
+    assert!(state
+      .overview_cache
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner)
+      .is_some());
+
+    let saved = update_subscription_profile_for_state(
+      &state,
+      SubscriptionProfile {
+        monthly_price: 250.0,
+        ..SubscriptionProfile::default()
+      },
+    )
+    .expect("update subscription profile");
+
+    assert_eq!(saved.monthly_price, 250.0);
+    assert_eq!(state.settings_revision.load(Ordering::Acquire), 1);
+    assert!(state
+      .overview_cache
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner)
+      .is_none());
     runtime.shutdown_and_join().expect("shutdown runtime");
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,7 +40,7 @@ use pricing::{
 use queries::{
   get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
 };
-use rate_limits::query_live_rate_limits;
+use rate_limits::LiveRateLimitClient;
 use tauri::{
   Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
   WebviewWindowBuilder,
@@ -141,11 +141,12 @@ impl refresh::TokenRefreshExecutor for AppTokenRefreshExecutor {
 struct AppLiveQuotaFetcher {
   db_path: PathBuf,
   live_cache: refresh::LiveQuotaCache,
+  client: Arc<LiveRateLimitClient>,
 }
 
 impl refresh::LiveQuotaFetcher for AppLiveQuotaFetcher {
   fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
-    query_live_rate_limits(timeout)
+    self.client.query(timeout)
   }
 
   fn fallback(&self) -> Option<LiveRateLimitSnapshot> {
@@ -2244,6 +2245,7 @@ pub fn run() {
           Arc::new(AppLiveQuotaFetcher {
             db_path: db_path.clone(),
             live_cache: live_rate_limits.clone(),
+            client: Arc::new(LiveRateLimitClient::new()),
           }),
           Arc::new(AppLiveQuotaPersister {
             db_path: db_path.clone(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2144,7 +2144,7 @@ fn effective_token_scan_kind(
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let last_full = get_last_full_scan_completed(&conn).map_err(|error| error.to_string())?;
   Ok(if full_maintenance_due(last_full.as_deref(), now) {
-    ScanKind::Full
+    ScanKind::Reconcile
   } else {
     ScanKind::Incremental
   })
@@ -3052,7 +3052,7 @@ mod tests {
     assert!(parsed_generation > 0);
     assert_eq!(parsed_generation, committed_generation);
     assert_eq!(source_generation, handle.status().source_generation);
-    assert_eq!(kind, refresh::TokenScanKind::Full);
+    assert_eq!(kind, refresh::TokenScanKind::Incremental);
     assert_eq!(result.codex_home, codex_home.to_string_lossy());
     assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
     runtime.shutdown_and_join().expect("shutdown runtime");
@@ -3214,7 +3214,7 @@ mod tests {
         utc_time("2026-07-11T00:00:00Z"),
       )
       .expect("select scan kind"),
-      ScanKind::Full
+      ScanKind::Reconcile
     );
     assert_eq!(
       effective_token_scan_kind(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{
-  atomic::{AtomicBool, AtomicU8, Ordering},
+  atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
   Arc, Mutex,
 };
 #[cfg(test)]
@@ -20,13 +20,16 @@ use std::sync::atomic::AtomicUsize;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
-use rusqlite::params;
+use rusqlite::{params, Connection};
 use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
   insert_live_rate_limit_snapshot, load_latest_rate_limits, open_connection,
   save_subscription_profile, save_sync_settings,
 };
-use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
+use importer::{
+  commit_prepared_scan, prepare_scan_with_cached_snapshot_connection,
+  recalculate_all_session_values, ScanKind,
+};
 use models::{
   ConversationDetail, ConversationFilters, ConversationPage, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
@@ -38,7 +41,7 @@ use pricing::{
   seed_pricing_catalog, OPENAI_API_PRICING_URL,
 };
 use queries::{
-  get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
+  get_conversation_detail, get_overview_with_connection, get_quota_trend, get_window_api_value, list_conversations,
 };
 use rate_limits::LiveRateLimitClient;
 use tauri::{
@@ -76,12 +79,34 @@ struct MenuBarPopupAnchor {
 }
 
 #[derive(Clone)]
+struct CachedMenuBarApiValue {
+  key: String,
+  usage_revision: u64,
+  title: String,
+}
+
+#[derive(Clone)]
+struct CachedOverview {
+  key: String,
+  usage_revision: u64,
+  quota_revision: u64,
+  settings_revision: u64,
+  value: OverviewResponse,
+}
+
+#[derive(Clone)]
 struct AppState {
   app_handle: Option<AppHandle>,
   db_path: PathBuf,
   refresh: AppRefreshHandle,
   usage_mutations: refresh::UsageMutationCoordinator,
   menu_bar_render_state: Arc<AtomicU8>,
+  menu_bar_usage_revision: Arc<AtomicU64>,
+  quota_revision: Arc<AtomicU64>,
+  settings_revision: Arc<AtomicU64>,
+  menu_bar_api_value_cache: Arc<Mutex<Option<CachedMenuBarApiValue>>>,
+  overview_cache: Arc<Mutex<Option<CachedOverview>>>,
+  overview_connection: Arc<Mutex<Connection>>,
   daily_value_tray: Option<TrayIcon>,
   live_rate_limits: refresh::LiveQuotaCache,
   menu_bar_popup_visible: Arc<AtomicBool>,
@@ -106,6 +131,7 @@ fn installed_refresh_handle(handle: refresh::RefreshCoordinatorHandle) -> AppRef
 #[derive(Clone)]
 struct AppTokenRefreshExecutor {
   db_path: PathBuf,
+  preparation_connection: Arc<Mutex<Option<Connection>>>,
 }
 
 impl refresh::TokenRefreshExecutor for AppTokenRefreshExecutor {
@@ -119,10 +145,15 @@ impl refresh::TokenRefreshExecutor for AppTokenRefreshExecutor {
       request.request.kind,
       started_at,
     )?;
-    let prepared_scan = prepare_scan(
+    let mut preparation_connection = self
+      .preparation_connection
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let prepared_scan = prepare_scan_with_cached_snapshot_connection(
       &self.db_path,
       request.request.codex_home,
       scan_kind,
+      &mut preparation_connection,
     )?;
     Ok(refresh::PreparedTokenRefresh::new(
       request.generation,
@@ -264,10 +295,17 @@ struct TauriRefreshEventSink {
 }
 
 impl refresh::RefreshEventSink for TauriRefreshEventSink {
-  fn publish_invalidation(&self, _: refresh::DisplayInvalidation) {
+  fn publish_invalidation(&self, value: refresh::DisplayInvalidation) {
     let Some(state) = self.app_handle.try_state::<AppState>() else {
       return;
     };
+    state
+      .menu_bar_usage_revision
+      .store(value.usage_revision, Ordering::Release);
+    state.quota_revision.store(value.quota_revision, Ordering::Release);
+    state
+      .settings_revision
+      .store(value.settings_revision, Ordering::Release);
     let popup_visible = state.menu_bar_popup_visible.load(Ordering::Acquire);
     refresh_daily_value_menu_bar(state.inner());
     if popup_visible {
@@ -379,6 +417,14 @@ fn refreshPricing(state: State<'_, AppState>) -> Result<Vec<PricingCatalogEntry>
     }
   };
   let catalog = refresh_pricing_catalog_for_state(state.inner(), official_entries.as_deref())?;
+  *state
+    .menu_bar_api_value_cache
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+  *state
+    .overview_cache
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
   refresh_daily_value_menu_bar(state.inner());
   Ok(catalog)
 }
@@ -436,8 +482,8 @@ fn getOverview(
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
   let live_rate_limits = maybe_live_rate_limits_for_bucket(state.inner(), bucket.as_deref(), live_window_offset)?;
-  get_overview(
-    &state.db_path,
+  cached_overview(
+    state.inner(),
     bucket,
     anchor,
     custom_start,
@@ -478,7 +524,7 @@ async fn getMenuBarPopupSnapshot(
     if force_refresh.unwrap_or(false) {
       refresh_popup_data(&state)?;
     }
-    build_passive_menu_bar_popup_snapshot(&state.db_path, &state.live_rate_limits)
+    build_passive_menu_bar_popup_snapshot(&state)
   })
   .await
   .map_err(|error| format!("Failed to join popup refresh: {error}"))?
@@ -518,30 +564,54 @@ async fn loadDashboard(
   custom_end: Option<String>,
   search: Option<String>,
   live_window_offset: Option<i64>,
+  include_conversations: Option<bool>,
 ) -> Result<DashboardSnapshot, String> {
   let state = state.inner().clone();
   tauri::async_runtime::spawn_blocking(move || {
     let normalized_bucket = bucket.clone().unwrap_or_else(|| "seven_day".to_string());
     let live_rate_limits =
       maybe_live_rate_limits_for_bucket(&state, Some(&normalized_bucket), live_window_offset)?;
-    let snapshot = load_dashboard_data(
-      &state.db_path,
+    let overview = cached_overview(
+      &state,
       Some(normalized_bucket.clone()),
       anchor.clone(),
       custom_start.clone(),
       custom_end.clone(),
-      search,
       live_rate_limits.clone(),
       live_window_offset,
     )?;
     let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
     let sync_settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+    let subscription_profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+    drop(conn);
+    let conversation_page = if include_conversations.unwrap_or(false) {
+      list_conversations(
+        &state.db_path,
+        Some(ConversationFilters {
+          bucket: Some(normalized_bucket),
+          anchor,
+          custom_start,
+          custom_end,
+          search,
+          live_window_offset,
+          cursor: None,
+          limit: Some(50),
+        }),
+        live_rate_limits.clone(),
+      )?
+    } else {
+      ConversationPage {
+        items: Vec::new(),
+        next_cursor: None,
+        has_more: false,
+      }
+    };
 
     Ok(DashboardSnapshot {
-      overview: snapshot.overview,
-      conversation_page: snapshot.conversation_page,
+      overview,
+      conversation_page,
       sync_settings,
-      subscription_profile: snapshot.subscription_profile,
+      subscription_profile,
       live_rate_limits,
     })
   })
@@ -969,16 +1039,38 @@ fn current_menu_bar_title_parts(
   };
   let bucket = effective_menu_bar_api_bucket(&configured_bucket, live_rate_limits);
   let api_value_title = if settings.show_menu_bar_daily_api_value {
-    let api_value_usd = get_window_api_value(
-      &state.db_path,
-      bucket.clone(),
-      if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
-      None,
-      None,
-      live_rate_limits.cloned(),
-      None,
-    )?;
-    Some(format!("${:.1}", api_value_usd))
+    let cache_key = menu_bar_api_value_cache_key(&bucket, &anchor, live_rate_limits);
+    let usage_revision = state.menu_bar_usage_revision.load(Ordering::Acquire);
+    let cached_title = state
+      .menu_bar_api_value_cache
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner)
+      .as_ref()
+      .filter(|cached| cached.key == cache_key && cached.usage_revision == usage_revision)
+      .map(|cached| cached.title.clone());
+    if let Some(title) = cached_title {
+      Some(title)
+    } else {
+      let api_value_usd = get_window_api_value(
+        &state.db_path,
+        bucket.clone(),
+        if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
+        None,
+        None,
+        live_rate_limits.cloned(),
+        None,
+      )?;
+      let title = format!("${:.1}", api_value_usd);
+      *state
+        .menu_bar_api_value_cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(CachedMenuBarApiValue {
+        key: cache_key,
+        usage_revision,
+        title: title.clone(),
+      });
+      Some(title)
+    }
   } else {
     None
   };
@@ -994,6 +1086,25 @@ fn current_menu_bar_title_parts(
     None
   };
   Ok((api_value_title, live_metric_title))
+}
+
+fn menu_bar_api_value_cache_key(
+  bucket: &str,
+  anchor: &str,
+  live_rate_limits: Option<&LiveRateLimitSnapshot>,
+) -> String {
+  let live_window = match bucket {
+    "five_hour" => live_rate_limits.and_then(|snapshot| snapshot.primary.as_ref()),
+    "seven_day" => live_rate_limits.and_then(|snapshot| snapshot.secondary.as_ref()),
+    _ => None,
+  };
+  format!(
+    "{}|{}|{}|{}",
+    bucket,
+    if bucket_uses_anchor(bucket) { anchor } else { "" },
+    live_window.and_then(|window| window.window_start.as_deref()).unwrap_or(""),
+    live_window.and_then(|window| window.resets_at.as_deref()).unwrap_or("")
+  )
 }
 
 fn menu_bar_title(api_value_title: Option<&str>, live_metric_title: Option<&str>) -> Option<String> {
@@ -1548,21 +1659,75 @@ fn live_snapshot_is_newer(
   }
 }
 
-fn build_passive_menu_bar_popup_snapshot(
-  db_path: &Path,
-  live_cache: &refresh::LiveQuotaCache,
-) -> Result<MenuBarPopupSnapshot, String> {
-  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+fn cached_overview(
+  state: &AppState,
+  bucket: Option<String>,
+  anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
+  live_rate_limits: Option<LiveRateLimitSnapshot>,
+  live_window_offset: Option<i64>,
+) -> Result<OverviewResponse, String> {
+  let key = serde_json::to_string(&(
+    &bucket,
+    &anchor,
+    &custom_start,
+    &custom_end,
+    &live_rate_limits,
+    live_window_offset,
+  ))
+  .map_err(|error| error.to_string())?;
+  let usage_revision = state.menu_bar_usage_revision.load(Ordering::Acquire);
+  let quota_revision = state.quota_revision.load(Ordering::Acquire);
+  let settings_revision = state.settings_revision.load(Ordering::Acquire);
+  let mut cache = state
+    .overview_cache
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner);
+  if let Some(cached) = cache.as_ref().filter(|cached| {
+    cached.key == key
+      && cached.usage_revision == usage_revision
+      && cached.quota_revision == quota_revision
+      && cached.settings_revision == settings_revision
+  }) {
+    return Ok(cached.value.clone());
+  }
+
+  let connection = state
+    .overview_connection
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner);
+  let value = get_overview_with_connection(
+    &connection,
+    bucket,
+    anchor,
+    custom_start,
+    custom_end,
+    live_rate_limits,
+    live_window_offset,
+  )?;
+  *cache = Some(CachedOverview {
+    key,
+    usage_revision,
+    quota_revision,
+    settings_revision,
+    value: value.clone(),
+  });
+  Ok(value)
+}
+
+fn build_passive_menu_bar_popup_snapshot(state: &AppState) -> Result<MenuBarPopupSnapshot, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
   drop(conn);
-  let live_rate_limits = live_cache
+  let live_rate_limits = state.live_rate_limits
     .rate_limits()
     .map(|snapshot| normalize_live_rate_limit_snapshot(snapshot.as_ref().clone()));
   let configured_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let selected_bucket = effective_menu_bar_api_bucket(&configured_bucket, live_rate_limits.as_ref());
   let anchor = bucket_uses_anchor(&selected_bucket).then(|| Local::now().format("%Y-%m-%d").to_string());
-  let overview = get_overview(
-    db_path,
+  let overview = cached_overview(
+    state,
     Some(selected_bucket.clone()),
     anchor,
     None,
@@ -1581,7 +1746,7 @@ fn build_passive_menu_bar_popup_snapshot(
       .map(|value| value.quota_trend.clone())
       .unwrap_or_default()
   } else {
-    get_quota_trend(db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
+    get_quota_trend(&state.db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
   };
 
   Ok(MenuBarPopupSnapshot {
@@ -2224,7 +2389,10 @@ pub fn run() {
         .map(|snapshot| snapshot.fetched_at);
       let epoch_backfill_is_pending =
         database::epoch_backfill_pending(&conn).map_err(|error| error.to_string())?;
-      drop(conn);
+      conn
+        .pragma_update(None, "cache_size", -32_768)
+        .map_err(|error| error.to_string())?;
+      let overview_connection = Arc::new(Mutex::new(conn));
 
       let live_rate_limits = refresh::LiveQuotaCache::new();
       if let Some(fallback) = display_fallback {
@@ -2241,6 +2409,7 @@ pub fn run() {
           refresh_config_from_saved_settings(&settings, live_last_success_at.as_deref()),
           Arc::new(AppTokenRefreshExecutor {
             db_path: db_path.clone(),
+            preparation_connection: Arc::new(Mutex::new(None)),
           }),
           Arc::new(AppLiveQuotaFetcher {
             db_path: db_path.clone(),
@@ -2280,6 +2449,12 @@ pub fn run() {
         refresh: installed_refresh_handle(refresh),
         usage_mutations,
         menu_bar_render_state: Arc::new(AtomicU8::new(MENU_RENDER_IDLE)),
+        menu_bar_usage_revision: Arc::new(AtomicU64::new(0)),
+        quota_revision: Arc::new(AtomicU64::new(0)),
+        settings_revision: Arc::new(AtomicU64::new(0)),
+        menu_bar_api_value_cache: Arc::new(Mutex::new(None)),
+        overview_cache: Arc::new(Mutex::new(None)),
+        overview_connection,
         daily_value_tray,
         live_rate_limits,
         menu_bar_popup_visible: Arc::new(AtomicBool::new(false)),
@@ -2735,12 +2910,22 @@ mod tests {
     usage_mutations: refresh::UsageMutationCoordinator,
     live_rate_limits: refresh::LiveQuotaCache,
   ) -> AppState {
+    let overview_connection = open_connection(&db_path).expect("open overview connection");
+    overview_connection
+      .pragma_update(None, "cache_size", -32_768)
+      .expect("configure overview cache");
     AppState {
       app_handle: None,
       db_path,
       refresh: Some(refresh),
       usage_mutations,
       menu_bar_render_state: Arc::new(AtomicU8::new(MENU_RENDER_IDLE)),
+      menu_bar_usage_revision: Arc::new(AtomicU64::new(0)),
+      quota_revision: Arc::new(AtomicU64::new(0)),
+      settings_revision: Arc::new(AtomicU64::new(0)),
+      menu_bar_api_value_cache: Arc::new(Mutex::new(None)),
+      overview_cache: Arc::new(Mutex::new(None)),
+      overview_connection: Arc::new(Mutex::new(overview_connection)),
       daily_value_tray: None,
       live_rate_limits,
       menu_bar_popup_visible: Arc::new(AtomicBool::new(false)),
@@ -2877,8 +3062,14 @@ mod tests {
     let db_path = directory.path().join("usage.sqlite");
     prepare_app_database(&db_path).expect("prepare app database");
     let cache = refresh::LiveQuotaCache::new();
+    let state = test_app_state(
+      db_path.clone(),
+      runtime.handle(),
+      refresh::UsageMutationCoordinator::new(),
+      cache,
+    );
 
-    let snapshot = build_passive_menu_bar_popup_snapshot(&db_path, &cache)
+    let snapshot = build_passive_menu_bar_popup_snapshot(&state)
       .expect("build passive popup snapshot");
 
     assert_eq!(snapshot.total_tokens_selected_bucket, 0);
@@ -2898,6 +3089,7 @@ mod tests {
 
   #[test]
   fn popup_snapshot_uses_seven_day_bucket_when_five_hour_quota_is_absent() {
+    let (runtime, _, _) = start_recording_runtime(disabled_refresh_config(None));
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
     prepare_app_database(&db_path).expect("prepare app database");
@@ -2926,8 +3118,14 @@ mod tests {
       Instant::now(),
       Utc::now(),
     );
+    let state = test_app_state(
+      db_path,
+      runtime.handle(),
+      refresh::UsageMutationCoordinator::new(),
+      cache,
+    );
 
-    let snapshot = build_passive_menu_bar_popup_snapshot(&db_path, &cache)
+    let snapshot = build_passive_menu_bar_popup_snapshot(&state)
       .expect("build popup snapshot");
 
     assert_eq!(snapshot.selected_bucket, "seven_day");
@@ -2936,6 +3134,7 @@ mod tests {
       snapshot.quota_7d.map(|window| window.remaining_percent),
       Some(79)
     );
+    runtime.shutdown_and_join().expect("shutdown runtime");
   }
 
   #[test]
@@ -3021,6 +3220,7 @@ mod tests {
     let token_executor = RecordingAppTokenExecutor {
       inner: AppTokenRefreshExecutor {
         db_path: db_path.clone(),
+        preparation_connection: Arc::new(Mutex::new(None)),
       },
       parsed: parsed_tx,
       committed: committed_tx,
@@ -3055,7 +3255,7 @@ mod tests {
     assert!(parsed_generation > 0);
     assert_eq!(parsed_generation, committed_generation);
     assert_eq!(source_generation, handle.status().source_generation);
-    assert_eq!(kind, refresh::TokenScanKind::Incremental);
+    assert_eq!(kind, refresh::TokenScanKind::Full);
     assert_eq!(result.codex_home, codex_home.to_string_lossy());
     assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
     runtime.shutdown_and_join().expect("shutdown runtime");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -165,6 +165,8 @@ pub struct ConversationFilters {
   pub custom_end: Option<String>,
   pub search: Option<String>,
   pub live_window_offset: Option<i64>,
+  pub cursor: Option<String>,
+  pub limit: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -333,10 +335,18 @@ pub struct OverviewResponse {
 #[serde(rename_all = "camelCase")]
 pub struct DashboardSnapshot {
   pub overview: OverviewResponse,
-  pub conversations: Vec<ConversationListItem>,
+  pub conversation_page: ConversationPage,
   pub sync_settings: SyncSettings,
   pub subscription_profile: SubscriptionProfile,
   pub live_rate_limits: Option<LiveRateLimitSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationPage {
+  pub items: Vec<ConversationListItem>,
+  pub next_cursor: Option<String>,
+  pub has_more: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -423,6 +433,8 @@ pub struct ConversationDetail {
   pub source_states: Vec<String>,
   pub sessions: Vec<ConversationSessionSummary>,
   pub turns: Vec<ConversationTurnPoint>,
+  pub next_turn_cursor: Option<usize>,
+  pub has_more_turns: bool,
   pub model_breakdown: Vec<ModelShare>,
   pub composition_breakdown: Vec<CompositionShare>,
 }
@@ -435,5 +447,9 @@ pub struct ScanResult {
   pub imported_sessions: usize,
   pub updated_sessions: usize,
   pub missing_sessions: usize,
+  pub scan_kind: String,
+  pub source_bytes_read: u64,
+  pub tail_parsed_files: usize,
+  pub fully_parsed_files: usize,
   pub last_completed_at: String,
 }

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -297,19 +297,23 @@ fn load_conversation_page_sql(
   };
   let sql = format!(
     "
-    WITH session_groups AS (
-      SELECT root_session_id,
-             COALESCE(NULLIF(MAX(title), ''), root_session_id) AS title,
-             MIN(started_at) AS started_at,
-             MAX(updated_at) AS updated_at,
-             COUNT(*) AS session_count,
-             GROUP_CONCAT(DISTINCT source_state) AS source_states
+    WITH matching_roots AS (
+      SELECT DISTINCT root_session_id
       FROM sessions
       WHERE ?3 IS NULL
          OR lower(COALESCE(title, '')) LIKE ?3
          OR lower(root_session_id) LIKE ?3
          OR lower(session_id) LIKE ?3
-      GROUP BY root_session_id
+    ), session_groups AS (
+      SELECT s.root_session_id,
+             COALESCE(NULLIF(MAX(title), ''), s.root_session_id) AS title,
+             MIN(started_at) AS started_at,
+             MAX(updated_at) AS updated_at,
+             COUNT(*) AS session_count,
+             GROUP_CONCAT(DISTINCT source_state) AS source_states
+      FROM sessions s
+      JOIN matching_roots mr ON mr.root_session_id = s.root_session_id
+      GROUP BY s.root_session_id
     ), event_groups AS (
       SELECT s.root_session_id,
              GROUP_CONCAT(DISTINCT e.model_id) AS model_ids,
@@ -2183,6 +2187,67 @@ mod tests {
     assert_eq!(second.items.len(), 50);
     assert_eq!(second.next_cursor.as_deref(), Some("100"));
     assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("session-069"));
+  }
+
+  #[test]
+  fn conversation_search_aggregates_every_session_in_a_matching_root() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "INSERT INTO sessions (session_id, root_session_id, title, source_state, started_at, created_at, imported_at, updated_at) VALUES ('root', 'root', 'Z Root title', 'active', '2026-07-13T07:00:00Z', '2026-07-13T07:00:00Z', '2026-07-13T07:00:00Z', '2026-07-13T08:00:00Z')",
+        [],
+      )
+      .expect("insert root session");
+    conn
+      .execute(
+        "INSERT INTO sessions (session_id, root_session_id, title, source_state, started_at, created_at, imported_at, updated_at) VALUES ('child-needle', 'root', 'Needle child', 'missing', '2026-07-13T08:00:00Z', '2026-07-13T08:00:00Z', '2026-07-13T08:00:00Z', '2026-07-13T09:00:00Z')",
+        [],
+      )
+      .expect("insert matching child session");
+    for (session_id, total_tokens, value_usd) in [("root", 10, 1.0), ("child-needle", 20, 2.0)] {
+      conn
+        .execute(
+          "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES (?1, '2026-07-13T08:30:00Z', ?2, 'gpt-5.4', ?3, 0, 0, 0, ?3, ?4, 0, 0)",
+          rusqlite::params![
+            session_id,
+            parse_rfc3339_local("2026-07-13T08:30:00Z")
+              .expect("event timestamp")
+              .timestamp_millis(),
+            total_tokens,
+            value_usd,
+          ],
+        )
+        .expect("insert usage event");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T00:00:00Z").expect("end"),
+    };
+
+    let page = load_conversation_page_sql(
+      &conn,
+      &SubscriptionProfile::default(),
+      &window,
+      Some("needle".to_string()),
+      None,
+      50,
+    )
+    .expect("search conversations");
+
+    assert_eq!(page.items.len(), 1);
+    let item = &page.items[0];
+    assert_eq!(item.root_session_id, "root");
+    assert_eq!(item.title, "Z Root title");
+    assert_eq!(item.started_at.as_deref(), Some("2026-07-13T07:00:00Z"));
+    assert_eq!(item.updated_at.as_deref(), Some("2026-07-13T09:00:00Z"));
+    assert_eq!(item.session_count, 2);
+    assert_eq!(item.subagent_count, 1);
+    assert_eq!(item.total_tokens, 30);
+    assert_eq!(item.api_value_usd, 3.0);
+    assert_eq!(item.source_states, vec!["active", "missing"]);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -1812,8 +1812,10 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
         SELECT id
         FROM rate_limit_samples
         WHERE bucket = ?1
-          AND window_start_ms = ?2
-          AND resets_at_ms = ?3
+          AND window_start_ms >= ?2
+          AND window_start_ms < ?2 + 60000
+          AND resets_at_ms >= ?3
+          AND resets_at_ms < ?3 + 60000
           AND sample_timestamp_ms >= bins.bin_start_ms
           AND sample_timestamp_ms < bins.bin_end_ms
         ORDER BY sample_timestamp_ms DESC, id DESC
@@ -2461,6 +2463,49 @@ mod tests {
         .collect::<Vec<_>>(),
       vec![2, 4]
     );
+  }
+
+  #[test]
+  fn backfilled_quota_samples_match_the_normalized_window_minute() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "
+        INSERT INTO rate_limit_samples (
+          source_kind, source_session_id, bucket, sample_timestamp,
+          limit_id, limit_name, plan_type, window_start, resets_at,
+          used_percent, remaining_percent, created_at,
+          sample_timestamp_ms, window_start_ms, resets_at_ms
+        ) VALUES (
+          'live', '', 'seven_day', '2026-07-13T07:00:12Z',
+          '', '', 'pro', '2026-07-13T06:00:36Z', '2026-07-20T06:00:44Z',
+          12, 88, '2026-07-13T07:00:12Z', ?1, ?2, ?3
+        )
+        ",
+        rusqlite::params![
+          parse_rfc3339_local("2026-07-13T07:00:12Z").expect("sample").timestamp_millis(),
+          parse_rfc3339_local("2026-07-13T06:00:36Z").expect("start").timestamp_millis(),
+          parse_rfc3339_local("2026-07-20T06:00:44Z").expect("end").timestamp_millis(),
+        ],
+      )
+      .expect("insert backfilled quota sample");
+    conn
+      .execute(
+        "INSERT INTO data_repairs (repair_key, completed_at) VALUES ('epoch_timestamp_backfill_v1', '2026-07-13T08:00:00Z')",
+        [],
+      )
+      .expect("mark epoch backfill complete");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end"),
+    };
+
+    let samples = load_quota_samples(&conn, &window);
+
+    assert_eq!(samples.iter().map(|sample| sample.used_percent).collect::<Vec<_>>(), vec![12]);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -91,14 +91,16 @@ struct RateLimitWindowSummary {
   end: DateTime<Local>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 pub struct DashboardData {
   pub overview: OverviewResponse,
   pub conversation_page: ConversationPage,
   pub subscription_profile: SubscriptionProfile,
 }
 
-pub fn get_overview(
-  db_path: &Path,
+pub fn get_overview_with_connection(
+  conn: &Connection,
   bucket: Option<String>,
   anchor: Option<String>,
   custom_start: Option<String>,
@@ -106,7 +108,6 @@ pub fn get_overview(
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
-  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let resolved_window = resolve_window(
     &conn,
@@ -210,20 +211,18 @@ pub fn list_conversations(
     live_rate_limits.as_ref(),
     filters.live_window_offset,
   )?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
-  let cursor = filters.cursor.clone();
   let limit = filters.limit.unwrap_or(50).clamp(1, 100);
-  let items = build_conversation_list(
-    &sessions,
-    &events,
+  load_conversation_page_sql(
+    &conn,
     &profile,
     &resolved_window.window,
     filters.search,
-  )?;
-  Ok(paginate_conversations(items, cursor.as_deref(), limit))
+    filters.cursor.as_deref(),
+    limit,
+  )
 }
 
+#[cfg(test)]
 pub fn load_dashboard_data(
   db_path: &Path,
   bucket: Option<String>,
@@ -233,6 +232,7 @@ pub fn load_dashboard_data(
   search: Option<String>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
+  include_conversations: bool,
 ) -> Result<DashboardData, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
@@ -260,41 +260,143 @@ pub fn load_dashboard_data(
     &resolved_window,
     live_rate_limits.clone(),
   )?;
-  let conversations = build_conversation_list(
-    &sessions,
-    &events,
-    &profile,
-    &resolved_window.window,
-    search,
-  )?;
+  let conversation_page = if include_conversations {
+    load_conversation_page_sql(&conn, &profile, &resolved_window.window, search, None, 50)?
+  } else {
+    ConversationPage {
+      items: Vec::new(),
+      next_cursor: None,
+      has_more: false,
+    }
+  };
 
   Ok(DashboardData {
     overview,
-    conversation_page: paginate_conversations(conversations, None, 50),
+    conversation_page,
     subscription_profile: profile,
   })
 }
 
-fn paginate_conversations(
-  items: Vec<ConversationListItem>,
+fn load_conversation_page_sql(
+  conn: &Connection,
+  profile: &SubscriptionProfile,
+  window: &Window,
+  search: Option<String>,
   cursor: Option<&str>,
   limit: usize,
-) -> ConversationPage {
-  let start = cursor
-    .and_then(|cursor| items.iter().position(|item| item.root_session_id == cursor))
-    .map(|index| index.saturating_add(1))
-    .unwrap_or(0);
-  let end = start.saturating_add(limit).min(items.len());
-  let page_items = items[start..end].to_vec();
-  let has_more = end < items.len();
-  let next_cursor = has_more
-    .then(|| page_items.last().map(|item| item.root_session_id.clone()))
-    .flatten();
-  ConversationPage {
-    items: page_items,
-    next_cursor,
+) -> Result<ConversationPage, String> {
+  let offset = cursor.and_then(|value| value.parse::<usize>().ok()).unwrap_or(0);
+  let search_pattern = search
+    .filter(|value| !value.trim().is_empty())
+    .map(|value| format!("%{}%", value.to_ascii_lowercase()));
+  let include_empty = i64::from(window.bucket == "total");
+  let event_filter = if epoch_backfill_complete(conn) || !has_legacy_usage_events(conn).map_err(|error| error.to_string())? {
+    "e.timestamp_ms >= ?1 AND e.timestamp_ms < ?2"
+  } else {
+    "((e.timestamp_ms >= ?1 AND e.timestamp_ms < ?2) OR (e.timestamp_ms IS NULL AND unixepoch(e.timestamp) * 1000 >= ?1 AND unixepoch(e.timestamp) * 1000 < ?2))"
+  };
+  let sql = format!(
+    "
+    WITH session_groups AS (
+      SELECT root_session_id,
+             COALESCE(NULLIF(MAX(title), ''), root_session_id) AS title,
+             MIN(started_at) AS started_at,
+             MAX(updated_at) AS updated_at,
+             COUNT(*) AS session_count,
+             GROUP_CONCAT(DISTINCT source_state) AS source_states
+      FROM sessions
+      WHERE ?3 IS NULL
+         OR lower(COALESCE(title, '')) LIKE ?3
+         OR lower(root_session_id) LIKE ?3
+         OR lower(session_id) LIKE ?3
+      GROUP BY root_session_id
+    ), event_groups AS (
+      SELECT s.root_session_id,
+             GROUP_CONCAT(DISTINCT e.model_id) AS model_ids,
+             SUM(e.input_tokens) AS input_tokens,
+             SUM(e.cached_input_tokens) AS cached_input_tokens,
+             SUM(e.output_tokens) AS output_tokens,
+             SUM(e.reasoning_output_tokens) AS reasoning_output_tokens,
+             SUM(e.total_tokens) AS total_tokens,
+             SUM(e.value_usd) AS api_value_usd,
+             MAX(e.fast_mode_effective) AS has_fast_mode
+      FROM usage_events e
+      JOIN sessions s ON s.session_id = e.session_id
+      WHERE {event_filter}
+      GROUP BY s.root_session_id
+    )
+    SELECT sg.root_session_id, sg.title, sg.started_at, sg.updated_at,
+           COALESCE(eg.model_ids, ''), COALESCE(eg.input_tokens, 0),
+           COALESCE(eg.cached_input_tokens, 0), COALESCE(eg.output_tokens, 0),
+           COALESCE(eg.reasoning_output_tokens, 0), COALESCE(eg.total_tokens, 0),
+           sg.session_count, COALESCE(eg.has_fast_mode, 0),
+           COALESCE(eg.api_value_usd, 0.0), COALESCE(sg.source_states, '')
+    FROM session_groups sg
+    LEFT JOIN event_groups eg ON eg.root_session_id = sg.root_session_id
+    WHERE ?4 = 1 OR COALESCE(eg.total_tokens, 0) > 0
+    ORDER BY COALESCE(eg.api_value_usd, 0.0) DESC, sg.updated_at DESC, sg.root_session_id ASC
+    LIMIT ?5 OFFSET ?6
+    "
+  );
+  let fetch_limit = limit.saturating_add(1);
+  let mut stmt = conn.prepare(&sql).map_err(|error| error.to_string())?;
+  let rows = stmt
+    .query_map(
+      rusqlite::params![
+        window.start.timestamp_millis(),
+        window.end.timestamp_millis(),
+        search_pattern,
+        include_empty,
+        fetch_limit as i64,
+        offset as i64,
+      ],
+      |row| {
+        let session_count = row.get::<_, i64>(10)?.max(0) as usize;
+        let api_value_usd = row.get::<_, f64>(12)?;
+        Ok(ConversationListItem {
+          root_session_id: row.get(0)?,
+          title: row.get(1)?,
+          started_at: row.get(2)?,
+          updated_at: row.get(3)?,
+          model_ids: split_sorted_csv(row.get::<_, String>(4)?),
+          input_tokens: row.get(5)?,
+          cached_input_tokens: row.get(6)?,
+          output_tokens: row.get(7)?,
+          reasoning_output_tokens: row.get(8)?,
+          total_tokens: row.get(9)?,
+          session_count,
+          subagent_count: session_count.saturating_sub(1),
+          has_fast_mode: row.get::<_, i64>(11)? != 0,
+          api_value_usd,
+          subscription_share: if profile.monthly_price > 0.0 {
+            api_value_usd / profile.monthly_price
+          } else {
+            0.0
+          },
+          source_states: split_sorted_csv(row.get::<_, String>(13)?),
+        })
+      },
+    )
+    .map_err(|error| error.to_string())?;
+  let mut items = rows.collect::<rusqlite::Result<Vec<_>>>().map_err(|error| error.to_string())?;
+  let has_more = items.len() > limit;
+  items.truncate(limit);
+  Ok(ConversationPage {
+    items,
+    next_cursor: has_more.then(|| offset.saturating_add(limit).to_string()),
     has_more,
-  }
+  })
+}
+
+fn split_sorted_csv(value: String) -> Vec<String> {
+  let mut values = value
+    .split(',')
+    .filter(|item| !item.is_empty())
+    .map(ToString::to_string)
+    .collect::<Vec<_>>();
+  values.sort();
+  values.dedup();
+  values
 }
 
 fn build_overview(
@@ -369,119 +471,6 @@ fn build_overview(
     composition_shares: composition_breakdown,
     live_rate_limits,
   })
-}
-
-fn build_conversation_list(
-  sessions: &HashMap<String, SessionRow>,
-  events: &[EventRow],
-  profile: &SubscriptionProfile,
-  window: &Window,
-  search: Option<String>,
-) -> Result<Vec<ConversationListItem>, String> {
-  let search = search.unwrap_or_default().to_ascii_lowercase();
-
-  let mut groups: BTreeMap<String, ConversationAccumulator> = BTreeMap::new();
-
-  for session in sessions.values() {
-    let group = groups
-      .entry(session.root_session_id.clone())
-      .or_insert_with(|| ConversationAccumulator {
-        title: session.title.clone(),
-        started_at: session.started_at.clone(),
-        updated_at: session.updated_at.clone(),
-        model_ids: HashSet::new(),
-        input_tokens: 0,
-        cached_input_tokens: 0,
-        output_tokens: 0,
-        reasoning_output_tokens: 0,
-        total_tokens: 0,
-        session_ids: HashSet::new(),
-        fast_session_ids: HashSet::new(),
-        api_value_usd: 0.0,
-        source_states: HashSet::new(),
-      });
-
-    if group.title.is_empty() {
-      group.title = session.title.clone();
-    }
-    group.started_at = min_option_string(group.started_at.take(), session.started_at.clone());
-    group.updated_at = max_option_string(group.updated_at.take(), session.updated_at.clone());
-    group.session_ids.insert(session.session_id.clone());
-    group.source_states.insert(session.source_state.clone());
-  }
-
-  for event in events {
-    let Some(session) = sessions.get(&event.session_id) else {
-      continue;
-    };
-    let group = groups.entry(session.root_session_id.clone()).or_default();
-    group.model_ids.insert(event.model_id.clone());
-    group.input_tokens += event.input_tokens;
-    group.cached_input_tokens += event.cached_input_tokens;
-    group.output_tokens += event.output_tokens;
-    group.reasoning_output_tokens += event.reasoning_output_tokens;
-    group.total_tokens += event.total_tokens;
-    group.api_value_usd += event.value_usd;
-    if event.fast_mode_effective {
-      group.fast_session_ids.insert(event.session_id.clone());
-    }
-  }
-
-  let mut items = Vec::new();
-  for (root_session_id, group) in groups {
-    let title = if group.title.trim().is_empty() {
-      root_session_id.clone()
-    } else {
-      group.title.clone()
-    };
-
-    if !search.is_empty()
-      && !title.to_ascii_lowercase().contains(&search)
-      && !root_session_id.to_ascii_lowercase().contains(&search)
-      && !group
-        .session_ids
-        .iter()
-        .any(|session_id| session_id.to_ascii_lowercase().contains(&search))
-    {
-      continue;
-    }
-
-    if group.total_tokens == 0 && window.bucket != "total" {
-      continue;
-    }
-
-    items.push(ConversationListItem {
-      root_session_id,
-      title,
-      started_at: group.started_at,
-      updated_at: group.updated_at,
-      model_ids: sorted_strings(group.model_ids),
-      input_tokens: group.input_tokens,
-      cached_input_tokens: group.cached_input_tokens,
-      output_tokens: group.output_tokens,
-      reasoning_output_tokens: group.reasoning_output_tokens,
-      total_tokens: group.total_tokens,
-      session_count: group.session_ids.len(),
-      subagent_count: group.session_ids.len().saturating_sub(1),
-      has_fast_mode: !group.fast_session_ids.is_empty(),
-      api_value_usd: group.api_value_usd,
-      subscription_share: if profile.monthly_price > 0.0 {
-        group.api_value_usd / profile.monthly_price
-      } else {
-        0.0
-      },
-      source_states: sorted_strings(group.source_states),
-    });
-  }
-
-  items.sort_by(|left, right| {
-    right
-      .api_value_usd
-      .total_cmp(&left.api_value_usd)
-      .then_with(|| right.updated_at.cmp(&left.updated_at))
-  });
-
-  Ok(items)
 }
 
 pub fn get_conversation_detail(
@@ -1435,7 +1424,21 @@ fn resolve_live_rate_limit_window(
         end: normalize_local_timestamp(active_window.resets_at.as_deref().and_then(parse_rfc3339_local)?),
       })
     });
-  let windows = load_live_rate_limit_windows(conn, bucket, current_window).map_err(|error| error.to_string())?;
+  if requested_offset == 0 {
+    if let Some(window) = current_window {
+      return Ok((window.start, window.end, window.start.date_naive(), 0, 2));
+    }
+  }
+  let requested_window_count = requested_offset
+    .saturating_add(2)
+    .clamp(1, MAX_LIVE_RATE_LIMIT_WINDOWS as i64) as usize;
+  let windows = load_live_rate_limit_windows(
+    conn,
+    bucket,
+    current_window,
+    requested_window_count,
+  )
+  .map_err(|error| error.to_string())?;
 
   if windows.is_empty() {
     return Err(format!(
@@ -1459,6 +1462,7 @@ fn load_live_rate_limit_windows(
   conn: &Connection,
   bucket: &str,
   current_window: Option<RateLimitWindowSummary>,
+  max_windows: usize,
 ) -> rusqlite::Result<Vec<RateLimitWindowSummary>> {
   let mut ordered = Vec::new();
   let mut seen = HashSet::new();
@@ -1473,7 +1477,7 @@ fn load_live_rate_limit_windows(
     }
     let previous_start = window.start;
     ordered.push(window);
-    if ordered.len() >= MAX_LIVE_RATE_LIMIT_WINDOWS {
+    if ordered.len() >= max_windows.clamp(1, MAX_LIVE_RATE_LIMIT_WINDOWS) {
       break;
     }
     cursor = load_previous_rate_limit_window(conn, bucket, previous_start)?;
@@ -1829,7 +1833,7 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     Err(_) => return Vec::new(),
   };
 
-  let samples = rows
+  let mut samples = rows
     .filter_map(Result::ok)
     .filter_map(|(timestamp_ms, used_percent)| {
       Local.timestamp_millis_opt(timestamp_ms).single().map(|timestamp| QuotaSample {
@@ -1838,11 +1842,14 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
       })
     })
     .collect::<Vec<_>>();
-  if !samples.is_empty() || epoch_backfill_complete(conn) {
+  if epoch_backfill_complete(conn) {
     return samples;
   }
 
-  load_legacy_quota_samples(conn, window, target_start, target_end)
+  samples.extend(load_legacy_quota_samples(conn, window, target_start, target_end));
+  samples.sort_by_key(|sample| sample.timestamp);
+  samples.dedup_by(|right, left| right.timestamp == left.timestamp && right.used_percent == left.used_percent);
+  samples
 }
 
 fn epoch_backfill_complete(conn: &Connection) -> bool {
@@ -2028,23 +2035,6 @@ impl CompositionAccumulator {
 }
 
 #[derive(Debug, Default)]
-struct ConversationAccumulator {
-  title: String,
-  started_at: Option<String>,
-  updated_at: Option<String>,
-  model_ids: HashSet<String>,
-  input_tokens: i64,
-  cached_input_tokens: i64,
-  output_tokens: i64,
-  reasoning_output_tokens: i64,
-  total_tokens: i64,
-  session_ids: HashSet<String>,
-  fast_session_ids: HashSet<String>,
-  api_value_usd: f64,
-  source_states: HashSet<String>,
-}
-
-#[derive(Debug, Default)]
 struct ConversationSessionAccumulator {
   parent_session_id: Option<String>,
   agent_nickname: Option<String>,
@@ -2113,42 +2103,53 @@ mod tests {
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
 
-  fn conversation_item(id: &str) -> ConversationListItem {
-    ConversationListItem {
-      root_session_id: id.to_string(),
-      title: id.to_string(),
-      started_at: None,
-      updated_at: None,
-      model_ids: Vec::new(),
-      input_tokens: 0,
-      cached_input_tokens: 0,
-      output_tokens: 0,
-      reasoning_output_tokens: 0,
-      total_tokens: 0,
-      session_count: 1,
-      subagent_count: 0,
-      has_fast_mode: false,
-      api_value_usd: 0.0,
-      subscription_share: 0.0,
-      source_states: Vec::new(),
-    }
-  }
-
   #[test]
-  fn conversation_pages_are_bounded_and_resume_after_the_cursor() {
-    let items = (0..120)
-      .map(|index| conversation_item(&format!("root-{index:03}")))
-      .collect::<Vec<_>>();
+  fn conversation_query_pages_in_sql_without_loading_every_item() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let event_timestamp = "2026-07-13T08:00:00Z";
+    let event_timestamp_ms = parse_rfc3339_local(event_timestamp).expect("event timestamp").timestamp_millis();
+    for index in 0..120 {
+      let session_id = format!("session-{index:03}");
+      conn
+        .execute(
+          "INSERT INTO sessions (session_id, root_session_id, title, source_state, created_at, imported_at, updated_at) VALUES (?1, ?1, ?2, 'active', ?3, ?3, ?3)",
+          rusqlite::params![session_id, format!("Conversation {index:03}"), "2026-07-13T08:00:00Z"],
+        )
+        .expect("insert session");
+      conn
+        .execute(
+          "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES (?1, ?2, ?3, 'gpt-5.4', 1, 0, 1, 0, 2, ?4, 0, 0)",
+          rusqlite::params![session_id, event_timestamp, event_timestamp_ms, index as f64],
+        )
+        .expect("insert usage event");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T00:00:00Z").expect("end"),
+    };
+    let profile = SubscriptionProfile::default();
 
-    let first = paginate_conversations(items.clone(), None, 50);
+    let first = load_conversation_page_sql(&conn, &profile, &window, None, None, 50).expect("first page");
     assert_eq!(first.items.len(), 50);
     assert!(first.has_more);
-    assert_eq!(first.next_cursor.as_deref(), Some("root-049"));
+    assert_eq!(first.next_cursor.as_deref(), Some("50"));
+    assert_eq!(first.items.first().map(|item| item.root_session_id.as_str()), Some("session-119"));
 
-    let second = paginate_conversations(items, first.next_cursor.as_deref(), 50);
+    let second = load_conversation_page_sql(
+      &conn,
+      &profile,
+      &window,
+      None,
+      first.next_cursor.as_deref(),
+      50,
+    )
+    .expect("second page");
     assert_eq!(second.items.len(), 50);
-    assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("root-050"));
-    assert_eq!(second.next_cursor.as_deref(), Some("root-099"));
+    assert_eq!(second.next_cursor.as_deref(), Some("100"));
+    assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("session-069"));
   }
 
   #[test]
@@ -2167,6 +2168,7 @@ mod tests {
       None,
       None,
       None,
+      true,
     )
     .expect("load seven-day dashboard");
     eprintln!(
@@ -2272,6 +2274,28 @@ mod tests {
         [],
       )
       .expect("insert legacy quota sample");
+    conn
+      .execute(
+        "
+        INSERT INTO rate_limit_samples (
+          source_kind, source_session_id, bucket, sample_timestamp,
+          limit_id, limit_name, plan_type, window_start, resets_at,
+          used_percent, remaining_percent, created_at,
+          sample_timestamp_ms, window_start_ms, resets_at_ms
+        ) VALUES (
+          'live', '', 'seven_day', '2026-07-13T06:30:00Z',
+          '', '', 'pro', '2026-07-13T06:00:00Z', '2026-07-20T06:00:00Z',
+          8, 92, '2026-07-13T06:30:00Z',
+          ?1, ?2, ?3
+        )
+        ",
+        rusqlite::params![
+          parse_rfc3339_local("2026-07-13T06:30:00Z").expect("sample").timestamp_millis(),
+          parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start").timestamp_millis(),
+          parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end").timestamp_millis(),
+        ],
+      )
+      .expect("insert normalized quota sample");
     let window = Window {
       bucket: "seven_day".to_string(),
       anchor: "2026-07-13".to_string(),
@@ -2281,8 +2305,7 @@ mod tests {
 
     let samples = load_quota_samples(&conn, &window);
 
-    assert_eq!(samples.len(), 1);
-    assert_eq!(samples[0].used_percent, 12);
+    assert_eq!(samples.iter().map(|sample| sample.used_percent).collect::<Vec<_>>(), vec![8, 12]);
   }
 
   #[test]
@@ -2894,15 +2917,44 @@ mod tests {
       secondary: None,
       fetched_at: "2026-03-26T11:20:00+08:00".to_string(),
     };
+    let older = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: Some(crate::models::RateLimitWindowSnapshot {
+        used_percent: 71,
+        remaining_percent: 29,
+        window_duration_mins: Some(300),
+        resets_at: Some("2026-03-26T06:27:36+08:00".to_string()),
+        window_start: Some("2026-03-26T01:27:36+08:00".to_string()),
+      }),
+      secondary: None,
+      fetched_at: "2026-03-26T06:20:00+08:00".to_string(),
+    };
+    insert_live_rate_limit_snapshot(&conn, &older).expect("insert older live window");
     insert_live_rate_limit_snapshot(&conn, &previous).expect("insert previous live window");
     insert_live_rate_limit_snapshot(&conn, &current).expect("insert current live window");
+
+    let current_window = resolve_window(
+      &conn,
+      Some("five_hour".to_string()),
+      None,
+      None,
+      None,
+      &[],
+      1,
+      Some(&current),
+      Some(0),
+    )
+    .expect("resolve current live window");
+    assert_eq!(current_window.live_window_count, 2);
 
     let window =
       resolve_window(&conn, Some("five_hour".to_string()), None, None, None, &[], 1, Some(&current), Some(1))
         .expect("resolve historical live window");
 
     assert_eq!(window.live_window_offset, 1);
-    assert!(window.live_window_count >= 2);
+    assert_eq!(window.live_window_count, 3);
     assert_eq!(window.window.start.to_rfc3339(), "2026-03-26T06:27:00+08:00");
     assert_eq!(window.window.end.to_rfc3339(), "2026-03-26T11:27:00+08:00");
   }

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::database::{get_subscription_profile, open_connection};
 use crate::models::{
-  CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem,
+  CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem, ConversationPage,
   ConversationSessionSummary, ConversationTurnPoint, LiveRateLimitSnapshot, ModelShare,
   OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SubscriptionProfile, TokenUsage,
   TrendPoint,
@@ -24,10 +24,8 @@ use crate::pricing::{
 
 const SQL_SESSIONS: &str = include_str!("../sql/queries/sessions.sql");
 const SQL_SESSIONS_FOR_ROOT: &str = include_str!("../sql/queries/sessions_for_root.sql");
-const SQL_USAGE_EVENTS: &str = include_str!("../sql/queries/usage_events.sql");
 const SQL_USAGE_EVENTS_FOR_ROOT: &str = include_str!("../sql/queries/usage_events_for_root.sql");
 const SQL_RATE_LIMIT_WINDOWS: &str = include_str!("../sql/queries/rate_limit_windows.sql");
-const SQL_QUOTA_SAMPLES: &str = include_str!("../sql/queries/quota_samples.sql");
 
 #[derive(Debug, Clone)]
 struct SessionRow {
@@ -95,7 +93,7 @@ struct RateLimitWindowSummary {
 
 pub struct DashboardData {
   pub overview: OverviewResponse,
-  pub conversations: Vec<ConversationListItem>,
+  pub conversation_page: ConversationPage,
   pub subscription_profile: SubscriptionProfile,
 }
 
@@ -109,9 +107,20 @@ pub fn get_overview(
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let resolved_window = resolve_window(
+    &conn,
+    bucket.clone(),
+    anchor.clone(),
+    custom_start.clone(),
+    custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
   build_overview(
     &conn,
@@ -134,7 +143,6 @@ pub fn get_quota_trend(
   live_rate_limits: Option<LiveRateLimitSnapshot>,
 ) -> Result<Vec<QuotaTrendPoint>, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let resolved_window = resolve_window(
     &conn,
@@ -142,17 +150,13 @@ pub fn get_quota_trend(
     None,
     None,
     None,
-    &events,
+    &[],
     profile.billing_anchor_day,
     live_rate_limits.as_ref(),
     None,
   )?;
   let window = &resolved_window.window;
-  let filtered_events: Vec<_> = events
-    .iter()
-    .filter(|event| event_in_window(event, window))
-    .cloned()
-    .collect();
+  let filtered_events = load_events_in_window(&conn, window).map_err(|error| error.to_string())?;
 
   Ok(build_quota_trend(
     &conn,
@@ -195,12 +199,27 @@ pub fn list_conversations(
   db_path: &Path,
   filters: Option<ConversationFilters>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
-) -> Result<Vec<ConversationListItem>, String> {
+) -> Result<ConversationPage, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
-  build_conversation_list(&conn, &sessions, &events, &profile, filters, live_rate_limits.as_ref())
+  let filters = filters.unwrap_or_default();
+  let resolved_window = resolve_window(
+    &conn,
+    filters.bucket.clone(),
+    filters.anchor.clone(),
+    filters.custom_start.clone(),
+    filters.custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    filters.live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
+  let cursor = filters.cursor.clone();
+  let limit = filters.limit.unwrap_or(50).clamp(1, 100);
+  let items = build_conversation_list(&conn, &sessions, &events, &profile, Some(filters), live_rate_limits.as_ref())?;
+  Ok(paginate_conversations(items, cursor.as_deref(), limit))
 }
 
 pub fn load_dashboard_data(
@@ -214,9 +233,20 @@ pub fn load_dashboard_data(
   live_window_offset: Option<i64>,
 ) -> Result<DashboardData, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let resolved_window = resolve_window(
+    &conn,
+    bucket.clone(),
+    anchor.clone(),
+    custom_start.clone(),
+    custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
 
   let overview = build_overview(
@@ -244,15 +274,39 @@ pub fn load_dashboard_data(
       custom_end,
       search,
       live_window_offset,
+      cursor: None,
+      limit: Some(50),
     }),
     live_rate_limits.as_ref(),
   )?;
 
   Ok(DashboardData {
     overview,
-    conversations,
+    conversation_page: paginate_conversations(conversations, None, 50),
     subscription_profile: profile,
   })
+}
+
+fn paginate_conversations(
+  items: Vec<ConversationListItem>,
+  cursor: Option<&str>,
+  limit: usize,
+) -> ConversationPage {
+  let start = cursor
+    .and_then(|cursor| items.iter().position(|item| item.root_session_id == cursor))
+    .map(|index| index.saturating_add(1))
+    .unwrap_or(0);
+  let end = start.saturating_add(limit).min(items.len());
+  let page_items = items[start..end].to_vec();
+  let has_more = end < items.len();
+  let next_cursor = has_more
+    .then(|| page_items.last().map(|item| item.root_session_id.clone()))
+    .flatten();
+  ConversationPage {
+    items: page_items,
+    next_cursor,
+    has_more,
+  }
 }
 
 fn build_overview(
@@ -479,7 +533,11 @@ fn build_conversation_list(
   Ok(items)
 }
 
-pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<ConversationDetail, String> {
+pub fn get_conversation_detail(
+  db_path: &Path,
+  root_session_id: &str,
+  turn_cursor: Option<usize>,
+) -> Result<ConversationDetail, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let sessions = load_sessions_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
   let events = load_events_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
@@ -584,6 +642,12 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
       .then_with(|| left.session_id.cmp(&right.session_id))
       .then_with(|| left.turn_id.cmp(&right.turn_id))
   });
+  let already_loaded = turn_cursor.unwrap_or(0);
+  let page_end = detail_turns.len().saturating_sub(already_loaded);
+  let page_start = page_end.saturating_sub(40);
+  let turn_page = detail_turns[page_start..page_end].to_vec();
+  let has_more_turns = page_start > 0;
+  let next_turn_cursor = has_more_turns.then_some(already_loaded.saturating_add(turn_page.len()));
 
   let mut session_summaries = Vec::new();
   for session in conversation_sessions {
@@ -647,7 +711,9 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     multiple_agent: session_summaries.len() > 1,
     source_states: sorted_strings(source_states),
     sessions: session_summaries,
-    turns: detail_turns,
+    turns: turn_page,
+    next_turn_cursor,
+    has_more_turns,
     model_breakdown,
     composition_breakdown,
   })
@@ -1149,23 +1215,43 @@ fn load_sessions_for_root_session(
   Ok(sessions)
 }
 
-fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
-  let mut stmt = conn.prepare(SQL_USAGE_EVENTS)?;
-  let rows = stmt.query_map([], |row| {
-    Ok(EventRow {
-      session_id: row.get(0)?,
-      timestamp: row.get(1)?,
-      model_id: row.get(2)?,
-      input_tokens: row.get(3)?,
-      cached_input_tokens: row.get(4)?,
-      output_tokens: row.get(5)?,
-      reasoning_output_tokens: row.get(6)?,
-      total_tokens: row.get(7)?,
-      value_usd: row.get(8)?,
-      fast_mode_auto: row.get::<_, i64>(9)? != 0,
-      fast_mode_effective: row.get::<_, i64>(10)? != 0,
-    })
-  })?;
+fn load_events_in_window(conn: &Connection, window: &Window) -> rusqlite::Result<Vec<EventRow>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
+    UNION ALL
+    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE timestamp_ms IS NULL
+      AND unixepoch(timestamp) * 1000 >= ?1
+      AND unixepoch(timestamp) * 1000 < ?2
+    ORDER BY timestamp ASC
+    ",
+  )?;
+  let rows = stmt.query_map(
+    rusqlite::params![window.start.timestamp_millis(), window.end.timestamp_millis()],
+    |row| {
+      Ok(EventRow {
+        session_id: row.get(0)?,
+        timestamp: row.get(1)?,
+        model_id: row.get(2)?,
+        input_tokens: row.get(3)?,
+        cached_input_tokens: row.get(4)?,
+        output_tokens: row.get(5)?,
+        reasoning_output_tokens: row.get(6)?,
+        total_tokens: row.get(7)?,
+        value_usd: row.get(8)?,
+        fast_mode_auto: row.get::<_, i64>(9)? != 0,
+        fast_mode_effective: row.get::<_, i64>(10)? != 0,
+      })
+    },
+  )?;
 
   rows.collect()
 }
@@ -1227,7 +1313,7 @@ fn resolve_window(
   anchor: Option<String>,
   custom_start: Option<String>,
   custom_end: Option<String>,
-  events: &[EventRow],
+  _events: &[EventRow],
   billing_anchor_day: i64,
   live_rate_limits: Option<&LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
@@ -1295,20 +1381,30 @@ fn resolve_window(
       (start, end, start_date, 0, 0)
     }
     "total" => {
-      if events.is_empty() {
+      let bounds = conn
+        .query_row(
+          "
+          SELECT
+            MIN(COALESCE(timestamp_ms, unixepoch(timestamp) * 1000)),
+            MAX(COALESCE(timestamp_ms, unixepoch(timestamp) * 1000))
+          FROM usage_events
+          ",
+          [],
+          |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, Option<i64>>(1)?)),
+        )
+        .map_err(|error| error.to_string())?;
+      if bounds.0.is_none() || bounds.1.is_none() {
         let start = local_midnight(anchor_date)?;
         (start, start + chrono::Duration::days(1), anchor_date, 0, 0)
       } else {
-        let first = events
-          .iter()
-          .filter_map(|event| parse_rfc3339_local(&event.timestamp))
-          .min()
-          .ok_or_else(|| "No valid event timestamps found.".to_string())?;
-        let last = events
-          .iter()
-          .filter_map(|event| parse_rfc3339_local(&event.timestamp))
-          .max()
-          .ok_or_else(|| "No valid event timestamps found.".to_string())?;
+        let first = Local
+          .timestamp_millis_opt(bounds.0.unwrap_or_default())
+          .single()
+          .ok_or_else(|| "No valid first usage timestamp found.".to_string())?;
+        let last = Local
+          .timestamp_millis_opt(bounds.1.unwrap_or_default())
+          .single()
+          .ok_or_else(|| "No valid last usage timestamp found.".to_string())?;
         let start_date = first.date_naive();
         let end_date = last.date_naive().checked_add_days(Days::new(1)).unwrap_or(last.date_naive());
         let start = local_midnight(start_date)?;
@@ -1647,34 +1743,46 @@ fn live_sample(live_rate_limits: &LiveRateLimitSnapshot, bucket: &str) -> Option
 }
 
 fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
-  let mut stmt = match conn.prepare(SQL_QUOTA_SAMPLES) {
+  let target_start = normalize_local_timestamp(window.start);
+  let target_end = normalize_local_timestamp(window.end);
+  let mut stmt = match conn.prepare(
+    "
+    SELECT sample_timestamp, used_percent
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND window_start_ms = ?2
+      AND resets_at_ms = ?3
+    UNION ALL
+    SELECT sample_timestamp, used_percent
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND (window_start_ms IS NULL OR resets_at_ms IS NULL)
+      AND window_start = ?4
+      AND resets_at = ?5
+    ORDER BY sample_timestamp ASC
+    ",
+  ) {
     Ok(stmt) => stmt,
     Err(_) => return Vec::new(),
   };
 
-  let rows = match stmt.query_map(rusqlite::params![window.bucket], |row| {
-    Ok((
-      row.get::<_, String>(0)?,
-      row.get::<_, i64>(1)?,
-      row.get::<_, String>(2)?,
-      row.get::<_, String>(3)?,
-    ))
-  }) {
+  let rows = match stmt.query_map(
+    rusqlite::params![
+      window.bucket,
+      target_start.timestamp_millis(),
+      target_end.timestamp_millis(),
+      target_start.to_rfc3339(),
+      target_end.to_rfc3339(),
+    ],
+    |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+  ) {
     Ok(rows) => rows,
     Err(_) => return Vec::new(),
   };
 
-  let target_start = normalize_local_timestamp(window.start);
-  let target_end = normalize_local_timestamp(window.end);
-
   rows
     .filter_map(Result::ok)
-    .filter_map(|(timestamp, used_percent, window_start, resets_at)| {
-      let sample_window_start = parse_rfc3339_local(&window_start).map(normalize_local_timestamp)?;
-      let sample_window_end = parse_rfc3339_local(&resets_at).map(normalize_local_timestamp)?;
-      if sample_window_start != target_start || sample_window_end != target_end {
-        return None;
-      }
+    .filter_map(|(timestamp, used_percent)| {
       parse_rfc3339_local(&timestamp).map(|timestamp| QuotaSample {
         timestamp,
         used_percent,
@@ -1898,6 +2006,69 @@ mod tests {
   use super::*;
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
+
+  fn conversation_item(id: &str) -> ConversationListItem {
+    ConversationListItem {
+      root_session_id: id.to_string(),
+      title: id.to_string(),
+      started_at: None,
+      updated_at: None,
+      model_ids: Vec::new(),
+      input_tokens: 0,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: 0,
+      session_count: 1,
+      subagent_count: 0,
+      has_fast_mode: false,
+      api_value_usd: 0.0,
+      subscription_share: 0.0,
+      source_states: Vec::new(),
+    }
+  }
+
+  #[test]
+  fn conversation_pages_are_bounded_and_resume_after_the_cursor() {
+    let items = (0..120)
+      .map(|index| conversation_item(&format!("root-{index:03}")))
+      .collect::<Vec<_>>();
+
+    let first = paginate_conversations(items.clone(), None, 50);
+    assert_eq!(first.items.len(), 50);
+    assert!(first.has_more);
+    assert_eq!(first.next_cursor.as_deref(), Some("root-049"));
+
+    let second = paginate_conversations(items, first.next_cursor.as_deref(), 50);
+    assert_eq!(second.items.len(), 50);
+    assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("root-050"));
+    assert_eq!(second.next_cursor.as_deref(), Some("root-099"));
+  }
+
+  #[test]
+  fn window_event_loader_does_not_return_rows_outside_the_requested_range() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    for timestamp in ["2026-07-01T00:00:00Z", "2026-07-10T00:00:00Z"] {
+      let timestamp_ms = parse_rfc3339_local(timestamp).expect("timestamp").timestamp_millis();
+      conn.execute(
+        "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES ('session', ?1, ?2, 'gpt-5.4', 1, 0, 1, 0, 2, 0.0, 0, 0)",
+        rusqlite::params![timestamp, timestamp_ms],
+      )
+      .expect("insert event");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-10".to_string(),
+      start: parse_rfc3339_local("2026-07-09T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-11T00:00:00Z").expect("end"),
+    };
+
+    let events = load_events_in_window(&conn, &window).expect("load window events");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].timestamp, "2026-07-10T00:00:00Z");
+  }
 
   #[test]
   fn groups_modern_snapshots_into_one_turn() {

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -1441,10 +1441,19 @@ fn resolve_live_rate_limit_window(
   .map_err(|error| error.to_string())?;
 
   if windows.is_empty() {
-    return Err(format!(
-      "Live rate limits are unavailable for the {} view. Check that Codex is installed and logged in.",
-      bucket
-    ));
+    let duration = match bucket {
+      "five_hour" => chrono::Duration::hours(5),
+      "seven_day" => chrono::Duration::days(7),
+      _ => {
+        return Err(format!(
+          "Live rate limits are unavailable for the {} view. Check that Codex is installed and logged in.",
+          bucket
+        ))
+      }
+    };
+    let end = normalize_local_timestamp(Local::now());
+    let start = end - duration;
+    return Ok((start, end, start.date_naive(), 0, 1));
   }
 
   let applied_offset = requested_offset.clamp(0, windows.len().saturating_sub(1) as i64);
@@ -2102,6 +2111,30 @@ mod tests {
   use super::*;
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
+
+  #[test]
+  fn seven_day_overview_without_quota_uses_a_rolling_window() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+
+    let overview = get_overview_with_connection(
+      &conn,
+      Some("seven_day".to_string()),
+      None,
+      None,
+      None,
+      None,
+      None,
+    )
+    .expect("load seven-day overview without quota samples");
+    let start = parse_rfc3339_local(&overview.window_start).expect("parse window start");
+    let end = parse_rfc3339_local(&overview.window_end).expect("parse window end");
+
+    assert_eq!(overview.bucket, "seven_day");
+    assert_eq!((end - start).num_hours(), 7 * 24);
+    assert_eq!(overview.live_window_offset, 0);
+    assert_eq!(overview.live_window_count, 1);
+  }
 
   #[test]
   fn conversation_query_pages_in_sql_without_loading_every_item() {

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -1747,8 +1747,8 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     FROM rate_limit_samples
     WHERE bucket = ?1
       AND (window_start_ms IS NULL OR resets_at_ms IS NULL)
-      AND window_start = ?4
-      AND resets_at = ?5
+      AND (unixepoch(window_start) / 60) * 60000 = ?2
+      AND (unixepoch(resets_at) / 60) * 60000 = ?3
     ORDER BY sample_timestamp ASC
     ",
   ) {
@@ -1761,8 +1761,6 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
       window.bucket,
       target_start.timestamp_millis(),
       target_end.timestamp_millis(),
-      target_start.to_rfc3339(),
-      target_end.to_rfc3339(),
     ],
     |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
   ) {
@@ -2084,6 +2082,41 @@ mod tests {
 
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].timestamp, "2026-07-10T00:00:00Z");
+  }
+
+  #[test]
+  fn legacy_quota_samples_match_the_normalized_window_minute() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "
+        INSERT INTO rate_limit_samples (
+          source_kind, source_session_id, bucket, sample_timestamp,
+          limit_id, limit_name, plan_type, window_start, resets_at,
+          used_percent, remaining_percent, created_at,
+          sample_timestamp_ms, window_start_ms, resets_at_ms
+        ) VALUES (
+          'live', '', 'seven_day', '2026-07-13T07:00:12Z',
+          '', '', 'pro', '2026-07-13T06:00:36Z', '2026-07-20T06:00:44Z',
+          12, 88, '2026-07-13T07:00:12Z',
+          NULL, NULL, NULL
+        )
+        ",
+        [],
+      )
+      .expect("insert legacy quota sample");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end"),
+    };
+
+    let samples = load_quota_samples(&conn, &window);
+
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].used_percent, 12);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -334,18 +334,13 @@ fn build_overview(
     live_window_offset,
   )?;
   let window = &resolved_window.window;
-  let filtered_events: Vec<_> = events
-    .iter()
-    .filter(|event| event_in_window(event, window))
-    .cloned()
-    .collect();
 
   let mut conversation_ids = HashSet::new();
   let mut total_value_usd = 0.0;
   let mut total_tokens = 0i64;
   let mut model_shares: HashMap<String, ModelShareAccumulator> = HashMap::new();
 
-  for event in &filtered_events {
+  for event in events {
     total_value_usd += event.value_usd;
     total_tokens += event.total_tokens;
     if let Some(session) = sessions.get(&event.session_id) {
@@ -365,9 +360,9 @@ fn build_overview(
     0.0
   };
 
-  let trend = build_trend(window, &filtered_events);
-  let quota_trend = build_quota_trend(conn, window, &filtered_events, live_rate_limits.as_ref());
-  let composition_breakdown = build_composition_breakdown(&filtered_events, catalog);
+  let trend = build_trend(window, events);
+  let quota_trend = build_quota_trend(conn, window, events, live_rate_limits.as_ref());
+  let composition_breakdown = build_composition_breakdown(events, catalog);
   let mut model_breakdown = model_shares
     .into_iter()
     .map(|(model_id, value)| ModelShare {
@@ -457,9 +452,6 @@ fn build_conversation_list(
   }
 
   for event in events {
-    if !event_in_window(event, &window) {
-      continue;
-    }
     let Some(session) = sessions.get(&event.session_id) else {
       continue;
     };
@@ -1514,35 +1506,31 @@ fn load_live_rate_limit_windows(
   Ok(ordered)
 }
 
-fn event_in_window(event: &EventRow, window: &Window) -> bool {
-  parse_rfc3339_local(&event.timestamp)
-    .map(|timestamp| timestamp >= window.start && timestamp < window.end)
-    .unwrap_or(false)
-}
-
 fn build_trend(window: &Window, events: &[EventRow]) -> Vec<TrendPoint> {
   let bins = build_bins(window);
-  let mut trend = Vec::new();
-  for bin in bins {
-    let mut api_value_usd = 0.0;
-    let mut total_tokens = 0i64;
-    for event in events {
-      let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
-        continue;
-      };
-      if timestamp >= bin.start && timestamp < bin.end {
-        api_value_usd += event.value_usd;
-        total_tokens += event.total_tokens;
-      }
+  let mut totals = vec![(0.0, 0i64); bins.len()];
+  for event in events {
+    let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
+      continue;
+    };
+    if let Some(index) = bins
+      .iter()
+      .position(|bin| timestamp >= bin.start && timestamp < bin.end)
+    {
+      totals[index].0 += event.value_usd;
+      totals[index].1 += event.total_tokens;
     }
-    trend.push(TrendPoint {
+  }
+  bins
+    .into_iter()
+    .zip(totals)
+    .map(|(bin, (api_value_usd, total_tokens))| TrendPoint {
       label: bin.label,
       timestamp: bin.timestamp,
       api_value_usd,
       total_tokens,
-    });
-  }
-  trend
+    })
+    .collect()
 }
 
 fn build_quota_trend(
@@ -1570,22 +1558,24 @@ fn build_quota_trend(
   samples.dedup_by(|right, left| right.timestamp == left.timestamp && right.used_percent == left.used_percent);
 
   let bins = build_elapsed_bins(window, window.end);
+  let mut bin_totals = vec![(0.0, 0i64); bins.len()];
+  for event in events {
+    let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
+      continue;
+    };
+    if let Some(index) = bins
+      .iter()
+      .position(|bin| timestamp >= bin.start && timestamp < bin.end)
+    {
+      bin_totals[index].0 += event.value_usd;
+      bin_totals[index].1 += event.total_tokens;
+    }
+  }
   let mut trend = Vec::new();
   let mut cumulative_api_value_usd = 0.0;
   let mut cumulative_tokens = 0i64;
 
-  for bin in bins {
-    let mut api_value_usd = 0.0;
-    let mut total_tokens = 0i64;
-    for event in events {
-      let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
-        continue;
-      };
-      if timestamp >= bin.start && timestamp < bin.end {
-        api_value_usd += event.value_usd;
-        total_tokens += event.total_tokens;
-      }
-    }
+  for (bin, (api_value_usd, total_tokens)) in bins.into_iter().zip(bin_totals) {
 
     cumulative_api_value_usd += api_value_usd;
     cumulative_tokens += total_tokens;
@@ -2043,6 +2033,32 @@ mod tests {
     assert_eq!(second.items.len(), 50);
     assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("root-050"));
     assert_eq!(second.next_cursor.as_deref(), Some("root-099"));
+  }
+
+  #[test]
+  #[ignore = "resource profiling helper; requires CODEX_PACER_PROFILE_DB"]
+  fn profile_real_seven_day_dashboard_load() {
+    let db_path = std::env::var_os("CODEX_PACER_PROFILE_DB")
+      .map(std::path::PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_DB to a database copy");
+    let started = std::time::Instant::now();
+    let data = load_dashboard_data(
+      &db_path,
+      Some("seven_day".to_string()),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+    )
+    .expect("load seven-day dashboard");
+    eprintln!(
+      "profile seven_day elapsed_ms={} first_page={} has_more={}",
+      started.elapsed().as_millis(),
+      data.conversation_page.items.len(),
+      data.conversation_page.has_more
+    );
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -7,7 +7,7 @@ use chrono::{
   DateTime, Datelike, Days, Local, LocalResult, Months, NaiveDate, NaiveDateTime, TimeZone,
   Timelike,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde_json::Value;
 
 use crate::database::{get_subscription_profile, open_connection};
@@ -25,7 +25,7 @@ use crate::pricing::{
 const SQL_SESSIONS: &str = include_str!("../sql/queries/sessions.sql");
 const SQL_SESSIONS_FOR_ROOT: &str = include_str!("../sql/queries/sessions_for_root.sql");
 const SQL_USAGE_EVENTS_FOR_ROOT: &str = include_str!("../sql/queries/usage_events_for_root.sql");
-const SQL_RATE_LIMIT_WINDOWS: &str = include_str!("../sql/queries/rate_limit_windows.sql");
+const MAX_LIVE_RATE_LIMIT_WINDOWS: usize = 64;
 
 #[derive(Debug, Clone)]
 struct SessionRow {
@@ -128,12 +128,8 @@ pub fn get_overview(
     &events,
     &profile,
     &catalog,
-    bucket,
-    anchor,
-    custom_start,
-    custom_end,
+    &resolved_window,
     live_rate_limits,
-    live_window_offset,
   )
 }
 
@@ -218,7 +214,13 @@ pub fn list_conversations(
   let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
   let cursor = filters.cursor.clone();
   let limit = filters.limit.unwrap_or(50).clamp(1, 100);
-  let items = build_conversation_list(&conn, &sessions, &events, &profile, Some(filters), live_rate_limits.as_ref())?;
+  let items = build_conversation_list(
+    &sessions,
+    &events,
+    &profile,
+    &resolved_window.window,
+    filters.search,
+  )?;
   Ok(paginate_conversations(items, cursor.as_deref(), limit))
 }
 
@@ -255,29 +257,15 @@ pub fn load_dashboard_data(
     &events,
     &profile,
     &catalog,
-    bucket.clone(),
-    anchor.clone(),
-    custom_start.clone(),
-    custom_end.clone(),
+    &resolved_window,
     live_rate_limits.clone(),
-    live_window_offset,
   )?;
   let conversations = build_conversation_list(
-    &conn,
     &sessions,
     &events,
     &profile,
-    Some(ConversationFilters {
-      bucket,
-      anchor,
-      custom_start,
-      custom_end,
-      search,
-      live_window_offset,
-      cursor: None,
-      limit: Some(50),
-    }),
-    live_rate_limits.as_ref(),
+    &resolved_window.window,
+    search,
   )?;
 
   Ok(DashboardData {
@@ -315,24 +303,9 @@ fn build_overview(
   events: &[EventRow],
   profile: &SubscriptionProfile,
   catalog: &HashMap<String, PricingCatalogEntry>,
-  bucket: Option<String>,
-  anchor: Option<String>,
-  custom_start: Option<String>,
-  custom_end: Option<String>,
+  resolved_window: &ResolvedWindow,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
-  live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
-  let resolved_window = resolve_window(
-    conn,
-    bucket,
-    anchor,
-    custom_start,
-    custom_end,
-    events,
-    profile.billing_anchor_day,
-    live_rate_limits.as_ref(),
-    live_window_offset,
-  )?;
   let window = &resolved_window.window;
 
   let mut conversation_ids = HashSet::new();
@@ -399,27 +372,13 @@ fn build_overview(
 }
 
 fn build_conversation_list(
-  conn: &Connection,
   sessions: &HashMap<String, SessionRow>,
   events: &[EventRow],
   profile: &SubscriptionProfile,
-  filters: Option<ConversationFilters>,
-  live_rate_limits: Option<&LiveRateLimitSnapshot>,
+  window: &Window,
+  search: Option<String>,
 ) -> Result<Vec<ConversationListItem>, String> {
-  let filters = filters.unwrap_or_default();
-  let window = resolve_window(
-    conn,
-    filters.bucket.clone(),
-    filters.anchor.clone(),
-    filters.custom_start.clone(),
-    filters.custom_end.clone(),
-    events,
-    profile.billing_anchor_day,
-    live_rate_limits,
-    filters.live_window_offset,
-  )?
-  .window;
-  let search = filters.search.unwrap_or_default().to_ascii_lowercase();
+  let search = search.unwrap_or_default().to_ascii_lowercase();
 
   let mut groups: BTreeMap<String, ConversationAccumulator> = BTreeMap::new();
 
@@ -1215,14 +1174,6 @@ fn load_events_in_window(conn: &Connection, window: &Window) -> rusqlite::Result
            fast_mode_auto, fast_mode_effective
     FROM usage_events
     WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
-    UNION ALL
-    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
-           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
-           fast_mode_auto, fast_mode_effective
-    FROM usage_events
-    WHERE timestamp_ms IS NULL
-      AND unixepoch(timestamp) * 1000 >= ?1
-      AND unixepoch(timestamp) * 1000 < ?2
     ORDER BY timestamp ASC
     ",
   )?;
@@ -1245,7 +1196,52 @@ fn load_events_in_window(conn: &Connection, window: &Window) -> rusqlite::Result
     },
   )?;
 
-  rows.collect()
+  let mut events = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+  if epoch_backfill_complete(conn) || !has_legacy_usage_events(conn)? {
+    return Ok(events);
+  }
+
+  let mut legacy_stmt = conn.prepare(
+    "
+    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE timestamp_ms IS NULL
+      AND unixepoch(timestamp) * 1000 >= ?1
+      AND unixepoch(timestamp) * 1000 < ?2
+    ORDER BY timestamp ASC
+    ",
+  )?;
+  let legacy_rows = legacy_stmt.query_map(
+    rusqlite::params![window.start.timestamp_millis(), window.end.timestamp_millis()],
+    |row| {
+      Ok(EventRow {
+        session_id: row.get(0)?,
+        timestamp: row.get(1)?,
+        model_id: row.get(2)?,
+        input_tokens: row.get(3)?,
+        cached_input_tokens: row.get(4)?,
+        output_tokens: row.get(5)?,
+        reasoning_output_tokens: row.get(6)?,
+        total_tokens: row.get(7)?,
+        value_usd: row.get(8)?,
+        fast_mode_auto: row.get::<_, i64>(9)? != 0,
+        fast_mode_effective: row.get::<_, i64>(10)? != 0,
+      })
+    },
+  )?;
+  events.extend(legacy_rows.collect::<rusqlite::Result<Vec<_>>>()?);
+  events.sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+  Ok(events)
+}
+
+fn has_legacy_usage_events(conn: &Connection) -> rusqlite::Result<bool> {
+  conn.query_row(
+    "SELECT EXISTS (SELECT 1 FROM usage_events WHERE timestamp_ms IS NULL LIMIT 1)",
+    [],
+    |row| Ok(row.get::<_, i64>(0)? != 0),
+  )
 }
 
 fn load_events_for_root_session(conn: &Connection, root_session_id: &str) -> rusqlite::Result<Vec<EventRow>> {
@@ -1278,25 +1274,26 @@ fn sum_all_api_value(conn: &Connection) -> rusqlite::Result<f64> {
 fn sum_window_api_value_sql(conn: &Connection, window: &Window) -> rusqlite::Result<f64> {
   let start_ms = window.start.timestamp_millis();
   let end_ms = window.end.timestamp_millis();
-  conn.query_row(
-    "
-    SELECT
-      COALESCE((
-        SELECT SUM(value_usd)
-        FROM usage_events
-        WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
-      ), 0.0)
-      + COALESCE((
-        SELECT SUM(value_usd)
-        FROM usage_events
-        WHERE timestamp_ms IS NULL
-          AND unixepoch(timestamp) * 1000 >= ?1
-          AND unixepoch(timestamp) * 1000 < ?2
-      ), 0.0)
-    ",
+  let modern = conn.query_row(
+    "SELECT COALESCE(SUM(value_usd), 0.0) FROM usage_events WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2",
     rusqlite::params![start_ms, end_ms],
     |row| row.get(0),
-  )
+  )?;
+  if epoch_backfill_complete(conn) || !has_legacy_usage_events(conn)? {
+    return Ok(modern);
+  }
+  let legacy = conn.query_row(
+    "
+    SELECT COALESCE(SUM(value_usd), 0.0)
+    FROM usage_events
+    WHERE timestamp_ms IS NULL
+      AND unixepoch(timestamp) * 1000 >= ?1
+      AND unixepoch(timestamp) * 1000 < ?2
+    ",
+    rusqlite::params![start_ms, end_ms],
+    |row| row.get::<_, f64>(0),
+  )?;
+  Ok(modern + legacy)
 }
 
 fn resolve_window(
@@ -1463,47 +1460,88 @@ fn load_live_rate_limit_windows(
   bucket: &str,
   current_window: Option<RateLimitWindowSummary>,
 ) -> rusqlite::Result<Vec<RateLimitWindowSummary>> {
-  let mut stmt = conn.prepare(SQL_RATE_LIMIT_WINDOWS)?;
-  let rows = stmt.query_map(rusqlite::params![bucket], |row| {
-    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-  })?;
-
-  let mut windows = Vec::new();
-  let mut seen = HashSet::new();
-  for row in rows {
-    let (window_start, resets_at) = row?;
-    let Some(start) = parse_rfc3339_local(&window_start).map(normalize_local_timestamp) else {
-      continue;
-    };
-    let Some(end) = parse_rfc3339_local(&resets_at).map(normalize_local_timestamp) else {
-      continue;
-    };
-    let key = (start.to_rfc3339(), end.to_rfc3339());
-    if !seen.insert(key) {
-      continue;
-    }
-    windows.push(RateLimitWindowSummary { start, end });
-  }
-
-  windows.sort_by(|left, right| right.end.cmp(&left.end).then_with(|| right.start.cmp(&left.start)));
-
   let mut ordered = Vec::new();
-  let mut cursor = current_window.or_else(|| windows.first().cloned());
+  let mut seen = HashSet::new();
+  let mut cursor = match current_window {
+    Some(window) => Some(window),
+    None => load_latest_rate_limit_window(conn, bucket)?,
+  };
   while let Some(window) = cursor {
-    if !ordered
-      .iter()
-      .any(|existing: &RateLimitWindowSummary| existing.start == window.start && existing.end == window.end)
-    {
-      ordered.push(window.clone());
+    let key = (window.start.timestamp_millis(), window.end.timestamp_millis());
+    if !seen.insert(key) {
+      break;
     }
-    cursor = windows
-      .iter()
-      .filter(|candidate| candidate.end <= window.start)
-      .max_by(|left, right| left.end.cmp(&right.end).then_with(|| left.start.cmp(&right.start)))
-      .cloned();
+    let previous_start = window.start;
+    ordered.push(window);
+    if ordered.len() >= MAX_LIVE_RATE_LIMIT_WINDOWS {
+      break;
+    }
+    cursor = load_previous_rate_limit_window(conn, bucket, previous_start)?;
   }
 
   Ok(ordered)
+}
+
+fn load_latest_rate_limit_window(
+  conn: &Connection,
+  bucket: &str,
+) -> rusqlite::Result<Option<RateLimitWindowSummary>> {
+  load_rate_limit_window_query(
+    conn,
+    "
+    SELECT window_start_ms, resets_at_ms
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND window_start_ms IS NOT NULL
+      AND resets_at_ms IS NOT NULL
+    ORDER BY window_start_ms DESC, resets_at_ms DESC
+    LIMIT 1
+    ",
+    rusqlite::params![bucket],
+  )
+}
+
+fn load_previous_rate_limit_window(
+  conn: &Connection,
+  bucket: &str,
+  before: DateTime<Local>,
+) -> rusqlite::Result<Option<RateLimitWindowSummary>> {
+  let before_ms = normalize_local_timestamp(before).timestamp_millis();
+  load_rate_limit_window_query(
+    conn,
+    "
+    SELECT window_start_ms, resets_at_ms
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND window_start_ms < ?2
+      AND (resets_at_ms / 60000) * 60000 <= ?2
+    ORDER BY window_start_ms DESC, resets_at_ms DESC
+    LIMIT 1
+    ",
+    rusqlite::params![bucket, before_ms],
+  )
+}
+
+fn load_rate_limit_window_query<P: rusqlite::Params>(
+  conn: &Connection,
+  sql: &str,
+  params: P,
+) -> rusqlite::Result<Option<RateLimitWindowSummary>> {
+  conn
+    .query_row(sql, params, |row| {
+      Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+    })
+    .optional()
+    .map(|row| {
+      row.and_then(|(start_ms, end_ms)| {
+        let start = Local.timestamp_millis_opt(start_ms).single()?;
+        let end = Local.timestamp_millis_opt(end_ms).single()?;
+        Some(RateLimitWindowSummary {
+          start: normalize_local_timestamp(start),
+          end: normalize_local_timestamp(end),
+        })
+      })
+    })
 }
 
 fn build_trend(window: &Window, events: &[EventRow]) -> Vec<TrendPoint> {
@@ -1735,14 +1773,96 @@ fn live_sample(live_rate_limits: &LiveRateLimitSnapshot, bucket: &str) -> Option
 fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
   let target_start = normalize_local_timestamp(window.start);
   let target_end = normalize_local_timestamp(window.end);
+  let sample_start_ms = window.start.timestamp_millis();
+  let sample_end_ms = window.end.timestamp_millis();
+  let bin_duration_ms = match window.bucket.as_str() {
+    "five_hour" => chrono::Duration::minutes(15).num_milliseconds(),
+    "seven_day" => chrono::Duration::hours(1).num_milliseconds(),
+    _ => chrono::Duration::hours(1).num_milliseconds(),
+  };
   let mut stmt = match conn.prepare(
     "
-    SELECT sample_timestamp, used_percent
-    FROM rate_limit_samples
-    WHERE bucket = ?1
-      AND window_start_ms = ?2
-      AND resets_at_ms = ?3
-    UNION ALL
+    WITH RECURSIVE bins(bin_start_ms, bin_end_ms) AS (
+      SELECT ?4, MIN(?4 + ?6, ?5)
+      WHERE ?4 < ?5
+      UNION ALL
+      SELECT bin_end_ms, MIN(bin_end_ms + ?6, ?5)
+      FROM bins
+      WHERE bin_end_ms < ?5
+    ),
+    latest_ids AS MATERIALIZED (
+      SELECT (
+        SELECT id
+        FROM rate_limit_samples
+        WHERE bucket = ?1
+          AND window_start_ms = ?2
+          AND resets_at_ms = ?3
+          AND sample_timestamp_ms >= bins.bin_start_ms
+          AND sample_timestamp_ms < bins.bin_end_ms
+        ORDER BY sample_timestamp_ms DESC, id DESC
+        LIMIT 1
+      ) AS id
+      FROM bins
+    )
+    SELECT sample.sample_timestamp_ms, sample.used_percent
+    FROM latest_ids
+    JOIN rate_limit_samples AS sample ON sample.id = latest_ids.id
+    ORDER BY sample.sample_timestamp_ms ASC
+    ",
+  ) {
+    Ok(stmt) => stmt,
+    Err(_) => return Vec::new(),
+  };
+
+  let rows = match stmt.query_map(
+    rusqlite::params![
+      window.bucket,
+      target_start.timestamp_millis(),
+      target_end.timestamp_millis(),
+      sample_start_ms,
+      sample_end_ms,
+      bin_duration_ms,
+    ],
+    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+  ) {
+    Ok(rows) => rows,
+    Err(_) => return Vec::new(),
+  };
+
+  let samples = rows
+    .filter_map(Result::ok)
+    .filter_map(|(timestamp_ms, used_percent)| {
+      Local.timestamp_millis_opt(timestamp_ms).single().map(|timestamp| QuotaSample {
+        timestamp,
+        used_percent,
+      })
+    })
+    .collect::<Vec<_>>();
+  if !samples.is_empty() || epoch_backfill_complete(conn) {
+    return samples;
+  }
+
+  load_legacy_quota_samples(conn, window, target_start, target_end)
+}
+
+fn epoch_backfill_complete(conn: &Connection) -> bool {
+  conn
+    .query_row(
+      "SELECT EXISTS (SELECT 1 FROM data_repairs WHERE repair_key = 'epoch_timestamp_backfill_v1')",
+      [],
+      |row| Ok(row.get::<_, i64>(0)? != 0),
+    )
+    .unwrap_or(true)
+}
+
+fn load_legacy_quota_samples(
+  conn: &Connection,
+  window: &Window,
+  target_start: DateTime<Local>,
+  target_end: DateTime<Local>,
+) -> Vec<QuotaSample> {
+  let mut stmt = match conn.prepare(
+    "
     SELECT sample_timestamp, used_percent
     FROM rate_limit_samples
     WHERE bucket = ?1
@@ -1755,7 +1875,6 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     Ok(stmt) => stmt,
     Err(_) => return Vec::new(),
   };
-
   let rows = match stmt.query_map(
     rusqlite::params![
       window.bucket,
@@ -1767,7 +1886,6 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     Ok(rows) => rows,
     Err(_) => return Vec::new(),
   };
-
   rows
     .filter_map(Result::ok)
     .filter_map(|(timestamp, used_percent)| {
@@ -2085,6 +2203,54 @@ mod tests {
   }
 
   #[test]
+  fn window_event_loader_keeps_legacy_rows_before_epoch_backfill_completes() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn.execute(
+      "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES ('legacy', '2026-07-10T00:00:00Z', NULL, 'gpt-5.4', 1, 0, 1, 0, 2, 1.5, 0, 0)",
+      [],
+    )
+    .expect("insert legacy event");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-10".to_string(),
+      start: parse_rfc3339_local("2026-07-09T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-11T00:00:00Z").expect("end"),
+    };
+
+    let events = load_events_in_window(&conn, &window).expect("load window events");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].session_id, "legacy");
+    assert_eq!(sum_window_api_value_sql(&conn, &window).expect("sum window"), 1.5);
+  }
+
+  #[test]
+  fn completed_epoch_backfill_skips_legacy_usage_event_fallback() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn.execute(
+      "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES ('legacy', '2026-07-10T00:00:00Z', NULL, 'gpt-5.4', 1, 0, 1, 0, 2, 1.5, 0, 0)",
+      [],
+    )
+    .expect("insert legacy event");
+    conn.execute(
+      "INSERT INTO data_repairs (repair_key, completed_at) VALUES ('epoch_timestamp_backfill_v1', '2026-07-13T08:00:00Z')",
+      [],
+    )
+    .expect("mark epoch backfill complete");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-10".to_string(),
+      start: parse_rfc3339_local("2026-07-09T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-11T00:00:00Z").expect("end"),
+    };
+
+    assert!(load_events_in_window(&conn, &window).expect("load window events").is_empty());
+    assert_eq!(sum_window_api_value_sql(&conn, &window).expect("sum window"), 0.0);
+  }
+
+  #[test]
   fn legacy_quota_samples_match_the_normalized_window_minute() {
     let conn = Connection::open_in_memory().expect("open database");
     init_db(&conn).expect("initialize database");
@@ -2117,6 +2283,101 @@ mod tests {
 
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].used_percent, 12);
+  }
+
+  #[test]
+  fn quota_samples_keep_only_the_latest_point_in_each_chart_bin() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let window_start = parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start");
+    let window_end = parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end");
+    for (timestamp, used_percent) in [
+      ("2026-07-13T06:05:00Z", 1),
+      ("2026-07-13T06:55:00Z", 2),
+      ("2026-07-13T07:10:00Z", 3),
+      ("2026-07-13T07:58:00Z", 4),
+    ] {
+      let timestamp_ms = parse_rfc3339_local(timestamp)
+        .expect("sample timestamp")
+        .timestamp_millis();
+      conn
+        .execute(
+          "
+          INSERT INTO rate_limit_samples (
+            source_kind, source_session_id, bucket, sample_timestamp,
+            limit_id, limit_name, plan_type, window_start, resets_at,
+            used_percent, remaining_percent, created_at,
+            sample_timestamp_ms, window_start_ms, resets_at_ms
+          ) VALUES (
+            'session', 'session', 'seven_day', ?1,
+            '', '', 'pro', '2026-07-13T06:00:00Z', '2026-07-20T06:00:00Z',
+            ?2, 100 - ?2, ?1, ?3, ?4, ?5
+          )
+          ",
+          rusqlite::params![
+            timestamp,
+            used_percent,
+            timestamp_ms,
+            window_start.timestamp_millis(),
+            window_end.timestamp_millis(),
+          ],
+        )
+        .expect("insert quota sample");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: window_start,
+      end: window_end,
+    };
+
+    let samples = load_quota_samples(&conn, &window);
+
+    assert_eq!(
+      samples
+        .iter()
+        .map(|sample| sample.used_percent)
+        .collect::<Vec<_>>(),
+      vec![2, 4]
+    );
+  }
+
+  #[test]
+  fn completed_epoch_backfill_does_not_scan_legacy_quota_rows() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "
+        INSERT INTO rate_limit_samples (
+          source_kind, source_session_id, bucket, sample_timestamp,
+          limit_id, limit_name, plan_type, window_start, resets_at,
+          used_percent, remaining_percent, created_at,
+          sample_timestamp_ms, window_start_ms, resets_at_ms
+        ) VALUES (
+          'live', '', 'seven_day', '2026-07-13T07:00:12Z',
+          '', '', 'pro', '2026-07-13T06:00:36Z', '2026-07-20T06:00:44Z',
+          12, 88, '2026-07-13T07:00:12Z',
+          NULL, NULL, NULL
+        )
+        ",
+        [],
+      )
+      .expect("insert legacy quota sample");
+    conn
+      .execute(
+        "INSERT INTO data_repairs (repair_key, completed_at) VALUES ('epoch_timestamp_backfill_v1', '2026-07-13T08:00:00Z')",
+        [],
+      )
+      .expect("mark epoch backfill complete");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end"),
+    };
+
+    assert!(load_quota_samples(&conn, &window).is_empty());
   }
 
   #[test]

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -2,7 +2,7 @@ use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
+use std::sync::{mpsc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -45,10 +45,151 @@ enum AppServerMessage {
   Closed,
 }
 
+#[derive(Clone)]
 struct AppServerCommandSpec {
   program: OsString,
   args: Vec<OsString>,
   hide_window: bool,
+}
+
+struct ReusableAppServerClient {
+  command_spec: AppServerCommandSpec,
+  command_path: PathBuf,
+  session: Option<AppServerSession>,
+  receiver: Option<mpsc::Receiver<AppServerMessage>>,
+}
+
+impl ReusableAppServerClient {
+  fn new(command_spec: AppServerCommandSpec, command_path: PathBuf) -> Self {
+    Self {
+      command_spec,
+      command_path,
+      session: None,
+      receiver: None,
+    }
+  }
+
+  fn query(&mut self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+    let started_at = Instant::now();
+    let reused_existing_session = self.session.is_some();
+    match self.query_once(started_at, timeout) {
+      Ok(snapshot) => Ok(snapshot),
+      Err(first_error) if reused_existing_session => {
+        self.disconnect();
+        if remaining_app_server_timeout(started_at, timeout).is_none() {
+          return Err(first_error);
+        }
+        self.query_once(started_at, timeout)
+      }
+      Err(error) => {
+        self.disconnect();
+        Err(error)
+      }
+    }
+  }
+
+  fn query_once(
+    &mut self,
+    started_at: Instant,
+    timeout: Duration,
+  ) -> Result<LiveRateLimitSnapshot, String> {
+    if self.session.is_none() {
+      self.connect(started_at, timeout)?;
+    }
+
+    let session = self
+      .session
+      .as_mut()
+      .ok_or_else(|| "Codex app-server session is unavailable.".to_string())?;
+    send_app_server_request(
+      &mut session.child,
+      rate_limit_request(),
+      "Failed to request live rate limits after Codex app-server initialization",
+      "Failed to flush Codex app-server rate-limit request",
+    )?;
+
+    loop {
+      let remaining = remaining_app_server_timeout(started_at, timeout)
+        .ok_or_else(|| "Timed out while querying live rate limits from Codex.".to_string())?;
+      let message = self
+        .receiver
+        .as_ref()
+        .ok_or_else(|| "Codex app-server response channel is unavailable.".to_string())?
+        .recv_timeout(remaining)
+        .map_err(|_| "Timed out while querying live rate limits from Codex.".to_string())?;
+      match message {
+        AppServerMessage::Initialized(Ok(())) => continue,
+        AppServerMessage::Initialized(Err(error)) => return Err(error),
+        AppServerMessage::RateLimits(result) => return result,
+        AppServerMessage::Closed => {
+          return Err("Codex app-server closed before returning live rate limits.".to_string())
+        }
+      }
+    }
+  }
+
+  fn connect(&mut self, started_at: Instant, timeout: Duration) -> Result<(), String> {
+    let (mut session, receiver) = start_app_server_session(&self.command_spec, &self.command_path)?;
+    send_app_server_request(
+      &mut session.child,
+      initialize_request(),
+      "Failed to initialize codex app-server",
+      "Failed to flush codex app-server init request",
+    )?;
+
+    let remaining = remaining_app_server_timeout(started_at, timeout)
+      .ok_or_else(|| "Timed out while initializing Codex app-server.".to_string())?;
+    match receiver
+      .recv_timeout(remaining)
+      .map_err(|_| "Timed out while initializing Codex app-server.".to_string())?
+    {
+      AppServerMessage::Initialized(Ok(())) => {}
+      AppServerMessage::Initialized(Err(error)) => return Err(error),
+      AppServerMessage::RateLimits(result) => return result.map(|_| ()),
+      AppServerMessage::Closed => {
+        return Err("Codex app-server closed before initialization completed.".to_string())
+      }
+    }
+
+    send_app_server_request(
+      &mut session.child,
+      initialized_notification(),
+      "Failed to notify Codex app-server that initialization completed",
+      "Failed to flush Codex app-server initialized notification",
+    )?;
+    self.session = Some(session);
+    self.receiver = Some(receiver);
+    Ok(())
+  }
+
+  fn disconnect(&mut self) {
+    self.receiver = None;
+    self.session = None;
+  }
+}
+
+pub struct LiveRateLimitClient {
+  inner: Mutex<ReusableAppServerClient>,
+}
+
+impl LiveRateLimitClient {
+  pub fn new() -> Self {
+    let codex_binary = resolve_codex_binary();
+    Self {
+      inner: Mutex::new(ReusableAppServerClient::new(
+        app_server_command_spec(&codex_binary),
+        codex_binary,
+      )),
+    }
+  }
+
+  pub fn query(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+    self
+      .inner
+      .lock()
+      .unwrap_or_else(|poisoned| poisoned.into_inner())
+      .query(timeout)
+  }
 }
 
 struct AppServerSession {
@@ -71,20 +212,22 @@ impl Drop for AppServerSession {
   }
 }
 
-pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
-  let started_at = Instant::now();
-  let codex_binary = resolve_codex_binary();
-  let command_spec = app_server_command_spec(&codex_binary);
-  query_live_rate_limits_with_command(started_at, timeout, command_spec, &codex_binary)
-}
-
+#[cfg(test)]
 fn query_live_rate_limits_with_command(
   started_at: Instant,
   timeout: Duration,
   command_spec: AppServerCommandSpec,
   command_path: &Path,
 ) -> Result<LiveRateLimitSnapshot, String> {
-  let mut command = app_server_command(&command_spec);
+  let mut client = ReusableAppServerClient::new(command_spec, command_path.to_path_buf());
+  client.query_once(started_at, timeout)
+}
+
+fn start_app_server_session(
+  command_spec: &AppServerCommandSpec,
+  command_path: &Path,
+) -> Result<(AppServerSession, mpsc::Receiver<AppServerMessage>), String> {
+  let mut command = app_server_command(command_spec);
   let child = command
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
@@ -128,7 +271,7 @@ fn query_live_rate_limits_with_command(
             "Codex app-server initialize failed: {}",
             json_error_message(error)
           ))));
-          return;
+          continue;
         }
         init_ok = true;
         let _ = sender.send(AppServerMessage::Initialized(Ok(())));
@@ -143,7 +286,7 @@ fn query_live_rate_limits_with_command(
         let _ = sender.send(AppServerMessage::RateLimits(Err(
           "Codex app-server returned rate limits before initialization completed.".to_string(),
         )));
-        return;
+        continue;
       }
 
       if let Some(error) = parsed.get("error") {
@@ -151,14 +294,14 @@ fn query_live_rate_limits_with_command(
           "Codex app-server rate-limit query failed: {}",
           json_error_message(error)
         ))));
-        return;
+        continue;
       }
 
       let Some(result) = parsed.get("result") else {
         let _ = sender.send(AppServerMessage::RateLimits(Err(
           "Codex app-server returned an empty rate-limit response.".to_string(),
         )));
-        return;
+        continue;
       };
 
       let response = serde_json::from_value::<AppServerRateLimitReadResponse>(result.clone())
@@ -166,80 +309,43 @@ fn query_live_rate_limits_with_command(
       let _ = sender.send(AppServerMessage::RateLimits(
         response.map(|value| convert_live_rate_limits(value.rate_limits)),
       ));
-      return;
+      continue;
     }
 
     let _ = sender.send(AppServerMessage::Closed);
   }));
 
-  if let Err(error) = send_app_server_request(
-    &mut session.child,
-    json!({
-      "id": INIT_REQUEST_ID,
-      "method": "initialize",
-      "params": {
-        "clientInfo": {
-          "name": "codex-counter",
-          "version": env!("CARGO_PKG_VERSION"),
-        },
-        "capabilities": {
-          "experimentalApi": true,
-        }
+  Ok((session, receiver))
+}
+
+fn initialize_request() -> Value {
+  json!({
+    "id": INIT_REQUEST_ID,
+    "method": "initialize",
+    "params": {
+      "clientInfo": {
+        "name": "codex-counter",
+        "version": env!("CARGO_PKG_VERSION"),
+      },
+      "capabilities": {
+        "experimentalApi": true,
       }
-    }),
-    "Failed to initialize codex app-server",
-    "Failed to flush codex app-server init request",
-  ) {
-    return Err(error);
-  }
-
-  let init_timeout = match remaining_app_server_timeout(started_at, timeout) {
-    Some(timeout) => timeout,
-    None => return Err("Timed out while initializing Codex app-server.".to_string()),
-  };
-  let init_response = match receiver.recv_timeout(init_timeout) {
-    Ok(message) => message,
-    Err(_) => return Err("Timed out while initializing Codex app-server.".to_string()),
-  };
-
-  match init_response {
-    AppServerMessage::Initialized(Ok(())) => {}
-    AppServerMessage::Initialized(Err(error)) => return Err(error),
-    AppServerMessage::RateLimits(result) => return result,
-    AppServerMessage::Closed => {
-      return Err("Codex app-server closed before initialization completed.".to_string())
     }
-  }
+  })
+}
 
-  for (message, write_context, flush_context) in post_initialize_messages() {
-    if let Err(error) =
-      send_app_server_request(&mut session.child, message, write_context, flush_context)
-    {
-      return Err(error);
-    }
-  }
+fn initialized_notification() -> Value {
+  json!({
+    "method": "initialized",
+    "params": {},
+  })
+}
 
-  let response = loop {
-    let timeout = match remaining_app_server_timeout(started_at, timeout) {
-      Some(timeout) => timeout,
-      None => return Err("Timed out while querying live rate limits from Codex.".to_string()),
-    };
-    let message = match receiver.recv_timeout(timeout) {
-      Ok(message) => message,
-      Err(_) => return Err("Timed out while querying live rate limits from Codex.".to_string()),
-    };
-
-    match message {
-      AppServerMessage::Initialized(Ok(())) => continue,
-      AppServerMessage::Initialized(Err(error)) => break Err(error),
-      AppServerMessage::RateLimits(result) => break result,
-      AppServerMessage::Closed => break Err(
-        "Codex app-server closed before returning live rate limits.".to_string(),
-      ),
-    }
-  };
-
-  response
+fn rate_limit_request() -> Value {
+  json!({
+    "id": READ_REQUEST_ID,
+    "method": "account/rateLimits/read",
+  })
 }
 
 fn remaining_app_server_timeout(started_at: Instant, timeout: Duration) -> Option<Duration> {
@@ -321,27 +427,6 @@ fn app_server_args() -> Vec<OsString> {
     OsString::from("app-server"),
     OsString::from("--listen"),
     OsString::from("stdio://"),
-  ]
-}
-
-fn post_initialize_messages() -> Vec<(Value, &'static str, &'static str)> {
-  vec![
-    (
-      json!({
-        "method": "initialized",
-        "params": {},
-      }),
-      "Failed to notify Codex app-server that initialization completed",
-      "Failed to flush Codex app-server initialized notification",
-    ),
-    (
-      json!({
-        "id": READ_REQUEST_ID,
-        "method": "account/rateLimits/read",
-      }),
-      "Failed to request live rate limits after Codex app-server initialization",
-      "Failed to flush Codex app-server rate-limit request",
-    ),
   ]
 }
 
@@ -621,6 +706,48 @@ mod tests {
   }
 
   #[test]
+  #[cfg(unix)]
+  fn repeated_live_queries_reuse_one_app_server_process() {
+    let temp_dir = tempfile::tempdir().expect("create fixture directory");
+    let launch_path = temp_dir.path().join("launches.txt");
+    let script = concat!(
+      "printf 'launch\\n' >> \"$1\"; ",
+      "while IFS= read -r line; do ",
+      "case \"$line\" in ",
+      "*codex-counter.init*) printf '%s\\n' '{\"id\":\"codex-counter.init\",\"result\":{}}' ;; ",
+      "*account/rateLimits/read*) printf '%s\\n' '{\"id\":\"codex-counter.rate-limits\",\"result\":{\"rateLimits\":{\"limitId\":\"codex\",\"limitName\":null,\"planType\":\"pro\",\"primary\":{\"usedPercent\":3,\"windowDurationMins\":10080,\"resetsAt\":1784498450},\"secondary\":null}}}' ;; ",
+      "esac; done"
+    );
+    let command_spec = super::AppServerCommandSpec {
+      program: "/bin/sh".into(),
+      args: vec![
+        "-c".into(),
+        script.into(),
+        "codex-pacer-reuse-fixture".into(),
+        launch_path.as_os_str().to_owned(),
+      ],
+      hide_window: false,
+    };
+    let mut client = super::ReusableAppServerClient::new(
+      command_spec,
+      PathBuf::from("local reusable fixture"),
+    );
+
+    let first = client.query(Duration::from_secs(1)).expect("first query");
+    let second = client.query(Duration::from_secs(1)).expect("second query");
+
+    assert_eq!(first.secondary.as_ref().map(|window| window.used_percent), Some(3));
+    assert_eq!(second.secondary.as_ref().map(|window| window.used_percent), Some(3));
+    assert_eq!(
+      std::fs::read_to_string(&launch_path)
+        .expect("read launches")
+        .lines()
+        .count(),
+      1
+    );
+  }
+
+  #[test]
   fn convert_window_calculates_remaining_and_start() {
     let converted = convert_window(super::AppServerRateLimitWindow {
       used_percent: 13,
@@ -658,11 +785,11 @@ mod tests {
   }
 
   #[test]
-  fn app_server_post_initialize_messages_follow_protocol_order() {
-    let messages = super::post_initialize_messages()
-      .into_iter()
-      .map(|(message, _, _)| message)
-      .collect::<Vec<_>>();
+  fn app_server_messages_follow_protocol_order() {
+    let messages = vec![
+      super::initialized_notification(),
+      super::rate_limit_request(),
+    ];
 
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[0].get("method").and_then(serde_json::Value::as_str), Some("initialized"));

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -181,24 +181,6 @@ impl TokenRequest {
     }
   }
 
-  pub(crate) fn manual_incremental_with_waiter(
-    codex_home: Option<String>,
-    waiter: TokenWaiterId,
-  ) -> Self {
-    let mut request = Self {
-      reasons: RefreshReason::Manual.into(),
-      kind: TokenScanKind::Incremental,
-      codex_home,
-      waiter_ids: TokenWaiterIds::default(),
-      planned_due_at: None,
-      source_generation: None,
-    };
-    request
-      .try_add_waiter(waiter)
-      .expect("an empty token request accepts one waiter");
-    request
-  }
-
   pub(crate) fn manual_full_with_waiter(codex_home: Option<String>, waiter: TokenWaiterId) -> Self {
     let mut request = Self::manual_full(codex_home);
     request

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -181,6 +181,24 @@ impl TokenRequest {
     }
   }
 
+  pub(crate) fn manual_incremental_with_waiter(
+    codex_home: Option<String>,
+    waiter: TokenWaiterId,
+  ) -> Self {
+    let mut request = Self {
+      reasons: RefreshReason::Manual.into(),
+      kind: TokenScanKind::Incremental,
+      codex_home,
+      waiter_ids: TokenWaiterIds::default(),
+      planned_due_at: None,
+      source_generation: None,
+    };
+    request
+      .try_add_waiter(waiter)
+      .expect("an empty token request accepts one waiter");
+    request
+  }
+
   pub(crate) fn manual_full_with_waiter(codex_home: Option<String>, waiter: TokenWaiterId) -> Self {
     let mut request = Self::manual_full(codex_home);
     request

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -2203,7 +2203,7 @@ impl RefreshCoordinatorHandle {
       }
       waiters.token.insert(waiter, reply_tx);
     }
-    let request = TokenRequest::manual_incremental_with_waiter(codex_home, waiter);
+    let request = TokenRequest::manual_full_with_waiter(codex_home, waiter);
     if let Err(error) = try_send_public(&intake.sender, RuntimeMessage::RequestToken(request)) {
       lock(&self.inner.waiters).token.remove(&waiter);
       return Err(error);

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -2203,7 +2203,7 @@ impl RefreshCoordinatorHandle {
       }
       waiters.token.insert(waiter, reply_tx);
     }
-    let request = TokenRequest::manual_full_with_waiter(codex_home, waiter);
+    let request = TokenRequest::manual_incremental_with_waiter(codex_home, waiter);
     if let Err(error) = try_send_public(&intake.sender, RuntimeMessage::RequestToken(request)) {
       lock(&self.inner.waiters).token.remove(&waiter);
       return Err(error);

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -5448,6 +5448,10 @@ impl TokenRefreshExecutor for TestTokenExecutor {
       imported_sessions: generation as usize,
       updated_sessions: generation as usize,
       missing_sessions: 0,
+      scan_kind: "incremental".to_string(),
+      source_bytes_read: 0,
+      tail_parsed_files: 0,
+      fully_parsed_files: 0,
       last_completed_at: "2026-07-11T00:00:00Z".to_string(),
     })
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import {
 import {
   getScanInProgress,
   getConversationDetail,
+  listConversations,
   loadDashboard,
   refreshPricing,
   scanCodexUsage,
@@ -105,8 +106,12 @@ function App() {
   const [shareDimension, setShareDimension] = useState<ShareDimension>('model')
   const [overview, setOverview] = useState<OverviewResponse | null>(null)
   const [conversations, setConversations] = useState<ConversationListItem[]>([])
+  const [conversationCursor, setConversationCursor] = useState<string | null>(null)
+  const [hasMoreConversations, setHasMoreConversations] = useState(false)
+  const [loadingMoreConversations, setLoadingMoreConversations] = useState(false)
   const [selectedRootSessionId, setSelectedRootSessionId] = useState<string | null>(null)
   const [detail, setDetail] = useState<ConversationDetail | null>(null)
+  const [loadingEarlierTurns, setLoadingEarlierTurns] = useState(false)
   const [syncSettings, setSyncSettings] = useState<SyncSettings | null>(null)
   const [subscriptionProfile, setSubscriptionProfile] = useState<SubscriptionProfile | null>(null)
   const [liveRateLimits, setLiveRateLimits] = useState<LiveRateLimitSnapshot | null>(null)
@@ -125,6 +130,7 @@ function App() {
   const latestDetailRequestIdRef = useRef(0)
   const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
   const refreshCompletionListenerReadyRef = useRef<Promise<boolean>>(Promise.resolve(false))
+  const refreshReloadTimerRef = useRef<number | null>(null)
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
   const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
@@ -181,7 +187,7 @@ function App() {
 
       startTransition(() => {
         const nextDetailCache = new Map<string, ConversationDetail>()
-        for (const conversation of snapshot.conversations) {
+        for (const conversation of snapshot.conversationPage.items) {
           const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
           if (
             cachedDetail &&
@@ -197,7 +203,9 @@ function App() {
 
         latestDetailRequestIdRef.current += 1
         setOverview(snapshot.overview)
-        setConversations(snapshot.conversations)
+        setConversations(snapshot.conversationPage.items)
+        setConversationCursor(snapshot.conversationPage.nextCursor)
+        setHasMoreConversations(snapshot.conversationPage.hasMore)
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
         setLiveRateLimits(snapshot.liveRateLimits)
@@ -218,9 +226,9 @@ function App() {
           ),
         )
         setSelectedRootSessionId((current) =>
-          current && snapshot.conversations.some((item) => item.rootSessionId === current)
+          current && snapshot.conversationPage.items.some((item) => item.rootSessionId === current)
             ? current
-            : snapshot.conversations[0]?.rootSessionId ?? null,
+            : snapshot.conversationPage.items[0]?.rootSessionId ?? null,
         )
       })
     } catch (error) {
@@ -232,6 +240,43 @@ function App() {
       }
     }
   }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t])
+
+  const loadMoreConversations = useCallback(async () => {
+    if (!conversationCursor || !hasMoreConversations || loadingMoreConversations) return
+    const requestId = latestLoadRequestIdRef.current
+    setLoadingMoreConversations(true)
+    try {
+      const page = await listConversations({
+        bucket,
+        anchor: bucketUsesAnchor(bucket) ? anchor : null,
+        customStart: bucket === 'custom' ? customStart : null,
+        customEnd: bucket === 'custom' ? customEnd : null,
+        search: deferredSearch || null,
+        liveWindowOffset: bucket === 'five_hour' || bucket === 'seven_day' ? liveWindowOffset : 0,
+        cursor: conversationCursor,
+        limit: 50,
+      })
+      if (requestId !== latestLoadRequestIdRef.current) return
+      setConversations((current) => {
+        const seen = new Set(current.map((item) => item.rootSessionId))
+        return [...current, ...page.items.filter((item) => !seen.has(item.rootSessionId))]
+      })
+      setConversationCursor(page.nextCursor)
+      setHasMoreConversations(page.hasMore)
+    } finally {
+      setLoadingMoreConversations(false)
+    }
+  }, [
+    anchor,
+    bucket,
+    conversationCursor,
+    customEnd,
+    customStart,
+    deferredSearch,
+    hasMoreConversations,
+    liveWindowOffset,
+    loadingMoreConversations,
+  ])
 
   const currentQueryKey = buildQueryKey(
     bucket,
@@ -314,7 +359,13 @@ function App() {
         .catch(() => {})
     }
     const reloadDashboard = () => {
-      void loadShellRef.current(true)
+      if (refreshReloadTimerRef.current !== null) {
+        window.clearTimeout(refreshReloadTimerRef.current)
+      }
+      refreshReloadTimerRef.current = window.setTimeout(() => {
+        refreshReloadTimerRef.current = null
+        void loadShellRef.current(true)
+      }, 200)
     }
     const handleCompletion = async (event: RefreshCompletedEvent) => {
       let visible: boolean
@@ -378,6 +429,10 @@ function App() {
     return () => {
       cancelled = true
       refreshCompletionListenerReadyRef.current = Promise.resolve(false)
+      if (refreshReloadTimerRef.current !== null) {
+        window.clearTimeout(refreshReloadTimerRef.current)
+        refreshReloadTimerRef.current = null
+      }
       document.removeEventListener('visibilitychange', handleDocumentVisibility)
       window.removeEventListener('focus', handleWindowFocus)
       for (const dispose of disposers) {
@@ -422,6 +477,30 @@ function App() {
       setStatusMessage(String(error))
     }
   }, [])
+
+  const loadEarlierTurns = useCallback(async () => {
+    if (!detail?.hasMoreTurns || detail.nextTurnCursor === null || loadingEarlierTurns) return
+    const requestId = latestDetailRequestIdRef.current
+    const rootSessionId = detail.rootSessionId
+    setLoadingEarlierTurns(true)
+    try {
+      const page = await getConversationDetail(rootSessionId, detail.nextTurnCursor)
+      if (requestId !== latestDetailRequestIdRef.current) return
+      setDetail((current) => {
+        if (!current || current.rootSessionId !== rootSessionId) return current
+        const merged = {
+          ...current,
+          turns: [...page.turns, ...current.turns],
+          nextTurnCursor: page.nextTurnCursor,
+          hasMoreTurns: page.hasMoreTurns,
+        }
+        detailCacheRef.current.set(rootSessionId, merged)
+        return merged
+      })
+    } finally {
+      setLoadingEarlierTurns(false)
+    }
+  }, [detail, loadingEarlierTurns])
 
   useEffect(() => {
     let cancelled = false
@@ -871,8 +950,9 @@ function App() {
                   {activeConversations.length === 0 ? (
                     <div className="empty-state">{t.conversationList.empty}</div>
                   ) : (
-                    activeConversations.map((conversation) => (
-                      <button
+                    <>
+                      {activeConversations.map((conversation) => (
+                        <button
                         key={conversation.rootSessionId}
                         className={`conversation-card ${
                           conversation.rootSessionId === selectedRootSessionId ? 'active' : ''
@@ -904,8 +984,21 @@ function App() {
                           <span>{formatShortDate(conversation.updatedAt, language)}</span>
                           <span>{formatPercent(conversation.subscriptionShare, language)}</span>
                         </div>
-                      </button>
-                    ))
+                        </button>
+                      ))}
+                      {hasMoreConversations ? (
+                        <button
+                          className="ghost-button"
+                          disabled={loadingMoreConversations}
+                          onClick={() => void loadMoreConversations()}
+                          type="button"
+                        >
+                          {loadingMoreConversations
+                            ? t.conversationList.loadingMore
+                            : t.conversationList.loadMore}
+                        </button>
+                      ) : null}
+                    </>
                   )}
                 </div>
               </aside>
@@ -967,14 +1060,26 @@ function App() {
                           <h3>{t.detail.turnUsage}</h3>
                         </div>
                         <p className="chart-note">
-                          {t.detail.latestTurns(Math.min(activeDetail.turns.length, 40))}
+                          {t.detail.latestTurns(activeDetail.turns.length)}
                         </p>
                       </div>
+                      {activeDetail.hasMoreTurns ? (
+                        <button
+                          className="ghost-button"
+                          disabled={loadingEarlierTurns}
+                          onClick={() => void loadEarlierTurns()}
+                          type="button"
+                        >
+                          {loadingEarlierTurns
+                            ? t.detail.loadingEarlierTurns
+                            : t.detail.loadEarlierTurns}
+                        </button>
+                      ) : null}
                       <div className="timeline-grid">
                         {activeDetail.turns.length === 0 ? (
                           <div className="empty-state">{t.detail.emptyTurns}</div>
                         ) : (
-                          activeDetail.turns.slice(-40).reverse().map((turn) => {
+                          [...activeDetail.turns].reverse().map((turn) => {
                             const session = sessionSummariesById.get(turn.sessionId)
                             const modelSummary = formatModelSummary(turn.modelIds, t)
                             const sessionLabel = formatSessionLabel(session, turn.sessionId, t)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import {
   shouldKeepConversationDetail,
 } from './app/dataFreshness'
 import {
+  selectionAfterDashboardReload,
   shouldLoadDashboardAfterManualRefresh,
   shouldLoadDashboardAfterSettingsSave,
   SurfaceRevisionGate,
@@ -126,6 +127,7 @@ function App() {
   const loadShellRef = useRef<(quiet?: boolean) => Promise<void>>(async () => {})
   const lastRequestedQueryKeyRef = useRef<string | null>(null)
   const latestLoadRequestIdRef = useRef(0)
+  const loadedQueryKeyRef = useRef<string | null>(null)
   const detailCacheRef = useRef(new Map<string, ConversationDetail>())
   const latestDetailRequestIdRef = useRef(0)
   const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
@@ -184,6 +186,15 @@ function App() {
       if (requestId !== latestLoadRequestIdRef.current) {
         return
       }
+      const resolvedQueryKey = buildQueryKey(
+        requestBucket,
+        requestAnchor,
+        requestCustomStart,
+        requestCustomEnd,
+        requestSearch,
+        snapshot.overview.liveWindowOffset,
+      )
+      const previousQueryKey = loadedQueryKeyRef.current
 
       startTransition(() => {
         const nextDetailCache = new Map<string, ConversationDetail>()
@@ -215,20 +226,10 @@ function App() {
         )
         setDashboardRevision((current) => current + 1)
         setLiveWindowOffset(snapshot.overview.liveWindowOffset)
-        setLoadedQueryKey(
-          buildQueryKey(
-            requestBucket,
-            requestAnchor,
-            requestCustomStart,
-            requestCustomEnd,
-            requestSearch,
-            snapshot.overview.liveWindowOffset,
-          ),
-        )
+        loadedQueryKeyRef.current = resolvedQueryKey
+        setLoadedQueryKey(resolvedQueryKey)
         setSelectedRootSessionId((current) =>
-          current && snapshot.conversationPage.items.some((item) => item.rootSessionId === current)
-            ? current
-            : null,
+          selectionAfterDashboardReload(current, previousQueryKey, resolvedQueryKey),
         )
       })
     } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -527,8 +527,8 @@ function App() {
 
   useEffect(() => {
     if (!hasBootstrapped || view !== 'conversations') return
-    void loadShell(false)
-  }, [hasBootstrapped, loadShell, view])
+    void loadShellRef.current(false)
+  }, [hasBootstrapped, view])
 
   useEffect(() => {
     if (!loadedQueryKey && selectedRootSessionId) return

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -228,7 +228,7 @@ function App() {
         setSelectedRootSessionId((current) =>
           current && snapshot.conversationPage.items.some((item) => item.rootSessionId === current)
             ? current
-            : snapshot.conversationPage.items[0]?.rootSessionId ?? null,
+            : null,
         )
       })
     } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,7 +96,7 @@ const BUCKETS: OverviewBucket[] = [
 function App() {
   const { language, setLanguage, t } = useI18n()
   const [view, setView] = useState<AppView>('overview')
-  const [bucket, setBucket] = useState<OverviewBucket>('subscription_month')
+  const [bucket, setBucket] = useState<OverviewBucket>('seven_day')
   const [liveWindowOffset, setLiveWindowOffset] = useState(0)
   const [anchor, setAnchor] = useState(todayInputValue())
   const [customStart, setCustomStart] = useState(todayInputValue())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,6 +182,7 @@ function App() {
         requestLiveWindowOffset,
         requestCustomStart,
         requestCustomEnd,
+        view === 'conversations',
       )
       if (requestId !== latestLoadRequestIdRef.current) {
         return
@@ -197,33 +198,37 @@ function App() {
       const previousQueryKey = loadedQueryKeyRef.current
 
       startTransition(() => {
-        const nextDetailCache = new Map<string, ConversationDetail>()
-        for (const conversation of snapshot.conversationPage.items) {
-          const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
-          if (
-            cachedDetail &&
-            shouldKeepConversationDetail(
-              cachedDetail,
-              conversation,
-              snapshot.subscriptionProfile.monthlyPrice,
-            )
-          ) {
-            nextDetailCache.set(conversation.rootSessionId, cachedDetail)
+        if (view === 'conversations') {
+          const nextDetailCache = new Map<string, ConversationDetail>()
+          for (const conversation of snapshot.conversationPage.items) {
+            const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
+            if (
+              cachedDetail &&
+              shouldKeepConversationDetail(
+                cachedDetail,
+                conversation,
+                snapshot.subscriptionProfile.monthlyPrice,
+              )
+            ) {
+              nextDetailCache.set(conversation.rootSessionId, cachedDetail)
+            }
           }
-        }
 
-        latestDetailRequestIdRef.current += 1
+          latestDetailRequestIdRef.current += 1
+          detailCacheRef.current = nextDetailCache
+          setDetail((current) =>
+            current && nextDetailCache.get(current.rootSessionId) === current ? current : null,
+          )
+        }
         setOverview(snapshot.overview)
-        setConversations(snapshot.conversationPage.items)
-        setConversationCursor(snapshot.conversationPage.nextCursor)
-        setHasMoreConversations(snapshot.conversationPage.hasMore)
+        if (view === 'conversations') {
+          setConversations(snapshot.conversationPage.items)
+          setConversationCursor(snapshot.conversationPage.nextCursor)
+          setHasMoreConversations(snapshot.conversationPage.hasMore)
+        }
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
         setLiveRateLimits(snapshot.liveRateLimits)
-        detailCacheRef.current = nextDetailCache
-        setDetail((current) =>
-          current && nextDetailCache.get(current.rootSessionId) === current ? current : null,
-        )
         setDashboardRevision((current) => current + 1)
         setLiveWindowOffset(snapshot.overview.liveWindowOffset)
         loadedQueryKeyRef.current = resolvedQueryKey
@@ -240,7 +245,7 @@ function App() {
         setStatusMessage(t.status.failedToLoad(t.buckets[requestBucket], String(error)))
       }
     }
-  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t])
+  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t, view])
 
   const loadMoreConversations = useCallback(async () => {
     if (!conversationCursor || !hasMoreConversations || loadingMoreConversations) return
@@ -368,26 +373,24 @@ function App() {
         void loadShellRef.current(true)
       }, 200)
     }
-    const handleCompletion = async (event: RefreshCompletedEvent) => {
-      let visible: boolean
+    const isDashboardActive = async () => {
       try {
-        visible = await getCurrentWindow().isVisible()
+        const [visible, focused] = await Promise.all([appWindow.isVisible(), appWindow.isFocused()])
+        return visible && focused
       } catch {
-        return
+        return false
       }
+    }
+    const handleCompletion = async (event: RefreshCompletedEvent) => {
+      const active = await isDashboardActive()
       if (cancelled) return
-      if (refreshRevisionGateRef.current.accept(event, visible) === 'reload') {
+      if (refreshRevisionGateRef.current.accept(event, active) === 'reload') {
         reloadDashboard()
       }
     }
     const handleVisible = async () => {
-      let visible: boolean
-      try {
-        visible = await getCurrentWindow().isVisible()
-      } catch {
-        return
-      }
-      if (cancelled || !visible) return
+      const active = await isDashboardActive()
+      if (cancelled || !active) return
       if (refreshRevisionGateRef.current.onVisible() === 'reload') {
         reloadDashboard()
       }
@@ -521,6 +524,11 @@ function App() {
     if (lastRequestedQueryKeyRef.current === currentQueryKey) return
     void loadShell(false)
   }, [currentQueryKey, hasBootstrapped, loadShell])
+
+  useEffect(() => {
+    if (!hasBootstrapped || view !== 'conversations') return
+    void loadShell(false)
+  }, [hasBootstrapped, loadShell, view])
 
   useEffect(() => {
     if (!loadedQueryKey && selectedRootSessionId) return

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2,7 +2,7 @@ import { invoke, isTauri } from '@tauri-apps/api/core'
 
 import type {
   ConversationFilters,
-  ConversationListItem,
+  ConversationPage,
   LiveRateLimitSnapshot,
   MenuBarPopupSnapshot,
   OverviewBucket,
@@ -206,6 +206,10 @@ export async function scanCodexUsage(codexHome?: string | null): Promise<import(
     importedSessions: 0,
     updatedSessions: 0,
     missingSessions: 0,
+    scanKind: 'incremental',
+    sourceBytesRead: 0,
+    tailParsedFiles: 0,
+    fullyParsedFiles: 0,
     lastCompletedAt: nowIso(),
   }))
 }
@@ -257,7 +261,7 @@ export async function loadDashboard(
     },
     () => ({
       overview: createMockOverview(bucket, anchor, customStart, customEnd),
-      conversations: [] as ConversationListItem[],
+      conversationPage: { items: [], nextCursor: null, hasMore: false } satisfies ConversationPage,
       syncSettings: createMockSyncSettings(),
       subscriptionProfile: createMockSubscriptionProfile(),
       liveRateLimits: createMockLiveRateLimits(),
@@ -265,8 +269,12 @@ export async function loadDashboard(
   )
 }
 
-export async function listConversations(filters: ConversationFilters) {
-  return invokeOrMock('listConversations', { filters }, () => [] satisfies ConversationListItem[])
+export async function listConversations(filters: ConversationFilters): Promise<ConversationPage> {
+  return invokeOrMock(
+    'listConversations',
+    { filters },
+    () => ({ items: [], nextCursor: null, hasMore: false }) satisfies ConversationPage,
+  )
 }
 
 export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {
@@ -275,8 +283,9 @@ export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {
 
 export async function getConversationDetail(
   rootSessionId: string,
+  turnCursor?: number | null,
 ): Promise<import('./types').ConversationDetail> {
-  return invokeOrMock('getConversationDetail', { rootSessionId }, () => {
+  return invokeOrMock('getConversationDetail', { rootSessionId, turnCursor: turnCursor ?? null }, () => {
     throw new Error(`Conversation ${rootSessionId} is unavailable in browser preview mode.`)
   })
 }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -248,6 +248,7 @@ export async function loadDashboard(
   liveWindowOffset?: number | null,
   customStart?: string | null,
   customEnd?: string | null,
+  includeConversations = false,
 ): Promise<import('./types').DashboardSnapshot> {
   return invokeOrMock(
     'loadDashboard',
@@ -258,6 +259,7 @@ export async function loadDashboard(
       customEnd: bucket === 'custom' ? customEnd ?? null : null,
       search: search ?? null,
       liveWindowOffset: liveWindowOffset ?? null,
+      includeConversations,
     },
     () => ({
       overview: createMockOverview(bucket, anchor, customStart, customEnd),

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -96,6 +96,8 @@ export type TranslationSet = {
     title: string
     shown: (count: number) => string
     empty: string
+    loadMore: string
+    loadingMore: string
   }
   detail: {
     eyebrow: string
@@ -105,6 +107,8 @@ export type TranslationSet = {
     turnTimelineEyebrow: string
     turnUsage: string
     latestTurns: (count: number) => string
+    loadEarlierTurns: string
+    loadingEarlierTurns: string
     emptyTurns: string
     emptySelection: string
     untitledTurn: string
@@ -345,6 +349,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       title: '根会话',
       shown: (count) => `显示 ${count} 条`,
       empty: '当前筛选条件下没有匹配对话。',
+      loadMore: '加载更多',
+      loadingMore: '正在加载…',
     },
     detail: {
       eyebrow: '对话详情',
@@ -353,6 +359,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       conversationCostBreakdown: '对话成本结构',
       turnTimelineEyebrow: 'Turn 时间线',
       turnUsage: 'Turn 用量',
+      loadEarlierTurns: '加载更早记录',
+      loadingEarlierTurns: '正在加载…',
       latestTurns: (count) => `最近 ${count} 个 turn`,
       emptyTurns: '该对话暂无 turn 级来源数据。',
       emptySelection: '选择一个对话以查看详细账本。',
@@ -587,6 +595,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       title: 'Root sessions',
       shown: (count) => `${count} shown`,
       empty: 'No conversations matched the current filter.',
+      loadMore: 'Load more',
+      loadingMore: 'Loading…',
     },
     detail: {
       eyebrow: 'Conversation detail',
@@ -596,6 +606,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       turnTimelineEyebrow: 'Turn timeline',
       turnUsage: 'Turn usage',
       latestTurns: (count) => `Latest ${count} turns`,
+      loadEarlierTurns: 'Load earlier turns',
+      loadingEarlierTurns: 'Loading…',
       emptyTurns: 'No turn-level source data is available for this conversation.',
       emptySelection: 'Select a conversation to inspect its detailed ledger.',
       untitledTurn: 'Untitled turn',

--- a/src/app/refreshEvents.ts
+++ b/src/app/refreshEvents.ts
@@ -41,6 +41,14 @@ export function shouldLoadDashboardAfterSettingsSave(
   return !codexHomeChanged || !listenerReady
 }
 
+export function selectionAfterDashboardReload(
+  currentSelection: string | null,
+  loadedQueryKey: string | null,
+  resolvedQueryKey: string,
+): string | null {
+  return loadedQueryKey === resolvedQueryKey ? currentSelection : null
+}
+
 export type SurfaceRequestKind = 'passive' | 'manual'
 
 export interface SurfaceRequestClaim {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -61,6 +61,10 @@ export interface ScanResult {
   importedSessions: number
   updatedSessions: number
   missingSessions: number
+  scanKind: 'incremental' | 'reconcile' | 'full'
+  sourceBytesRead: number
+  tailParsedFiles: number
+  fullyParsedFiles: number
   lastCompletedAt: string
 }
 
@@ -200,7 +204,7 @@ export interface OverviewResponse {
 
 export interface DashboardSnapshot {
   overview: OverviewResponse
-  conversations: ConversationListItem[]
+  conversationPage: ConversationPage
   syncSettings: SyncSettings
   subscriptionProfile: SubscriptionProfile
   liveRateLimits: LiveRateLimitSnapshot | null
@@ -213,6 +217,14 @@ export interface ConversationFilters {
   customEnd?: string | null
   search?: string | null
   liveWindowOffset?: number | null
+  cursor?: string | null
+  limit?: number | null
+}
+
+export interface ConversationPage {
+  items: ConversationListItem[]
+  nextCursor: string | null
+  hasMore: boolean
 }
 
 export interface ConversationListItem {
@@ -291,6 +303,8 @@ export interface ConversationDetail {
   sourceStates: string[]
   sessions: ConversationSessionSummary[]
   turns: ConversationTurnPoint[]
+  nextTurnCursor: number | null
+  hasMoreTurns: boolean
   modelBreakdown: ModelShare[]
   compositionBreakdown: CompositionShare[]
 }

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { isTauri } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import { ChartNoAxesCombined, RefreshCw } from 'lucide-react'
 
 import { getMenuBarPopupSnapshot, handleMenuBarPopupAction, resizeMenuBarPopup } from '../app/api'
@@ -105,7 +106,16 @@ export function MenuBarPopup() {
   }, [])
 
   useEffect(() => {
-    void loadSnapshot(false)
+    if (!isTauri()) {
+      void loadSnapshot(false)
+      return
+    }
+    void getCurrentWindow()
+      .isVisible()
+      .then((visible) => {
+        if (visible) void loadSnapshot(false)
+      })
+      .catch(() => {})
   }, [loadSnapshot])
 
   const schedulePopupResize = useCallback(() => {
@@ -164,7 +174,12 @@ export function MenuBarPopup() {
     trackRegistration(
       listen('codex-counter://menu-bar-popup-refresh', () => {
         if (!cancelled) {
-          void loadSnapshot(false)
+          void getCurrentWindow()
+            .isVisible()
+            .then((visible) => {
+              if (!cancelled && visible) void loadSnapshot(false)
+            })
+            .catch(() => {})
         }
       }),
     )


### PR DESCRIPTION
## What changed

- Treat accounts without a five-hour quota as seven-day-only accounts. The menu bar API value follows the active seven-day window instead of showing an empty or misclassified value.
- Open the dashboard on the seven-day overview by default.
- Page conversation history in SQL and load conversation details only after the user selects one.
- Query quota trends by the exact quota window instead of reading every historical row in the bucket.
- Keep hidden dashboard and menu bar surfaces from issuing duplicate refresh queries.
- Make automatic scans incremental. They now inspect active sessions, pending repairs, and incomplete archived tails. Manual scans and the daily reconciliation still perform the full consistency pass.
- Reuse SQLite and live quota resources where it is safe, cache repeated overview and menu bar calculations, and add indexes for the remaining hot queries.

## Root cause

The one-minute refresh path still did work intended for a full reconciliation. It loaded every import state, session source path, conversation relation, and quota row for a bucket. It also checked every archived file and could reparse large session files after metadata-only changes. With a 344 MB database, roughly 445,000 quota samples, and more than 2,400 archived sessions, those reads accumulated quickly.

The regular refresh path now reads about 49 active import records on the test machine. Archived records stay out of the hot path unless a file is pending repair or has an incomplete final line. New parent sessions and replay parents use indexed, single-row lookups when needed.

## Validation

- `cargo test`: 407 passed, 2 profiling helpers ignored
- `npm test -- --run`: 15 passed
- `npm run lint`: passed
- `git diff --check`: passed
- Release DMG build: passed

A 30-minute run with automatic scanning set to one minute read 34.41 MiB in total and averaged 0.14% of one CPU core. The previous build had reached 1.52 GB. A second 130-second smoke test using the final DMG read 4 KiB while idle. Stack sampling showed only the incremental import and indexed SQLite paths; the full source-map, relation, quota-history, and archived-directory scans did not recur.
