### PR TITLE
Release Codex Pacer 1.2.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,10 @@ If this public repository has just been initialized and `develop` is not availab
 
 ## Verification
 
+- [ ] `npm test`
 - [ ] `npm run lint`
 - [ ] `npm run build`
-- [ ] `cargo test`
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --locked`
 
 ## Checklist
 

--- a/.superpowers/sdd/task-2b2-report.md
+++ b/.superpowers/sdd/task-2b2-report.md
@@ -1,0 +1,101 @@
+# Task 2B2 production integration report
+
+Date: 2026-07-10
+
+Base commit: `eee8405ae960ceecb9134579294f770d92a13352`
+
+## Result
+
+The importer now removes direct-parent token replay from explicit fork sessions. It resolves a parent source without walking the archive, reads only replay metadata and token counters, computes the reviewed cutoff, and applies that cutoff inside the existing session transaction. When a parent cannot be used, the first explicit-fork snapshot falls back to `last_token_usage`; roots and thread-spawn-only sessions keep their previous cumulative accounting.
+
+## RED to GREEN evidence
+
+Each named test was run separately before and after the production change.
+
+| Test | RED value | GREEN value |
+| --- | ---: | ---: |
+| `fork_replay_counts_only_child_usage` | child `310`, expected `50` | child `50`; parent `260`; family `310` |
+| `incremental_fork_scan_loads_unchanged_archived_parent` | child `310`, expected `50` | child `50`; unchanged archived parent `260`; family `310` |
+| `nested_fork_replay_uses_direct_parent` | child `310`, expected `50` | root `260`; child `50`; grandchild `20`; family `330` |
+| `parent_path_validation_rejects_child_file_with_replayed_parent_meta` | child `150`, expected `90` | child `90`; parent remains `25` |
+| `fork_first_snapshot_uses_last_usage_as_baseline` | child `1000`, expected `40` | child `40` |
+| `thread_spawn_without_fork_keeps_full_usage` | `1000` before the change | `1000` after the change |
+
+The thread-spawn test was a guard rather than a RED case. It passed on both runs.
+
+## Implementation
+
+Changed production file: `src-tauri/src/importer.rs`.
+
+- Added `inherited_token_snapshot_cutoff` to `ParsedSession`, initialized to zero by the parser.
+- Built the session source map before changed files are processed. Priority is `sessions`, then `import_state`, then UUID-bearing files in the current scan.
+- Added an on-demand direct-parent cache keyed by requested parent ID. The cache stores both loaded snapshots and unavailable results.
+- Validated UUID-bearing filenames against the requested parent ID. Paths without a filename UUID must have a matching first usable `session_meta.payload.id`.
+- Added a parent replay reader that prefilters unrelated JSONL lines before JSON parsing. It retains only timestamp, cumulative token usage, and optional last token usage. It does not retain model names, rate limits, titles, or message text, and warnings contain only IDs and source paths.
+- Connected direct-parent snapshots to `replayed_child_snapshot_cutoff()` for changed explicit forks with a valid fork timestamp.
+- Started persistence from the final skipped cumulative snapshot and iterated from the cutoff. Explicit forks with cutoff zero use `last_token_usage` for the first counted snapshot when available. Later snapshots retain the existing cumulative high-water behavior.
+- Kept usage deletion, value calculation, usage insertion, import-state updates, and commit inside the existing session transaction.
+
+No schema, repair key, pricing rule, topology rule, public command response, UI, or test expectation changed.
+
+## Commands and results
+
+Named tests, each run with its own exact filter:
+
+```bash
+tests=(
+  fork_replay_counts_only_child_usage
+  incremental_fork_scan_loads_unchanged_archived_parent
+  nested_fork_replay_uses_direct_parent
+  parent_path_validation_rejects_child_file_with_replayed_parent_meta
+  fork_first_snapshot_uses_last_usage_as_baseline
+  thread_spawn_without_fork_keeps_full_usage
+)
+for test_name in $tests; do
+  cargo test --manifest-path src-tauri/Cargo.toml "importer::tests::$test_name" --locked -- --exact --nocapture
+done
+```
+
+All six named filters passed after implementation.
+
+Full importer suite:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests --locked
+```
+
+Result: `64 passed; 0 failed; 83 filtered out` in the library target. The binary target ran zero tests and passed.
+
+Compiler check:
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml --locked
+```
+
+Result: exit code 0 with no warnings.
+
+Whitespace check:
+
+```bash
+git diff --check
+```
+
+Result: exit code 0.
+
+## Self-review
+
+- Source resolution follows the required priority and uses persisted paths for parents omitted from an incremental scan.
+- Parent lookup does not add an archive-directory walk.
+- The reader rejects a stale child UUID path even when that child replays the requested parent's metadata.
+- Nested forks read their direct parent file, not the root file or already persisted token totals.
+- The cache key is the requested direct-parent ID, and unavailable reads are cached.
+- The replay reader parses only prefiltered `session_meta` and `event_msg/token_count` records. It never logs file contents or parser errors.
+- A nonzero cutoff seeds `previous_usage` from the last skipped raw snapshot. At-or-below high-water snapshots remain non-billable, and later growth still uses `diff_usage()`.
+- The cutoff and fallback only change explicit forks. Thread-spawn-only children and roots still bill the full first cumulative snapshot.
+- The production diff is limited to `src-tauri/src/importer.rs`; this report is the only additional file.
+
+## Concerns
+
+No known blocking concern remains. The conservative path is intentional: if a parent source is missing, unreadable, invalid, or points at another UUID, the importer uses cutoff zero and the explicit-fork first-snapshot fallback instead of guessing replay length.
+
+The required verification scope covers the importer suite and a locked compiler check, not the entire workspace test suite. A separate default `cargo fmt --check` was informational only and reported existing repository-wide formatting differences in untouched files; it did not modify the working tree.

--- a/.superpowers/sdd/task-2b2-report.md
+++ b/.superpowers/sdd/task-2b2-report.md
@@ -99,3 +99,69 @@ Result: exit code 0.
 No known blocking concern remains. The conservative path is intentional: if a parent source is missing, unreadable, invalid, or points at another UUID, the importer uses cutoff zero and the explicit-fork first-snapshot fallback instead of guessing replay length.
 
 The required verification scope covers the importer suite and a locked compiler check, not the entire workspace test suite. A separate default `cargo fmt --check` was informational only and reported existing repository-wide formatting differences in untouched files; it did not modify the working tree.
+
+## Review follow-up: conservative parent metadata parsing
+
+The first Task 2B2 review found two reader boundary problems. The parent reader could deserialize an unrelated line into a full `serde_json::Value`, and damaged token candidates were skipped instead of making the parent unavailable. The follow-up is limited to `src-tauri/src/importer.rs` and keeps the existing source locator, cache, warnings, matcher, and persistence behavior.
+
+### Follow-up RED to GREEN evidence
+
+| Test | RED | GREEN |
+| --- | --- | --- |
+| `parent_replay_reader_rejects_malformed_token_candidate_between_snapshots` | `.is_err()` failed because two valid snapshots were stitched across malformed JSON | reader returns `Err(())` at the malformed candidate |
+| `parent_replay_reader_rejects_token_count_without_timestamp` | `.is_err()` failed because the incomplete candidate was skipped | reader returns `Err(())` when a structural token event has no timestamp |
+| `parent_replay_reader_rejects_token_count_without_total_usage` | `.is_err()` failed because the incomplete candidate was skipped | reader returns `Err(())` when token info has no cumulative total |
+| `parent_replay_reader_rejects_non_numeric_token_usage` | `.is_err()` failed because the string input count became zero | reader returns `Err(())` for an invalid numeric representation |
+| `parent_replay_reader_ignores_nested_token_types_in_unrelated_root_record` | guard passed with one snapshot totaling `100` | guard still passes with one snapshot totaling `100` |
+
+The first four tests failed at their intended assertions before production changed. The nested-type test is a structural guard, so it passed before and after the implementation.
+
+### Follow-up implementation
+
+- Replaced full-`Value` parsing in `read_parent_replay_snapshots()` with small serde structs.
+- The first envelope borrows only the root timestamp, root type, payload ID, and payload type from the JSONL line.
+- A second numeric envelope runs only after the first envelope identifies a root `event_msg` whose payload type is `token_count`.
+- Serde skips unknown fields. The reader does not retain or materialize message bodies, rate limits, model labels, titles, or other payload content.
+- Prefiltered candidate JSON that cannot be parsed now returns `Err(())`.
+- Structural token events require a timestamp, `info`, and `total_token_usage`. Invalid token numbers also return `Err(())`.
+- Non-token `event_msg` records and unrelated root records remain ignored, even when nested objects contain `event_msg` and `token_count` type fields.
+- Reader errors remain opaque. No file contents or parser details reach the existing warning path.
+
+### Follow-up commands and results
+
+Focused reader tests were run separately with exact filters:
+
+```bash
+tests=(
+  parent_replay_reader_rejects_malformed_token_candidate_between_snapshots
+  parent_replay_reader_rejects_token_count_without_timestamp
+  parent_replay_reader_rejects_token_count_without_total_usage
+  parent_replay_reader_rejects_non_numeric_token_usage
+  parent_replay_reader_ignores_nested_token_types_in_unrelated_root_record
+)
+for test_name in $tests; do
+  cargo test --manifest-path src-tauri/Cargo.toml "importer::tests::$test_name" --locked -- --exact --nocapture
+done
+```
+
+Result: all five focused filters passed after implementation.
+
+The six original Task 2B2 fork and thread-spawn filters were also rerun separately. All six passed with their previously recorded accounting values.
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests --locked
+cargo check --manifest-path src-tauri/Cargo.toml --locked
+git diff --check
+```
+
+Final result: `69 passed; 0 failed; 83 filtered out` for the importer library tests. The binary target ran zero tests and passed. `cargo check` and `git diff --check` returned exit code 0, and the compiler emitted no warnings.
+
+### Follow-up self-review and concerns
+
+- Root and payload type checks, not raw substring matches, decide whether a line is a token snapshot.
+- The substring prefilter only avoids parsing clearly unrelated lines. A line admitted by the prefilter must pass the borrowed structural envelope.
+- Token details use integer fields with serde defaults for absent components, preserving the existing zero defaults and derived `total_tokens` behavior. Present values with the wrong JSON type are rejected.
+- A damaged candidate makes the cached parent unavailable, so the existing conservative explicit-fork fallback applies. Cache keys and warning content did not change.
+- No schema, repair key, query, pricing rule, UI, public response, or test expectation changed.
+
+No blocking concern remains. Allocation telemetry was not added; the privacy boundary is enforced by the small serde field set and verified by code inspection plus the nested-structure guard.

--- a/.superpowers/sdd/task-3c2-report.md
+++ b/.superpowers/sdd/task-3c2-report.md
@@ -1,0 +1,83 @@
+# Refresh Task 3C2 report
+
+## Result
+
+Refresh work now runs on three persistent named threads: one coordinator, one token worker, and one live worker. Token parsing and commit no longer delay live fetching, and the coordinator remains available while either lane executes or waits for the usage mutation lock.
+
+Manual token and live requests return blocking tickets with typed `Result<Arc<T>, RefreshError>` outcomes. Callers that join the same generation receive the same `Arc`, including the exact `ScanResult` or live snapshot produced by that generation. Intake channels, worker channels, and waiter registries have fixed capacities. A full registry returns `Busy` instead of growing without limit.
+
+## Runtime behavior
+
+- The coordinator processes Task 3C1 action vectors in order and owns the only `PreparedSlot`. A parsed token payload moves from the worker to that slot, then moves once into commit or is dropped synchronously on discard. Missing, duplicate, or mismatched payload events become typed failures and cannot strand a waiter.
+- Worker outcomes carry the exact completion payload. The coordinator keeps that `Arc` only while it resolves the corresponding action vector, so the runtime has no generation history or unbounded result cache.
+- Token parsing happens before the refresh mutation ticket is requested. Only commit uses `UsageMutationCoordinator` at refresh priority. The worker records queue wait and rechecks shutdown plus source generation after acquiring the mutation slot.
+- The live worker never takes the usage mutation lock. It calls the fetcher with the existing ten-second timeout and keeps the single fetch and persist path bounded.
+- Parse, commit, fetch, and persist calls are wrapped with panic recovery. A panic resolves the affected waiters as a typed failure, clears the lane state, and leaves the persistent worker available for later requests.
+- Shared status changes to running before work is dispatched. Status and metrics use atomics and fixed histogram buckets. They cover planned due time, actual worker start, start lag, duration, success age, failure streak, retry time, coalescing, missed deadlines, waiter counts, live timeouts, token work statistics, mutation wait, and database busy results. Saturating counters use compare-and-exchange loops.
+- Start lag above five seconds and more than one active live executor increment fixed warning counters. Error detail is length bounded, and append-fast-path count remains zero because importer append work belongs to a later task.
+
+## Shutdown and source changes
+
+Shutdown is explicit and idempotent. The first call closes intake, rejects queued manual waiters with `Shutdown`, drops any prepared payload, marks the workers for shutdown, closes their command senders, drains bounded outcome channels, and joins all three threads. A repeated call returns the same completed teardown result without sending more commands.
+
+An executor call that has already entered its body may finish during teardown, but shutdown prevents a later publish. A token worker waiting for the mutation lock checks shutdown again after it acquires the permit and skips commit when teardown has begun. Source generation is checked at the same boundary. Token commit and live persist also check for a source change before reporting success, so stale results do not resolve tickets or publish events.
+
+## Power activity scope
+
+The macOS activity guard now lives in `refresh/power.rs` and uses `NSActivityOptions::Background`. Guards cover only token parse, token commit, live fetch, and live persist. Mutation queue waits, coordinator waits, scheduler sleeps, cache fallback, and rendering hold no activity.
+
+The remaining legacy paths use the same narrow guard around the combined scan body, live query, and database snapshot insert. The previous scheduler-loop guard was removed. An injectable activity factory lets the concurrency tests verify guard entry and release without depending on macOS.
+
+## TDD record
+
+The first focused RED run failed to compile with exit code 101 because the runtime types, activity counter, and panic hooks did not exist. The complete set of 30 required tests was then added before the implementation; that run also exited 101 on the missing runtime contracts.
+
+The first compiling runtime suite exposed two useful ordering defects. Duplicate gate entry did not match the intended generation, and the startup-lag test was measuring coordinator setup instead of the actual worker start boundary. Later concurrency runs also exercised source changes during token commit and live persist, persisted success age after short monotonic uptime, and extreme interval timestamp conversion. Those four regressions remain as extra coverage, bringing the focused runtime suite to 34 tests.
+
+All required cases now pass, including independent lane starts, exact shared results, one pending follow-up, bounded duplicate storms, panic recovery, disabled scheduling with manual work, start-lag warnings, mutation lock ordering, prepared-payload discard, source invalidation, bounded capacities, saturating counters, and every specified shutdown point. The activity tests also prove that queue and wait time are outside the guard.
+
+## Verification
+
+The final implementation passed:
+
+```text
+cargo check --manifest-path src-tauri/Cargo.toml --locked --lib
+finished successfully with no warnings
+
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests
+34 passed; 0 failed
+
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::power::tests
+2 passed; 0 failed
+
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::
+114 passed; 0 failed
+
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+296 library tests passed; 0 failed
+main tests: 0 failed
+doc tests: 0 failed
+```
+
+Scoped `rustfmt --check` passed for `runtime.rs`, `power.rs`, and `refresh/mod.rs`. `git diff --check` also passed.
+
+An independent contract review found no unresolved Critical or Important issue in the runtime, shutdown/channel cycles, prepared ownership, result pairing, action order, source checks, panic recovery, fixed metrics, power scope, or legacy guard changes. It also repeated the refresh and full Rust suites. A separate race scan ran the saturated shutdown case 25 times without a failure.
+
+## Deferred work and caveats
+
+Task 3C3 still owns concrete child-process reap coverage. Task 4 owns publish-before-persist and persistence retry behavior. Task 5 owns Tauri command routing and removal of the remaining legacy refresh paths. Append parsing and frontend work also remain out of scope.
+
+Two low-priority review notes remain. The rare partial thread-spawn failure path does not explicitly join every thread that started before the failure, although normal runtime shutdown joins all three. Event sink callbacks are trusted not to panic or re-enter the runtime. Neither affects the required Task 3C2 paths or the verified teardown behavior.
+
+## Self-review
+
+- Exactly three long-lived runtime threads are created, with no thread per trigger or generation.
+- The coordinator never runs executor work or waits for the mutation lock.
+- Prepared token data has one owner at every point and is dropped on discard, stale work, failure, or shutdown.
+- Successful tickets are paired with their generation's exact immutable result.
+- Public intake and waiter registration are linearized with shutdown and remain bounded.
+- Live execution stays independent of token parsing and commit.
+- Activity guards exclude coordinator wait, mutation wait, scheduler sleep, rendering, and cache fallback.
+- No importer, frontend, Task 4 persistence semantics, or Task 5 command routing was added early.
+
+No unresolved Task 3C2 defect is known.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-07-13
+
+### Added
+- the dashboard now opens on the 7-day view, and conversation history is loaded in pages with detail fetched only after selection
+- the menu bar uses the current 7-day window for API-equivalent value when Codex does not provide a 5-hour quota
+
+### Changed
+- routine refreshes use incremental file discovery, durable parser checkpoints, bounded database queries, and cached dashboard results
+- quota charts read only the selected normalized window and keep one sample per chart bin instead of loading the full bucket history
+- frontend refresh and conversation loading avoid duplicate requests when the view, search, or time window changes
+
+### Fixed
+- Codex accounts without a 5-hour quota no longer lose their 7-day quota or fail to open the default dashboard
+- incremental scans no longer revisit the full archived session tree every minute, while pending repair files still receive targeted retries
+- subscription profile changes invalidate cached overview values immediately
+- conversation search keeps complete root-session totals and metadata when only a child session matches
+- historical quota samples with second-level timestamps remain visible after epoch backfill
+
+### Upgrade notes
+- install 1.2.2 over 1.2.0 without uninstalling or deleting the local database
+- existing usage, quota history, subscription settings, menu bar preferences, and custom Codex paths are retained
+- automatic refresh remains incremental; a bounded full reconciliation runs only when the source changes or scheduled maintenance is due
+
 ## [1.2.0] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-11
+
 ### Added
 - GPT-5.6 Sol, Terra, and Luna model recognition with bundled Standard API pricing; the `gpt-5.6` alias uses Sol pricing
 - automatic discovery of the Codex CLI bundled with the ChatGPT desktop app on macOS, while retaining standalone CLI and `CODEX_BIN` support
+- independent background refresh lanes for local token usage and online quota data, with bounded retries and missed-refresh recovery
 
 ### Changed
-- changing a custom Codex home now starts a full refresh without reusing scan times from the previous directory
-- dashboard refreshes now wait for an active scan to finish and reload conversation details when their source values have changed
+- active session logs are parsed from durable checkpoints instead of being reread from the beginning on every refresh
+- usage and quota records are appended or reconciled in place instead of deleting and rebuilding unchanged history
+- menu bar totals are calculated with bounded SQLite aggregates, and frontend refresh polling has been replaced with backend events
+- database timestamp migration now runs in small resumable batches so startup remains responsive on larger histories
+- changing a custom Codex home starts a full refresh without reusing scan times from the previous directory
 
 ### Fixed
 - GPT-5.6 API-equivalent values now recalculate at startup, including rows that were zero or used a cache-write price as the output price
 - incremental imports now capture final snapshots moved into `archived_sessions`, refresh titles from `session_index.jsonl`, avoid saving partial results from unreadable files, and repair missing conversation links
 - persisted quota fallback now chooses the latest timestamp by its actual instant and never combines windows from different samples
+- forked and nested sessions no longer rebill usage inherited from their parent, including single-snapshot and temporarily missing-parent cases
+- token and quota refreshes no longer overwrite newer results, block one another, or lose a scheduled retry when settings change
+- complete JSONL records without a trailing newline are imported instead of being skipped permanently
+- refresh scratch memory and temporary spool files are released promptly after commits and menu bar updates
+
+### Upgrade notes
+- macOS users can install 1.2.0 over 1.1.1 or 1.1.2 without uninstalling the previous version
+- the existing local database is migrated in place; session history, token usage, quota samples, subscription settings, menu bar preferences, and custom Codex paths are retained
+- the first launch may perform a bounded background timestamp backfill, but token and online quota refresh continue independently while it runs
 
 ## [1.1.2] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- GPT-5.6 Sol, Terra, and Luna model recognition with bundled Standard API pricing; the `gpt-5.6` alias uses Sol pricing
+- automatic discovery of the Codex CLI bundled with the ChatGPT desktop app on macOS, while retaining standalone CLI and `CODEX_BIN` support
+
+### Changed
+- changing a custom Codex home now starts a full refresh without reusing scan times from the previous directory
+- dashboard refreshes now wait for an active scan to finish and reload conversation details when their source values have changed
+
+### Fixed
+- GPT-5.6 API-equivalent values now recalculate at startup, including rows that were zero or used a cache-write price as the output price
+- incremental imports now capture final snapshots moved into `archived_sessions`, refresh titles from `session_index.jsonl`, avoid saving partial results from unreadable files, and repair missing conversation links
+- persisted quota fallback now chooses the latest timestamp by its actual instant and never combines windows from different samples
+
 ## [1.1.2] - 2026-05-19
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,10 @@ Keep contributions:
 Recommended verification before opening a pull request:
 
 ```bash
+npm test
 npm run lint
 npm run build
-cargo test
+cargo test --manifest-path src-tauri/Cargo.toml --locked
 ```
 
 If your change affects documentation or user-facing behavior, update the relevant docs in the same pull request when they are in scope. If you touch shared copy, keep English and Chinese surfaces aligned.
@@ -51,6 +52,7 @@ If your change affects documentation or user-facing behavior, update the relevan
 - Frontend: React + TypeScript + Vite
 - Desktop shell: Tauri 2
 - Backend and data layer: Rust + SQLite
+- On macOS, live quota testing can use the Codex CLI bundled with `ChatGPT.app`; a standalone CLI and `CODEX_BIN` remain supported
 
 ## Pull request checklist
 
@@ -58,9 +60,10 @@ If your change affects documentation or user-facing behavior, update the relevan
 - [ ] My pull request targets `develop` unless it is release-only work
 - [ ] If `develop` does not exist yet in a newly initialized public repository, I coordinated with the maintainer before opening the first pull request
 - [ ] The change is scoped and explained clearly
+- [ ] I ran `npm test`
 - [ ] I ran `npm run lint`
 - [ ] I ran `npm run build`
-- [ ] I ran `cargo test`
+- [ ] I ran `cargo test --manifest-path src-tauri/Cargo.toml --locked`
 - [ ] I updated in-scope docs if behavior or setup changed
 - [ ] I avoided unrelated changes
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ English | [简体中文](./README.zh-CN.md)
 - Imports local Codex usage data from `~/.codex` or a custom `CODEX_HOME`
 - Builds a local SQLite index for fast analysis and drill-down views
 - Estimates API-equivalent value and subscription payoff from token usage
+- Recognizes GPT-5.6 Sol, Terra, and Luna with bundled Standard API pricing
 - Tracks rolling quota windows, including `5-hour` and `7-day` pacing when available
 - Breaks usage down by conversation, root session, subagent, model, and token composition
 - Provides a macOS menu bar experience for quick quota checks
@@ -47,6 +48,8 @@ The documentation set for installation, packaging, and release notes is maintain
 - [Packaging and release](./docs/en/packaging-and-release.md)
 - [Release notes for v1.1.2](./docs/en/release-notes-v1.1.2.md)
 
+On macOS, Codex Pacer can use the Codex CLI bundled with the ChatGPT desktop app for live quota reads. It discovers `/Applications/ChatGPT.app/Contents/Resources/codex` automatically. A standalone Codex CLI and the `CODEX_BIN` override remain supported.
+
 ## Development
 
 Requirements:
@@ -74,7 +77,7 @@ Production build:
 ```bash
 npm install
 npm run build
-cargo test
+cargo test --manifest-path src-tauri/Cargo.toml --locked
 npm run tauri build
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ On macOS, Codex Pacer can use the Codex CLI bundled with the ChatGPT desktop app
 
 Requirements:
 
-- Node.js 20+
+- Node.js 22.18+
 - Rust toolchain
 - Tauri build prerequisites for your platform
 - Local Codex data under `~/.codex` or a custom `CODEX_HOME`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ English | [简体中文](./README.zh-CN.md)
 
 **Codex Pacer** is a local-first desktop app for understanding Codex usage as pace, value, and session-level activity. It helps you see how quickly you are consuming quota, what that usage is worth in API-equivalent terms, and which conversations or subagents are driving it.
 
-> Current stable release: **v1.2.0**
+> Current stable release: **v1.2.2**
 > Official download: signed and notarized **macOS Apple Silicon DMG** via GitHub Releases. Windows installer publishing is paused for this release.
 
 ## Highlights
@@ -40,13 +40,13 @@ Codex Pacer is local-first:
 
 ## Getting started
 
-The documentation set for installation, packaging, and release notes is maintained for the public `v1.2.0` release. Start with:
+The documentation set for installation, packaging, and release notes is maintained for the public `v1.2.2` release. Start with:
 
 - [Getting started](./docs/en/getting-started.md)
 - [Installing on macOS](./docs/en/installing-on-macos.md)
 - [Installing on Windows](./docs/en/installing-on-windows.md)
 - [Packaging and release](./docs/en/packaging-and-release.md)
-- [Release notes for v1.2.0](./docs/en/release-notes-v1.2.0.md)
+- [Release notes for v1.2.2](./docs/en/release-notes-v1.2.2.md)
 
 On macOS, Codex Pacer can use the Codex CLI bundled with the ChatGPT desktop app for live quota reads. It discovers `/Applications/ChatGPT.app/Contents/Resources/codex` automatically. A standalone Codex CLI and the `CODEX_BIN` override remain supported.
 
@@ -83,7 +83,7 @@ npm run tauri build
 
 ## Project status
 
-`v1.2.0` is the current stable release line.
+`v1.2.2` is the current stable release line.
 
 Current release packaging focus:
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ English | [简体中文](./README.zh-CN.md)
 
 **Codex Pacer** is a local-first desktop app for understanding Codex usage as pace, value, and session-level activity. It helps you see how quickly you are consuming quota, what that usage is worth in API-equivalent terms, and which conversations or subagents are driving it.
 
-> Current stable release: **v1.1.2**
-> Official download: signed **macOS Apple Silicon DMG** via GitHub Releases. Windows installer publishing is paused for this release.
+> Current stable release: **v1.2.0**
+> Official download: signed and notarized **macOS Apple Silicon DMG** via GitHub Releases. Windows installer publishing is paused for this release.
 
 ## Highlights
 
@@ -40,13 +40,13 @@ Codex Pacer is local-first:
 
 ## Getting started
 
-The documentation set for installation, packaging, and release notes is maintained for the public `v1.1.2` release. Start with:
+The documentation set for installation, packaging, and release notes is maintained for the public `v1.2.0` release. Start with:
 
 - [Getting started](./docs/en/getting-started.md)
 - [Installing on macOS](./docs/en/installing-on-macos.md)
 - [Installing on Windows](./docs/en/installing-on-windows.md)
 - [Packaging and release](./docs/en/packaging-and-release.md)
-- [Release notes for v1.1.2](./docs/en/release-notes-v1.1.2.md)
+- [Release notes for v1.2.0](./docs/en/release-notes-v1.2.0.md)
 
 On macOS, Codex Pacer can use the Codex CLI bundled with the ChatGPT desktop app for live quota reads. It discovers `/Applications/ChatGPT.app/Contents/Resources/codex` automatically. A standalone Codex CLI and the `CODEX_BIN` override remain supported.
 
@@ -83,7 +83,7 @@ npm run tauri build
 
 ## Project status
 
-`v1.1.2` is the current stable release line.
+`v1.2.0` is the current stable release line.
 
 Current release packaging focus:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,7 +54,7 @@ Codex Pacer 是本地优先的：
 
 环境要求：
 
-- Node.js 20+
+- Node.js 22.18+
 - Rust toolchain
 - 当前平台所需的 Tauri 构建依赖
 - `~/.codex` 或自定义 `CODEX_HOME` 中的本地 Codex 数据

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,8 +8,8 @@
 
 **Codex Pacer** 是一个本地优先的桌面应用，用来把 Codex 使用情况转换成更容易行动的视角：额度节奏、API 等价价值，以及会话级别的使用分析。你可以更快看清自己消耗额度的速度、订阅回报，以及哪些对话或 subagent 正在驱动这些使用量。
 
-> 当前稳定版本：**v1.1.2**
-> 官方下载：通过 GitHub Releases 获取已签名的 **macOS Apple Silicon DMG**。本版本暂缓发布 Windows 安装包。
+> 当前稳定版本：**v1.2.0**
+> 官方下载：通过 GitHub Releases 获取已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**。本版本暂缓发布 Windows 安装包。
 
 ## 核心能力
 
@@ -40,13 +40,13 @@ Codex Pacer 是本地优先的：
 
 ## 开始使用
 
-安装、打包和发布说明已按公开 `v1.1.2` 版本维护。可以从这些文档入口开始：
+安装、打包和发布说明已按公开 `v1.2.0` 版本维护。可以从这些文档入口开始：
 
 - [快速开始](./docs/zh-CN/getting-started.md)
 - [在 macOS 上安装](./docs/zh-CN/installing-on-macos.md)
 - [在 Windows 上安装](./docs/zh-CN/installing-on-windows.md)
 - [打包与发布](./docs/zh-CN/packaging-and-release.md)
-- [v1.1.2 发布说明](./docs/zh-CN/release-notes-v1.1.2.md)
+- [v1.2.0 发布说明](./docs/zh-CN/release-notes-v1.2.0.md)
 
 在 macOS 上，Codex Pacer 可以使用 ChatGPT 桌面应用内置的 Codex CLI 读取实时额度。应用会自动发现 `/Applications/ChatGPT.app/Contents/Resources/codex`。独立安装的 Codex CLI 和 `CODEX_BIN` 覆盖配置仍然可用。
 
@@ -83,7 +83,7 @@ npm run tauri build
 
 ## 项目状态
 
-`v1.1.2` 是当前稳定发布线。
+`v1.2.0` 是当前稳定发布线。
 
 当前发布重点：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,7 @@
 - 从 `~/.codex` 或自定义 `CODEX_HOME` 导入本地 Codex 使用数据
 - 建立本地 SQLite 索引，便于快速分析和下钻
 - 基于 token 使用量估算 API 等价价值与订阅回本情况
+- 支持 GPT-5.6 Sol、Terra 和 Luna，并内置 Standard API 定价
 - 在可用时跟踪 `5小时`、`7天` 等滚动额度窗口的使用节奏
 - 按对话、root session、subagent、模型、token 构成拆解使用情况
 - 提供 macOS 菜单栏入口，方便快速查看额度状态
@@ -47,6 +48,8 @@ Codex Pacer 是本地优先的：
 - [打包与发布](./docs/zh-CN/packaging-and-release.md)
 - [v1.1.2 发布说明](./docs/zh-CN/release-notes-v1.1.2.md)
 
+在 macOS 上，Codex Pacer 可以使用 ChatGPT 桌面应用内置的 Codex CLI 读取实时额度。应用会自动发现 `/Applications/ChatGPT.app/Contents/Resources/codex`。独立安装的 Codex CLI 和 `CODEX_BIN` 覆盖配置仍然可用。
+
 ## 开发
 
 环境要求：
@@ -74,7 +77,7 @@ npm run dev
 ```bash
 npm install
 npm run build
-cargo test
+cargo test --manifest-path src-tauri/Cargo.toml --locked
 npm run tauri build
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 **Codex Pacer** 是一个本地优先的桌面应用，用来把 Codex 使用情况转换成更容易行动的视角：额度节奏、API 等价价值，以及会话级别的使用分析。你可以更快看清自己消耗额度的速度、订阅回报，以及哪些对话或 subagent 正在驱动这些使用量。
 
-> 当前稳定版本：**v1.2.0**
+> 当前稳定版本：**v1.2.2**
 > 官方下载：通过 GitHub Releases 获取已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**。本版本暂缓发布 Windows 安装包。
 
 ## 核心能力
@@ -40,13 +40,13 @@ Codex Pacer 是本地优先的：
 
 ## 开始使用
 
-安装、打包和发布说明已按公开 `v1.2.0` 版本维护。可以从这些文档入口开始：
+安装、打包和发布说明已按公开 `v1.2.2` 版本维护。可以从这些文档入口开始：
 
 - [快速开始](./docs/zh-CN/getting-started.md)
 - [在 macOS 上安装](./docs/zh-CN/installing-on-macos.md)
 - [在 Windows 上安装](./docs/zh-CN/installing-on-windows.md)
 - [打包与发布](./docs/zh-CN/packaging-and-release.md)
-- [v1.2.0 发布说明](./docs/zh-CN/release-notes-v1.2.0.md)
+- [v1.2.2 发布说明](./docs/zh-CN/release-notes-v1.2.2.md)
 
 在 macOS 上，Codex Pacer 可以使用 ChatGPT 桌面应用内置的 Codex CLI 读取实时额度。应用会自动发现 `/Applications/ChatGPT.app/Contents/Resources/codex`。独立安装的 Codex CLI 和 `CODEX_BIN` 覆盖配置仍然可用。
 
@@ -83,7 +83,7 @@ npm run tauri build
 
 ## 项目状态
 
-`v1.2.0` 是当前稳定发布线。
+`v1.2.2` 是当前稳定发布线。
 
 当前发布重点：
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -12,7 +12,7 @@ It is built to help you answer practical questions such as:
 
 ## Requirements
 
-- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.1.2`.
+- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.2.0`.
 - Local Codex data under `~/.codex` or a custom `CODEX_HOME`
 
 For development from source, you will also need:
@@ -25,8 +25,8 @@ For development from source, you will also need:
 
 Official public downloads are published through GitHub Releases:
 
-- signed **macOS Apple Silicon DMG**
-- no Windows installer is attached to `v1.1.2`; use the Windows guide only for source validation
+- signed and notarized **macOS Apple Silicon DMG**
+- no Windows installer is attached to `v1.2.0`; use the Windows guide only for source validation
 
 Start here:
 
@@ -106,4 +106,4 @@ npm run tauri build
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Packaging and release](./packaging-and-release.md)
-- [Release notes for v1.1.2](./release-notes-v1.1.2.md)
+- [Release notes for v1.2.0](./release-notes-v1.2.0.md)

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -12,7 +12,7 @@ It is built to help you answer practical questions such as:
 
 ## Requirements
 
-- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.2.0`.
+- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.2.2`.
 - Local Codex data under `~/.codex` or a custom `CODEX_HOME`
 
 For development from source, you will also need:
@@ -26,7 +26,7 @@ For development from source, you will also need:
 Official public downloads are published through GitHub Releases:
 
 - signed and notarized **macOS Apple Silicon DMG**
-- no Windows installer is attached to `v1.2.0`; use the Windows guide only for source validation
+- no Windows installer is attached to `v1.2.2`; use the Windows guide only for source validation
 
 Start here:
 
@@ -106,4 +106,4 @@ npm run tauri build
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Packaging and release](./packaging-and-release.md)
-- [Release notes for v1.2.0](./release-notes-v1.2.0.md)
+- [Release notes for v1.2.2](./release-notes-v1.2.2.md)

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -17,7 +17,7 @@ It is built to help you answer practical questions such as:
 
 For development from source, you will also need:
 
-- Node.js 20+
+- Node.js 22.18+
 - Rust toolchain
 - Tauri build prerequisites for your platform
 

--- a/docs/en/installing-on-macos.md
+++ b/docs/en/installing-on-macos.md
@@ -2,7 +2,7 @@
 
 ## macOS install path
 
-The macOS public installer for **Codex Pacer** is the signed **Apple Silicon DMG** published through GitHub Releases.
+The macOS public installer for **Codex Pacer** is the signed and notarized **Apple Silicon DMG** published through GitHub Releases.
 
 ## Happy path
 

--- a/docs/en/installing-on-windows.md
+++ b/docs/en/installing-on-windows.md
@@ -2,7 +2,7 @@
 
 ## Windows test-stage status
 
-Windows installer publishing is paused for `v1.1.2`. No Windows setup `.exe` is attached to the current stable GitHub Release.
+Windows installer publishing is paused for `v1.2.0`. No Windows setup `.exe` is attached to the current stable GitHub Release.
 
 Windows support is currently in a test stage. When a future release includes a Windows installer, it is unsigned unless Windows code signing is separately configured for that release, and Windows SmartScreen may warn that the publisher is unknown.
 
@@ -12,7 +12,7 @@ Windows support is currently in a test stage. When a future release includes a W
 2. Install the Windows Tauri prerequisites.
 3. Run `npm ci`.
 4. Run `npm run lint`, `npm run build`, and `cargo test --manifest-path src-tauri/Cargo.toml --locked`.
-5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.1.2` on Windows.
+5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.2.0` on Windows.
 
 ## After installation
 
@@ -27,7 +27,7 @@ When testing a local Windows build:
 ## Notes
 
 - GitHub Releases is the official distribution channel.
-- `v1.1.2` only publishes the macOS Apple Silicon DMG asset.
+- `v1.2.0` only publishes the macOS Apple Silicon DMG asset.
 - Any locally built Windows setup `.exe` remains a test-stage NSIS installer.
 - A Windows installer does not install the Codex CLI and does not create Codex usage history.
 - Stable Windows support, Windows code signing, and auto-update delivery are not currently promised.

--- a/docs/en/installing-on-windows.md
+++ b/docs/en/installing-on-windows.md
@@ -2,7 +2,7 @@
 
 ## Windows test-stage status
 
-Windows installer publishing is paused for `v1.2.0`. No Windows setup `.exe` is attached to the current stable GitHub Release.
+Windows installer publishing is paused for `v1.2.2`. No Windows setup `.exe` is attached to the current stable GitHub Release.
 
 Windows support is currently in a test stage. When a future release includes a Windows installer, it is unsigned unless Windows code signing is separately configured for that release, and Windows SmartScreen may warn that the publisher is unknown.
 
@@ -12,7 +12,7 @@ Windows support is currently in a test stage. When a future release includes a W
 2. Install the Windows Tauri prerequisites.
 3. Run `npm ci`.
 4. Run `npm run lint`, `npm run build`, and `cargo test --manifest-path src-tauri/Cargo.toml --locked`.
-5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.2.0` on Windows.
+5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.2.2` on Windows.
 
 ## After installation
 
@@ -27,7 +27,7 @@ When testing a local Windows build:
 ## Notes
 
 - GitHub Releases is the official distribution channel.
-- `v1.2.0` only publishes the macOS Apple Silicon DMG asset.
+- `v1.2.2` only publishes the macOS Apple Silicon DMG asset.
 - Any locally built Windows setup `.exe` remains a test-stage NSIS installer.
 - A Windows installer does not install the Codex CLI and does not create Codex usage history.
 - Stable Windows support, Windows code signing, and auto-update delivery are not currently promised.

--- a/docs/en/packaging-and-release.md
+++ b/docs/en/packaging-and-release.md
@@ -8,7 +8,7 @@ The stable packaged asset is:
 
 - signed and notarized **macOS Apple Silicon DMG**
 
-Windows installer publishing is paused for `v1.2.0`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
+Windows installer publishing is paused for `v1.2.2`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
 
 - unsigned **Windows NSIS setup EXE** for local compatibility testing and early validation only
 
@@ -29,7 +29,7 @@ The intended public release flow is:
 
 1. Confirm public branding and documentation are ready for release.
 2. Build, notarize, and staple the macOS Apple Silicon DMG.
-3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.2.0`.
+3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.2.2`.
 4. Publish the release assets through GitHub Releases.
 5. Attach or include release notes for the tagged version.
 
@@ -39,15 +39,15 @@ Public release preparation is driven by the release scripts below:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.2.0
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
-Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, submits it for notarization, staples the ticket, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.2.0`.
+Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, submits it for notarization, staples the ticket, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.2.2`.
 
 ## Platform isolation rules
 
@@ -77,7 +77,7 @@ Windows-specific tray popup placement, hidden child-process windows, and unsigne
 - Create the Git tag for the stable release version.
 - Create the GitHub Release from that tag.
 - Upload the signed, notarized, and stapled Apple Silicon DMG.
-- Do not upload a Windows NSIS setup EXE for `v1.2.0`.
+- Do not upload a Windows NSIS setup EXE for `v1.2.2`.
 - Add the matching release notes document for the version being published.
 - Verify the download and install flow after publication.
 
@@ -89,8 +89,8 @@ For public docs and announcements, use this message consistently:
 
 - official distribution channel: GitHub Releases
 - stable release asset: signed and notarized macOS Apple Silicon DMG
-- Windows installer: paused for `v1.2.0`
-- current stable line: `v1.2.0`
+- Windows installer: paused for `v1.2.2`
+- current stable line: `v1.2.2`
 
 ## Related docs
 
@@ -98,4 +98,4 @@ For public docs and announcements, use this message consistently:
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Release runbook](./release-runbook.md)
-- [Release notes for v1.2.0](./release-notes-v1.2.0.md)
+- [Release notes for v1.2.2](./release-notes-v1.2.2.md)

--- a/docs/en/packaging-and-release.md
+++ b/docs/en/packaging-and-release.md
@@ -6,9 +6,9 @@ The stable public release of **Codex Pacer** is distributed through **GitHub Rel
 
 The stable packaged asset is:
 
-- signed **macOS Apple Silicon DMG**
+- signed and notarized **macOS Apple Silicon DMG**
 
-Windows installer publishing is paused for `v1.1.2`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
+Windows installer publishing is paused for `v1.2.0`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
 
 - unsigned **Windows NSIS setup EXE** for local compatibility testing and early validation only
 
@@ -28,8 +28,8 @@ Keep release messaging aligned with this scope so the project does not over-prom
 The intended public release flow is:
 
 1. Confirm public branding and documentation are ready for release.
-2. Build the signed macOS Apple Silicon DMG.
-3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.1.2`.
+2. Build, notarize, and staple the macOS Apple Silicon DMG.
+3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.2.0`.
 4. Publish the release assets through GitHub Releases.
 5. Attach or include release notes for the tagged version.
 
@@ -39,15 +39,15 @@ Public release preparation is driven by the release scripts below:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.2
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
-Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.1.2`.
+Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, submits it for notarization, staples the ticket, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.2.0`.
 
 ## Platform isolation rules
 
@@ -76,8 +76,8 @@ Windows-specific tray popup placement, hidden child-process windows, and unsigne
 
 - Create the Git tag for the stable release version.
 - Create the GitHub Release from that tag.
-- Upload the signed Apple Silicon DMG.
-- Do not upload a Windows NSIS setup EXE for `v1.1.2`.
+- Upload the signed, notarized, and stapled Apple Silicon DMG.
+- Do not upload a Windows NSIS setup EXE for `v1.2.0`.
 - Add the matching release notes document for the version being published.
 - Verify the download and install flow after publication.
 
@@ -88,9 +88,9 @@ GitHub Releases is more than a file host in the current workflow. It is the publ
 For public docs and announcements, use this message consistently:
 
 - official distribution channel: GitHub Releases
-- stable release asset: signed macOS Apple Silicon DMG
-- Windows installer: paused for `v1.1.2`
-- current stable line: `v1.1.2`
+- stable release asset: signed and notarized macOS Apple Silicon DMG
+- Windows installer: paused for `v1.2.0`
+- current stable line: `v1.2.0`
 
 ## Related docs
 
@@ -98,4 +98,4 @@ For public docs and announcements, use this message consistently:
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Release runbook](./release-runbook.md)
-- [Release notes for v1.1.2](./release-notes-v1.1.2.md)
+- [Release notes for v1.2.0](./release-notes-v1.2.0.md)

--- a/docs/en/release-notes-v1.2.0.md
+++ b/docs/en/release-notes-v1.2.0.md
@@ -1,0 +1,41 @@
+# Codex Pacer v1.2.0
+
+## Summary
+
+Version 1.2.0 focuses on reliable background refresh and lower resource use. Token statistics and online quota now refresh through independent workers, so a slow local scan does not hold up live quota updates and a live request does not delay token imports.
+
+The importer now reads only the completed tail of growing session files. It also updates usage and quota history in place instead of rebuilding unchanged rows. Menu bar totals are calculated inside SQLite, which avoids loading a large usage history just to render a value.
+
+## What changed
+
+- added GPT-5.6 Sol, Terra, and Luna recognition with bundled Standard API-equivalent pricing
+- added automatic discovery of the Codex CLI bundled with the ChatGPT desktop app on macOS
+- separated token and online quota refresh scheduling, retries, and freshness tracking
+- replaced frontend refresh polling with backend events
+- added durable parser checkpoints for growing JSONL session files
+- reduced database write amplification for usage and quota history
+- moved timestamp migration into bounded, resumable background batches
+- corrected forked-session accounting, including nested forks and temporarily unavailable parent files
+- fixed stale refresh overwrites, listener startup races, shutdown races, and lost retry work
+- fixed complete final JSONL records being skipped when the file has no trailing newline
+- reduced refresh allocation retention and temporary spool size on macOS
+
+## Upgrading from 1.1.1 or 1.1.2
+
+Install 1.2.0 over the existing application. You do not need to uninstall the previous version or remove its database.
+
+Codex Pacer keeps the same app name, bundle identifier, and local data location. On first launch, it adds the new schema fields and indexes in place. Existing conversations, token usage, quota samples, subscription settings, menu bar preferences, and custom Codex paths are preserved.
+
+Older timestamp rows are filled in by a small resumable background job. Normal token and online quota refresh continue independently while that work runs. Compatibility tests build databases from the exact 1.1.1 and 1.1.2 schemas, populate user data, upgrade them to 1.2.0, and verify the stored values and database integrity.
+
+## Performance notes
+
+Local restart testing on the release build no longer showed the previous roughly 53 MiB startup and per-refresh write bursts. A clean-cache launch wrote 1.68 MiB over 75 seconds, including one background refresh. A four-minute sample averaged 1.53% of one CPU core, read 0.18 MiB, and wrote 5.30 MiB. Refresh memory peaks returned to roughly 136–142 MiB of physical footprint after the work completed.
+
+These figures describe the release test machine and dataset; actual use depends on session history and refresh activity.
+
+## Packaging
+
+The public macOS asset is an Apple Silicon DMG distributed through GitHub Releases with a SHA-256 checksum. The release is Developer ID signed, notarized by Apple, stapled, and checked with Gatekeeper before publication.
+
+Windows installer publishing remains paused for this release.

--- a/docs/en/release-notes-v1.2.2.md
+++ b/docs/en/release-notes-v1.2.2.md
@@ -1,0 +1,38 @@
+# Codex Pacer v1.2.2
+
+## Summary
+
+Version 1.2.2 fixes the repeated disk reads reported on large Codex histories. Routine one-minute refreshes now inspect the small set of active, changed, or pending-repair files instead of walking the full archive. Dashboard and quota queries are bounded to the selected window, and conversation history loads in pages.
+
+This release also supports Codex accounts that no longer expose a 5-hour quota. The dashboard opens on the 7-day view, keeps the weekly quota visible, and uses that same 7-day window for the menu bar API-equivalent value.
+
+## What changed
+
+- default dashboard view changed to the current 7-day window
+- 7-day quota remains available when the 5-hour quota is absent
+- menu bar API-equivalent value falls back to the current 7-day window
+- routine scans use incremental discovery and durable parser checkpoints
+- archived sessions are reconciled during bounded maintenance instead of every automatic refresh
+- quota trends query the exact normalized window and retain one point per chart bin
+- overview data is cached and invalidated when usage, quota, or subscription settings change
+- conversation lists use SQL pagination, and turn details load only after selection
+- duplicate dashboard reads on view and search changes have been removed
+- pending repair files without import state are retried directly
+
+## Resource validation
+
+The release work was tested with automatic scanning set to one minute. Over a 30-minute sample, Codex Pacer read 34.41 MiB and averaged 0.14% of one CPU core. The trace did not show recurring full archive scans. A separate 130-second smoke test of the packaged app recorded 4 KiB of reads after launch.
+
+These figures come from the release test machine and its local Codex history. Results will vary with active sessions, database size, and whether a scheduled reconciliation is due.
+
+## Upgrading from 1.2.0
+
+Install 1.2.2 over the existing app. Do not uninstall the previous version or delete the local database.
+
+Codex Pacer keeps the same app name, bundle identifier, and data location. Existing conversations, token usage, quota samples, subscription settings, menu bar preferences, and custom Codex paths remain in place.
+
+## Packaging
+
+The public macOS asset is an Apple Silicon DMG distributed through GitHub Releases with a SHA-256 checksum. The release is Developer ID signed, notarized by Apple, stapled, and checked with Gatekeeper before publication.
+
+Windows installer publishing remains paused for this release.

--- a/docs/en/release-runbook.md
+++ b/docs/en/release-runbook.md
@@ -5,19 +5,19 @@
 This runbook is for maintainers producing public **Codex Pacer** release assets:
 
 - signed, notarized, and stapled Apple Silicon DMG
-- Windows compatibility checks, with Windows installer publishing paused for `v1.2.0`
+- Windows compatibility checks, with Windows installer publishing paused for `v1.2.2`
 - published through GitHub Releases
 
 The local release entry points are:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.2.0
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
 The macOS release scripts default `CARGO_TARGET_DIR` to `~/Library/Caches/CodexPacer/cargo-target` so signed macOS bundles are produced outside cloud-synced folders such as iCloud Drive. This avoids `codesign` failures caused by Finder and file-provider metadata on `.app` bundles.
@@ -101,7 +101,7 @@ GitHub Releases is the handoff point between maintainer workflow and user instal
 ## Build the signed DMG
 
 ```bash
-./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
 ```
 
 What the build script does:
@@ -129,7 +129,7 @@ What the build script does:
 Run this on Windows:
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
 What the Windows build script does:
@@ -152,7 +152,7 @@ If you need to override the Windows build output location, set `CARGO_TARGET_DIR
 
 ```powershell
 $env:CARGO_TARGET_DIR = "C:\Users\you\AppData\Local\CodexPacer\cargo-target"
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
 ### Optional target override
@@ -161,7 +161,7 @@ If you need to pass a specific Tauri target triple, set `TAURI_TARGET` before ru
 
 ```bash
 export TAURI_TARGET="aarch64-apple-darwin"
-./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
 ```
 
 `TAURI_TARGET` stays on the Tauri CLI side of the command, before the final `--` that introduces Cargo runner args such as `--locked`.
@@ -174,8 +174,8 @@ If you need to override the build output location, export `CARGO_TARGET_DIR` bef
 
 ```bash
 export CARGO_TARGET_DIR="$HOME/Library/Caches/CodexPacer/custom-target"
-./scripts/release/build-macos-release.sh 1.2.0
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other cloud/file-provider folders. Signed `.app` bundles created there can pick up `com.apple.FinderInfo` metadata and fail during `codesign`.
@@ -184,8 +184,8 @@ Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other clo
 
 ```bash
 git status --short
-git tag v1.2.0
-git push origin v1.2.0
+git tag v1.2.2
+git push origin v1.2.2
 ```
 
 The publish script expects:
@@ -198,18 +198,18 @@ The publish script expects:
 ## Publish the GitHub Release
 
 ```bash
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 The publish script uses:
 
-- the built DMG for `v1.2.0`
+- the built DMG for `v1.2.2`
 - the sibling `.sha256` checksum file
-- `docs/en/release-notes-v1.2.0.md`
+- `docs/en/release-notes-v1.2.2.md`
 
 It publishes those assets with `gh release create`.
 
-For `v1.2.0`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
+For `v1.2.2`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
 
 ## macOS manual smoke test
 
@@ -255,7 +255,7 @@ Run this before announcing Windows availability publicly:
 Useful spot check:
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.0_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.2_x64-setup.exe"
 ```
 
 ## Troubleshooting

--- a/docs/en/release-runbook.md
+++ b/docs/en/release-runbook.md
@@ -4,20 +4,20 @@
 
 This runbook is for maintainers producing public **Codex Pacer** release assets:
 
-- signed Apple Silicon DMG
-- Windows compatibility checks, with Windows installer publishing paused for `v1.1.2`
+- signed, notarized, and stapled Apple Silicon DMG
+- Windows compatibility checks, with Windows installer publishing paused for `v1.2.0`
 - published through GitHub Releases
 
 The local release entry points are:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.2
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
 The macOS release scripts default `CARGO_TARGET_DIR` to `~/Library/Caches/CodexPacer/cargo-target` so signed macOS bundles are produced outside cloud-synced folders such as iCloud Drive. This avoids `codesign` failures caused by Finder and file-provider metadata on `.app` bundles.
@@ -101,7 +101,7 @@ GitHub Releases is the handoff point between maintainer workflow and user instal
 ## Build the signed DMG
 
 ```bash
-./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
 ```
 
 What the build script does:
@@ -129,7 +129,7 @@ What the build script does:
 Run this on Windows:
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
 What the Windows build script does:
@@ -152,7 +152,7 @@ If you need to override the Windows build output location, set `CARGO_TARGET_DIR
 
 ```powershell
 $env:CARGO_TARGET_DIR = "C:\Users\you\AppData\Local\CodexPacer\cargo-target"
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
 ### Optional target override
@@ -161,7 +161,7 @@ If you need to pass a specific Tauri target triple, set `TAURI_TARGET` before ru
 
 ```bash
 export TAURI_TARGET="aarch64-apple-darwin"
-./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
 ```
 
 `TAURI_TARGET` stays on the Tauri CLI side of the command, before the final `--` that introduces Cargo runner args such as `--locked`.
@@ -174,8 +174,8 @@ If you need to override the build output location, export `CARGO_TARGET_DIR` bef
 
 ```bash
 export CARGO_TARGET_DIR="$HOME/Library/Caches/CodexPacer/custom-target"
-./scripts/release/build-macos-release.sh 1.1.2
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other cloud/file-provider folders. Signed `.app` bundles created there can pick up `com.apple.FinderInfo` metadata and fail during `codesign`.
@@ -184,8 +184,8 @@ Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other clo
 
 ```bash
 git status --short
-git tag v1.1.2
-git push origin v1.1.2
+git tag v1.2.0
+git push origin v1.2.0
 ```
 
 The publish script expects:
@@ -198,18 +198,18 @@ The publish script expects:
 ## Publish the GitHub Release
 
 ```bash
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 The publish script uses:
 
-- the built DMG for `v1.1.2`
+- the built DMG for `v1.2.0`
 - the sibling `.sha256` checksum file
-- `docs/en/release-notes-v1.1.2.md`
+- `docs/en/release-notes-v1.2.0.md`
 
 It publishes those assets with `gh release create`.
 
-For `v1.1.2`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
+For `v1.2.0`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
 
 ## macOS manual smoke test
 
@@ -255,7 +255,7 @@ Run this before announcing Windows availability publicly:
 Useful spot check:
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.1.2_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.0_x64-setup.exe"
 ```
 
 ## Troubleshooting

--- a/docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
+++ b/docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
@@ -1,0 +1,581 @@
+# Codex 5.6 and ChatGPT app compatibility implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Codex Pacer accurate with the GPT-5.6 model family and the merged ChatGPT desktop app, while repairing confirmed stale and partial data-update paths.
+
+**Architecture:** Preserve the current JSONL-to-SQLite pipeline. Extend the executable resolver and pricing catalog at their existing boundaries, then make importer, persisted quota, and frontend cache updates fail safely. Startup pricing-signature comparison remains the migration trigger for historical value recalculation.
+
+**Tech stack:** Rust 2021, rusqlite, serde_json, Tauri 2, React 19, TypeScript 5.9, Node 22, Vite 8.
+
+## Global constraints
+
+- Keep `CODEX_BIN` and explicit `CODEX_HOME` settings authoritative.
+- Keep Codex Pacer branding, bundle identifiers, database names, and internal event names unchanged.
+- Treat `gpt-5.6` as an alias for `gpt-5.6-sol`.
+- Use OpenAI Standard API prices, not Codex credit rates.
+- Preserve unknown model IDs and assign no guessed API-equivalent value.
+- Do not expose implementation notes or migration mechanics in the user interface.
+- Every production behavior change begins with a test that fails for the expected reason.
+
+---
+
+### Task 1: GPT-5.6 pricing and historical value repair
+
+**Files:**
+
+- Modify: `src-tauri/src/pricing.rs`
+- Modify: `src-tauri/src/importer.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+
+- Consumes: `pricing_seed()`, `parse_official_pricing_catalog()`, `resolve_pricing()`, and the existing startup pricing-signature check.
+- Produces: catalog entries for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; row parsing that uses the last price as output; automatic repair and recalculation of stored values.
+
+- [ ] **Step 1: Add failing pricing tests**
+
+Add tests that require exact prices, dated-prefix fallback, alias behavior, distinct display names, and the new four-price official row:
+
+```rust
+#[test]
+fn resolve_pricing_includes_gpt_56_family_and_alias() {
+    let catalog = pricing_seed()
+        .into_iter()
+        .map(|entry| (entry.model_id.clone(), entry))
+        .collect::<HashMap<_, _>>();
+
+    for (model, input, cached, output) in [
+        ("gpt-5.6", 5.0, 0.5, 30.0),
+        ("gpt-5.6-sol-2026-07-09", 5.0, 0.5, 30.0),
+        ("gpt-5.6-terra-2026-07-09", 2.5, 0.25, 15.0),
+        ("gpt-5.6-luna-2026-07-09", 1.0, 0.1, 6.0),
+    ] {
+        let pricing = resolve_pricing(&catalog, model).expect(model);
+        assert_eq!(pricing.input_price_per_million, input);
+        assert_eq!(pricing.cached_input_price_per_million, cached);
+        assert_eq!(pricing.output_price_per_million, output);
+    }
+}
+
+#[test]
+fn parses_gpt_56_cache_write_price_without_treating_it_as_output() {
+    let html = complete_standard_fixture_with_gpt56_rows();
+    let catalog = parse_official_pricing_catalog(&html)
+        .expect("parse pricing")
+        .into_iter()
+        .map(|entry| (entry.model_id.clone(), entry))
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(catalog["gpt-5.6-sol"].output_price_per_million, 30.0);
+    assert_eq!(catalog["gpt-5.6-terra"].output_price_per_million, 15.0);
+    assert_eq!(catalog["gpt-5.6-luna"].output_price_per_million, 6.0);
+}
+
+fn complete_standard_fixture_with_gpt56_rows() -> String {
+    concat!(
+        "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.6-sol&quot;],[0,5],[0,0.5],[0,6.25],[0,30]]],[1,[[0,&quot;gpt-5.6-terra&quot;],[0,2.5],[0,0.25],[0,3.125],[0,15]]],[1,[[0,&quot;gpt-5.6-luna&quot;],[0,1],[0,0.1],[0,1.25],[0,6]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
+        "<astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,1.75],[0,0.175],[0,14]]]]]}]]]}\"></astro-island>"
+    ).to_string()
+}
+```
+
+- [ ] **Step 2: Run the pricing tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml pricing::tests::resolve_pricing_includes_gpt_56_family_and_alias -- --exact
+cargo test --manifest-path src-tauri/Cargo.toml pricing::tests::parses_gpt_56_cache_write_price_without_treating_it_as_output -- --exact
+```
+
+Expected: the first test fails because 5.6 has no catalog entry; the second fails because `6.25` is read as Sol output.
+
+- [ ] **Step 3: Implement the model catalog and row-boundary parser**
+
+Add the official Standard prices to the seed. Store the alias with `effective_model_id` set to `gpt-5.6-sol`. Refactor row parsing to collect values only until the next model-name marker:
+
+```rust
+let next_row = block[name_end..]
+    .find(marker)
+    .map(|offset| name_end + offset)
+    .unwrap_or(block.len());
+let row_source = &block[name_end..next_row];
+let mut value_cursor = 0usize;
+let mut values = Vec::new();
+while let Some(value) = parse_next_pricing_value(row_source, &mut value_cursor) {
+    values.push(value);
+}
+
+let input = values.first().copied().flatten();
+let cached_input = values.get(1).copied().flatten();
+let output = values.last().copied().flatten();
+```
+
+Require the three explicit GPT-5.6 rows in `required_models`. Add prefix resolution in this order: Sol, Terra, Luna, then the family alias. Add display names and existing-theme chart colors for all four IDs.
+
+- [ ] **Step 4: Add failing corruption and startup-recalculation tests**
+
+Insert an official Sol row with input `5.0`, cached input `0.5`, and output `6.25`, then call `seed_pricing_catalog`. Assert output becomes `30.0`. Add a startup database test with a zero-valued `gpt-5.6-sol` usage event and assert `prepare_app_database` recalculates it.
+
+- [ ] **Step 5: Verify the repair tests fail for the intended reasons**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml pricing::tests::seed_repairs_misparsed_gpt_56_output_prices -- --exact
+cargo test --manifest-path src-tauri/Cargo.toml tests::startup_database_prepare_recalculates_new_gpt_56_values -- --exact
+```
+
+Expected: the malformed official row remains `6.25`, and the event remains zero.
+
+- [ ] **Step 6: Repair only the known malformed pattern**
+
+Allow `PreserveOfficial` seeding to replace a GPT-5.6 row only when its current output equals `input * 1.25`, within floating-point tolerance. Correct official rows remain untouched. The existing before-and-after pricing signature then triggers `recalculate_all_session_values`.
+
+- [ ] **Step 7: Add and pass a GPT-5.6 importer fixture**
+
+Create a JSONL fixture in the importer test with `turn_context.payload.model = "gpt-5.6-sol"` and a token snapshot. Assert token totals and the Standard API-equivalent value. Run the full pricing and importer test modules.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add src-tauri/src/pricing.rs src-tauri/src/importer.rs src-tauri/src/lib.rs
+git commit -m "fix: support GPT-5.6 pricing and value repair"
+```
+
+### Task 2: ChatGPT desktop executable discovery
+
+**Files:**
+
+- Modify: `src-tauri/src/rate_limits.rs`
+
+**Interfaces:**
+
+- Consumes: `resolve_codex_binary_from_env()` and `app_server_command_spec()`.
+- Produces: macOS candidate paths for the merged ChatGPT app and legacy Codex app without changing Windows or Linux behavior.
+
+- [ ] **Step 1: Add failing macOS resolver tests**
+
+```rust
+#[test]
+#[cfg(target_os = "macos")]
+fn resolve_codex_binary_prefers_chatgpt_app_bundle() {
+    let resolved = super::resolve_codex_binary_from_env(
+        None,
+        None,
+        Some(Path::new("/Users/CodexUser")),
+        existing_paths(&[
+            "/Applications/ChatGPT.app/Contents/Resources/codex",
+            "/opt/homebrew/bin/codex",
+        ]),
+    );
+    assert_eq!(resolved, PathBuf::from("/Applications/ChatGPT.app/Contents/Resources/codex"));
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn resolve_codex_binary_uses_legacy_app_when_chatgpt_is_missing() {
+    let resolved = super::resolve_codex_binary_from_env(
+        None,
+        None,
+        Some(Path::new("/Users/CodexUser")),
+        existing_paths(&["/Applications/Codex.app/Contents/Resources/codex"]),
+    );
+    assert_eq!(resolved, PathBuf::from("/Applications/Codex.app/Contents/Resources/codex"));
+}
+```
+
+- [ ] **Step 2: Run both tests and verify RED**
+
+Expected: both resolve to the fallback command name because app bundle paths are absent from the candidate list.
+
+- [ ] **Step 3: Add ordered macOS bundle candidates**
+
+Inside the non-Windows candidate builder, prepend system and user `ChatGPT.app` paths, followed by system and user `Codex.app` paths under `#[cfg(target_os = "macos")]`. Keep `CODEX_BIN` resolution outside this list so it stays first.
+
+- [ ] **Step 4: Verify GREEN and remove platform-only warnings**
+
+Conditionally import Windows-only test types. Run `cargo test --manifest-path src-tauri/Cargo.toml rate_limits::tests` and require clean compiler output.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add src-tauri/src/rate_limits.rs
+git commit -m "fix: discover Codex inside the ChatGPT app"
+```
+
+### Task 3: Importer update integrity
+
+**Files:**
+
+- Modify: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+
+- Consumes: `perform_scan()`, `perform_incremental_scan()`, `ImportState`, session JSONL, and `session_index.jsonl`.
+- Produces: validated custom homes, immediate moved-archive imports, title-only refresh, read-error retry, and topology self-repair.
+
+- [ ] **Step 1: Add failing tests for each confirmed importer edge**
+
+Add five tests. Reuse the existing `write_session_file`, `write_session_file_with_parent`, `session_usage_totals`, and `conversation_link` test helpers:
+
+```rust
+#[test]
+fn invalid_custom_home_does_not_advance_completed_scan_time() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let missing = directory.path().join("missing-codex-home");
+
+    let error = perform_scan(&db_path, Some(missing.to_string_lossy().to_string()))
+        .expect_err("missing home must fail");
+    assert!(error.contains("existing directory"));
+
+    let conn = open_connection(&db_path).expect("open db");
+    let completed: Option<String> = conn
+        .query_row(
+            "SELECT last_scan_completed_at FROM sync_settings WHERE singleton_id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("load completion");
+    assert!(completed.is_none());
+}
+
+#[test]
+fn incremental_scan_imports_final_snapshot_after_active_file_is_archived() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    let archived = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&archived).expect("archive");
+    let session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let archived_path = archived.join(active_path.file_name().expect("filename"));
+    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+
+    write_session_file(
+        &active_path,
+        session_id,
+        &[
+            ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+            ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+        ],
+    );
+    std::fs::rename(&active_path, &archived_path).expect("archive session");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, session_id).4, 200);
+    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+}
+
+#[test]
+fn full_scan_refreshes_title_when_only_session_index_changes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    write_session_file(
+        &sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl")),
+        session_id,
+        &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let index_path = codex_home.join("session_index.jsonl");
+    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"A\"}}\n"))
+        .expect("title A");
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"B\"}}\n"))
+        .expect("title B");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let title: String = conn
+        .query_row("SELECT title FROM sessions WHERE session_id = ?1", params![session_id], |row| row.get(0))
+        .expect("title");
+    assert_eq!(title, "B");
+}
+
+#[test]
+fn invalid_utf8_does_not_commit_partial_session_or_import_state() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    let path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let mut file = File::create(&path).expect("session file");
+    writeln!(file, "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session_id}\"}}}}")
+        .expect("meta");
+    file.write_all(&[0xff, b'\n']).expect("invalid utf8");
+    writeln!(file, "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}")
+        .expect("tail");
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan skips bad file");
+    let conn = open_connection(&db_path).expect("open db");
+    let sessions_count: i64 = conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0)).expect("sessions");
+    let states_count: i64 = conn.query_row("SELECT COUNT(*) FROM import_state", [], |row| row.get(0)).expect("states");
+    assert_eq!((sessions_count, states_count), (0, 0));
+}
+
+#[test]
+fn incremental_scan_repairs_missing_conversation_link_without_source_change() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let parent = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let child = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    write_session_file_with_parent(
+        &sessions.join(format!("rollout-2026-07-10T00-00-00-{parent}.jsonl")),
+        parent,
+        None,
+        &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    write_session_file_with_parent(
+        &sessions.join(format!("rollout-2026-07-10T00-01-00-{child}.jsonl")),
+        child,
+        Some(parent),
+        &[("2026-07-10T00:01:00Z", 50, 10, 5, 55)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open db");
+    conn.execute("DELETE FROM conversation_links WHERE session_id = ?1", params![child])
+        .expect("remove link");
+    drop(conn);
+
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("repair scan");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(conversation_link(&conn, child).expect("child link").0, parent);
+}
+```
+
+Use concrete assertions: final token total equals the appended snapshot, source state is `archived`, title equals `B`, partial session count is zero, and the child root equals its parent.
+
+- [ ] **Step 2: Run each test and verify RED**
+
+Run each exact test name with `cargo test --manifest-path src-tauri/Cargo.toml importer::tests::<name> -- --exact`. Confirm each failure matches the audited behavior.
+
+- [ ] **Step 3: Validate and expand Codex home paths**
+
+Add a helper that expands exactly `~` and `~/...` against the resolved home directory, then rejects a path that does not exist or is not a directory:
+
+```rust
+fn validate_codex_home(path: PathBuf, home_dir: Option<&Path>) -> Result<PathBuf, String> {
+    let expanded = expand_home_prefix(path, home_dir)?;
+    if !expanded.is_dir() {
+        return Err(format!("Codex home is not an existing directory: {}", expanded.display()));
+    }
+    Ok(expanded)
+}
+```
+
+Call this before `set_last_scan_started`.
+
+- [ ] **Step 4: Detect active files moved to the archive**
+
+Load `source_bucket` into `ImportState`. During an incremental scan, build the active path set. For each missing active import state, test `codex_home/archived_sessions/<original filename>`. Add an existing match as an archived `SessionFile` so normal parsing and duplicate-state cleanup handle it.
+
+- [ ] **Step 5: Refresh titles and topology independently of changed JSONL**
+
+On a full scan, load `session_index.jsonl` once and update matching non-empty titles even if no session file changed. Add `conversation_links_need_repair()` that detects a session without a link or with a direct-parent mismatch. Recompute links when this check or the existing topology flag is true.
+
+- [ ] **Step 6: Propagate line read errors**
+
+Replace `map_while(Result::ok)` in `parse_session_file_once` with an explicit loop:
+
+```rust
+for line_result in BufReader::new(file).lines() {
+    let line = line_result.map_err(|error| {
+        SessionParseError::Fatal(format!("Failed to read {}: {error}", session_file.path.display()))
+    })?;
+    // Existing JSON parsing follows.
+}
+```
+
+Keep malformed JSON lines retryable, including an incomplete trailing record.
+
+- [ ] **Step 7: Run all importer tests and verify GREEN**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml importer::tests`. Require all old incomplete-line and replay tests to remain green.
+
+- [ ] **Step 8: Commit Task 3**
+
+```bash
+git add src-tauri/src/importer.rs
+git commit -m "fix: make session imports update safely"
+```
+
+### Task 4: Persisted live-quota freshness
+
+**Files:**
+
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+
+- Consumes: `rate_limit_samples.sample_timestamp` and `load_persisted_live_rate_limits_for_source()`.
+- Produces: absolute-time ordering and a snapshot containing only windows from the same sample instant.
+
+- [ ] **Step 1: Add failing mixed-offset and mixed-sample tests**
+
+Insert `2026-07-10T09:00:00+08:00` followed by `2026-07-10T02:00:00Z`; assert the latter wins. Insert an older primary and secondary pair plus a newer primary-only sample; assert the result contains the newer primary and no secondary.
+
+- [ ] **Step 2: Run both tests and verify RED**
+
+Expected: text sorting chooses `09:00+08:00`, and the loader combines windows from different samples.
+
+- [ ] **Step 3: Order by SQLite time and select one coherent sample**
+
+Use `ORDER BY julianday(sample_timestamp) DESC, id DESC`. Parse each selected timestamp with `DateTime::parse_from_rfc3339`, find the newest instant, and discard a window whose timestamp differs from that instant. Set `fetched_at` to the retained timestamp.
+
+- [ ] **Step 4: Run live-rate fallback tests and verify GREEN**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml tests::background_live_rate_limit` and the two new exact tests.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src-tauri/src/lib.rs
+git commit -m "fix: select coherent persisted quota samples"
+```
+
+### Task 5: Settings, detail cache, and overlapping refreshes
+
+**Files:**
+
+- Create: `src/app/dataFreshness.ts`
+- Create: `scripts/test-data-freshness.mjs`
+- Modify: `src/App.tsx`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/database/sync_settings.rs`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Consumes: `ConversationDetail`, `ConversationListItem`, `SubscriptionProfile`, scan state, and saved sync settings.
+- Produces: cache-retention and scan-settle helpers plus freshness reset when Codex home changes.
+
+- [ ] **Step 1: Add failing Node behavior tests**
+
+Export these pure helpers from `src/app/dataFreshness.ts`:
+
+```ts
+export function shouldKeepConversationDetail(
+  cached: ConversationDetail,
+  summary: ConversationListItem,
+  monthlyPrice: number,
+): boolean
+
+export async function waitForOverlappingScan(
+  getScanInProgress: () => Promise<boolean>,
+  waitForScanToSettle: () => Promise<void>,
+): Promise<void>
+```
+
+The Node test imports the TypeScript file directly. It asserts cache rejection when API value or expected subscription share changes, cache retention when all derived values match, and one settle wait when scan state is true.
+
+- [ ] **Step 2: Run the Node test and verify RED**
+
+Run `node scripts/test-data-freshness.mjs`. Expected: module or export not found.
+
+- [ ] **Step 3: Implement the helpers and use them in App.tsx**
+
+Use a small epsilon for floating-point comparisons. In `loadShell`, retain cached detail only through `shouldKeepConversationDetail`. After `refreshBackgroundData`, call `waitForOverlappingScan(getScanInProgress, waitForScanToSettle)` before `loadShell(false)`.
+
+- [ ] **Step 4: Add a failing Rust test for source switching**
+
+Save settings with scan timestamps, change only `codex_home`, call the backend normalization helper, and assert both exposed scan timestamps and `last_full_scan_completed_at` are cleared.
+
+- [ ] **Step 5: Reset freshness and trigger the new full scan**
+
+Add `clear_scan_timestamps()` in `database/sync_settings.rs`. Call it after saving when normalized `codex_home` changed. In `handleSaveSettings`, update `syncSettingsRef.current` immediately and call `loadShell(true)` when the home changed; otherwise call `loadShell(false)`.
+
+- [ ] **Step 6: Add the Node test to npm test and verify GREEN**
+
+Add `test:data-freshness` to `package.json` and include it in `npm test`. Run `npm test`, `npm run lint`, and `npm run build`.
+
+- [ ] **Step 7: Commit Task 5**
+
+```bash
+git add src/app/dataFreshness.ts scripts/test-data-freshness.mjs src/App.tsx src-tauri/src/lib.rs src-tauri/src/database/sync_settings.rs package.json
+git commit -m "fix: invalidate stale dashboard data"
+```
+
+### Task 6: Documentation and full verification
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+
+- Consumes: final verified behavior and exact commands.
+- Produces: current setup guidance and a concise change record.
+
+- [ ] **Step 1: Update setup and test commands**
+
+State that Codex Pacer can use the CLI bundled with the ChatGPT desktop app on macOS. Replace root-level `cargo test` examples with:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+```
+
+- [ ] **Step 2: Humanize and audit the documentation**
+
+Keep the prose factual. Scan for placeholders, em dashes, en dashes, stale Codex app-only wording, and accidental implementation notes.
+
+- [ ] **Step 3: Run static and unit verification**
+
+```bash
+npm test
+npm run lint
+npm run build
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+./scripts/release/audit-public-branding.sh
+./scripts/release/test-build-macos-release.sh
+```
+
+- [ ] **Step 4: Run real local-data verification without mutating the live Pacer database**
+
+Copy the current `~/.codex` session and index files to a temporary Codex home. Run the backend scan against a temporary SQLite database. Compare session count, latest session model, latest token total, and GPT-5.6 API-equivalent value with direct JSONL inspection.
+
+- [ ] **Step 5: Verify the ChatGPT-bundled app-server and packaged app**
+
+Run initialize plus `account/rateLimits/read` through `/Applications/ChatGPT.app/Contents/Resources/codex`. Build the Tauri app, launch it with the temporary database and copied Codex home, then confirm dashboard, conversation detail, model legend, refresh, and live quota behavior.
+
+- [ ] **Step 6: Review the complete diff**
+
+Run `git diff develop...HEAD`, `git diff --check`, and `git status --short`. Confirm no personal paths, copied session content, credentials, build products, or unrelated dependency changes are tracked.
+
+- [ ] **Step 7: Commit documentation and any verification-only fixtures**
+
+```bash
+git add README.md README.zh-CN.md CONTRIBUTING.md CHANGELOG.md docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
+git commit -m "docs: document ChatGPT and GPT-5.6 support"
+```
+
+- [ ] **Step 8: Push the development branch**
+
+```bash
+git push -u origin codex/adapt-chatgpt-codex-5-6
+```
+
+Report the branch, commit list, exact verification results, remaining warnings or environmental limits, and the user tests needed before starting the pull-request process.

--- a/docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
+++ b/docs/superpowers/plans/2026-07-10-codex-5-6-chatgpt-compatibility.md
@@ -4,9 +4,9 @@
 
 **Goal:** Keep Codex Pacer accurate with the GPT-5.6 model family and the merged ChatGPT desktop app, while repairing confirmed stale and partial data-update paths.
 
-**Architecture:** Preserve the current JSONL-to-SQLite pipeline. Extend the executable resolver and pricing catalog at their existing boundaries, then make importer, persisted quota, and frontend cache updates fail safely. Startup pricing-signature comparison remains the migration trigger for historical value recalculation.
+**Architecture:** Preserve the current JSONL-to-SQLite pipeline. Extend the executable resolver and pricing catalog at their existing boundaries, then make importer, persisted quota, and frontend cache updates fail safely. Historical value recalculation is triggered by either a changed price-bearing catalog signature or a pending durable pricing-resolution repair.
 
-**Tech stack:** Rust 2021, rusqlite, serde_json, Tauri 2, React 19, TypeScript 5.9, Node 22, Vite 8.
+**Tech stack:** Rust 2021, rusqlite, serde_json, Tauri 2, React 19, TypeScript 5.9, Node 22.18 or newer, Vite 8.
 
 ## Global constraints
 
@@ -30,7 +30,7 @@
 
 **Interfaces:**
 
-- Consumes: `pricing_seed()`, `parse_official_pricing_catalog()`, `resolve_pricing()`, and the existing startup pricing-signature check.
+- Consumes: `pricing_seed()`, `parse_official_pricing_catalog()`, `resolve_pricing()`, the startup pricing-signature check, and the durable pricing-resolution repair marker.
 - Produces: catalog entries for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; row parsing that uses the last price as output; automatic repair and recalculation of stored values.
 
 - [ ] **Step 1: Add failing pricing tests**
@@ -131,7 +131,7 @@ Expected: the malformed official row remains `6.25`, and the event remains zero.
 
 - [ ] **Step 6: Repair only the known malformed pattern**
 
-Allow `PreserveOfficial` seeding to replace a GPT-5.6 row only when its current output equals `input * 1.25`, within floating-point tolerance. Correct official rows remain untouched. The existing before-and-after pricing signature then triggers `recalculate_all_session_values`.
+Allow `PreserveOfficial` seeding to replace a GPT-5.6 row only when its current output equals `input * 1.25`, within floating-point tolerance. Correct official rows remain untouched. A changed before-and-after pricing signature triggers `recalculate_all_session_values`; the durable repair marker also guarantees a one-time recalculation for resolver-only changes.
 
 - [ ] **Step 7: Add and pass a GPT-5.6 importer fixture**
 

--- a/docs/superpowers/plans/2026-07-10-fork-token-accounting.md
+++ b/docs/superpowers/plans/2026-07-10-fork-token-accounting.md
@@ -1,0 +1,315 @@
+# Fork token accounting implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove parent token history copied into Codex fork files, repair existing usage rows, and install a verified macOS build.
+
+**Architecture:** Keep cumulative usage as the monotonic high-water mark. Parse `last_token_usage`, identify exact direct-parent replay prefixes for explicit forks, and use the final copied cumulative value as the child baseline. A new durable repair key forces unchanged session files through the corrected importer.
+
+**Tech stack:** Rust 2021, rusqlite, serde_json, Tauri 2, React 19, TypeScript 5.9, Node 22.18 or newer, macOS release shell scripts.
+
+## Global constraints
+
+- Apply cross-session replay removal only to `session_meta.payload.forked_from_id`.
+- Require at least two consecutive exact `(total_token_usage, last_token_usage)` pairs.
+- Keep timestamps and model labels out of replay matching.
+- Keep the `usage_events` schema and public response types unchanged.
+- Preserve cumulative high-water handling for repeated and non-monotonic totals.
+- Fall back to legacy cumulative accounting when `last_token_usage` is absent.
+- Do not read or log user and model message bodies during replay matching.
+- Every production behavior change begins with a test that fails for the expected reason.
+
+---
+
+### Task 1: Reproduce fork replay and inherited baselines
+
+**Files:**
+
+- Modify: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+
+- Consumes: `perform_scan()`, `session_usage_totals()`, and JSONL test fixtures.
+- Produces: regression tests for copied parent history, inherited first snapshots, and non-fork subagents.
+
+- [ ] **Step 1: Add a fixture that writes cumulative and last usage**
+
+Add a test helper that writes both source counters without depending on production parsing helpers:
+
+```rust
+#[derive(Clone, Copy)]
+struct TokenFixture {
+  timestamp: &'static str,
+  total: (i64, i64, i64, i64),
+  last: (i64, i64, i64, i64),
+}
+
+fn token_count_line(fixture: TokenFixture) -> String {
+  let (input, cached, output, total) = fixture.total;
+  let (last_input, last_cached, last_output, last_total) = fixture.last;
+  format!(
+    concat!(
+      "{{\"timestamp\":\"{}\",\"type\":\"event_msg\",\"payload\":{{",
+      "\"type\":\"token_count\",\"info\":{{",
+      "\"total_token_usage\":{{\"input_tokens\":{},\"cached_input_tokens\":{},",
+      "\"output_tokens\":{},\"reasoning_output_tokens\":0,\"total_tokens\":{}}},",
+      "\"last_token_usage\":{{\"input_tokens\":{},\"cached_input_tokens\":{},",
+      "\"output_tokens\":{},\"reasoning_output_tokens\":0,\"total_tokens\":{}}}",
+      "}}}}}}\n"
+    ),
+    fixture.timestamp, input, cached, output, total,
+    last_input, last_cached, last_output, last_total,
+  )
+}
+```
+
+- [ ] **Step 2: Add the copied-prefix regression test**
+
+Create a parent with cumulative totals `100`, `180`, and `260`. Create an explicit child fork whose first three numeric pairs are identical but whose timestamps use the child creation time. Append one new child snapshot with total `310` and last usage `50`. Assert parent total `260`, child total `50`, and root-family total `310`.
+
+- [ ] **Step 3: Add first-snapshot and non-fork tests**
+
+For an explicit fork with cumulative total `1000` and last total `40`, assert child total `40`. For a session that has only `thread_spawn.parent_thread_id`, use the same counters and assert total `1000`, proving that normal child sessions keep their existing semantics.
+
+- [ ] **Step 4: Run the three focused tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::fork_replay_counts_only_child_usage -- --exact
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::fork_first_snapshot_uses_last_usage_as_baseline -- --exact
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::thread_spawn_without_fork_keeps_full_usage -- --exact
+```
+
+Expected: the fork tests report the full inherited cumulative totals. The thread-spawn test passes and remains a guard during implementation.
+
+### Task 2: Parse source counters and remove exact replay prefixes
+
+**Files:**
+
+- Modify: `src-tauri/src/models.rs`
+- Modify: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+
+- Consumes: `total_token_usage`, optional `last_token_usage`, the direct parent's source path, and `persist_session()`.
+- Produces: `UsageSnapshot.last_usage`, an explicit fork parent ID, linear replay matching, and corrected deltas.
+
+- [ ] **Step 1: Retain last-turn usage and explicit fork identity**
+
+Extend the internal snapshot data and parser:
+
+```rust
+pub struct UsageSnapshot {
+  pub timestamp: String,
+  pub model_id: String,
+  pub usage: TokenUsage,
+  pub last_usage: Option<TokenUsage>,
+  pub plan_type: Option<String>,
+  pub limit_id: Option<String>,
+  pub limit_name: Option<String>,
+  pub explicit_fast_mode: Option<bool>,
+}
+```
+
+Add `forked_from_session_id: Option<String>` to `SessionMetaCandidate` and `ParsedSession`. Populate it only from `payload.forked_from_id`; keep the existing broader `parent_session_id` behavior.
+
+- [ ] **Step 2: Add unit tests for replay matching**
+
+Test a complete match, a match starting inside the parent sequence, a one-record match that returns zero, and a sequence interrupted by a missing last-usage value.
+
+```rust
+assert_eq!(longest_inherited_prefix(&child, &parent), 3);
+assert_eq!(longest_inherited_prefix(&one_record_child, &parent), 0);
+assert_eq!(longest_inherited_prefix(&legacy_child, &parent), 0);
+```
+
+- [ ] **Step 3: Run matching tests and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::replay_prefix_ -- --nocapture
+```
+
+Expected: compilation fails because the replay-key and prefix functions do not exist.
+
+- [ ] **Step 4: Implement linear prefix matching**
+
+Define an equality-only replay key and KMP prefix scan:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UsageReplayKey {
+  total_usage: TokenUsage,
+  last_usage: TokenUsage,
+}
+
+fn usage_replay_key(snapshot: &UsageSnapshot) -> Option<UsageReplayKey> {
+  Some(UsageReplayKey {
+    total_usage: snapshot.usage.clone(),
+    last_usage: snapshot.last_usage.clone()?,
+  })
+}
+```
+
+Build the child pattern only through its first missing key. Scan parent segments with a KMP prefix table. Return zero for matches shorter than two records.
+
+- [ ] **Step 5: Resolve and cache direct-parent sequences**
+
+Build a session source-path map from current scan files and `sessions.source_path`. For each changed explicit fork, read only `turn_context` and `event_msg/token_count` metadata from the direct parent. Cache `Vec<Option<UsageReplayKey>>` by parent session ID for the rest of the scan.
+
+- [ ] **Step 6: Apply the corrected baseline in persistence**
+
+Store the inherited prefix length on `ParsedSession`. Start `previous_usage` from the last skipped snapshot. If no prefix was found for an explicit fork, use `last_usage` for its first delta when present. Continue using `diff_usage()` for later snapshots.
+
+```rust
+let mut previous_usage = parsed
+  .inherited_token_snapshot_count
+  .checked_sub(1)
+  .and_then(|index| parsed.snapshots.get(index))
+  .map(|snapshot| snapshot.usage.clone());
+
+for snapshot in parsed.snapshots.iter().skip(parsed.inherited_token_snapshot_count) {
+  let delta = match previous_usage.as_ref() {
+    Some(previous) => diff_usage(previous, &snapshot.usage),
+    None if parsed.forked_from_session_id.is_some() => {
+      snapshot.last_usage.clone().unwrap_or_else(|| snapshot.usage.clone())
+    }
+    None => snapshot.usage.clone(),
+  };
+  previous_usage = Some(snapshot.usage.clone());
+  // Persist non-zero monotonic deltas through the existing path.
+}
+```
+
+- [ ] **Step 7: Verify GREEN and preserve monotonic tests**
+
+Run all `importer::tests` and require the new fork tests plus existing replay, archive, source-switch, and pending-repair tests to pass.
+
+### Task 3: Force a durable historical rebuild
+
+**Files:**
+
+- Modify: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+
+- Consumes: `data_repairs`, `data_repair_pending_files`, and unchanged import-state metadata.
+- Produces: the `token_usage_fork_replay_v3` repair marker and a retryable one-time sweep.
+
+- [ ] **Step 1: Add a failing v2-to-v3 repair test**
+
+Create an unchanged fork file and preseed overcounted `usage_events`, matching `import_state`, `rate_limit_sample_backfill_v1`, and `token_usage_monotonic_v2`. Run `perform_incremental_scan()` and assert that the corrected rows replace the stale rows and `token_usage_fork_replay_v3` is recorded.
+
+- [ ] **Step 2: Run the repair test and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests::v3_repair_rebuilds_unchanged_fork_usage -- --exact
+```
+
+Expected: no file is reimported because the installed v2 marker is already complete.
+
+- [ ] **Step 3: Replace the repair key and keep pending-file behavior**
+
+Set the active token repair key to `token_usage_fork_replay_v3`. Do not delete the v2 marker. Reuse the existing full-scan promotion, per-file pending records, and completion marker.
+
+- [ ] **Step 4: Verify repair retry tests**
+
+Run the v3 test and all existing tests that contain `repair` in their name. Confirm that an unreadable file remains pending and a later successful read clears it.
+
+### Task 4: Validate with real data and the full test matrix
+
+**Files:**
+
+- No production file changes.
+
+**Interfaces:**
+
+- Consumes: a temporary copy of `~/.codex`, a temporary SQLite database, and the independent audit script.
+- Produces: corrected totals, database integrity evidence, and complete automated-test output.
+
+- [ ] **Step 1: Run formatting and focused Rust tests**
+
+```bash
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+cargo test --manifest-path src-tauri/Cargo.toml importer::tests --locked
+```
+
+- [ ] **Step 2: Run the complete project checks**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+npm test
+npm run lint
+npm run build
+./scripts/release/test-build-macos-release.sh
+```
+
+- [ ] **Step 3: Scan a copied source into a temporary database**
+
+Copy `~/.codex` into a temporary directory, run the importer against a temporary SQLite database, and compare all-time plus selected-root totals with `/tmp/codex_pacer_token_replay_audit.py`. Require `PRAGMA quick_check = ok`, zero exact duplicate usage rows, and a repaired total within the audit's documented conservative bounds.
+
+- [ ] **Step 4: Verify the installed database repair on a backup**
+
+Copy `~/Library/Application Support/com.codex.counter/codex-counter.sqlite` to a temporary path. Run the new importer against the copy. Confirm the v3 marker exists, pending v3 files are reported, settings are unchanged, and the current root no longer contains the copied parent prefix.
+
+### Task 5: Build, install, and launch the macOS app
+
+**Files:**
+
+- Build artifacts under an external `CARGO_TARGET_DIR`.
+- Install: `/Applications/Codex Pacer.app`.
+
+**Interfaces:**
+
+- Consumes: the release script, local Developer ID identity, and the completed source tree.
+- Produces: a signed app, DMG, checksum, installed app, running process, and repaired live database.
+
+- [ ] **Step 1: Commit and verify a clean release tree**
+
+```bash
+git add docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md \
+  docs/superpowers/plans/2026-07-10-fork-token-accounting.md \
+  src-tauri/src/models.rs src-tauri/src/importer.rs
+git commit -m "fix: remove fork token replay from usage totals"
+git status --short
+```
+
+- [ ] **Step 2: Build the signed app and DMG**
+
+Use an external target directory because the repository is stored in iCloud:
+
+```bash
+export CARGO_TARGET_DIR="$HOME/.cache/codex-pacer-target"
+export APPLE_SIGNING_IDENTITY="$(security find-identity -v -p codesigning | sed -n 's/.*\"\(Developer ID Application:[^\"]*\)\".*/\1/p' | head -n 1)"
+./scripts/release/build-macos-release.sh 1.1.2
+```
+
+Require the app bundle, DMG, and SHA-256 file to exist. Run `codesign --verify --deep --strict` and `hdiutil verify` on the generated artifacts.
+
+- [ ] **Step 3: Replace the installed app safely**
+
+Quit Codex Pacer, copy the existing app to a timestamped temporary backup, install the newly built bundle into `/Applications`, and remove the backup only after launch verification.
+
+```bash
+osascript -e 'tell application "Codex Pacer" to quit' || true
+ditto "/Applications/Codex Pacer.app" "/tmp/Codex Pacer.previous.app"
+rm -rf "/Applications/Codex Pacer.app"
+ditto "$CARGO_TARGET_DIR/release/bundle/macos/Codex Pacer.app" "/Applications/Codex Pacer.app"
+open -a "/Applications/Codex Pacer.app"
+```
+
+- [ ] **Step 4: Verify the running installation**
+
+Confirm the process executable resolves inside `/Applications/Codex Pacer.app`, the bundle version is `1.1.2`, the code signature passes, the v3 repair marker appears after scan completion, SQLite quick check returns `ok`, and the dashboard database totals match the corrected importer output.
+
+- [ ] **Step 5: Push the development branch**
+
+```bash
+git push origin codex/adapt-chatgpt-codex-5-6
+```
+
+Report the installed app path, DMG path, checksum, test commands, corrected before-and-after totals, and any source files that remain pending. Ask the user to test before starting the PR flow.

--- a/docs/superpowers/plans/2026-07-10-fork-token-accounting.md
+++ b/docs/superpowers/plans/2026-07-10-fork-token-accounting.md
@@ -12,7 +12,7 @@
 
 - Apply cross-session replay removal only to `session_meta.payload.forked_from_id`.
 - Require at least two consecutive exact `(total_token_usage, last_token_usage)` pairs.
-- Keep timestamps and model labels out of replay matching.
+- Do not compare child and parent timestamps; exclude parent records created after the explicit fork timestamp.
 - Keep the `usage_events` schema and public response types unchanged.
 - Preserve cumulative high-water handling for repeated and non-monotonic totals.
 - Fall back to legacy cumulative accounting when `last_token_usage` is absent.
@@ -116,7 +116,7 @@ Add `forked_from_session_id: Option<String>` to `SessionMetaCandidate` and `Pars
 
 - [ ] **Step 2: Add unit tests for replay matching**
 
-Test a complete match, a match starting inside the parent sequence, a one-record match that returns zero, and a sequence interrupted by a missing last-usage value.
+Test a complete match, a match starting inside the parent sequence, a one-record match that returns zero, and a sequence interrupted by a missing last-usage value. Add a same-total record whose last usage changes and assert that cumulative canonicalization removes it. Add a parent record after the fork whose numbers equal the child's first new usage and assert that the match stops before it.
 
 ```rust
 assert_eq!(longest_inherited_prefix(&child, &parent), 3);
@@ -153,11 +153,11 @@ fn usage_replay_key(snapshot: &UsageSnapshot) -> Option<UsageReplayKey> {
 }
 ```
 
-Build the child pattern only through its first missing key. Scan parent segments with a KMP prefix table. Return zero for matches shorter than two records.
+Reduce parent and child snapshots to strictly increasing cumulative high-water records. Keep each canonical child's original snapshot index so the matched prefix can map back to the raw sequence. Build the child pattern only through its first missing key. Exclude parent records later than the explicit fork timestamp, scan the remaining parent segments with a KMP prefix table, and return zero for matches shorter than two records.
 
 - [ ] **Step 5: Resolve and cache direct-parent sequences**
 
-Build a session source-path map from current scan files and `sessions.source_path`. For each changed explicit fork, read only `turn_context` and `event_msg/token_count` metadata from the direct parent. Cache `Vec<Option<UsageReplayKey>>` by parent session ID for the rest of the scan.
+Build a session source-path map from current scan files and `sessions.source_path`. For each changed explicit fork, read only timestamps and `event_msg/token_count` metadata from the direct parent. Cache the raw replay records by parent session ID for the rest of the scan, then apply each child's fork-time cutoff before canonicalization and matching.
 
 - [ ] **Step 6: Apply the corrected baseline in persistence**
 
@@ -212,9 +212,9 @@ cargo test --manifest-path src-tauri/Cargo.toml importer::tests::v3_repair_rebui
 
 Expected: no file is reimported because the installed v2 marker is already complete.
 
-- [ ] **Step 3: Replace the repair key and keep pending-file behavior**
+- [ ] **Step 3: Add the repair key and keep pending-file behavior**
 
-Set the active token repair key to `token_usage_fork_replay_v3`. Do not delete the v2 marker. Reuse the existing full-scan promotion, per-file pending records, and completion marker.
+Add `token_usage_fork_replay_v3` without deleting the v2 constant or marker. Promote an incremental request to a full scan when either repair is pending, merge both sets of pending paths into the changed-file set, and keep retrying v2 pending files. Record completion for each sweep independently. Reuse the existing per-file pending records and completion helpers.
 
 - [ ] **Step 4: Verify repair retry tests**
 

--- a/docs/superpowers/plans/2026-07-10-importer-write-amplification.md
+++ b/docs/superpowers/plans/2026-07-10-importer-write-amplification.md
@@ -1,0 +1,470 @@
+# Importer and write amplification implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make active JSONL imports append-only in the normal case, preserve a safe full-rebuild fallback, skip unchanged pricing and title writes, and prune redundant quota history in bounded batches.
+
+**Architecture:** `import_state` gains a durable byte checkpoint with source fingerprints and cumulative token state. A typed parser reads complete records after that offset and persists derived rows plus the next checkpoint in one transaction. Identity, repair, topology, or parser changes select the existing full rebuild path. Pricing, title, and history maintenance use semantic no-op checks and bounded transactions.
+
+**Tech Stack:** Rust 2021, Rusqlite 0.37, Serde, Serde JSON, SHA-256 fingerprints, Chrono, existing importer integration fixtures.
+
+## Global constraints
+
+- Prerequisite: complete and verify the refresh-correctness and presentation plans first. In particular, this slice reuses presentation Tasks 1 and 2 for epoch and rate-limit writers.
+- Slice 2 owns usage epoch writes, latest quota, and change-point persistence. This plan calls those helpers and does not duplicate their SQL.
+- A typical append reads no old JSON payload beyond two fingerprint blocks totaling at most 8 KiB, then reads only bytes after the saved offset.
+- Checkpoint and derived data commit in the same SQLite transaction. A failure advances neither.
+- Checkpoints stop at the last complete newline. An incomplete tail is reread on the next scan.
+- File shrink, replacement, fingerprint mismatch, parser version change, repair, or topology change uses a full rebuild.
+- Full fallback produces the same sessions, usage events, quota points, persisted turns, and import state as a clean full import.
+- Unchanged pricing, titles, and repeated quota values cause no semantic row rewrite.
+- Cleanup performs one bounded transaction per dispatch and never runs `VACUUM` automatically.
+
+---
+
+### Task 1: Add durable append checkpoints and validation
+
+**Files:**
+- Modify: `src-tauri/sql/schema.sql:104-111`
+- Create: `src-tauri/src/database/import_state.rs`
+- Modify: `src-tauri/src/database.rs:1-55`
+- Modify: `src-tauri/src/importer.rs:1631-1655`
+- Modify: `src-tauri/src/importer.rs:1991-1998`
+- Test: `src-tauri/src/database/import_state.rs`
+
+**Interfaces:**
+- Consumes: legacy `import_state` rows.
+- Produces: `ImportCheckpoint`, `ImportCheckpointState`, validated `ImportState`, schema migration, load, and transactional upsert helpers.
+
+- [ ] **Step 1: Write failing migration and validation tests**
+
+Add `init_db_adds_append_checkpoint_columns_to_legacy_import_state`, `legacy_row_loads_with_missing_checkpoint_state`, `partial_cumulative_checkpoint_loads_as_invalid`, `negative_or_mismatched_offsets_load_as_invalid`, and `valid_checkpoint_round_trips`.
+
+```rust
+let state = load_import_state_row(&conn, "/tmp/session.jsonl").unwrap().unwrap();
+assert!(matches!(state.checkpoint, ImportCheckpointState::Missing));
+conn.execute("UPDATE import_state SET parsed_offset = 20, last_complete_line_offset = 10 WHERE source_path = ?1", [state.source_path]).unwrap();
+let state = load_import_state_row(&conn, "/tmp/session.jsonl").unwrap().unwrap();
+assert!(matches!(state.checkpoint, ImportCheckpointState::Invalid(_)));
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked append_checkpoint -- --nocapture`.
+
+Expected: migration columns and import-state module are missing.
+
+- [ ] **Step 3: Add nullable migration columns**
+
+Add:
+
+```text
+parsed_offset
+parsed_file_size
+prefix_fingerprint
+checkpoint_tail_fingerprint
+last_complete_line_offset
+last_cumulative_input_tokens
+last_cumulative_cached_input_tokens
+last_cumulative_output_tokens
+last_cumulative_reasoning_output_tokens
+last_cumulative_total_tokens
+last_model_id
+parser_schema_version
+```
+
+`ensure_import_state_schema` follows the existing `PRAGMA table_info` migration pattern. It never opens or scans source files.
+
+- [ ] **Step 4: Implement exact checkpoint contracts**
+
+```rust
+pub const SESSION_PARSER_SCHEMA_VERSION: i64 = 1;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImportCheckpoint {
+  pub parsed_offset: u64,
+  pub parsed_file_size: u64,
+  pub prefix_fingerprint: String,
+  pub checkpoint_tail_fingerprint: String,
+  pub last_complete_line_offset: u64,
+  pub last_cumulative_usage: Option<TokenUsage>,
+  pub last_model_id: Option<String>,
+  pub parser_schema_version: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CheckpointValidationError {
+  PartialFields,
+  NegativeOffset,
+  OffsetMismatch,
+  OffsetBeyondFile,
+  MissingFingerprint,
+  UnsupportedVersion,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ImportCheckpointState {
+  Missing,
+  Valid(ImportCheckpoint),
+  Invalid(CheckpointValidationError),
+}
+```
+
+Five token columns must be all NULL or all present. Require `parsed_offset == last_complete_line_offset`, nonnegative offsets, and `parsed_offset <= parsed_file_size`. SQLite read failures still return `Err`; malformed checkpoint content returns a usable `ImportState` with `Invalid`, allowing the importer to select a safe rebuild rather than aborting the scan.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked append_checkpoint
+git add src-tauri/sql/schema.sql src-tauri/src/database.rs src-tauri/src/database/import_state.rs src-tauri/src/importer.rs
+git commit -m "feat: add durable session append checkpoints"
+```
+
+### Task 2: Parse typed complete records and produce full checkpoints
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/Cargo.lock`
+- Create: `src-tauri/src/importer/session_parser.rs`
+- Modify: `src-tauri/src/importer.rs:1-20`
+- Modify: `src-tauri/src/importer.rs:727-992`
+- Modify: `src-tauri/src/database/conversation_turns.rs`
+- Test: `src-tauri/src/importer/session_parser.rs`
+
+**Interfaces:**
+- Consumes: current JSONL record formats, Slice 2 durable turn contracts, and the typed replay-envelope pattern in `importer.rs:1189-1249`.
+- Produces: borrowed record envelopes, complete-line reading, stable fingerprints, `SessionImport::Full`, turn upserts, and parse-byte diagnostics.
+
+- [ ] **Step 1: Write failing parser-equivalence tests**
+
+Add `typed_parser_matches_existing_usage_quota_and_turn_output`, `valid_json_without_terminal_newline_does_not_advance_checkpoint`, `typed_parser_ignores_unrelated_nested_token_fields`, `typed_parser_preserves_user_and_final_assistant_messages`, `invalid_utf8_is_fatal`, and `full_parse_reports_bytes_and_checkpoint`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked typed_parser -- --nocapture`.
+
+Expected: typed parser module is absent.
+
+- [ ] **Step 3: Add SHA-256 and exact parser result types**
+
+Add `sha2 = "0.10"` and define:
+
+```rust
+pub enum SessionImport {
+  Full {
+    parsed: ParsedSession,
+    checkpoint: ImportCheckpoint,
+    parsed_bytes: u64,
+  },
+  Append {
+    parsed: ParsedSessionTail,
+    checkpoint: ImportCheckpoint,
+    parsed_bytes: u64,
+  },
+}
+
+#[derive(serde::Deserialize)]
+struct SessionRecordEnvelope<'a> {
+  #[serde(default)]
+  timestamp: Option<&'a str>,
+  #[serde(rename = "type", default)]
+  record_type: Option<&'a str>,
+  #[serde(default, borrow)]
+  payload: Option<SessionPayloadEnvelope<'a>>,
+}
+```
+
+Parse detailed payloads only for the records needed by persisted derivatives: `session_meta`, `turn_context`, `event_msg/token_count`, task start/complete, user messages, agent messages, and final-answer response items. Emit the same `ConversationTurnPoint` values as the existing turn builder. Unknown records remain ignored and unrelated nested token-looking fields never affect totals.
+
+- [ ] **Step 4: Implement complete-line reading and fingerprints**
+
+Use `BufRead::read_until(b'\n', &mut bytes)`. Parse only buffers ending in newline. Keep the offset before an incomplete EOF buffer. SHA-256 covers at most the first 4 KiB and the 4 KiB ending at `parsed_offset`; store lowercase hex. A full parse returns the checkpoint and exact bytes passed through the JSON parser.
+
+- [ ] **Step 5: Run equivalence tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked typed_parser
+cargo test --manifest-path src-tauri/Cargo.toml --locked parent_replay_reader
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/src/importer.rs src-tauri/src/importer/session_parser.rs src-tauri/src/database/conversation_turns.rs
+git commit -m "refactor: parse typed complete session records"
+```
+
+### Task 3: Add the append fast path and atomic persistence
+
+**Files:**
+- Modify: `src-tauri/src/importer/session_parser.rs`
+- Modify: `src-tauri/src/importer.rs:175-327`
+- Modify: `src-tauri/src/importer.rs:1372-1526`
+- Modify: `src-tauri/src/database/import_state.rs`
+- Modify: `src-tauri/src/database/usage_events.rs`
+- Modify: `src-tauri/src/database/rate_limit_samples.rs`
+- Modify: `src-tauri/src/database/conversation_turns.rs`
+- Modify: `src-tauri/src/models.rs:421-430`
+- Modify: `src/app/types.ts:58-66`
+- Modify: `src/app/api.ts:202-213`
+- Test: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+- Consumes: Tasks 1 and 2 checkpoints plus Slice 2 append writers.
+- Produces: `ParsedSessionTail`, `parse_session_update`, `persist_session_update`, append metrics, and unchanged full rebuild behavior.
+
+- [ ] **Step 1: Write failing append and rollback tests**
+
+Add `append_growth_preserves_existing_usage_event_ids`, `append_growth_parses_only_new_bytes`, `append_uses_checkpoint_cumulative_usage`, `append_writes_quota_through_change_point_helper`, `append_updates_active_turn_without_rebuilding_older_turns`, and `checkpoint_rolls_back_with_usage_quota_and_turn_rows`.
+
+```rust
+let before_ids = usage_event_ids(&conn, session_id);
+append_token_record(&session_path, cumulative_usage(200));
+let result = perform_incremental_scan(&db_path, None).unwrap();
+let after_ids = usage_event_ids(&conn, session_id);
+assert_eq!(&after_ids[..before_ids.len()], before_ids.as_slice());
+assert_eq!(result.append_fast_path_files, 1);
+assert!(result.source_bytes_read < appended_bytes + 8_192);
+```
+
+- [ ] **Step 2: Run tests and verify current rebuild behavior**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked append_growth -- --nocapture`.
+
+Expected: old event IDs are replaced and diagnostics are absent.
+
+- [ ] **Step 3: Add import selection and tail contracts**
+
+```rust
+pub enum FullRebuildReason {
+  MissingCheckpoint,
+  InvalidCheckpoint,
+  FileShrank,
+  FingerprintMismatch,
+  ParserSchemaChanged,
+  PendingRepair,
+  TopologyChanged,
+  ReplacedSource,
+}
+
+pub struct TurnResumeState {
+  pub active_turn: Option<ConversationTurnPoint>,
+  pub next_synthetic_sequence: u64,
+}
+
+pub(super) fn parse_session_update(
+  session_file: &SessionFile,
+  state: Option<&ImportState>,
+  turn_resume: TurnResumeState,
+  titles: &HashMap<String, String>,
+  force_full_rebuild: bool,
+) -> Result<SessionImport, SessionParseError>;
+```
+
+`TurnResumeState` contains the last persisted active turn and next synthetic turn sequence for that session. Tail parsing begins with it, checkpoint cumulative usage, and last model. A `session_meta` record or parent/fork change returns `TopologyChanged` before any transaction begins.
+
+- [ ] **Step 4: Append derived rows and checkpoint in one transaction**
+
+`persist_session_update` uses Slice 2 `insert_usage_events`, `append_session_rate_limit_samples`, and `upsert_session_turns`. It updates session metadata and checkpoint in the same transaction. It never deletes existing rows on `SessionImport::Append`; the currently active turn may be updated in place while completed older turns retain their IDs. Keep the current delete-and-rebuild code for `SessionImport::Full`.
+
+Extend the serialized Rust and TypeScript `ScanResult` contracts with `source_bytes_read`/`sourceBytesRead`, `append_fast_path_files`/`appendFastPathFiles`, and `full_rebuild_files`/`fullRebuildFiles`. Update the frontend mock to return zero for all three fields. Tests and bounded token metrics use them to verify behavior without accumulating per-file history.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked append_growth
+cargo test --manifest-path src-tauri/Cargo.toml --locked checkpoint_rolls_back
+git add src-tauri/src/importer.rs src-tauri/src/importer/session_parser.rs src-tauri/src/database/import_state.rs src-tauri/src/database/usage_events.rs src-tauri/src/database/rate_limit_samples.rs src-tauri/src/database/conversation_turns.rs src-tauri/src/models.rs src/app/types.ts src/app/api.ts
+git commit -m "feat: append new session records transactionally"
+```
+
+### Task 4: Enforce the full-rebuild fallback matrix
+
+**Files:**
+- Modify: `src-tauri/src/importer/session_parser.rs`
+- Modify: `src-tauri/src/importer.rs:128-327`
+- Test: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+- Consumes: Task 3 import selection and current repair, fork replay, archive, and topology logic.
+- Produces: deterministic `FullRebuildReason` selection and clean-import equivalence.
+
+- [ ] **Step 1: Write failing fallback tests**
+
+Add `append_fallback_rebuilds_truncated_file`, `append_fallback_rebuilds_replaced_same_path`, `append_fallback_rebuilds_on_prefix_mismatch`, `append_fallback_rebuilds_on_tail_mismatch`, `append_fallback_rebuilds_on_parser_version_change`, `partial_checkpoint_selects_invalid_checkpoint_rebuild`, `malformed_checkpoint_selects_invalid_checkpoint_rebuild`, `append_fallback_rebuilds_on_topology_record`, and `append_fallback_matches_clean_full_import`.
+
+- [ ] **Step 2: Run tests and verify missing fallback classifications**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked append_fallback -- --nocapture`.
+
+- [ ] **Step 3: Implement identity validation before parsing the tail**
+
+Map `ImportCheckpointState::Missing` to `MissingCheckpoint`, `Invalid(_)` to `InvalidCheckpoint`, and only `Valid` to append validation. Require current size at least `parsed_file_size` as well as `parsed_offset`, matching prefix and checkpoint-tail hashes, matching schema version, and no pending repair. Archive path changes take one full parse. Never copy a checkpoint across paths merely because session IDs match. A successful full rebuild replaces malformed fields with one valid checkpoint in the same transaction.
+
+- [ ] **Step 4: Compare fallback output with a clean database**
+
+The equivalence test sorts and compares all session fields, usage-event value fields, quota change points, persisted conversation turns, links, and checkpoint values. Preserve existing fork replay, archive completion, invalid UTF-8, and incomplete-tail tests.
+
+- [ ] **Step 5: Run regression tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked append_fallback
+cargo test --manifest-path src-tauri/Cargo.toml --locked fork_replay
+cargo test --manifest-path src-tauri/Cargo.toml --locked archived
+git add src-tauri/src/importer.rs src-tauri/src/importer/session_parser.rs
+git commit -m "fix: rebuild safely when append identity changes"
+```
+
+### Task 5: Skip unchanged pricing writes and event recalculation
+
+**Files:**
+- Modify: `src-tauri/src/pricing.rs:36-230`
+- Modify: `src-tauri/src/pricing.rs:452-518`
+- Modify: `src-tauri/src/database.rs`
+- Modify: `src-tauri/src/importer.rs:88-99`
+- Modify: `src-tauri/src/lib.rs:201-224`
+- Modify: `src-tauri/src/lib.rs:580-608`
+- Test: `src-tauri/src/pricing.rs`
+- Test: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: existing value-bearing pricing signature and repair marker.
+- Produces: `PricingCatalogChange`, one-time startup initialization, no-op upsert, and read-only scan catalog loading.
+
+- [ ] **Step 1: Write failing no-op and rollback tests**
+
+Add `repeated_initializer_does_not_rewrite_unchanged_rows`, `unchanged_scan_does_not_invoke_catalog_initializer`, `unchanged_signature_does_not_update_usage_events`, and `metadata_only_change_does_not_recalculate_values`. Keep existing rollback and malformed GPT-5.6 repair tests.
+
+- [ ] **Step 2: Run tests and record current writes**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked pricing_signature -- --nocapture`.
+
+Expected: `updated_at` and usage-event update counters change on an identical refresh.
+
+- [ ] **Step 3: Add semantic change classification**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PricingCatalogChange { Unchanged, MetadataOnly, ValueChanged }
+
+pub fn apply_pricing_catalog_refresh(
+  conn: &Connection,
+  official_entries: Option<&[PricingCatalogEntry]>,
+) -> Result<PricingCatalogChange, String>;
+
+pub fn initialize_pricing_catalog(
+  conn: &Connection,
+) -> Result<PricingCatalogChange, String>;
+
+pub fn load_catalog_map(
+  conn: &Connection,
+) -> rusqlite::Result<HashMap<String, PricingCatalogEntry>>;
+```
+
+Upsert rows only when a semantic field differs. Ignore incoming `updated_at` when deciding equality. `initialize_pricing_catalog` seeds only when the catalog is empty or the known repair is pending, and is called from database/app startup migration wiring, never from a scan.
+
+- [ ] **Step 4: Recalculate only value changes**
+
+Remove `seed_pricing_catalog` and repair checks from `perform_scan_with_scope`; scans call read-only `load_catalog_map`. `refresh_pricing_catalog_atomically` recalculates all session values only for `ValueChanged` or an incomplete resolver repair. A metadata-only result updates catalog provenance in the same transaction but performs no usage-event update.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked pricing
+cargo test --manifest-path src-tauri/Cargo.toml --locked pricing_refresh_rolls_back
+git add src-tauri/src/pricing.rs src-tauri/src/database.rs src-tauri/src/importer.rs src-tauri/src/lib.rs
+git commit -m "perf: skip unchanged pricing and event rewrites"
+```
+
+### Task 6: Update titles only when values change
+
+**Files:**
+- Modify: `src-tauri/src/importer.rs:575-611`
+- Modify: `src-tauri/src/importer.rs:215-219`
+- Test: `src-tauri/src/importer.rs`
+
+**Interfaces:**
+- Consumes: current `session_index.jsonl` title map.
+- Produces: one conditional title transaction and changed-row count.
+
+- [ ] **Step 1: Write failing title-write tests**
+
+Add `full_scan_does_not_update_unchanged_titles`, `changed_title_updates_once`, and `title_batch_rolls_back_together`. Preserve `full_scan_refreshes_title_when_only_session_index_changes`.
+
+- [ ] **Step 2: Run tests and verify unconditional updates**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked session_titles -- --nocapture`.
+
+- [ ] **Step 3: Implement conditional prepared updates**
+
+Sort by session ID, open one transaction, reuse one statement, and execute:
+
+```sql
+UPDATE sessions
+SET title = ?1
+WHERE session_id = ?2
+  AND title IS NOT ?1
+```
+
+Return the total changed rows for diagnostics.
+
+- [ ] **Step 4: Run title tests**
+
+Run the focused command and the existing title-only change test. Expected: unchanged scan reports zero title writes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/importer.rs
+git commit -m "perf: update only changed session titles"
+```
+
+### Task 7: Prune old quota duplicates in bounded batches
+
+**Files:**
+- Modify: `src-tauri/src/database/rate_limit_samples.rs`
+- Modify: `src-tauri/src/database.rs`
+- Modify: `src-tauri/src/refresh/runtime.rs`
+- Test: `src-tauri/src/database/rate_limit_samples.rs`
+- Test: `src-tauri/src/refresh/runtime.rs`
+
+**Interfaces:**
+- Consumes: Slice 2 epoch fields and new change-point writer.
+- Produces: `QuotaCleanupBatchResult`, idempotent old-row cleanup, and coordinator deadline guard.
+
+- [ ] **Step 1: Write failing cleanup and scheduling tests**
+
+Add `cleanup_keeps_first_and_last_of_constant_run`, `cleanup_keeps_percent_changes`, `cleanup_deletes_at_most_batch_size`, `cleanup_resume_is_idempotent`, `cleanup_waits_for_epoch_backfill_completion`, `cleanup_never_touches_legacy_null_epoch_rows`, and `cleanup_does_not_start_within_thirty_seconds_of_refresh_deadline`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked quota_cleanup -- --nocapture`.
+
+- [ ] **Step 3: Implement one bounded batch**
+
+```rust
+pub struct QuotaCleanupBatchResult {
+  pub deleted_rows: usize,
+  pub complete: bool,
+}
+
+pub fn prune_redundant_rate_limit_samples_batch(
+  conn: &mut Connection,
+  batch_size: usize,
+) -> rusqlite::Result<QuotaCleanupBatchResult>;
+```
+
+Return without mutation unless the Slice 2 epoch repair marker is complete. Select redundant IDs with `LAG` and `LEAD`, restricted by `sample_timestamp_ms IS NOT NULL AND window_start_ms IS NOT NULL AND resets_at_ms IS NOT NULL`, partitioned by `(bucket, window_start_ms, resets_at_ms)`, and ordered by `(sample_timestamp_ms, id)`. Delete at most 500 IDs in one transaction. Preserve first, last, every percent change, and every legacy NULL-epoch row. Mark `quota_history_change_point_cleanup_v1` complete only when a post-backfill batch deletes zero rows.
+
+- [ ] **Step 4: Dispatch only in a safe idle window**
+
+The coordinator gives epoch backfill priority and does not enqueue quota cleanup until that repair is complete. It starts one cleanup batch only when token and live are idle and the next deadline is more than 30 seconds away. Completion may queue another batch through the event channel. It never loops inside one worker and never runs `VACUUM`.
+
+- [ ] **Step 5: Run full slice verification and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+cargo clippy --manifest-path src-tauri/Cargo.toml --locked --lib
+npm test
+npm run lint
+npm run build
+git add src-tauri/src/database.rs src-tauri/src/database/rate_limit_samples.rs src-tauri/src/refresh/runtime.rs
+git commit -m "perf: prune redundant quota history in bounded batches"
+```
+
+Expected: append tests read only new bytes, fallback equivalence holds, unchanged scans avoid pricing and title writes, cleanup remains bounded, and all existing fork, archive, freshness, and pricing tests pass. Clippy exits successfully; compare its output with the recorded 16-warning repository baseline and fix every new warning in changed files.

--- a/docs/superpowers/plans/2026-07-10-presentation-bounded-queries.md
+++ b/docs/superpowers/plans/2026-07-10-presentation-bounded-queries.md
@@ -1,0 +1,656 @@
+# Presentation and bounded queries implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make tray and popup reads bounded, move all tray computation off the UI thread, reduce database row materialization, split the popup bundle, and cap dashboard caches.
+
+**Architecture:** Indexed epoch fields and compact latest-quota storage feed a versioned `DisplaySnapshotStore`. A background snapshot service consumes Slice 1 invalidations and publishes immutable presentation revisions. Tray setters receive precomputed diffs, while the popup and dashboard consume revisioned snapshots without polling.
+
+**Tech Stack:** Rust 2021, Tauri 2.10, Rusqlite 0.37 with bundled SQLite, React 19 for the dashboard, plain TypeScript DOM for the lightweight popup, Vite 8, Node 22.18 test scripts.
+
+## Global constraints
+
+- Prerequisite: complete and verify the refresh-correctness plan first. This slice consumes its coordinator invalidations and completion events.
+- Snapshot getters perform no source I/O and remain below 5 ms p95.
+- Tray main-thread apply remains below 2 ms p95 and contains no database, file, process, or formatting work.
+- Token or quota commit reaches the visible tray within 100 ms p95 and the visible popup within 150 ms p95.
+- Popup payload is at most 64 KB. Popup JavaScript is at most 150 KB minified and 50 KB gzip and contains no dashboard, Recharts, React, or ReactDOM dependency.
+- The popup is created on first tray use. Hidden popup and dashboard surfaces execute zero data queries during a 10-minute observation.
+- Existing popup structure, colors, keyboard Escape behavior, visible focus, accessible labels, stable loading layout, and reduced-motion behavior remain intact.
+- Conversation detail cache is limited to 20 entries and 32 MB. Default detail response includes the newest 40 turns.
+- Existing mixed-offset timestamp and live-window correctness tests remain passing.
+
+---
+
+### Task 1: Add indexed epoch fields and bounded backfill
+
+**Files:**
+- Modify: `src-tauri/sql/schema.sql:29-42`
+- Modify: `src-tauri/sql/schema.sql:126-140`
+- Modify: `src-tauri/sql/indexes.sql`
+- Create: `src-tauri/src/database/epoch_backfill.rs`
+- Create: `src-tauri/src/database/usage_events.rs`
+- Modify: `src-tauri/src/database.rs:1-55`
+- Modify: `src-tauri/src/importer.rs:1469-1490`
+- Modify: `src-tauri/src/refresh/runtime.rs`
+- Test: `src-tauri/src/database/epoch_backfill.rs`
+- Test: `src-tauri/src/database/usage_events.rs`
+- Test: `src-tauri/src/refresh/runtime.rs`
+
+**Interfaces:**
+- Consumes: RFC3339 timestamps already stored by the importer.
+- Produces: `timestamp_ms`, quota epoch columns, partial compatibility indexes, `parse_epoch_millis`, `insert_usage_events`, bounded backfill progress, and resumable maintenance dispatch.
+
+- [ ] **Step 1: Write failing schema, parser, and batch tests**
+
+Add `init_db_adds_epoch_columns_without_scanning_history`, `epoch_parser_orders_mixed_offsets_by_instant`, `new_usage_event_writes_timestamp_ms`, `backfill_updates_at_most_requested_batch_size`, `compatibility_query_includes_null_epoch_rows`, `integrity_check_is_ok_after_epoch_migration`, `epoch_backfill_runs_one_batch_per_maintenance_dispatch`, `epoch_backfill_resumes_from_null_rows_after_restart`, and `snapshot_getter_remains_available_while_epoch_backfill_waits`.
+
+```rust
+assert!(parse_epoch_millis("2026-07-10T10:00:00+08:00").unwrap()
+  < parse_epoch_millis("2026-07-10T03:00:01Z").unwrap());
+let progress = backfill_epoch_batch(&conn, 1_000).unwrap();
+assert!(progress.usage_rows_updated + progress.quota_rows_updated <= 1_000);
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::epoch_backfill::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::usage_events::tests
+```
+
+Expected: schema columns and modules are missing.
+
+- [ ] **Step 3: Add nullable migration fields and partial indexes**
+
+New installs include:
+
+```sql
+timestamp_ms INTEGER
+sample_timestamp_ms INTEGER
+window_start_ms INTEGER
+resets_at_ms INTEGER
+```
+
+Existing installs use `ensure_epoch_schema` with `ALTER TABLE` only. Add:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_ms
+  ON usage_events(timestamp_ms, id) WHERE timestamp_ms IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_missing_epoch
+  ON usage_events(id) WHERE timestamp_ms IS NULL;
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_window_ms
+  ON rate_limit_samples(bucket, window_start_ms, resets_at_ms, sample_timestamp_ms, id)
+  WHERE window_start_ms IS NOT NULL AND resets_at_ms IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_missing_epoch
+  ON rate_limit_samples(id) WHERE sample_timestamp_ms IS NULL;
+```
+
+- [ ] **Step 4: Implement bounded write and backfill helpers**
+
+Use:
+
+```rust
+pub struct EpochBackfillProgress {
+  pub usage_rows_updated: usize,
+  pub quota_rows_updated: usize,
+  pub complete: bool,
+}
+
+pub fn parse_epoch_millis(value: &str) -> Result<i64, String> {
+  DateTime::parse_from_rfc3339(value)
+    .map(|value| value.timestamp_millis())
+    .map_err(|error| error.to_string())
+}
+
+pub fn backfill_epoch_batch(conn: &Connection, batch_size: usize) -> rusqlite::Result<EpochBackfillProgress>;
+```
+
+Each batch reads at most 1,000 NULL rows by ID and commits once. The remaining NULL rows are the durable progress marker; write the corresponding `data_repairs` completion row only when none remain. Change `persist_session` to call `insert_usage_events`, which always binds `timestamp_ms` for new rows.
+
+Register `EpochBackfill` as a low-priority `BackgroundMaintenance` intent with the Slice 1 coordinator. Startup checks the repair marker without scanning source data. A maintenance worker runs exactly one batch, yields through the coordinator event channel, and queues another only when both refresh lanes are idle and the next deadline is more than 30 seconds away. NULL rows are the restart cursor, so termination between batches resumes safely. Foreground snapshot reads continue to use the compatibility branch and never wait for migration completion.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::epoch_backfill::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::usage_events::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked epoch_backfill_runs_one_batch_per_maintenance_dispatch
+git add src-tauri/sql src-tauri/src/database.rs src-tauri/src/database/epoch_backfill.rs src-tauri/src/database/usage_events.rs src-tauri/src/importer.rs src-tauri/src/refresh/runtime.rs
+git commit -m "perf: add indexed epoch timestamps and bounded backfill"
+```
+
+### Task 2: Store latest quota separately and compact new history
+
+**Files:**
+- Modify: `src-tauri/sql/schema.sql`
+- Modify: `src-tauri/sql/indexes.sql`
+- Modify: `src-tauri/src/database/rate_limit_samples.rs`
+- Modify: `src-tauri/src/database.rs:8-18`
+- Modify: `src-tauri/src/lib.rs:1152-1285`
+- Modify: `src-tauri/src/models.rs:170-224`
+- Test: `src-tauri/src/database/rate_limit_samples.rs`
+
+**Interfaces:**
+- Consumes: Task 1 epoch parser and current rate-limit records.
+- Produces: `latest_rate_limits`, `RateLimitWriteStats`, exact fallback lookup, and shared append/replace writers for Slice 3.
+
+- [ ] **Step 1: Write failing latest and change-point tests**
+
+Add `repeated_live_percent_updates_latest_without_growing_history`, `changed_percent_adds_one_history_point`, `new_window_keeps_previous_close_and_new_start`, `session_batch_keeps_first_change_and_last`, `latest_quota_uses_epoch_order`, and `latest_lookup_does_not_scan_history`.
+
+```rust
+let first = insert_live_rate_limit_snapshot(&conn, &live_snapshot(40, "2026-07-10T10:00:00Z")).unwrap();
+let repeated = insert_live_rate_limit_snapshot(&conn, &live_snapshot(40, "2026-07-10T10:05:00Z")).unwrap();
+assert_eq!(first.historical_inserted, 2);
+assert_eq!(repeated.historical_inserted, 0);
+assert_eq!(repeated.latest_updated, 2);
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked database::rate_limit_samples::tests`.
+
+Expected: latest table and write statistics are missing.
+
+- [ ] **Step 3: Add latest table and common write contracts**
+
+Create a two-row-per-source table keyed by `(source_kind, bucket)` with snapshot timestamp, epoch fields, limit metadata, window bounds, and percent fields. Define:
+
+```rust
+pub struct RateLimitWriteStats {
+  pub observed: usize,
+  pub historical_inserted: usize,
+  pub latest_updated: usize,
+}
+
+pub fn append_session_rate_limit_samples(
+  conn: &Connection,
+  session_id: &str,
+  samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<RateLimitWriteStats>;
+
+pub fn replace_session_rate_limit_samples(
+  conn: &Connection,
+  session_id: &str,
+  samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<RateLimitWriteStats>;
+```
+
+- [ ] **Step 4: Implement step-change writes and fallback reads**
+
+Within one transaction, upsert latest first. Insert historical data for a window start, a percent change, and the previous window close. Repeated equal values only update latest. `load_latest_rate_limits` orders by integer epoch and combines primary and secondary only when they share a snapshot timestamp; it never runs `ORDER BY julianday(...)` over history.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked database::rate_limit_samples::tests
+git add src-tauri/sql src-tauri/src/database.rs src-tauri/src/database/rate_limit_samples.rs src-tauri/src/lib.rs src-tauri/src/models.rs
+git commit -m "perf: store latest quota and compact new history"
+```
+
+### Task 3: Replace full-table presentation reads with bounded window queries
+
+**Files:**
+- Create: `src-tauri/src/queries/presentation.rs`
+- Create: `src-tauri/sql/queries/usage_events_window.sql`
+- Create: `src-tauri/sql/queries/conversation_page.sql`
+- Create: `src-tauri/sql/queries/presentation_usage_summary.sql`
+- Modify: `src-tauri/sql/queries/quota_samples.sql`
+- Modify: `src-tauri/sql/queries/rate_limit_windows.sql`
+- Modify: `src-tauri/src/queries.rs:32-257`
+- Modify: `src-tauri/src/queries.rs:1153-1207`
+- Modify: `src-tauri/src/queries.rs:1324-1669`
+- Test: `src-tauri/src/queries/presentation.rs`
+
+**Interfaces:**
+- Consumes: Task 1 time indexes, Task 2 quota storage, and existing `ResolvedWindow` rules.
+- Produces: window summary, one-pass trend accumulation, exact quota-window reads, and bounded conversation pages.
+
+- [ ] **Step 1: Write failing query-plan and row-visit tests**
+
+Add `presentation_summary_filters_before_materialization`, `quota_query_selects_exact_window`, `quota_plan_uses_window_index`, `usage_plan_uses_timestamp_index`, `window_accumulator_visits_selected_rows_only`, `total_overview_streams_without_event_vector`, `mixed_offset_compatibility_matches_backfill`, and `compatibility_millisecond_boundaries_match_epoch_branch`.
+
+- [ ] **Step 2: Run tests and verify current amplification**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked queries::presentation::tests -- --nocapture`.
+
+Expected: new tests fail; the fixture observes full event and bucket row counts.
+
+- [ ] **Step 3: Add bounded summary and window-event SQL**
+
+```rust
+pub struct WindowUsageSummary {
+  pub api_value_usd: f64,
+  pub total_tokens: i64,
+  pub conversation_count: usize,
+}
+
+pub fn load_window_usage_summary(
+  conn: &Connection,
+  window: &ResolvedWindow,
+) -> rusqlite::Result<WindowUsageSummary>;
+```
+
+The SQL uses `SUM` and `COUNT(DISTINCT sessions.root_session_id)` with `timestamp_ms >= start` and `< end`. While backfill is incomplete, a UNION branch reads only the partial NULL-epoch index and compares `unixepoch(timestamp) * 1000` with the same millisecond bounds. Add exact start-inclusive/end-exclusive boundary assertions so the compatibility and epoch branches cannot diverge by units. `total` uses aggregate `MIN/MAX` instead of loading events.
+
+Change the existing `ResolvedWindow` visibility to `pub(super)` so `queries::presentation` can reuse the single canonical local-time and live-window resolver instead of duplicating its rules.
+
+- [ ] **Step 4: Make trend and quota accumulation one pass**
+
+Stream selected rows ordered by epoch and advance a bin cursor once per event. Change quota SQL to bind `(bucket, window_start_ms, resets_at_ms)`. Limit historical live windows to 512. Preserve current local-time labels and live-window correctness tests.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked queries::presentation::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked menu_bar_api_value_uses_selected_live_window
+git add src-tauri/sql/queries src-tauri/src/queries.rs src-tauri/src/queries
+git commit -m "perf: bound presentation and dashboard window reads"
+```
+
+### Task 4: Publish versioned display snapshots
+
+**Files:**
+- Create: `src-tauri/src/presentation.rs`
+- Create: `src-tauri/src/presentation/snapshot.rs`
+- Modify: `src-tauri/src/models.rs`
+- Modify: `src-tauri/src/lib.rs:1-102`
+- Modify: `src-tauri/src/lib.rs:268-275`
+- Modify: `src-tauri/src/lib.rs:1341-1418`
+- Modify: `src-tauri/src/refresh/live_cache.rs`
+- Modify: `src/App.tsx`
+- Modify: `src/menu-bar-popup/MenuBarPopup.tsx`
+- Modify: `src/app/refreshEvents.ts`
+- Modify: `src/app/types.ts`
+- Modify: `src/app/api.ts`
+- Test: `src-tauri/src/presentation/snapshot.rs`
+
+**Interfaces:**
+- Consumes: Slice 1 `DisplayInvalidation`, `LiveQuotaCache`, and Task 3 bounded queries.
+- Produces: `DisplaySnapshotStore`, `DisplaySnapshotService`, `DisplaySnapshotEvent`, and passive memory getters.
+
+- [ ] **Step 1: Write failing revision and getter tests**
+
+Add `snapshot_getter_performs_no_source_io`, `builder_discards_stale_source_revisions`, `revision_during_build_queues_one_rebuild`, `presentation_revision_increases_after_publish`, `fresh_live_cache_overlays_unpersisted_quota`, `blocked_live_persistence_does_not_delay_snapshot_or_tray`, `raw_refresh_completion_does_not_reload_surface_data`, `failed_completion_clears_refreshing_without_replacing_data`, and `popup_payload_is_at_most_65536_bytes`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked presentation::snapshot::tests`.
+
+- [ ] **Step 3: Add exact snapshot types**
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisplaySourceRevisions {
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub settings_revision: u64,
+  pub source_generation: u64,
+}
+
+pub struct DisplaySnapshot {
+  pub source_revisions: DisplaySourceRevisions,
+  pub source_commit: CommitMarker,
+  pub presentation_revision: u64,
+  pub popup: MenuBarPopupSnapshot,
+  pub tray: TraySnapshotInput,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisplaySnapshotEvent {
+  pub presentation_revision: u64,
+  pub popup: MenuBarPopupSnapshot,
+}
+
+impl DisplaySnapshotStore {
+  pub fn current(&self) -> Arc<DisplaySnapshot>;
+  pub fn current_event(&self) -> DisplaySnapshotEvent;
+}
+
+impl DisplaySnapshotBuilder {
+  pub fn build(
+    &self,
+    conn: &Connection,
+    live: &LiveQuotaState,
+    revisions: &DisplaySourceRevisions,
+    source_commit: CommitMarker,
+  ) -> Result<DisplaySnapshot, String>;
+}
+```
+
+`DisplaySnapshotBuilder::build` receives a cloned `LiveQuotaState`, source revisions, and the latest `CommitMarker` alongside the database connection. It overlays the in-memory live primary/secondary values and a terminal trend point on bounded historical SQL results. The resulting snapshot carries the monotonic marker for the newest represented token/quota commit, and the builder never waits for live-history persistence.
+
+- [ ] **Step 4: Implement latest-wins rebuild and passive commands**
+
+Publish an empty revision-zero snapshot at startup. Capture source revisions before build; discard a result if they change and queue one latest rebuild. Replace `getMenuBarPopupSnapshot(force_refresh)` with a memory clone that has no force parameter. Manual refresh uses the Slice 1 coordinator. Emit `codex-counter://display-snapshot-updated` only after a consistent snapshot is published.
+
+Replace the interim Slice 1 data gate on both surfaces: `codex-counter://refresh-completed` may only settle the matching manual spinner or error state, while `codex-counter://display-snapshot-updated` is the sole event that may apply data. Accept only a strictly higher `presentationRevision`; hidden surfaces retain only the highest pending revision. Remove the raw-refresh reload path and test its absence in source.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked presentation::snapshot::tests
+git add src-tauri/src/presentation.rs src-tauri/src/presentation src-tauri/src/models.rs src-tauri/src/lib.rs src-tauri/src/refresh/live_cache.rs src/App.tsx src/menu-bar-popup/MenuBarPopup.tsx src/app/api.ts src/app/refreshEvents.ts src/app/types.ts
+git commit -m "feat: publish versioned bounded display snapshots"
+```
+
+### Task 5: Move tray computation off the main thread
+
+**Files:**
+- Create: `src-tauri/src/presentation/tray.rs`
+- Modify: `src-tauri/src/lib.rs:610-673`
+- Modify: `src-tauri/src/lib.rs:1847-1908`
+- Modify: `src-tauri/src/lib.rs:2132-2158`
+- Test: `src-tauri/src/presentation/tray.rs`
+
+**Interfaces:**
+- Consumes: Task 4 immutable display snapshots.
+- Produces: `TrayPresentation`, `TrayPresentationDiff`, and latest-wins `TrayPresenter`.
+
+- [ ] **Step 1: Write failing diff and ordering tests**
+
+Add `unchanged_snapshot_calls_no_setters`, `diff_contains_changed_fields_only`, `newer_revision_during_apply_runs_one_follow_up`, `older_revision_cannot_replace_newer`, and `main_thread_receives_precomputed_values`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked presentation::tray::tests`.
+
+- [ ] **Step 3: Implement presentation values and diffs**
+
+```rust
+pub struct TrayPresentation {
+  pub title: Option<String>,
+  pub tooltip: Option<String>,
+  pub show_logo: bool,
+  pub visible: bool,
+}
+
+pub fn diff_tray_presentation(
+  previous: Option<&TrayPresentation>,
+  next: &TrayPresentation,
+) -> TrayPresentationDiff;
+```
+
+Compute strings, settings, live values, and icon choice on the worker. The main-thread closure captures only the tray handle and diff, then calls the necessary setters.
+
+- [ ] **Step 4: Replace the dropped-refresh flag**
+
+Store `rendering_revision` and `pending_revision`. A busy presenter records the highest pending revision. Completion applies at most one follow-up using the newest snapshot. Remove `menu_bar_refresh_in_progress` and all database access from the main-thread closure.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked presentation::tray::tests
+git add src-tauri/src/presentation/tray.rs src-tauri/src/lib.rs
+git commit -m "perf: move tray rendering off the UI thread"
+```
+
+### Task 6: Lazy-load a lightweight popup without layout shifts
+
+**Files:**
+- Create: `src/app/bootstrap.tsx`
+- Create: `src/menu-bar-popup/bootstrap.ts`
+- Create: `src/menu-bar-popup/render.ts`
+- Create: `src/menu-bar-popup/sevenDayChart.ts`
+- Create: `src/menu-bar-popup/icons.ts`
+- Delete: `src/menu-bar-popup/MenuBarPopup.tsx`
+- Modify: `src/main.tsx`
+- Modify: `src/styles.css:1-33`
+- Modify: `src-tauri/src/lib.rs:1505-1560`
+- Modify: `src-tauri/src/lib.rs:2150-2152`
+- Create: `scripts/test-presentation.mjs`
+- Create: `scripts/check-popup-bundle.mjs`
+- Modify: `vite.config.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: Task 4 display snapshot events and passive getter.
+- Produces: dynamic surface entry points, a plain DOM popup renderer, and enforced bundle budgets.
+
+- [ ] **Step 1: Write failing behavior and bundle-source tests**
+
+Test `popup_accepts_higher_revision_only`, `manual_refresh_keeps_snapshot_visible`, `hidden_popup_performs_no_getter`, `popup_has_no_set_interval`, `main_has_no_static_surface_import`, and `popup_keeps_escape_and_accessible_labels`.
+
+- [ ] **Step 2: Register tests and verify failure**
+
+Add `test:presentation` and run `npm run test:presentation`.
+
+Expected: static imports, React popup, and polling assertions fail.
+
+- [ ] **Step 3: Split entry points and preserve UI semantics**
+
+`main.tsx` imports shared CSS, detects the surface, then dynamically imports `app/bootstrap.tsx` or `menu-bar-popup/bootstrap.ts`. The popup uses DOM elements with the existing CSS class names. Inline Lucide-compatible SVG paths provide dashboard and refresh icons. Buttons retain `aria-label`, keyboard focus, Escape handling, and click feedback. Existing content remains mounted while `refreshing` changes.
+
+Replace the remote Google font import with platform UI and monospace fallback stacks to avoid network work and font layout shift. Keep current font weights and element dimensions. Respect the existing reduced-motion media rule for the refresh icon.
+
+- [ ] **Step 4: Create popup on first tray click and enforce the bundle**
+
+Remove popup creation from setup. `toggle_menu_bar_popup` creates it only when absent and reads enablement from the current display snapshot instead of SQLite. Configure Vite manifest output. `check-popup-bundle.mjs` follows the popup chunk imports, rejects React, ReactDOM, Recharts, and dashboard modules, then checks 150 KB minified and 50 KB gzip limits.
+
+- [ ] **Step 5: Run tests, build, and commit**
+
+```bash
+npm run test:presentation
+npm run build
+node scripts/check-popup-bundle.mjs
+git add package.json scripts/check-popup-bundle.mjs scripts/test-presentation.mjs src/main.tsx src/app/bootstrap.tsx src/menu-bar-popup src/styles.css src-tauri/src/lib.rs vite.config.ts
+git commit -m "perf: lazy load an event-driven popup surface"
+```
+
+### Task 7: Bound conversation pages, turns, search, and detail cache
+
+**Files:**
+- Modify: `src-tauri/sql/schema.sql`
+- Modify: `src-tauri/sql/indexes.sql`
+- Create: `src-tauri/sql/queries/conversation_detail_summary.sql`
+- Create: `src-tauri/sql/queries/conversation_detail_breakdowns.sql`
+- Create: `src-tauri/sql/queries/conversation_turn_page.sql`
+- Create: `src-tauri/src/database/conversation_turns.rs`
+- Create: `src-tauri/src/queries/pagination.rs`
+- Modify: `src-tauri/src/database.rs`
+- Modify: `src-tauri/src/importer.rs`
+- Modify: `src-tauri/src/refresh/runtime.rs`
+- Modify: `src-tauri/src/models.rs:159-168`
+- Modify: `src-tauri/src/models.rs:321-417`
+- Modify: `src-tauri/src/queries.rs:195-257`
+- Modify: `src-tauri/src/queries.rs:483-655`
+- Modify: `src-tauri/src/lib.rs:248-349`
+- Create: `src/app/sizedLru.ts`
+- Create: `src/app/requestGeneration.ts`
+- Create: `src/app/surfaceRevision.ts`
+- Modify: `src/app/types.ts`
+- Modify: `src/app/api.ts`
+- Modify: `src/App.tsx:99-399`
+- Modify: `scripts/test-data-freshness.mjs`
+
+**Interfaces:**
+- Consumes: Task 3 bounded query primitives and Task 4 revisions.
+- Produces: indexed durable turn rows, resumable turn-index repair, `ConversationPage`, turn cursor pages, 250 ms search debounce, stale-response rejection, and a dual-limit LRU.
+
+- [ ] **Step 1: Write failing Rust and Node tests**
+
+Add `conversation_page_clamps_limit_to_100`, `pages_do_not_duplicate_items`, `detail_query_plan_uses_turn_cursor_index`, `detail_reads_at_most_41_turn_rows_for_newest_40`, `turn_cursor_returns_strictly_older_turns`, `legacy_turn_index_repair_runs_one_bounded_batch`, `foreground_detail_never_parses_source_jsonl`, `browsing_one_thousand_details_keeps_at_most_20_entries`, `browsing_one_thousand_details_never_exceeds_32mb`, `oversized_detail_is_not_cached`, `search_debounces_250ms`, `superseded_search_response_is_ignored`, and `superseded_detail_response_is_ignored`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked queries::pagination::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked conversation_turns
+npm run test:data-freshness
+```
+
+- [ ] **Step 3: Add exact page and cursor contracts**
+
+```rust
+pub struct ConversationPage {
+  pub items: Vec<ConversationListItem>,
+  pub offset: u32,
+  pub next_offset: Option<u32>,
+  pub total_count: u64,
+}
+
+pub struct ConversationTurnCursor {
+  pub last_activity_at_ms: i64,
+  pub session_id: String,
+  pub turn_id: String,
+}
+
+pub struct ConversationTurnPage {
+  pub items: Vec<ConversationTurnPoint>,
+  pub next_cursor: Option<ConversationTurnCursor>,
+}
+```
+
+Default conversation-list page size is 50 and maximum is 100. Add `conversation_turns` keyed by `(session_id, turn_id)`, with explicit turn/message/token columns, `root_session_id`, and `last_activity_at_ms`. Index `(root_session_id, last_activity_at_ms DESC, session_id DESC, turn_id DESC)`. The first page runs `ORDER BY` on that tuple with `LIMIT 41`, returns 40, and uses the extra row only to determine `next_cursor`; older pages add a strict tuple cursor predicate. Detail totals, per-session values, model breakdown, and composition breakdown use SQL aggregate/group queries over indexed session joins rather than an event `Vec`. The foreground path never calls `build_turns_for_session` or opens a source JSONL file.
+
+Full and incremental imports transactionally replace or upsert derived turn rows. Add nullable `import_state.turn_index_version`; legacy rows remain queryable but report turns pending until a low-priority coordinator repair parses at most eight files or 8 MB per dispatch, then yields. The repair uses the same refresh-deadline guard as epoch backfill, persists progress per session, and emits an invalidation after each committed batch. Foreground detail commands never perform this repair.
+
+- [ ] **Step 4: Add the dual-limit cache and visibility gate**
+
+```typescript
+const detailCache = new SizedLruCache<string, ConversationDetail>({
+  maxEntries: 20,
+  maxBytes: 32 * 1024 * 1024,
+  sizeOf: estimateConversationDetailBytes,
+})
+```
+
+Reject one entry larger than 32 MB. Use explicit 250 ms debounce rather than `useDeferredValue` as a network debounce. Hidden surfaces record the highest revision and reload once when shown.
+
+`estimateConversationDetailBytes` walks retained strings and arrays once using their encoded/string storage lengths; it must not call `JSON.stringify`, clone the detail, or retain a second serialized copy merely to measure cache size.
+
+Use a monotonically increasing `RequestGeneration` for conversation search, pagination, and selected-detail requests. Starting a newer request invalidates older in-flight responses; where Tauri invoke cannot be cancelled, completion checks `isCurrent(generation)` before changing rows, selection, cache, error, or loading state.
+
+```typescript
+export class RequestGeneration {
+  private current = 0
+  begin(): number { return ++this.current }
+  isCurrent(generation: number): boolean { return generation === this.current }
+  invalidate(): void { this.current += 1 }
+}
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked queries::pagination::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked conversation_turns
+npm run test:data-freshness
+npm run test:presentation
+git add src-tauri/sql src-tauri/src/database.rs src-tauri/src/database/conversation_turns.rs src-tauri/src/importer.rs src-tauri/src/refresh/runtime.rs src-tauri/src/queries/pagination.rs src-tauri/src/queries.rs src-tauri/src/models.rs src-tauri/src/lib.rs src/app/sizedLru.ts src/app/requestGeneration.ts src/app/surfaceRevision.ts src/app/types.ts src/app/api.ts src/App.tsx scripts/test-data-freshness.mjs
+git commit -m "perf: bound conversation pages and detail cache"
+```
+
+### Task 8: Enforce presentation performance budgets
+
+**Files:**
+- Create: `.github/workflows/release-build.yml`
+- Create: `scripts/check-hidden-surface-activity.mjs`
+- Create: `scripts/perf/assert-runtime-budgets.mjs`
+- Create: `scripts/perf/measure-macos-runtime.sh`
+- Create: `scripts/perf/parse-xctrace-wakeups.mjs`
+- Create: `src-tauri/src/presentation/metrics.rs`
+- Modify: `scripts/check-popup-bundle.mjs`
+- Modify: `package.json`
+- Modify: `src-tauri/src/database.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/presentation.rs`
+- Modify: `src-tauri/src/presentation/snapshot.rs`
+- Modify: `src-tauri/src/presentation/tray.rs`
+- Modify: `src/menu-bar-popup/bootstrap.ts`
+- Test: changed Rust presentation modules and Node scripts.
+
+**Interfaces:**
+- Consumes: metrics exposed by snapshot, tray, and query test probes.
+- Produces: repeatable CI budget checks and a local hidden-window probe.
+
+- [ ] **Step 1: Add failing threshold assertions**
+
+The scripts must reject payloads above 65,536 bytes, popup bundles above either size limit, any hidden data getter call, and any detail cache above either cap. Rust tests assert snapshot getter p95 below 5 ms on the 200,000-usage/400,000-quota fixture, tray main-thread apply p95 below 2 ms with no I/O, that the main-thread backend receives precomputed values only, and `PRAGMA integrity_check` returns exactly `ok` after all migrations, backfills, and cleanup fixtures.
+
+The macOS probe enforces every awake-process runtime budget from the approved design: scheduled start lag p95 at most 2 seconds and maximum 5 seconds, resume catch-up at most 5 seconds, active app-server children at most one, live timeout at most 10 seconds, commit-to-tray p95 at most 100 ms, commit-to-popup p95 at most 150 ms, refresh-related main-thread tasks p99 below 16 ms, reused popup content p95 below 100 ms, first popup creation p95 below 300 ms, fully hidden CPU average below 0.2 percent and p95 below 0.5 percent, at most two total process wakeups per minute, zero hidden queries for ten minutes, and stable resident memory rather than growth proportional to history.
+
+Do not calculate a percentile from one observation. Deterministic fake-clock tests execute at least 100 scheduled starts. The release-app probe requires at least 30 production-path samples for commit-to-tray, commit-to-popup, reused popup, and cold popup creation, plus at least eight real scheduled starts during the hidden run. `assert-runtime-budgets.mjs` fails on an insufficient sample count before checking percentiles.
+
+- [ ] **Step 2: Run the budget scripts before final wiring**
+
+Run `npm run build && node scripts/check-popup-bundle.mjs && node scripts/check-hidden-surface-activity.mjs`.
+
+Expected: scripts fail until manifest names and probes are wired.
+
+- [ ] **Step 3: Wire deterministic test probes**
+
+Use counters compiled under `cfg(test)` for source row visits, snapshot getter duration, tray apply calls, and hidden getter calls. Production `PerformanceCounters` use atomics plus fixed latency buckets and never retain an accumulating sample vector:
+
+```rust
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PerformanceSnapshot {
+  pub scheduler_wakeups: u64,
+  pub scheduled_start_lag_samples: u64,
+  pub scheduled_start_lag_p95_ms: f64,
+  pub scheduled_start_lag_max_ms: f64,
+  pub resume_catch_up_max_ms: f64,
+  pub active_live_children_max: u64,
+  pub live_query_duration_max_ms: f64,
+  pub live_timeout_count: u64,
+  pub snapshot_build_p95_ms: f64,
+  pub snapshot_getter_p95_ms: f64,
+  pub tray_queue_p95_ms: f64,
+  pub tray_apply_p95_ms: f64,
+  pub main_thread_task_p99_ms: f64,
+  pub commit_to_tray_visible_p95_ms: f64,
+  pub commit_to_tray_visible_samples: u64,
+  pub publish_to_tray_visible_p95_ms: f64,
+  pub commit_to_popup_visible_p95_ms: f64,
+  pub commit_to_popup_visible_samples: u64,
+  pub publish_to_popup_visible_p95_ms: f64,
+  pub reused_popup_p95_ms: f64,
+  pub reused_popup_samples: u64,
+  pub first_popup_p95_ms: f64,
+  pub first_popup_samples: u64,
+  pub popup_payload_bytes_max: u64,
+  pub hidden_query_count: u64,
+}
+```
+
+Keep both source-commit and snapshot-publish timestamps for at most the newest 32 presentation revisions. `DisplayInvalidation` passes the monotonic source commit through the builder into `DisplaySnapshot`; coalesced rebuilds retain the newest represented commit. After a visible surface applies a revision, it sends one revision acknowledgment. The acceptance histogram measures source commit-to-visible, which includes snapshot build and event delivery; publish-to-visible remains a separate diagnostic. The backend then removes both timestamps. Duplicate, hidden, and stale acknowledgments are ignored, so observability cannot grow memory with refresh history.
+
+When `CODEX_PACER_PERF_REPORT_PATH` is present, an opt-in diagnostic reporter writes one final JSON snapshot at shutdown; ordinary launches perform no report-file I/O. Every probe points `CODEX_PACER_DATA_DIR` at a temporary fixture directory, and diagnostic iteration mode refuses to start against the normal application data path.
+
+`measure-macos-runtime.sh` uses separate phases and report files:
+
+1. Launch the release binary, hide both windows, and leave it uninterrupted for 600 seconds. No popup, manual refresh, synthetic revision, or visibility action is allowed. Sample `%CPU` and RSS once per second and measure hidden queries, scheduled starts, and process wakeups. Reject an RSS increase above both 16 MB and five percent between the post-warmup and final windows.
+2. Start a fresh fixture process, keep the target surfaces visible, and drive at least 30 revisions through the production commit, snapshot, tray, event, and acknowledgment path for commit-to-visible percentiles.
+3. Start a fresh fixture process and recreate the popup at least 30 times for the cold-creation percentile; measure reused cached content separately without contributing to hidden-phase samples.
+
+The script merges the phase reports only after validating their labels and sample counts, then passes them to `assert-runtime-budgets.mjs`. The fake-clock runtime test from Slice 1 enforces the resume allowance without putting the developer machine to sleep.
+
+During the uninterrupted hidden phase only, record the target process with `xcrun xctrace record --template "Power Profiler"`. `parse-xctrace-wakeups.mjs` exports the trace, filters the Codex Pacer PID/coalition, and calculates total application wakeups per minute. The gate fails if the process-level measurement is unavailable; the coordinator's internal `scheduler_wakeups` counter is diagnostic only and cannot substitute for the acceptance measurement.
+
+Add a GitHub Actions matrix for `macos-14` and `windows-latest` that installs Node 22.18 and the declared Rust toolchain, runs `npm ci`, frontend tests/lint/build, Rust tests, and `npm run tauri build`. Runtime CPU thresholds remain a local macOS gate because hosted-runner load is nondeterministic; Windows must complete the release build.
+
+- [ ] **Step 4: Run full slice verification**
+
+```bash
+npm test
+npm run lint
+npm run build
+node scripts/check-popup-bundle.mjs
+node scripts/check-hidden-surface-activity.mjs
+bash scripts/perf/measure-macos-runtime.sh --duration 600
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+cargo test --manifest-path src-tauri/Cargo.toml --locked database_integrity_after_all_migrations
+cargo clippy --manifest-path src-tauri/Cargo.toml --locked --lib
+```
+
+Expected: all functional tests and budgets pass. Clippy exits successfully; compare its output with the recorded 16-warning repository baseline and fix every new warning in changed files. Whole-repository pre-existing Clippy debt outside changed modules remains separately documented.
+
+- [ ] **Step 5: Commit the performance gates**
+
+```bash
+git add .github/workflows/release-build.yml package.json scripts src-tauri/src src/menu-bar-popup/bootstrap.ts
+git commit -m "test: enforce presentation resource budgets"
+```

--- a/docs/superpowers/plans/2026-07-10-refresh-correctness.md
+++ b/docs/superpowers/plans/2026-07-10-refresh-correctness.md
@@ -1,0 +1,553 @@
+# Refresh correctness implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the coupled polling scheduler with independent token and live quota lanes that use fixed deadlines, singleflight, coalesced triggers, truthful freshness, and completion events.
+
+**Architecture:** A pure state machine decides when work starts and how triggers merge. A channel runtime launches token and live workers independently, then publishes typed completion and invalidation events. Tauri commands become adapters around one coordinator; passive reads never start work.
+
+**Tech Stack:** Rust 2021, Tauri 2.10, `std::sync::mpsc`, Chrono, Rusqlite, React 19, TypeScript 5.9, Node 22.18 test scripts.
+
+## Global constraints
+
+- Execute this slice first. Run its full verification and review checkpoint before starting the presentation or importer plans.
+- `auto_scan_enabled` is the master switch. When enabled, token and live quota refresh on independent schedules even while windows are hidden. When disabled, scheduled work stops and manual work remains available.
+- The live app-server timeout is exactly 10 seconds, and at most one live child process may run.
+- A trigger received during active work produces at most one follow-up generation and is never discarded.
+- Runtime deadlines use a monotonic clock. Wall time restores state after launch and displays freshness only.
+- Passive getters do not scan files, query the app-server, or wait for active work.
+- Frontend automatic refresh timers are removed. Existing content, focus visibility, and reduced-motion behavior remain stable during manual refresh.
+
+---
+
+### Task 1: Add the deterministic lane state machine
+
+**Files:**
+- Create: `src-tauri/src/refresh/mod.rs`
+- Create: `src-tauri/src/refresh/schedule.rs`
+- Modify: `src-tauri/src/lib.rs:1-6`
+- Test: `src-tauri/src/refresh/schedule.rs`
+
+**Interfaces:**
+- Consumes: persisted success timestamps and normalized refresh settings.
+- Produces: `RefreshConfig`, `RefreshLane`, `RefreshReason`, `TokenScanKind`, `CoordinatorEvent`, `CoordinatorAction`, and `CoordinatorState`.
+
+- [ ] **Step 1: Write failing deadline and lane-independence tests**
+
+Add `persisted_success_maps_remaining_wall_time_to_monotonic_deadline`, `missing_persisted_success_starts_one_immediate_catch_up`, `invalid_persisted_success_starts_one_immediate_catch_up`, `overdue_persisted_success_starts_one_immediate_catch_up`, `due_lanes_start_together_and_advance_from_planned_deadlines`, `token_running_does_not_block_due_live_lane`, `missed_intervals_coalesce_into_one_catch_up`, `shorter_interval_recalculates_deadline_immediately`, and `backward_wall_clock_does_not_move_runtime_deadline`.
+
+Use this central assertion:
+
+```rust
+let base = Instant::now();
+let wall = utc("2026-07-10T10:00:00Z");
+let config = test_config(Duration::from_secs(300), Some(wall));
+let mut state = CoordinatorState::new(config, base, wall);
+let actions = state.handle(base + Duration::from_secs(300), CoordinatorEvent::Timer);
+assert!(actions.iter().any(|value| matches!(value, CoordinatorAction::StartToken(_))));
+assert!(actions.iter().any(|value| matches!(value, CoordinatorAction::StartLive(_))));
+assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
+assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::schedule::tests
+```
+
+Expected: compilation fails because the refresh module does not exist.
+
+- [ ] **Step 3: Implement the public scheduling contracts**
+
+Add to `refresh/mod.rs`:
+
+```rust
+pub(crate) const LIVE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RefreshLane { Token, Live }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshReason { Startup, Scheduled, Manual, SettingsChanged, Wake, Fallback }
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum TokenScanKind { Incremental, Full }
+
+#[derive(Clone, Debug)]
+pub(crate) struct RefreshConfig {
+  pub auto_scan_enabled: bool,
+  pub interval: Duration,
+  pub codex_home: Option<String>,
+  pub token_last_success_wall: Option<DateTime<Utc>>,
+  pub live_last_success_wall: Option<DateTime<Utc>>,
+}
+```
+
+Keep `CoordinatorState` pure and pass `Instant` to `handle`. Advance from the planned deadline:
+
+```rust
+fn advance_fixed_deadline(mut deadline: Instant, interval: Duration, now: Instant) -> (Instant, u64) {
+  let mut elapsed_intervals = 0;
+  while deadline <= now {
+    deadline += interval;
+    elapsed_intervals += 1;
+  }
+  (deadline, elapsed_intervals.saturating_sub(1))
+}
+
+fn initial_deadline(
+  monotonic_now: Instant,
+  wall_now: DateTime<Utc>,
+  last_success: Option<DateTime<Utc>>,
+  interval: Duration,
+) -> Instant {
+  let Some(age) = last_success.and_then(|value| wall_now.signed_duration_since(value).to_std().ok()) else {
+    return monotonic_now;
+  };
+  monotonic_now + interval.saturating_sub(age)
+}
+```
+
+The settings adapter maps a malformed persisted timestamp to `None`. Missing, malformed, future, and overdue values produce one startup intent; once that generation is recorded as running they cannot enqueue a duplicate catch-up.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::schedule::tests`.
+
+Expected: all Task 1 tests pass without real sleeps.
+
+- [ ] **Step 5: Commit the scheduler model**
+
+```bash
+git add src-tauri/src/refresh src-tauri/src/lib.rs
+git commit -m "feat: add deterministic refresh lane scheduler"
+```
+
+### Task 2: Coalesce overlap, back off independently, and guard source generations
+
+**Files:**
+- Modify: `src-tauri/src/refresh/mod.rs`
+- Modify: `src-tauri/src/refresh/schedule.rs`
+- Test: `src-tauri/src/refresh/schedule.rs`
+
+**Interfaces:**
+- Consumes: Task 1 lane state.
+- Produces: reason sets, generation-tagged execution requests, waiter IDs, retry deadlines, and `DisplayInvalidation`.
+
+- [ ] **Step 1: Write failing overlap and retry tests**
+
+Add `triggers_during_run_create_one_follow_up_generation`, `multiple_triggers_merge_reason_bits`, `manual_live_waiter_joins_running_generation`, `failed_lanes_back_off_independently`, `source_change_rejects_old_completion`, and `source_change_discards_prepared_token_before_commit`.
+
+```rust
+let first = start_token_generation(&mut state, base);
+state.handle(base + Duration::from_secs(1), CoordinatorEvent::RequestToken(TokenRequest::scheduled()));
+state.handle(base + Duration::from_secs(2), CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)));
+let actions = state.handle(base + Duration::from_secs(3), CoordinatorEvent::TokenFinished(success(first)));
+assert_eq!(actions.iter().filter(|value| matches!(value, CoordinatorAction::StartToken(_))).count(), 1);
+assert!(matches!(actions.last(), Some(CoordinatorAction::StartToken(request)) if request.kind == TokenScanKind::Full));
+```
+
+- [ ] **Step 2: Run tests and verify behavioral failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::schedule::tests`.
+
+Expected: new assertions fail because pending and retry state are absent.
+
+- [ ] **Step 3: Implement merge and retry rules**
+
+Use a dependency-free reason set and bounded delay:
+
+```rust
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ReasonSet(u8);
+
+impl ReasonSet {
+  pub fn insert(&mut self, reason: RefreshReason) { self.0 |= 1 << reason as u8; }
+  pub fn is_empty(self) -> bool { self.0 == 0 }
+}
+
+fn retry_delay(failure_streak: u32, interval: Duration, jitter: Duration) -> Duration {
+  const STEPS: [u64; 6] = [5, 15, 30, 60, 120, 300];
+  let index = failure_streak.saturating_sub(1) as usize;
+  Duration::from_secs(STEPS[index.min(STEPS.len() - 1)])
+    .saturating_add(jitter)
+    .min(interval)
+    .min(Duration::from_secs(300))
+}
+```
+
+Production jitter is capped at one second; tests pass zero. Keep normal deadlines unchanged by retries. Before a prepared token refresh enters the mutation queue, recheck its source generation; discard it without database writes when the source changed. Increment revisions only when both worker generation and source generation match.
+
+Use these generation and event contracts throughout all three slices:
+
+```rust
+#[derive(Clone, Debug)]
+pub(crate) struct TokenRequest {
+  pub reasons: ReasonSet,
+  pub kind: TokenScanKind,
+  pub codex_home: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TokenExecutionRequest {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub request: TokenRequest,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LiveExecutionRequest {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub reasons: ReasonSet,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CommitMarker {
+  pub sequence: u64,
+  pub committed_at: Instant,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DisplayInvalidation {
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub settings_revision: u64,
+  pub source_generation: u64,
+  pub commit: CommitMarker,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshCompletedEvent {
+  pub refresh_revision: u64,
+  pub lane: RefreshLane,
+  pub generation: u64,
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub source_generation: u64,
+  pub succeeded: bool,
+  pub failure: Option<String>,
+  pub completed_at: String,
+}
+```
+
+- [ ] **Step 4: Run schedule tests**
+
+Run the same focused command. Expected: one follow-up is produced, retry caps hold, and stale completions do not publish.
+
+- [ ] **Step 5: Commit overlap handling**
+
+```bash
+git add src-tauri/src/refresh
+git commit -m "feat: coalesce refresh triggers and guard source generations"
+```
+
+### Task 3: Add the channel runtime and independent workers
+
+**Files:**
+- Create: `src-tauri/src/refresh/runtime.rs`
+- Create: `src-tauri/src/refresh/power.rs`
+- Create: `src-tauri/src/refresh/mutation.rs`
+- Modify: `src-tauri/src/refresh/mod.rs`
+- Modify: `src-tauri/src/importer.rs`
+- Test: `src-tauri/src/refresh/runtime.rs`
+- Test: `src-tauri/src/refresh/mutation.rs`
+
+**Interfaces:**
+- Consumes: Task 2 coordinator actions.
+- Produces: `RefreshCoordinatorHandle`, executor traits, `RefreshStatus`, blocking manual tickets, `RefreshEventSink`, and serialized usage-mutation arbitration.
+
+- [ ] **Step 1: Write channel-gated concurrency tests**
+
+Add `token_worker_does_not_delay_live_worker_start`, `concurrent_live_callers_share_one_executor_generation`, `active_live_children_never_exceeds_one`, `live_timeout_terminates_and_reaps_child`, `startup_status_is_busy_before_worker_body_runs`, `completion_services_one_pending_follow_up`, `worker_panic_becomes_failure`, `disabled_scheduler_runs_manual_requests`, `scheduled_start_lag_is_recorded`, `start_lag_above_five_seconds_warns`, `resume_starts_overdue_lanes_within_five_seconds`, `token_parse_runs_before_usage_commit_lock`, `held_usage_commit_lock_does_not_delay_live_lane`, and `pricing_waits_behind_refresh_mutation`.
+
+- [ ] **Step 2: Run tests and verify compilation failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests -- --nocapture`.
+
+Expected: runtime types are missing.
+
+- [ ] **Step 3: Implement runtime traits and `recv_timeout` loop**
+
+```rust
+pub(crate) trait TokenRefreshExecutor: Send + Sync {
+  fn parse(&self, request: TokenExecutionRequest) -> Result<PreparedTokenRefresh, String>;
+  fn commit(&self, prepared: PreparedTokenRefresh) -> Result<ScanResult, String>;
+}
+
+pub(crate) struct PreparedTokenRefresh {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub started_at: DateTime<Utc>,
+  pub prepared_scan: PreparedScan,
+}
+
+pub(crate) trait LiveQuotaFetcher: Send + Sync {
+  fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String>;
+  fn fallback(&self) -> Option<LiveRateLimitSnapshot>;
+}
+
+pub(crate) trait LiveQuotaPersister: Send + Sync {
+  fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String>;
+}
+
+pub(crate) trait RefreshEventSink: Send + Sync {
+  fn publish_invalidation(&self, value: DisplayInvalidation);
+  fn publish_completion(&self, value: RefreshCompletedEvent);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MutationPhase { Queued, Parsing, WaitingToCommit, Committed, Failed }
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum MutationPriority { Pricing, Maintenance, Refresh }
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LaneStatus {
+  pub running: bool,
+  pub generation: Option<u64>,
+  pub pending: bool,
+  pub last_success_at: Option<String>,
+  pub next_due_at: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshStatus {
+  pub token: LaneStatus,
+  pub live: LaneStatus,
+  pub mutation_phase: Option<MutationPhase>,
+  pub source_generation: u64,
+}
+```
+
+The runtime calls `rx.recv_timeout(state.next_wait(clock.monotonic_now()))`, marks running state before spawn, and launches token and live actions on separate named threads. Catch worker panics and convert them into failure completions.
+
+Refactor the importer entry point into a read-only `prepare_scan` that produces `PreparedTokenRefresh` and a transactional `commit_prepared_scan`. Preparation performs no freshness, repair, title, pricing, or derived-row write; the coordinator owns attempt state until commit. `UsageMutationCoordinator` serializes only the commit closure. Token discovery and JSON parsing run in `Parsing` before requesting the lock; the phase changes to `WaitingToCommit` only around the writer queue. Refresh commits outrank maintenance, which outranks pricing recalculation. Waiting for this queue never holds the coordinator channel or live singleflight, and live publication does not acquire the usage-mutation lock.
+
+Add fixed-bucket histograms and counters rather than retaining per-run samples. `RefreshLaneMetrics` exposes `scheduled_due_at`, `started_at`, `start_lag_ms`, `duration_ms`, `last_success_age_ms`, `failure_streak`, `retry_at`, `missed_deadline_count`, `coalesced_trigger_count`, `running_generation`, and `pending_reasons`. Live metrics add app-server duration, timeout count, active child count, fallback age, and waiter count. Token metrics add files visited, bytes read, append fast-path count, full-rebuild count, mutation-lock wait, and database-busy count. Warn when start lag exceeds five seconds, active live children exceeds one, or success age exceeds the interval plus active retry allowance.
+
+- [ ] **Step 4: Scope macOS activity to actual work**
+
+Move `SchedulerActivity` to `refresh/power.rs`. Use `NSActivityOptions::Background`. Construct the guard immediately before an executor call and drop it immediately afterward. The coordinator wait loop holds no activity guard.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests
+git add src-tauri/src/refresh src-tauri/src/importer.rs
+git commit -m "feat: coordinate independent refresh workers"
+```
+
+### Task 4: Publish truthful live quota before persistence
+
+**Files:**
+- Create: `src-tauri/src/refresh/live_cache.rs`
+- Modify: `src-tauri/src/refresh/mod.rs`
+- Modify: `src-tauri/src/refresh/runtime.rs`
+- Modify: `src-tauri/src/models.rs:215-224`
+- Modify: `src-tauri/src/lib.rs:1084-1328`
+- Test: `src-tauri/src/refresh/live_cache.rs`
+
+**Interfaces:**
+- Consumes: Task 3 live fetcher and persister.
+- Produces: `LiveQuotaState`, `LiveQuotaCache`, fixed timeout behavior, fallback metadata, and persistence retry actions.
+
+- [ ] **Step 1: Write failing freshness tests**
+
+Add `fallback_never_becomes_fresh_for_ttl`, `fallback_preserves_source_and_last_success`, `fresh_value_is_visible_before_persistence_finishes`, `fetch_receives_ten_second_timeout`, `live_failure_does_not_run_token_inline`, `persistence_failure_retries_without_refetch`, `newer_live_snapshot_supersedes_pending_persistence_retry`, `persistence_retry_is_capped`, and `persistence_retry_does_not_move_live_deadline`.
+
+```rust
+let fallback = store.publish_fallback(old_snapshot(), utc("2026-07-10T10:00:00Z"));
+assert!(fallback.is_fallback);
+assert_eq!(fallback.source_fetched_at.as_deref(), Some("2026-07-09T10:00:00+00:00"));
+assert_eq!(fallback.last_live_success_at, None);
+assert!(store.needs_live_refresh(Duration::from_secs(300)));
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run `cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::live_cache::tests`.
+
+Expected: cache state types are missing.
+
+- [ ] **Step 3: Add serialized live state**
+
+```rust
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveQuotaState {
+  pub rate_limits: Option<LiveRateLimitSnapshot>,
+  pub source_fetched_at: Option<String>,
+  pub cached_at: String,
+  pub is_fallback: bool,
+  pub last_live_success_at: Option<String>,
+  pub refreshing: bool,
+}
+
+pub(crate) struct LivePersistenceRetryState {
+  pub latest_pending: Option<Arc<LiveRateLimitSnapshot>>,
+  pub failure_streak: u32,
+  pub retry_at: Option<Instant>,
+  pub running: bool,
+}
+```
+
+`publish_live` updates source and success time. `publish_fallback` updates cache time only and remains due for retry.
+
+- [ ] **Step 4: Publish before persistence and remove inline fallback scans**
+
+On live success, update cache, increment quota revision, emit an invalidation carrying a monotonic `CommitMarker`, and emit completion before starting persistence. A persistence failure stores only the latest pending snapshot and schedules `CoordinatorAction::PersistLive` with the same 5/15/30/60/120/300-second sequence, capped by the configured interval and 300 seconds. It never runs the live fetcher, increments the live fetch failure streak, or changes the normal live deadline. Only one persistence action runs; a newer live snapshot replaces an older pending retry, and success clears the independent persistence state. Replace `get_live_rate_limits_history_fallback` synchronous scanning with an asynchronous `RefreshReason::Fallback` token intent.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::live_cache::tests
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests
+git add src-tauri/src/refresh src-tauri/src/models.rs src-tauri/src/lib.rs
+git commit -m "fix: preserve truthful live quota freshness"
+```
+
+### Task 5: Route Tauri lifecycle and settings through the coordinator
+
+**Files:**
+- Modify: `src-tauri/src/database/sync_settings.rs:407-500`
+- Modify: `src-tauri/src/database.rs:10-18`
+- Modify: `src-tauri/src/lib.rs:92-102`
+- Modify: `src-tauri/src/lib.rs:166-466`
+- Modify: `src-tauri/src/lib.rs:1919-2181`
+- Modify: `src-tauri/src/models.rs`
+- Test: `src-tauri/src/database/sync_settings.rs`
+- Test: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: coordinator handle and live cache.
+- Produces: one coordinator in `AppState`, passive getters, manual waiters, immediate config updates, and resume forwarding.
+
+- [ ] **Step 1: Write failing integration tests**
+
+Add `settings_save_does_not_overwrite_newer_scan_freshness`, `settings_change_wakes_coordinator_immediately`, `codex_home_change_requests_full_scan`, `passive_live_getter_does_not_start_fetch`, `popup_snapshot_read_does_not_start_scan`, `manual_scan_uses_coordinator_generation`, and `pricing_recalculation_uses_lower_priority_mutation_ticket`.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked settings_save_does_not_overwrite_newer_scan_freshness
+cargo test --manifest-path src-tauri/Cargo.toml --locked passive_live_getter_does_not_start_fetch
+```
+
+- [ ] **Step 3: Make settings saves configuration-only**
+
+For an unchanged Codex home, stop updating `last_scan_started_at` and `last_scan_completed_at` in the conflict clause. For a changed home, clear freshness in the same transaction. `updateSyncSettings` sends the normalized config to the coordinator before returning.
+
+- [ ] **Step 4: Replace scheduler and command paths**
+
+Store `refresh: RefreshCoordinatorHandle` and the Task 3 mutation coordinator in `AppState`; remove scan and live atomic flags, the coarse `usage_mutation_lock`, and old spawn functions. `getScanInProgress` derives its compatibility boolean from `RefreshStatus`, while `getRefreshStatus` exposes the exact mutation phase. `getLiveRateLimits` returns cache, and manual commands request waiters. Pricing requests take a lower-priority mutation ticket and never hold the refresh coordinator. Build the app and forward resume:
+
+```rust
+let app = builder.build(tauri::generate_context!())
+  .expect("error while building tauri application");
+app.run(|app_handle, event| {
+  if matches!(event, tauri::RunEvent::Resumed) {
+    let _ = app_handle.state::<AppState>().refresh.notify_resume();
+  }
+});
+```
+
+Setup queues startup intents and does not call the three old scheduler entry points.
+
+- [ ] **Step 5: Run Rust tests and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+git add src-tauri/src/database.rs src-tauri/src/database/sync_settings.rs src-tauri/src/lib.rs src-tauri/src/models.rs
+git commit -m "refactor: route refresh commands through coordinator"
+```
+
+### Task 6: Replace frontend polling with revision-gated events
+
+**Files:**
+- Create: `src/app/refreshEvents.ts`
+- Create: `scripts/test-refresh-events.mjs`
+- Modify: `src/App.tsx:1-399`
+- Modify: `src/menu-bar-popup/MenuBarPopup.tsx:50-149`
+- Modify: `src/app/api.ts:202-280`
+- Modify: `src/app/dataFreshness.ts:87-116`
+- Modify: `src/app/types.ts:82-135`
+- Modify: `scripts/test-data-freshness.mjs`
+- Modify: `package.json:9-18`
+
+**Interfaces:**
+- Consumes: `codex-counter://refresh-completed` and passive getters.
+- Produces: `SurfaceRevisionGate`, visible reloads, hidden coalescing, and event-driven manual refresh state.
+
+- [ ] **Step 1: Write the failing Node tests**
+
+```javascript
+const gate = new SurfaceRevisionGate()
+assert.equal(gate.accept({ refreshRevision: 1, succeeded: true }, true), 'reload')
+assert.equal(gate.accept({ refreshRevision: 1, succeeded: true }, true), 'ignore')
+assert.equal(gate.accept({ refreshRevision: 2, succeeded: true }, false), 'defer')
+assert.equal(gate.accept({ refreshRevision: 3, succeeded: true }, false), 'defer')
+assert.equal(gate.onVisible(), 'reload')
+assert.equal(gate.onVisible(), 'ignore')
+```
+
+The script also asserts that refresh effects in `App.tsx` and `MenuBarPopup.tsx` contain no `setInterval`, `refreshBackgroundData`, or settings-open live polling. Add `failed_completion_does_not_reload_data` and `manual_waiter_failure_clears_refreshing_and_keeps_previous_data`.
+
+- [ ] **Step 2: Register the script and verify failure**
+
+Add `test:refresh-events` to `package.json` and `npm test`, then run `npm run test:refresh-events`.
+
+Expected: module import or source assertions fail.
+
+- [ ] **Step 3: Implement the pure revision gate**
+
+```typescript
+export class SurfaceRevisionGate {
+  private appliedRevision = 0
+  private pendingRevision = 0
+
+  accept(event: RefreshCompletedEvent, visible: boolean): 'reload' | 'defer' | 'ignore' {
+    if (!event.succeeded || event.refreshRevision <= Math.max(this.appliedRevision, this.pendingRevision)) return 'ignore'
+    if (!visible) {
+      this.pendingRevision = event.refreshRevision
+      return 'defer'
+    }
+    this.appliedRevision = event.refreshRevision
+    return 'reload'
+  }
+
+  onVisible(): 'reload' | 'ignore' {
+    if (this.pendingRevision <= this.appliedRevision) return 'ignore'
+    this.appliedRevision = this.pendingRevision
+    return 'reload'
+  }
+}
+```
+
+- [ ] **Step 4: Wire both surfaces without automatic timers**
+
+As an interim Slice 1 bridge, App listens for successful completion, checks Tauri window visibility, and reloads only for `reload`. Popup removes its interval; showing it performs one passive read. A failed completion never reloads data. Manual commands await their coordinator ticket and clear `refreshing` in `finally`, so failure leaves the prior cards and source timestamp visible. Preserve Escape handling, labels, focus states, and stable height.
+
+This raw-completion data reload is deliberately removed in presentation Task 4. In the final architecture, `refresh-completed` controls spinner/error state only; `display-snapshot-updated` is the sole trigger allowed to apply new data.
+
+- [ ] **Step 5: Run full slice verification and commit**
+
+```bash
+npm test
+npm run lint
+npm run build
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+cargo clippy --manifest-path src-tauri/Cargo.toml --locked --lib
+git add package.json scripts/test-data-freshness.mjs scripts/test-refresh-events.mjs src/App.tsx src/menu-bar-popup/MenuBarPopup.tsx src/app/api.ts src/app/dataFreshness.ts src/app/refreshEvents.ts src/app/types.ts
+git commit -m "perf: replace frontend refresh polling with events"
+```
+
+Expected: all tests, lint, build, and Rust tests pass. Clippy exits successfully; compare its output with the recorded 16-warning repository baseline and fix every new warning in changed files. Frontend sources have no automatic refresh timer.

--- a/docs/superpowers/plans/2026-07-11-release-1.2.0.md
+++ b/docs/superpowers/plans/2026-07-11-release-1.2.0.md
@@ -164,4 +164,3 @@
 - [ ] **Step 5: Merge, tag, publish, and clean up**
 
   Merge the release PR, create tag `v1.2.0` at the merged `main` commit, publish the GitHub Release with the verified artifacts, then delete the local and remote release branch.
-

--- a/docs/superpowers/plans/2026-07-11-release-1.2.0.md
+++ b/docs/superpowers/plans/2026-07-11-release-1.2.0.md
@@ -1,0 +1,167 @@
+# Codex Pacer 1.2.0 Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare, verify, sign, notarize, and publish Codex Pacer 1.2.0 without exposing private credentials and without breaking upgrades from 1.1.1 or 1.1.2.
+
+**Architecture:** The release branch starts at the latest `develop` merge and targets `main`. Compatibility is verified at the SQLite schema and persisted-settings boundaries before building. The existing macOS release script remains the only build path so signing, notarization, stapling, Gatekeeper checks, checksums, and release artifact naming stay reproducible.
+
+**Tech Stack:** Tauri 2, Rust, SQLite, React, TypeScript, npm, Apple `codesign`, `notarytool`, `stapler`, `spctl`, GitHub CLI.
+
+## Global Constraints
+
+- Release version is exactly `1.2.0` in `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`.
+- Never write Apple credentials, Apple ID values, passwords, private home paths, or signing secrets into the repository, shell history, logs, PR text, checksums, or release artifacts.
+- Use `scripts/release/build-macos-release.sh 1.2.0` as the release build entrypoint.
+- The public release must be Developer ID signed, notarized, stapled, and accepted by Gatekeeper.
+- Existing databases and preferences created by 1.1.1 and 1.1.2 must open and migrate in place without losing usage, quota, settings, subscription, or conversation data.
+- The release PR targets `main` and remains unmerged until Codex review passes and the user explicitly confirms the merge.
+
+---
+
+### Task 1: Verify version and upgrade boundaries
+
+**Files:**
+- Inspect: `package.json`
+- Inspect: `package-lock.json`
+- Inspect: `src-tauri/Cargo.toml`
+- Inspect: `src-tauri/Cargo.lock`
+- Inspect: `src-tauri/tauri.conf.json`
+- Inspect: `src-tauri/sql/schema.sql`
+- Inspect: `src-tauri/src/database.rs`
+- Test: `src-tauri/src/database.rs`
+
+**Interfaces:**
+- Consumes: databases and settings produced by tags `v1.1.1` and `v1.1.2`.
+- Produces: evidence that `init_db` upgrades both versions to the 1.2.0 schema without destructive resets.
+
+- [ ] **Step 1: Compare all committed version declarations with `1.2.0`**
+
+  Run a script that reads each manifest and fails on any mismatch.
+
+- [ ] **Step 2: Diff schema and migration behavior against `v1.1.1` and `v1.1.2`**
+
+  Review every new table, column, index, repair marker, and startup migration. Confirm migrations use additive DDL or transactional repair paths.
+
+- [ ] **Step 3: Add or extend legacy database tests only if an upgrade boundary lacks coverage**
+
+  Build representative 1.1.1 and 1.1.2 databases, call the current `init_db`, and assert preserved row counts and values plus the new schema objects.
+
+- [ ] **Step 4: Run the focused compatibility tests**
+
+  Run: `cargo test --manifest-path src-tauri/Cargo.toml legacy -- --nocapture`
+
+  Expected: every legacy migration test passes with no data-loss assertion failure.
+
+### Task 2: Write release notes and changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Create: `docs/en/release-notes-v1.2.0.md`
+- Create: `docs/zh-CN/release-notes-v1.2.0.md`
+
+**Interfaces:**
+- Consumes: commit history from `v1.1.2` through the release branch.
+- Produces: concise English and Chinese notes suitable for the repository and GitHub Release.
+
+- [ ] **Step 1: Group user-visible changes by behavior**
+
+  Cover ChatGPT/Codex discovery, GPT-5.6 pricing, fork accounting, refresh correctness, lower resource use, menu bar rendering, and database migration behavior.
+
+- [ ] **Step 2: State upgrade compatibility plainly**
+
+  Tell 1.1.1 and 1.1.2 users that the existing local database is migrated in place and that uninstalling the old version is unnecessary.
+
+- [ ] **Step 3: Humanize the final English and Chinese copy**
+
+  Remove promotional wording, repetitive summaries, vague claims, and implementation-heavy phrasing while preserving technical accuracy.
+
+- [ ] **Step 4: Verify links, headings, version numbers, and dates**
+
+  Run repository text searches for stale versions and broken local release-note references.
+
+### Task 3: Audit private information and public packaging
+
+**Files:**
+- Inspect: all tracked files changed since `v1.1.2`
+- Inspect: macOS `.app` and `.dmg` contents after build
+- Run: `scripts/release/audit-public-branding.sh`
+
+**Interfaces:**
+- Consumes: tracked release diff and generated artifacts.
+- Produces: a clean scan with no credentials, private paths, personal email addresses, temporary measurements, or local backup files.
+
+- [ ] **Step 1: Scan tracked text and Git diff for credential patterns**
+
+  Search for password assignments, Apple credential values, private home paths, tokens, signing key material, and local measurement paths.
+
+- [ ] **Step 2: Run the repository public-branding audit**
+
+  Expected: exit code 0.
+
+- [ ] **Step 3: Inspect built app and DMG file lists**
+
+  Confirm only expected runtime resources are packaged and no `.env`, database, log, backup, plan output, or measurement file is present.
+
+- [ ] **Step 4: Scan extracted strings and metadata without printing secrets**
+
+  Report only matched file names and pattern categories. Do not print secret values.
+
+### Task 4: Run release validation and macOS signing workflow
+
+**Files:**
+- Execute: `scripts/release/build-macos-release.sh`
+- Inspect: generated `.app`, `.dmg`, and `.sha256`
+
+**Interfaces:**
+- Consumes: a clean release branch and credentials supplied outside the repository.
+- Produces: signed, notarized, stapled, Gatekeeper-approved 1.2.0 macOS artifacts.
+
+- [ ] **Step 1: Confirm signing identity and secure notarization configuration**
+
+  Use environment variables or an existing keychain profile without echoing their values. Stop if notarization cannot be configured without exposing credentials.
+
+- [ ] **Step 2: Run the full macOS release build**
+
+  Run: `scripts/release/build-macos-release.sh 1.2.0`
+
+  Expected: npm install, branding audit, lint, frontend build, Rust tests, Tauri build, Developer ID signature verification, notarization, staple validation, Gatekeeper assessment, DMG integrity check, and checksum generation all pass.
+
+- [ ] **Step 3: Verify signatures and notarization independently**
+
+  Run `codesign --verify --deep --strict`, `spctl --assess`, `xcrun stapler validate`, `hdiutil verify`, and `shasum -a 256 -c` against the final artifacts.
+
+- [ ] **Step 4: Install the built app over the existing local installation and smoke-test startup**
+
+  Preserve a rollback copy, replace `/Applications/Codex Pacer.app`, launch it, and confirm the existing database opens with current token and quota data.
+
+### Task 5: Publish the release PR and GitHub Release
+
+**Files:**
+- Commit: release notes and any compatibility tests required by Task 1.
+- Upload after merge: final `.dmg` and `.sha256` artifacts.
+
+**Interfaces:**
+- Consumes: verified release commit and macOS artifacts built from that exact commit.
+- Produces: a ready-for-review PR to `main`, followed by tag `v1.2.0` and a public GitHub Release after explicit merge approval.
+
+- [ ] **Step 1: Commit and push `codex/release-1.2.0`**
+
+  Stage only reviewed release files, commit with a release-specific message, and push with upstream tracking.
+
+- [ ] **Step 2: Create a ready-for-review PR targeting `main`**
+
+  Include the user-visible changes, compatibility evidence, privacy audit, build commands, signature/notarization results, and remaining limitations.
+
+- [ ] **Step 3: Wait for Codex review using PR reaction groups**
+
+  Poll for Codex `EYES`, `THUMBS_UP`, P1, or P2 without posting `@codex review`.
+
+- [ ] **Step 4: Request explicit merge confirmation after Codex `THUMBS_UP`**
+
+  Do not merge until the user confirms after seeing the final diff and validation summary.
+
+- [ ] **Step 5: Merge, tag, publish, and clean up**
+
+  Merge the release PR, create tag `v1.2.0` at the merged `main` commit, publish the GitHub Release with the verified artifacts, then delete the local and remote release branch.
+

--- a/docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
+++ b/docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
@@ -1,0 +1,353 @@
+# Auto refresh quota fallback implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent a newer session history timestamp from replacing a valid online quota value during a failed background refresh.
+
+**Architecture:** Keep source precedence separate from timestamp ordering. A live value confirmed in the current process wins first, followed by persisted live data, then an existing display fallback, and finally session history. Compare timestamps only within the live source group. The change stays in the Rust fallback loader and its tests. The frontend and database schema do not change.
+
+**Tech Stack:** Rust 2021, Tauri 2, rusqlite, chrono, Cargo tests, npm scripts, TypeScript, Vite, ESLint.
+
+## Global Constraints
+
+- A session timestamp must never outrank an online value merely because it is later.
+- A live fallback remains eligible for another live refresh and must not be treated as a fresh success.
+- Startup fallback loading must prefer persisted live data before session history.
+- Passive reads must not start a fetch or a scan.
+- Use the current codex/release-1.2.0 branch as explicitly requested by the user.
+- Do not change the frontend or database schema for this fix.
+
+---
+
+### Task 1: Add failing mixed-source fallback tests
+
+**Files:**
+
+- Modify: src-tauri/src/lib.rs in the existing test module, near background_live_rate_limit_fallback_prefers_newest_persisted_sample
+
+**Interfaces:**
+
+- Consumes: prepare_app_database, database::replace_session_rate_limit_samples, insert_live_rate_limit_snapshot, LiveQuotaCache, and load_display_live_rate_limit_fallback.
+- Produces: Regression tests that fail against the current mixed-source timestamp selection and preserve the existing history fallback contract.
+
+- [ ] **Step 1: Add small test builders for live and session samples**
+
+Add test-only helpers beside the existing quota fallback tests. Use a fixed five-hour window so each fixture has a coherent bucket and a distinct value:
+
+~~~rust
+fn test_live_quota_snapshot(fetched_at: &str, remaining_percent: i64) -> LiveRateLimitSnapshot {
+  LiveRateLimitSnapshot {
+    limit_id: Some("codex".to_string()),
+    limit_name: Some("Codex".to_string()),
+    plan_type: Some("pro".to_string()),
+    primary: Some(RateLimitWindowSnapshot {
+      used_percent: 100 - remaining_percent,
+      remaining_percent,
+      window_duration_mins: Some(300),
+      resets_at: Some("2026-07-12T05:00:00+08:00".to_string()),
+      window_start: Some("2026-07-12T00:00:00+08:00".to_string()),
+    }),
+    secondary: None,
+    fetched_at: fetched_at.to_string(),
+  }
+}
+
+fn test_session_quota_sample(
+  session_id: &str,
+  sample_timestamp: &str,
+  remaining_percent: i64,
+) -> crate::models::RateLimitSampleRecord {
+  crate::models::RateLimitSampleRecord {
+    source_kind: "session".to_string(),
+    source_session_id: Some(session_id.to_string()),
+    bucket: "five_hour".to_string(),
+    sample_timestamp: sample_timestamp.to_string(),
+    limit_id: Some("codex".to_string()),
+    limit_name: Some("Codex".to_string()),
+    plan_type: Some("pro".to_string()),
+    window_start: "2026-07-12T00:00:00+08:00".to_string(),
+    resets_at: "2026-07-12T05:00:00+08:00".to_string(),
+    used_percent: 100 - remaining_percent,
+    remaining_percent,
+  }
+}
+~~~
+
+- [ ] **Step 2: Add the current-process live value regression test**
+
+Add background_live_fallback_keeps_current_live_over_newer_session. Insert a session sample at 2026-07-12T00:10:00+08:00, put a live snapshot at 2026-07-12T00:05:00+08:00 into the cache with publish_live, then call load_display_live_rate_limit_fallback. Assert that the returned timestamp is 2026-07-12T00:05:00+08:00 and the returned remaining value is the live value, not the session value:
+
+~~~rust
+#[test]
+fn background_live_fallback_keeps_current_live_over_newer_session() {
+  let directory = tempdir().expect("tempdir");
+  let db_path = directory.path().join("usage.sqlite");
+  prepare_app_database(&db_path).expect("prepare app database");
+  let conn = open_connection(&db_path).expect("open database");
+  database::replace_session_rate_limit_samples(
+    &conn,
+    "session-late",
+    &[test_session_quota_sample(
+      "session-late",
+      "2026-07-12T00:10:00+08:00",
+      20,
+    )],
+  )
+  .expect("insert newer session sample");
+  drop(conn);
+
+  let live_cache = refresh::LiveQuotaCache::new();
+  live_cache.publish_live(
+    Arc::new(test_live_quota_snapshot(
+      "2026-07-12T00:05:00+08:00",
+      88,
+    )),
+    Instant::now(),
+    Utc::now(),
+  );
+
+  let snapshot = load_display_live_rate_limit_fallback(&db_path, &live_cache)
+    .expect("load fallback");
+
+  assert_eq!(snapshot.fetched_at, "2026-07-12T00:05:00+08:00");
+  assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(88));
+}
+~~~
+
+- [ ] **Step 3: Add the persisted live precedence test**
+
+Add background_live_fallback_prefers_persisted_live_over_newer_session. Insert a persisted live snapshot at 2026-07-12T00:05:00+08:00 with 88 percent remaining and a session sample at 2026-07-12T00:10:00+08:00 with 20 percent remaining. Use an empty cache and assert that the fallback returns the persisted live snapshot:
+
+~~~rust
+#[test]
+fn background_live_fallback_prefers_persisted_live_over_newer_session() {
+  let directory = tempdir().expect("tempdir");
+  let db_path = directory.path().join("usage.sqlite");
+  prepare_app_database(&db_path).expect("prepare app database");
+  let conn = open_connection(&db_path).expect("open database");
+  insert_live_rate_limit_snapshot(
+    &conn,
+    &test_live_quota_snapshot("2026-07-12T00:05:00+08:00", 88),
+  )
+  .expect("insert persisted live sample");
+  database::replace_session_rate_limit_samples(
+    &conn,
+    "session-late",
+    &[test_session_quota_sample(
+      "session-late",
+      "2026-07-12T00:10:00+08:00",
+      20,
+    )],
+  )
+  .expect("insert newer session sample");
+  drop(conn);
+
+  let snapshot = load_display_live_rate_limit_fallback(
+    &db_path,
+    &refresh::LiveQuotaCache::new(),
+  )
+  .expect("load fallback");
+
+  assert_eq!(snapshot.fetched_at, "2026-07-12T00:05:00+08:00");
+  assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(88));
+}
+~~~
+
+- [ ] **Step 4: Add the no-live history fallback test**
+
+Add background_live_fallback_uses_session_when_no_live_data_exists. Insert only the session sample, use an empty cache, and assert that the session timestamp and remaining value are returned. This protects the last-resort behavior.
+
+~~~rust
+#[test]
+fn background_live_fallback_uses_session_when_no_live_data_exists() {
+  let directory = tempdir().expect("tempdir");
+  let db_path = directory.path().join("usage.sqlite");
+  prepare_app_database(&db_path).expect("prepare app database");
+  let conn = open_connection(&db_path).expect("open database");
+  database::replace_session_rate_limit_samples(
+    &conn,
+    "session-only",
+    &[test_session_quota_sample(
+      "session-only",
+      "2026-07-12T00:10:00+08:00",
+      20,
+    )],
+  )
+  .expect("insert session sample");
+  drop(conn);
+
+  let snapshot = load_display_live_rate_limit_fallback(
+    &db_path,
+    &refresh::LiveQuotaCache::new(),
+  )
+  .expect("load history fallback");
+
+  assert_eq!(snapshot.fetched_at, "2026-07-12T00:10:00+08:00");
+  assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(20));
+}
+~~~
+
+- [ ] **Step 5: Run the focused tests and verify the failure**
+
+Run:
+
+~~~bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked background_live_rate_limit_fallback -- --nocapture
+~~~
+
+Expected result: the new current-process and persisted-live tests fail because load_display_live_rate_limit_fallback currently calls load_persisted_live_rate_limits_from_connection with no source filter and compares session rows with live rows. The session-only test may pass before the production change.
+
+- [ ] **Step 6: Commit the failing regression tests**
+
+~~~bash
+git add src-tauri/src/lib.rs
+git commit -m "test: cover mixed-source quota fallback"
+~~~
+
+### Task 2: Implement source-prioritized fallback loading
+
+**Files:**
+
+- Modify: src-tauri/src/lib.rs in load_display_live_rate_limit_fallback and app setup fallback initialization
+
+**Interfaces:**
+
+- Consumes: the failing tests from Task 1, LiveQuotaCache::state, LiveQuotaCache::rate_limits, load_persisted_live_rate_limits_from_connection, and newest_live_rate_limit_snapshot.
+- Produces: a fallback loader that compares only live candidates before considering session history.
+
+- [ ] **Step 1: Add a source-priority helper for startup data**
+
+Add this helper near load_persisted_live_rate_limits_from_connection:
+
+~~~rust
+fn load_preferred_persisted_live_rate_limits(
+  conn: &rusqlite::Connection,
+) -> Option<LiveRateLimitSnapshot> {
+  load_persisted_live_rate_limits_from_connection(conn, Some("live"))
+    .or_else(|| load_persisted_live_rate_limits_from_connection(conn, Some("session")))
+}
+~~~
+
+Change app setup so display_fallback calls this helper instead of loading with no source filter and then trying session again:
+
+~~~rust
+let display_fallback = load_preferred_persisted_live_rate_limits(&conn);
+~~~
+
+Keep live_last_success_at sourced from Some("live") so the scheduler still restores the live deadline from online data only.
+
+- [ ] **Step 2: Replace mixed-source fallback selection**
+
+Update load_display_live_rate_limit_fallback to use the following order:
+
+~~~rust
+fn load_display_live_rate_limit_fallback(
+  db_path: &Path,
+  live_cache: &refresh::LiveQuotaCache,
+) -> Option<LiveRateLimitSnapshot> {
+  let memory = live_cache
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone());
+  let memory_is_live = live_cache.state().last_live_success_at.is_some();
+  let Ok(conn) = open_connection(db_path) else {
+    return memory;
+  };
+
+  let persisted_live = load_persisted_live_rate_limits_from_connection(&conn, Some("live"));
+  if memory_is_live {
+    return newest_live_rate_limit_snapshot([memory, persisted_live]);
+  }
+  if persisted_live.is_some() {
+    return persisted_live;
+  }
+  memory.or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")))
+}
+~~~
+
+This preserves timestamp comparison for two live candidates. It prevents a session row from entering that comparison. A live value published by this process remains the display value even when the database contains a later session timestamp. A startup cache that has only a historical value gives persisted live data the next chance before keeping history.
+
+- [ ] **Step 3: Run the focused regression tests**
+
+Run:
+
+~~~bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked background_live_rate_limit_fallback -- --nocapture
+~~~
+
+Expected result: all fallback tests pass, including the existing test that chooses a newer persisted live sample and the new tests from Task 1.
+
+- [ ] **Step 4: Run formatter and focused neighboring tests**
+
+Run:
+
+~~~bash
+cargo fmt --all -- --check
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::live_cache::tests -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests -- --nocapture
+~~~
+
+Expected result: formatting and all focused Rust tests pass. The runtime tests must still show that a failed live request triggers a retry and a fallback token intent.
+
+- [ ] **Step 5: Commit the production fix**
+
+~~~bash
+git add src-tauri/src/lib.rs
+git commit -m "fix: prioritize live quota fallback sources"
+~~~
+
+### Task 3: Run full verification and prepare the branch
+
+**Files:**
+
+- Inspect: src-tauri/src/lib.rs
+- Inspect: docs/superpowers/specs/2026-07-12-auto-quota-fallback-design.md
+- Inspect: docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
+
+**Interfaces:**
+
+- Consumes: the committed regression tests and source-priority implementation from Tasks 1 and 2.
+- Produces: evidence that the fix does not break refresh runtime behavior, frontend checks, formatting, or build output.
+
+- [ ] **Step 1: Run the complete Rust test suite**
+
+Run:
+
+~~~bash
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+~~~
+
+Expected result: every Rust test passes. Intentional panic messages from existing worker recovery tests are acceptable only when the tests finish successfully.
+
+- [ ] **Step 2: Run frontend tests, lint, and build**
+
+Run:
+
+~~~bash
+npm test
+npm run lint
+npm run build
+~~~
+
+Expected result: all Node test scripts pass, ESLint exits successfully, and TypeScript plus Vite produce a successful build.
+
+- [ ] **Step 3: Inspect the final diff for scope and formatting**
+
+Run:
+
+~~~bash
+git diff --check HEAD~2..HEAD
+git diff --stat HEAD~2..HEAD
+git status --short --branch
+~~~
+
+Expected result: only the fallback tests and source-priority loader changed in the implementation commits, the design and plan documents are present, and the working tree is clean.
+
+- [ ] **Step 4: Push the current branch after verification**
+
+Run:
+
+~~~bash
+git push origin codex/release-1.2.0
+~~~
+
+Do not create or merge a pull request in this plan. The project workflow requires the user to test the pushed branch and explicitly approve entering the PR process.

--- a/docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
+++ b/docs/superpowers/plans/2026-07-12-auto-quota-fallback.md
@@ -281,12 +281,12 @@ Expected result: all fallback tests pass, including the existing test that choos
 Run:
 
 ~~~bash
-cargo fmt --all -- --check
+cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
 cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::live_cache::tests -- --nocapture
 cargo test --manifest-path src-tauri/Cargo.toml --locked refresh::runtime::tests -- --nocapture
 ~~~
 
-Expected result: formatting and all focused Rust tests pass. The runtime tests must still show that a failed live request triggers a retry and a fallback token intent.
+Expected result: the focused Rust tests pass. The repository currently contains formatting differences outside this change, so do not reformat the whole crate. The runtime tests must still show that a failed live request triggers a retry and a fallback token intent.
 
 - [ ] **Step 5: Commit the production fix**
 

--- a/docs/superpowers/specs/2026-07-10-codex-5-6-chatgpt-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-10-codex-5-6-chatgpt-compatibility-design.md
@@ -31,7 +31,7 @@ On macOS, automatic discovery uses this order:
 5. Homebrew, `/usr/local/bin`, and `~/.cargo/bin` locations.
 6. The command name `codex`, which lets the operating system search `PATH`.
 
-Windows behavior stays unchanged. Linux keeps its existing standalone CLI lookup. The app-server transport and JSON-RPC methods also stay unchanged because the current bundled executable passed a real initialize and live quota read.
+Windows behavior stays unchanged. Linux keeps its existing standalone CLI lookup. The app-server transport and quota method stay the same. After `initialize` succeeds, Pacer now sends the standard `initialized` notification before reading live quota data.
 
 ## Pricing and data repair
 
@@ -43,7 +43,7 @@ The bundled Standard prices per million tokens are:
 | GPT-5.6 Terra | $2.50 | $0.25 | $15.00 |
 | GPT-5.6 Luna | $1.00 | $0.10 | $6.00 |
 
-The seed catalog adds these rows at startup. The existing pricing-signature check then detects the new rows and recalculates stored usage values, including GPT-5.6 events that were previously worth zero.
+The seed catalog adds these rows at startup. Historical values are recalculated when price-bearing catalog fields change or when the durable `pricing_value_resolution_v2` repair has not completed. The catalog update, recalculation, and repair marker share one transaction, so a failed upgrade can be retried without leaving mixed values behind.
 
 There is one repair case for users who clicked "Refresh pricing" after OpenAI added the new cache-write column but before this fix. Those databases can contain official GPT-5.6 rows whose output price is 1.25 times the input price: 6.25 for Sol, 3.125 for Terra, or 1.25 for Luna. Seeding may replace only that known malformed pattern. Correct official rows remain untouched. A later successful online refresh marks the corrected rows official again.
 
@@ -55,15 +55,19 @@ The audit found several update paths where valid local data can remain stale or 
 
 - A custom Codex home expands a leading `~` and must exist as a directory before a scan starts. An invalid path returns an error and does not advance the completed-scan timestamp.
 - Changing the Codex home clears the old freshness timestamps and triggers a full scan after settings are saved. Existing history stays in Pacer, while the new source becomes the active refresh target.
+- The resolved Codex home is stored with scan freshness. A default source change from A to B is detected even when the saved selector remains empty, and an incomplete first scan stays due for a full retry.
+- An authoritative source scan marks sessions from the previous home missing and removes their import state even when the old files still exist elsewhere on disk.
 - Incremental scans check whether a previously active file moved to the flat `archived_sessions` directory. This imports the final token snapshot immediately instead of waiting for daily maintenance.
 - A full scan refreshes titles from `session_index.jsonl` even when the session JSONL files did not change.
 - A UTF-8 read failure aborts that file before its metadata is committed. Ordinary incomplete JSON at the end of a file remains retryable on the next size or mtime change.
 - A missing or inconsistent conversation link triggers topology repair even when the source file itself did not change.
 - Persisted quota rows are ordered by their parsed RFC3339 instant, not by text. Primary and secondary windows are combined only when they came from the same sample time.
-- Conversation-detail cache entries are retained only while their source time, API-equivalent value, and subscription share still match the refreshed dashboard.
+- Conversation-detail cache entries are retained only while the refreshed title, timestamps, model set, token totals, session composition, API-equivalent value, and source states still match.
 - If a periodic refresh finds another scan in progress, the frontend waits for that scan to settle before loading the dashboard.
+- Pricing refreshes and scans share one mutation lock, so a scan cannot write values from an older catalog after a refresh commits.
+- A failed Codex-home change restores the previous settings and subscription profile, then rescans the restored source before reporting the error.
 
-These fixes keep the existing database schema. They use current metadata and comparisons, so users do not need to delete or rebuild their Pacer database.
+The database migration adds one nullable internal field, `last_scan_codex_home`, to bind freshness to the resolved source. Existing databases are upgraded automatically; users do not need to delete or rebuild them.
 
 ## User-visible behavior
 

--- a/docs/superpowers/specs/2026-07-10-codex-5-6-chatgpt-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-10-codex-5-6-chatgpt-compatibility-design.md
@@ -1,0 +1,102 @@
+# Codex 5.6 and ChatGPT app compatibility design
+
+## Problem
+
+Codex Pacer still imports the current session format, but two parts of the integration have fallen behind the July 2026 Codex release.
+
+First, the macOS build only looks for a standalone `codex` executable in Homebrew, `/usr/local/bin`, or `~/.cargo/bin`. The current ChatGPT desktop app ships its own executable at `/Applications/ChatGPT.app/Contents/Resources/codex`. A machine with the ChatGPT app but no standalone CLI cannot load live quota data.
+
+Second, the pricing catalog stops at GPT-5.5. A real GPT-5.6 Sol session imported 1,963,678 tokens into the local database with an API-equivalent value of zero. The official pricing page also added a cache-write price between cached input and output for GPT-5.6 rows. The existing parser reads the third number as output, so a pricing refresh can store the cache-write price as the output price.
+
+The current GPT-5.6 session files still live under `~/.codex/sessions` and retain the `session_meta`, `turn_context`, and `event_msg/token_count` records used by the importer. The live `account/rateLimits/read` request also succeeds against the executable bundled with ChatGPT 26.707.30751. No session-path or JSONL schema migration is needed for this release.
+
+## Chosen approach
+
+The compatibility work has three focused parts:
+
+1. Discover the Codex executable inside the ChatGPT app before trying legacy app and standalone CLI locations on macOS. `CODEX_BIN` remains the first choice so explicit configuration still wins.
+2. Add exact catalog, display, color, and prefix-resolution support for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` using the official Standard API prices. Treat the official `gpt-5.6` alias as Sol.
+3. Parse each official pricing row within its own boundary. The first value is input, the second is cached input, and the last value is output. Any optional middle value, including cache-write pricing, does not affect Pacer because local usage records do not contain cache-write token counts.
+
+This approach avoids guessing a price for unknown future models. Unknown model IDs remain visible but keep a zero API-equivalent value until OpenAI publishes a matching price.
+
+## Executable discovery
+
+On macOS, automatic discovery uses this order:
+
+1. An existing path from `CODEX_BIN`.
+2. `/Applications/ChatGPT.app/Contents/Resources/codex`.
+3. `~/Applications/ChatGPT.app/Contents/Resources/codex`.
+4. The equivalent system and user paths for the legacy `Codex.app` name.
+5. Homebrew, `/usr/local/bin`, and `~/.cargo/bin` locations.
+6. The command name `codex`, which lets the operating system search `PATH`.
+
+Windows behavior stays unchanged. Linux keeps its existing standalone CLI lookup. The app-server transport and JSON-RPC methods also stay unchanged because the current bundled executable passed a real initialize and live quota read.
+
+## Pricing and data repair
+
+The bundled Standard prices per million tokens are:
+
+| Model | Input | Cached input | Output |
+| --- | ---: | ---: | ---: |
+| GPT-5.6 / GPT-5.6 Sol | $5.00 | $0.50 | $30.00 |
+| GPT-5.6 Terra | $2.50 | $0.25 | $15.00 |
+| GPT-5.6 Luna | $1.00 | $0.10 | $6.00 |
+
+The seed catalog adds these rows at startup. The existing pricing-signature check then detects the new rows and recalculates stored usage values, including GPT-5.6 events that were previously worth zero.
+
+There is one repair case for users who clicked "Refresh pricing" after OpenAI added the new cache-write column but before this fix. Those databases can contain official GPT-5.6 rows whose output price is 1.25 times the input price: 6.25 for Sol, 3.125 for Terra, or 1.25 for Luna. Seeding may replace only that known malformed pattern. Correct official rows remain untouched. A later successful online refresh marks the corrected rows official again.
+
+Official-page parsing accepts both the older three-price rows and the new four-price rows. The parser still requires the supported flagship rows to be present before it replaces the catalog, which prevents a partial or structurally changed page from silently wiping valid prices.
+
+## Session refresh safety
+
+The audit found several update paths where valid local data can remain stale or be recorded only in part. This release fixes the cases that can silently lose or mislabel data:
+
+- A custom Codex home expands a leading `~` and must exist as a directory before a scan starts. An invalid path returns an error and does not advance the completed-scan timestamp.
+- Changing the Codex home clears the old freshness timestamps and triggers a full scan after settings are saved. Existing history stays in Pacer, while the new source becomes the active refresh target.
+- Incremental scans check whether a previously active file moved to the flat `archived_sessions` directory. This imports the final token snapshot immediately instead of waiting for daily maintenance.
+- A full scan refreshes titles from `session_index.jsonl` even when the session JSONL files did not change.
+- A UTF-8 read failure aborts that file before its metadata is committed. Ordinary incomplete JSON at the end of a file remains retryable on the next size or mtime change.
+- A missing or inconsistent conversation link triggers topology repair even when the source file itself did not change.
+- Persisted quota rows are ordered by their parsed RFC3339 instant, not by text. Primary and secondary windows are combined only when they came from the same sample time.
+- Conversation-detail cache entries are retained only while their source time, API-equivalent value, and subscription share still match the refreshed dashboard.
+- If a periodic refresh finds another scan in progress, the frontend waits for that scan to settle before loading the dashboard.
+
+These fixes keep the existing database schema. They use current metadata and comparisons, so users do not need to delete or rebuild their Pacer database.
+
+## User-visible behavior
+
+Model charts and conversation details show the names GPT-5.6 Sol, GPT-5.6 Terra, and GPT-5.6 Luna. Each model gets a distinct chart color, while the text label remains the primary identifier. No workflow depends on color alone.
+
+Codex Pacer keeps its current product name and continues to describe the imported data as Codex usage. The ChatGPT app change affects executable discovery, not the meaning of the analytics.
+
+## Failure handling
+
+If no executable exists, live quota reads return the existing launch error and persisted session-derived quota samples remain available as the fallback. An invalid `CODEX_BIN` does not block automatic discovery.
+
+If the official pricing page cannot be fetched or parsed, Pacer keeps the bundled catalog. If a model has no supported catalog entry, its token totals remain correct and only its API-equivalent value stays zero.
+
+## Verification
+
+Tests cover these behaviors before production code changes:
+
+- ChatGPT app discovery wins over legacy and standalone locations on macOS.
+- Explicit `CODEX_BIN` still wins.
+- The GPT-5.6 alias and all three variants resolve exact and dated model IDs.
+- Official three-price and four-price rows use the last value as output.
+- Seeding repairs the known cache-write-column corruption without overwriting correct official prices.
+- Startup recalculation changes a stored GPT-5.6 event from zero to the expected value.
+- A GPT-5.6 JSONL fixture imports token totals and API-equivalent value correctly.
+- Invalid custom homes, moved archives, title-only changes, UTF-8 failures, and missing topology links follow the refresh rules above.
+- Mixed-offset quota timestamps select the true latest sample and do not combine different sample times.
+- Derived-value changes invalidate a cached conversation detail, and a busy background refresh waits before reloading.
+
+Final verification includes the Rust test suite, frontend tests, lint, production web build, Tauri build checks, a real scan of a copied `~/.codex` data set, and a live quota request through the executable bundled with `/Applications/ChatGPT.app`.
+
+## Sources
+
+- [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
+- [Codex pricing and GPT-5.6 model guidance](https://developers.openai.com/codex/pricing)
+- [Codex app documentation](https://developers.openai.com/codex/app)
+- [ChatGPT desktop app July 2026 update](https://learn.chatgpt.com/docs/whats-new#july-6-10-2026)

--- a/docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md
+++ b/docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md
@@ -12,7 +12,9 @@ A second case occurs when the first child snapshot already contains an inherited
 
 The importer will keep the cumulative counter as its monotonic high-water mark. It will also parse `last_token_usage` for replay identification and first-snapshot recovery.
 
-For a session with an explicit `forked_from_id`, the importer will load the direct parent's numeric token sequence. It will compare each child snapshot by the exact pair `(total_token_usage, last_token_usage)`. A copied prefix is removed only when at least two consecutive child pairs match one contiguous slice of the direct parent's sequence. Timestamps and model labels do not participate because Codex can rewrite them during a fork.
+For a session with an explicit `forked_from_id`, the importer will load the direct parent's numeric token sequence. Parent and child sequences are first reduced to the same cumulative high-water records used for billing. This removes repeated snapshots, including records where total usage is unchanged but last usage differs. The importer then compares each child record by the exact pair `(total_token_usage, last_token_usage)`. A copied prefix is removed only when at least two consecutive child pairs match one contiguous slice of the direct parent's sequence.
+
+Child and parent timestamps do not need to be equal because Codex rewrites copied timestamps. The explicit fork timestamp still supplies a causal boundary: parent records created after the fork cannot have been inherited and are excluded before matching. Model labels do not participate in matching.
 
 The matching algorithm finds the longest child prefix contained in the parent sequence in linear time. Missing `last_token_usage` breaks a candidate match. This keeps older JSONL formats on the existing cumulative-counter path.
 
@@ -24,13 +26,13 @@ Sessions linked only through `source.subagent.thread_spawn.parent_thread_id` do 
 
 `UsageSnapshot` will retain both cumulative and last-turn token usage. `ParsedSession` will separately retain the explicit fork parent ID so the importer can distinguish a true fork from a normal spawned subagent.
 
-At scan time, the importer builds a session-to-source-path map from the files in the current scan and existing session records. When a changed explicit fork is parsed, the importer reads the direct parent's numeric token records on demand and caches the result for sibling forks. It does not load message text into memory.
+At scan time, the importer builds a session-to-source-path map from the files in the current scan and existing session records. When a changed explicit fork is parsed, the importer reads the direct parent's token numbers and timestamps on demand, drops records later than the fork, and caches the result for sibling forks. It does not load message text into memory.
 
 The persisted `usage_events` table remains unchanged. It continues to store deltas, not source cumulative counters. API-equivalent value is calculated from the corrected deltas in the same transaction that replaces the session's usage rows.
 
 ## Historical repair
 
-The existing `token_usage_monotonic_v2` repair marker has already completed on installed databases. The new algorithm therefore uses `token_usage_fork_replay_v3`. Its absence forces a full scan and rebuilds unchanged usage files under the selected Codex home.
+The existing `token_usage_monotonic_v2` repair marker has already completed on installed databases. The new algorithm therefore adds `token_usage_fork_replay_v3`. Its absence forces a full scan and rebuilds unchanged usage files under the selected Codex home. The importer continues to load and retry any older v2 pending files instead of abandoning them when v3 is introduced.
 
 If a source file is unreadable, the existing pending-file mechanism records it and retries it on a later scan. A direct parent that is no longer available cannot support exact prefix matching. In that case the child still receives the first-snapshot baseline correction, and the importer logs that full replay matching was unavailable.
 
@@ -38,13 +40,16 @@ Historical sessions from a different Codex home can only be rebuilt while their 
 
 ## Performance
 
-Normal root sessions do no extra file work. An explicit fork loads only its direct parent's numeric token records. Multiple children of one parent share the cached sequence for the duration of the scan. Prefix matching uses a KMP-style prefix table, so its cost is proportional to the parent and child sequence lengths.
+Normal root sessions do no extra file work. An explicit fork loads only its direct parent's numeric token records. Multiple children of one parent share the raw sequence for the duration of the scan, then apply their own fork-time cutoff. Prefix matching uses a KMP-style prefix table, so its cost is proportional to the parent and child sequence lengths.
 
 ## Verification
 
 Automated tests cover:
 
 - a child that copies three parent snapshots and then adds new usage;
+- a copied sequence that starts in the middle of the parent history;
+- unchanged cumulative totals with different last-usage values producing no extra match or charge;
+- parent usage after the fork being ineligible for replay matching;
 - a fork whose first snapshot contains a large inherited baseline;
 - a normal spawned subagent that must not use fork replay removal;
 - a nested fork that compares against its direct parent;

--- a/docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md
+++ b/docs/superpowers/specs/2026-07-10-fork-token-accounting-design.md
@@ -1,0 +1,57 @@
+# Fork token accounting design
+
+## Problem
+
+Codex fork files can begin with a copy of the direct parent's `token_count` history. The copied records keep the parent's numeric `total_token_usage` and `last_token_usage` values, but Codex rewrites their timestamps to the fork creation time. Codex Pacer currently treats every file as an independent counter. It starts the child at zero and imports the copied cumulative history again.
+
+The local audit found no duplicate SQLite rows and no duplicate import-state records. The error is in the JSONL import semantics. Across the current data set, the copied history accounts for about 43 percent of the displayed all-time total. In the active root conversation, it accounts for about 86 percent.
+
+A second case occurs when the first child snapshot already contains an inherited cumulative baseline. For example, a child may report `total_token_usage.total_tokens = 153235349` while `last_token_usage.total_tokens = 289826`. Counting the cumulative value assigns the parent's history to the child. The child's first real increment is the `last_token_usage` value.
+
+## Selected approach
+
+The importer will keep the cumulative counter as its monotonic high-water mark. It will also parse `last_token_usage` for replay identification and first-snapshot recovery.
+
+For a session with an explicit `forked_from_id`, the importer will load the direct parent's numeric token sequence. It will compare each child snapshot by the exact pair `(total_token_usage, last_token_usage)`. A copied prefix is removed only when at least two consecutive child pairs match one contiguous slice of the direct parent's sequence. Timestamps and model labels do not participate because Codex can rewrite them during a fork.
+
+The matching algorithm finds the longest child prefix contained in the parent sequence in linear time. Missing `last_token_usage` breaks a candidate match. This keeps older JSONL formats on the existing cumulative-counter path.
+
+After a match, the last copied cumulative value becomes the child's baseline. The first new child snapshot is calculated against that baseline. If no reliable parent prefix is available, the first explicit-fork snapshot uses `last_token_usage` when present. Later snapshots continue to use cumulative high-water differences, which preserves the existing protection against repeated and non-monotonic totals.
+
+Sessions linked only through `source.subagent.thread_spawn.parent_thread_id` do not use cross-session replay removal. The audit did not find copied token prefixes in those files. Their current accounting remains unchanged.
+
+## Data flow
+
+`UsageSnapshot` will retain both cumulative and last-turn token usage. `ParsedSession` will separately retain the explicit fork parent ID so the importer can distinguish a true fork from a normal spawned subagent.
+
+At scan time, the importer builds a session-to-source-path map from the files in the current scan and existing session records. When a changed explicit fork is parsed, the importer reads the direct parent's numeric token records on demand and caches the result for sibling forks. It does not load message text into memory.
+
+The persisted `usage_events` table remains unchanged. It continues to store deltas, not source cumulative counters. API-equivalent value is calculated from the corrected deltas in the same transaction that replaces the session's usage rows.
+
+## Historical repair
+
+The existing `token_usage_monotonic_v2` repair marker has already completed on installed databases. The new algorithm therefore uses `token_usage_fork_replay_v3`. Its absence forces a full scan and rebuilds unchanged usage files under the selected Codex home.
+
+If a source file is unreadable, the existing pending-file mechanism records it and retries it on a later scan. A direct parent that is no longer available cannot support exact prefix matching. In that case the child still receives the first-snapshot baseline correction, and the importer logs that full replay matching was unavailable.
+
+Historical sessions from a different Codex home can only be rebuilt while their source files are available. Selecting that source again causes an authoritative full scan. Missing source files remain visible as missing and are not silently treated as repaired data.
+
+## Performance
+
+Normal root sessions do no extra file work. An explicit fork loads only its direct parent's numeric token records. Multiple children of one parent share the cached sequence for the duration of the scan. Prefix matching uses a KMP-style prefix table, so its cost is proportional to the parent and child sequence lengths.
+
+## Verification
+
+Automated tests cover:
+
+- a child that copies three parent snapshots and then adds new usage;
+- a fork whose first snapshot contains a large inherited baseline;
+- a normal spawned subagent that must not use fork replay removal;
+- a nested fork that compares against its direct parent;
+- a missing `last_token_usage` field that keeps legacy cumulative behavior;
+- the new repair marker rebuilding unchanged, previously overcounted rows;
+- repeated and non-monotonic snapshots retaining their current high-water behavior.
+
+Integration verification runs the importer against a copied `~/.codex` tree and a temporary SQLite database. The test compares corrected totals with the independent read-only audit, checks database integrity, and confirms that the installed database can be repaired without deleting settings.
+
+The release check then runs Rust tests, frontend tests, lint, the production build, the macOS release script, code-signature verification, DMG verification, installation into `/Applications`, application launch, and a post-launch database query.

--- a/docs/superpowers/specs/2026-07-10-refresh-performance-stability-design.md
+++ b/docs/superpowers/specs/2026-07-10-refresh-performance-stability-design.md
@@ -1,0 +1,290 @@
+# Refresh performance and stability design
+
+## Problem
+
+Codex Pacer cannot currently guarantee that token statistics and live quota data refresh on the configured schedule. The token scanner, live quota query, tray renderer, popup snapshot builder, and frontend timers can all initiate overlapping work. Several of those paths are synchronous, and some run database or process I/O on the macOS main thread.
+
+The scheduler starts a token scan before it starts the live quota query. It schedules the next token run from the previous completion time, so scan duration becomes part of the refresh interval. A failed scan remains due and can be retried by the five-second scheduler poll. Live and tray work use atomic running flags; a trigger that arrives while a worker is busy is discarded instead of being queued.
+
+The presentation path amplifies the problem. Opening or polling the menu-bar popup can run a due token scan, load all usage events, build a full overview, load the events again for the seven-day quota trend, and read every historical quota sample for the selected bucket. Tray rendering performs database work inside `run_on_main_thread`, and a stale live cache can also start the Codex app-server from that path.
+
+The production database measured during this review was 245.4 MB and contained 2,247 sessions, about 167,600 usage events, and about 419,900 quota samples. A current seven-day view needed about 4,800 usage events and 5,000 quota samples, but the existing queries loaded about 167,600 and 209,300 rows. Quota history and its indexes accounted for about 82.8 percent of the database. Within a quota window, retaining value changes instead of every repeated observation could remove about 83 percent of five-hour rows and 92 percent of seven-day rows.
+
+Changed session files have a second source of write amplification. The incremental importer parses a changed JSONL file from the beginning, deletes every derived usage event and quota sample for the session, then rebuilds them. This is expensive for active files that grow by a few lines but are already tens of megabytes long.
+
+## Goals
+
+The design has six goals:
+
+1. Token and live quota refreshes start on independent fixed schedules and cannot delay one another.
+2. A trigger that arrives during active work is coalesced and eventually serviced. It is never silently lost.
+3. Passive UI reads never start a scan, launch a process, or perform an unbounded database query.
+4. Tray rendering performs no file, database, or process I/O on the UI thread.
+5. Normal background work reads and writes only data that changed, while memory use remains bounded as history grows.
+6. Failures expose stale data honestly, retry with bounded backoff, and recover after settings changes, sleep, clock changes, truncation, and database contention.
+
+## User-visible refresh semantics
+
+`auto_scan_enabled` remains the master automatic-refresh switch.
+
+When automatic refresh is enabled, the token lane and live quota lane use the configured refresh interval but maintain independent deadlines. They continue to run when the dashboard and popup are hidden. Menu visibility and the selected dashboard bucket do not determine whether live quota data stays fresh.
+
+When automatic refresh is disabled, both scheduled lanes pause. Manual token scans and manual live quota refreshes remain available. Opening a window or popup only reads the latest snapshot; it does not silently override the disabled setting.
+
+A passive read may return stale data with explicit freshness metadata. A manual refresh may wait for the current singleflight generation for up to the fixed live-query timeout. If that generation fails, the UI keeps the prior data and shows its source timestamp instead of presenting it as fresh.
+
+## Selected architecture
+
+One `RefreshCoordinator` owns the scheduling state for token, live quota, and display snapshot work. Callers submit intents through a channel. Only the coordinator decides whether to start work, merge a trigger into a running generation, schedule a retry, or publish a completion.
+
+The coordinator owns state, not the work itself. Token parsing, app-server queries, SQLite persistence, and display snapshot construction run on bounded workers. Workers send typed completion messages back to the coordinator. This keeps scheduling responsive while a scan or external process is slow.
+
+The main units are:
+
+- `RefreshCoordinator`: owns deadlines, lane generations, pending reasons, retry state, and configuration changes.
+- `TokenRefreshExecutor`: runs incremental or full imports and reports timing, source generation, and committed usage revision.
+- `LiveQuotaExecutor`: owns the only app-server singleflight and reports source time separately from cache time.
+- `DisplaySnapshotStore`: keeps one small immutable snapshot with usage, quota, settings, and presentation revisions.
+- `DisplaySnapshotBuilder`: uses bounded SQL queries to rebuild the snapshot off the UI thread.
+- `TrayPresenter`: compares the new presentation with the last applied presentation. The main-thread closure only calls tray setters.
+- Surface event bridges: notify the popup and visible dashboard that a newer revision is available.
+
+The existing `lib.rs` command layer will become a thin adapter around these units. Refresh and presentation logic should move into focused modules instead of expanding the current file.
+
+## Coordinator state and scheduling
+
+Each data lane stores:
+
+```text
+interval
+next_deadline
+running_generation
+pending_reasons
+last_attempt_at
+last_success_at
+failure_streak
+retry_at
+source_generation
+```
+
+The in-process deadline uses a monotonic clock. On startup, the coordinator maps the persisted wall-clock success time to the current monotonic clock. Invalid, missing, or overdue persisted timestamps produce one immediate catch-up run.
+
+After a scheduled run starts, the next normal deadline advances from the prior planned deadline until it lies in the future. It does not use the worker completion time. If the application misses several intervals while asleep, the coordinator records the missed count and starts one catch-up generation. It does not replay every missed interval.
+
+Manual, startup, settings, scheduled, wake, and fallback triggers are represented as reason bits. If a lane is idle, a trigger may start it. If it is running, the coordinator merges the reason into `pending_reasons`. When the generation completes, the coordinator starts at most one follow-up generation if the pending reasons still require newer data.
+
+The coordinator records pending or running state before a worker is spawned. The UI cannot observe a false idle state during startup.
+
+Configuration changes wake the coordinator through its channel. Shortening the interval recalculates deadlines immediately. Changing the resolved Codex home increments `source_generation`, clears freshness for the previous source, and queues a full scan. A completion from an older source generation cannot publish freshness for the new source.
+
+The coordinator is the only owner of refresh freshness. A settings save updates configuration fields without reading and rewriting `last_scan_*` or live success fields. This removes the race where an older settings snapshot can overwrite a newer completion.
+
+Runtime scheduling never derives elapsed time from the wall clock after startup. A backward wall-clock change can affect display timestamps but cannot pause a monotonic deadline. An application resume signal wakes the coordinator, which recalculates overdue work and queues one catch-up per lane.
+
+## Retry and timeout behavior
+
+Token and live failures have separate counters. A failure schedules a retry with jittered delays based on 5, 15, 30, 60, 120, and 300 seconds. The delay is capped by the configured interval and five minutes. A successful generation resets the lane's failure counter.
+
+Retry deadlines do not move the normal fixed-rate deadline. A retry and a scheduled trigger that become due together merge into one generation. A failure in one lane never forces or delays the other lane.
+
+The live app-server timeout is fixed at 10 seconds. It never scales with the refresh interval. Foreground and background requests join the same generation, so at most one app-server child process is active.
+
+Fallback data records these fields separately:
+
+```text
+source_fetched_at
+cached_at
+is_fallback
+last_live_success_at
+```
+
+Loading a persisted fallback may update `cached_at`, but it cannot update `source_fetched_at` or `last_live_success_at`. A fallback therefore remains stale and does not suppress the next retry.
+
+Live fallback reads the in-memory snapshot or `latest_rate_limits` only. It never starts a token scan on the caller thread. If a repair requires session-derived quota history, the fallback path submits a token intent to the coordinator and returns without waiting for it.
+
+Fresh live data is published to the in-memory snapshot before historical persistence. SQLite persistence follows on a worker. A persistence failure records a metric and queues a bounded retry, but it does not hide a successfully fetched quota value from the tray or popup.
+
+Usage mutations remain serialized at commit time because SQLite has one writer. Parsing can proceed before the mutation lock is available. State distinguishes queued, parsing, waiting-to-commit, and committed work instead of reporting all four as scanning. Pricing recalculation is a lower-priority mutation and cannot block the live lane.
+
+## Versioned display snapshots
+
+`DisplaySnapshotStore` keeps one bounded value:
+
+```text
+usage_revision
+quota_revision
+settings_revision
+presentation_revision
+generated_at
+token_summary
+quota_summary
+quota_trend
+menu_settings
+freshness
+```
+
+The store does not cache all events, conversations, or quota history. Its serialized popup payload must remain at or below 64 KB.
+
+A committed token scan increments `usage_revision`. A successful live fetch increments `quota_revision`. A relevant settings update increments `settings_revision`. The snapshot builder captures those three revisions before querying. If any source revision changes while the snapshot is being built, it publishes only the consistent result and queues one latest-wins rebuild.
+
+Snapshot getters only clone the current bounded snapshot. They do not invoke the coordinator, query SQLite, or run the app-server. Refresh commands submit an intent and return a ticket or the current stale snapshot as appropriate.
+
+The dashboard and popup only accept events with a higher presentation revision. This prevents an older asynchronous response from replacing newer data.
+
+## Tray and popup behavior
+
+The tray presentation is computed on a worker from the display snapshot. The main-thread closure receives preformatted title, tooltip, icon visibility, and tray visibility values. It compares them with the last applied values and only calls setters whose values changed.
+
+If a new display revision arrives while tray work is active, the presenter marks itself dirty. When the current apply finishes, it performs one follow-up render using the newest revision. The final update cannot be discarded because a previous update was running.
+
+The popup WebView is created on first tray use instead of application startup. Once created, it may remain hidden for fast subsequent opens, but it runs no periodic data timer while hidden. Its entry point uses a dynamic import so the popup bundle does not load the dashboard or Recharts code.
+
+The popup opens with the latest in-memory snapshot. Existing content remains visible during a manual refresh. A small refreshing state may change, but the data panel and measured window height do not collapse. The backend sends a versioned snapshot event when fresh work completes.
+
+The main dashboard also removes its independent automatic-refresh timer. When hidden, it records the newest revision without loading the dashboard. It performs one reload when shown. Search requests use a 250 ms debounce and ignore or cancel superseded work so hidden or obsolete queries do not compete with tray updates.
+
+## Query and storage changes
+
+Presentation queries must filter before rows enter Rust.
+
+Menu and popup summaries use dedicated SQL for API-equivalent value, total tokens, and distinct root conversation count. Trend queries group events into the required time bins in one pass. The popup does not call the full dashboard overview builder. Dashboard overview queries use the same indexed window predicates, and the conversation list uses bounded pages instead of rebuilding every conversation for each search.
+
+Quota history queries select the exact `(bucket, window_start, resets_at)` window through the existing composite index. A small `latest_rate_limits` table stores the newest primary and secondary values for fallback reads. The latest lookup no longer sorts an entire bucket with `julianday(sample_timestamp)`.
+
+Indexed time comparisons use integer epoch milliseconds. New usage events and quota samples populate the epoch fields at ingest. Existing rows are backfilled in bounded batches with a durable progress marker. Foreground presentation remains usable between batches. The compatibility query includes rows without an epoch until the backfill completes.
+
+Quota history stores step changes rather than every repeated observation. The latest table is updated for freshness. The historical table inserts a row when a window begins, when used percent changes, and when a prior window closes. Repeating the same value does not grow history. Existing redundant rows are pruned in bounded background batches. Each cleanup transaction yields before the next batch and does not begin when a refresh deadline is within 30 seconds. The migration does not run an automatic full `VACUUM`; freed pages remain available for SQLite reuse.
+
+Database initialization and bundled pricing seed work run at startup or migration time, not on every scan. Pricing refresh compares a value-bearing catalog signature before recalculating events. An unchanged signature performs no event update. Title maintenance updates only changed values and uses one transaction.
+
+## Append-only session import
+
+The import-state row gains a durable append checkpoint:
+
+```text
+parsed_offset
+parsed_file_size
+prefix_fingerprint
+checkpoint_tail_fingerprint
+last_complete_line_offset
+last_cumulative_usage
+last_model_id
+parser_schema_version
+```
+
+The fingerprint covers a fixed prefix and a small block ending at the saved offset. If the file still has the same identity, its size is at least the saved offset, and both fingerprints match, the importer seeks directly to `parsed_offset`. It parses only complete new JSONL records and appends derived usage and quota changes.
+
+The checkpoint stops at the last complete newline. An incomplete trailing record is read again on the next scan. Derived rows and the new checkpoint commit in the same transaction, so a failure cannot advance the offset beyond persisted data.
+
+The importer falls back to the existing full parse and session rebuild when any of these conditions holds:
+
+- the file shrank or was replaced;
+- a fingerprint does not match;
+- the parser schema version changed;
+- a pending historical repair requires a rebuild;
+- fork or topology metadata changed in a way that invalidates the checkpoint;
+- the saved checkpoint is malformed or incomplete.
+
+New files, archived moves, and explicit repair paths may take the full path once, then establish a fresh checkpoint. The parser uses typed record envelopes and borrows fields where practical so unrelated JSON payloads do not become large generic value trees.
+
+## Memory limits
+
+No new cache may grow with the number of usage events, quota samples, or conversations.
+
+Conversation details use an LRU with both count and byte limits. The default limits are 20 entries and 32 MB. The detail command returns the newest 40 turns by default; older turns require cursor pagination. Conversation lists use bounded pages instead of returning every root conversation.
+
+Workers stream SQLite rows into aggregates where possible. They do not materialize a full usage-event vector merely to compute a tray or popup value. The display snapshot and refresh state remain small fixed-size structures.
+
+## Power behavior
+
+The scheduler waits on its event channel until the next real deadline or configuration message. It no longer opens SQLite every five seconds to check settings.
+
+On macOS, process activity guards cover the actual scan or live query only. Background work uses a background-appropriate activity classification. The application does not hold a user-initiated activity for the lifetime of the scheduler thread.
+
+## Observability
+
+Debug logs and test probes record these fields per lane:
+
+```text
+scheduled_due_at
+started_at
+start_lag_ms
+duration_ms
+last_success_age_ms
+failure_streak
+retry_at
+missed_deadline_count
+coalesced_trigger_count
+running_generation
+pending_reasons
+```
+
+Live metrics also record app-server duration, timeout count, active child count, fallback age, and singleflight waiters. Token metrics record files visited, bytes read, append fast-path count, full-rebuild count, mutation-lock wait, and database busy count. Presentation metrics record snapshot build time, tray queue time, main-thread apply time, payload size, and event-to-visible lag.
+
+Warnings are emitted when start lag exceeds five seconds, live child count exceeds one, or last success age exceeds the interval plus the active retry allowance. Metrics are bounded counters and timings, not an unbounded event history.
+
+## Delivery slices
+
+The work is delivered in three independently testable slices on the same development branch. Each slice receives its own implementation plan and review checkpoint so later storage work cannot obscure refresh regressions in the earlier slices.
+
+### Slice 1: refresh correctness
+
+Introduce the coordinator, independent token and live lanes, fixed deadlines, singleflight, pending-trigger coalescing, bounded timeout, backoff, source generations, and truthful fallback freshness. Replace frontend-driven automatic refresh with completion events.
+
+This slice is complete when token and live work cannot block each other's scheduled start and no trigger is lost during overlap.
+
+### Slice 2: presentation and bounded queries
+
+Add versioned display snapshots, worker-side tray computation, lazy popup loading, dynamic bundle splitting, indexed window queries, latest quota storage, quota change points, and bounded UI caches.
+
+This slice is complete when passive getters are bounded memory reads and tray main-thread work contains no I/O.
+
+### Slice 3: importer and write amplification
+
+Add append checkpoints, typed tail parsing, transactional fallback, pricing signature skips, conditional title updates, and bounded historical cleanup.
+
+This slice is complete when a normal active-session append reads only new bytes and does not delete or rebuild the session's existing derived history.
+
+## Acceptance budgets
+
+All timing budgets apply while the process is awake on a supported machine. Sleep recovery has a separate catch-up allowance.
+
+| Measure | Required result |
+| --- | ---: |
+| Scheduled lane start lag | p95 at or below 2 seconds, maximum 5 seconds |
+| Wake catch-up start | at or below 5 seconds after resume is observed |
+| Active app-server children | at most 1 |
+| Live query timeout | at most 10 seconds |
+| Token or quota commit to visible tray | p95 at or below 100 ms |
+| Token or quota commit to visible popup | p95 at or below 150 ms |
+| Snapshot memory getter | p95 below 5 ms |
+| Tray main-thread apply | p95 below 2 ms, no I/O |
+| Main-thread longest task from refresh work | p99 below 16 ms |
+| Reused popup cached content | p95 below 100 ms |
+| First lazy popup creation | p95 below 300 ms |
+| Popup serialized snapshot | at or below 64 KB |
+| Popup JavaScript | at or below 150 KB minified and 50 KB gzip |
+| Hidden-window dashboard and popup queries | 0 during a 10-minute observation |
+| Fully hidden idle CPU | average below 0.2 percent, p95 below 0.5 percent |
+| Application idle wakeups | at most 2 per minute |
+| Conversation detail cache | at most 20 entries and 32 MB |
+
+An unchanged automatic cycle performs no pricing rewrite, title rewrite, full event-table load, full quota-bucket load, or historical quota insert. A typical active JSONL append reads only bytes after the saved offset. Resident memory does not grow linearly with historical row count.
+
+## Verification
+
+Coordinator tests use a fake monotonic clock and injected token, live, persistence, and event executors. They cover independent deadlines, fixed-rate scheduling, overlap coalescing, interval changes, retry caps, startup pending state, stale fallback behavior, source-generation invalidation, sleep catch-up, backward wall-clock changes, and one active live child.
+
+Presentation tests cover revision ordering, a revision arriving during tray rendering, diff-only tray setters, no I/O in the main-thread closure, stable popup content during refresh, stale response rejection, hidden-window inactivity, popup bundle composition, payload size, and event-to-visible timing.
+
+Database tests use a fixture with at least 200,000 usage events and 400,000 quota samples. Query plans must use the selected time and window indexes. Snapshot getters must stay below their budget, and repeated quota values must not add historical rows.
+
+Importer tests cover append-only growth, incomplete trailing lines, truncation, replacement with the same path, fingerprint mismatch, parser-version changes, fork repair, archived moves, transaction rollback, and a full-rebuild fallback that produces exactly the same derived rows as a clean import.
+
+Memory tests browse 1,000 conversation details and verify both LRU limits. Long-running tests hide both windows for ten minutes and record query count, scheduler wakeups, CPU, and resident-memory stability.
+
+Final verification runs frontend tests, ESLint, the production frontend build, Rust tests, targeted Clippy checks for changed modules, SQLite integrity checks, query-plan assertions, a local macOS release build, and the Windows release build in CI. Existing unrelated whole-repository formatting and Clippy debt is not mixed into this work.
+
+## Out of scope
+
+This design does not keep a persistent app-server process, add an external telemetry service, cache the complete event history, or run an automatic full database vacuum. It also does not redesign dashboard visuals. Unrelated correctness and release-pipeline findings from the broader audit remain separate work so they do not delay the refresh and performance fixes.

--- a/docs/superpowers/specs/2026-07-12-auto-quota-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-12-auto-quota-fallback-design.md
@@ -1,0 +1,50 @@
+# Auto refresh quota fallback source precedence
+
+## Context
+
+The application has two refresh paths for online quota data. A manual refresh usually succeeds because it waits for a live app-server request. The background scheduler can occasionally fail that request and ask the live worker for a fallback value.
+
+The fallback loader currently combines in-memory data, persisted `live` samples, and `session` history. It then selects the candidate with the greatest timestamp. That comparison treats an observation from an old session as equivalent to a successful online fetch. A later historical timestamp can therefore replace a valid online value.
+
+## Decision
+
+Fallback selection will respect source precedence before comparing timestamps:
+
+1. A live value already confirmed by the current process remains the preferred value.
+2. If the process has no confirmed live value, use the newest persisted `live` sample.
+3. If no persisted live sample exists, keep an available display fallback.
+4. Use `session` history only when no live value is available.
+
+Timestamp ordering will apply only between values from the same source class. A `session` timestamp will never outrank an online value merely because it is later.
+
+The existing cache field `last_live_success_at` identifies whether the current in-memory value has been produced by a live request in this process. Startup loading will also prefer persisted `live` data before loading `session` history, so the cache does not begin with a historical value when an online value is available.
+
+## Data flow
+
+When a live request fails, `AppLiveQuotaFetcher::fallback` will use the source-prioritized loader. If the cache contains a live value from the current process, the loader returns it without consulting session history. Otherwise it checks the database for `source_kind = 'live'`, then falls back to the existing display value or `source_kind = 'session'` history.
+
+The runtime will continue to mark the live lane as needing refresh after a fallback. This change affects which value is displayed while the retry is pending. It does not suppress retries, change refresh intervals, or turn a fallback into a fresh live success.
+
+## Implementation scope
+
+- Update `src-tauri/src/lib.rs` so automatic fallback loading separates persisted live samples from session history.
+- Update startup fallback selection to use the same source precedence.
+- Keep existing timestamp comparison helpers for candidates that share the same source class.
+- Add regression tests for a later session timestamp failing to replace a current in-memory live value.
+- Add regression coverage showing that persisted live data wins over a newer session record and that session history remains available when no live data exists.
+
+No frontend behavior or database schema changes are required.
+
+## Error handling
+
+If the database cannot be opened, the loader returns the available in-memory value. If no in-memory or persisted live value exists, the loader may return a session fallback as it does today. A fallback never updates the live success timestamp and remains eligible for another live refresh.
+
+## Verification
+
+The implementation will follow a red, green, refactor cycle:
+
+1. Add the regression tests and run them to confirm the current mixed-source selection fails.
+2. Implement the smallest source-priority change.
+3. Run the focused Rust tests, the existing refresh event tests, the full Rust test suite, lint, and the frontend build.
+
+Acceptance requires that a newer session timestamp cannot replace a current live value during a failed background refresh, while the existing historical fallback behavior still works when no live data is available.

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -12,7 +12,7 @@
 
 ## 环境要求
 
-- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.1.2` 暂缓发布 Windows 安装包
+- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.2.0` 暂缓发布 Windows 安装包
 - 本地 Codex 数据位于 `~/.codex` 或自定义 `CODEX_HOME`
 
 如果你要从源码开发，还需要：
@@ -25,8 +25,8 @@
 
 官方公开下载方式均通过 GitHub Releases 提供：
 
-- 已签名的 **macOS Apple Silicon DMG**
-- `v1.1.2` 不附加 Windows 安装包；Windows 文档仅用于源码验证
+- 已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**
+- `v1.2.0` 不附加 Windows 安装包；Windows 文档仅用于源码验证
 
 请先阅读：
 
@@ -106,4 +106,4 @@ npm run tauri build
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [打包与发布](./packaging-and-release.md)
-- [v1.1.2 发布说明](./release-notes-v1.1.2.md)
+- [v1.2.0 发布说明](./release-notes-v1.2.0.md)

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -17,7 +17,7 @@
 
 如果你要从源码开发，还需要：
 
-- Node.js 20+
+- Node.js 22.18+
 - Rust toolchain
 - 当前平台所需的 Tauri 构建依赖
 

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -12,7 +12,7 @@
 
 ## 环境要求
 
-- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.2.0` 暂缓发布 Windows 安装包
+- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.2.2` 暂缓发布 Windows 安装包
 - 本地 Codex 数据位于 `~/.codex` 或自定义 `CODEX_HOME`
 
 如果你要从源码开发，还需要：
@@ -26,7 +26,7 @@
 官方公开下载方式均通过 GitHub Releases 提供：
 
 - 已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**
-- `v1.2.0` 不附加 Windows 安装包；Windows 文档仅用于源码验证
+- `v1.2.2` 不附加 Windows 安装包；Windows 文档仅用于源码验证
 
 请先阅读：
 
@@ -106,4 +106,4 @@ npm run tauri build
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [打包与发布](./packaging-and-release.md)
-- [v1.2.0 发布说明](./release-notes-v1.2.0.md)
+- [v1.2.2 发布说明](./release-notes-v1.2.2.md)

--- a/docs/zh-CN/installing-on-macos.md
+++ b/docs/zh-CN/installing-on-macos.md
@@ -2,7 +2,7 @@
 
 ## macOS 安装路径
 
-**Codex Pacer** 的 macOS 公开安装包，是通过 GitHub Releases 发布的、已签名的 **Apple Silicon DMG**。
+**Codex Pacer** 的 macOS 公开安装包，是通过 GitHub Releases 发布的、已签名并完成 Apple notarization 的 **Apple Silicon DMG**。
 
 ## 标准安装流程
 

--- a/docs/zh-CN/installing-on-windows.md
+++ b/docs/zh-CN/installing-on-windows.md
@@ -2,7 +2,7 @@
 
 ## Windows 测试阶段状态
 
-`v1.1.2` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
+`v1.2.0` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
 
 Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windows 安装包，除非该版本单独配置了 Windows code signing，否则安装包默认未签名，Windows SmartScreen 可能会提示发布者未知。
 
@@ -12,7 +12,7 @@ Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windo
 2. 安装 Windows Tauri 前置依赖。
 3. 运行 `npm ci`。
 4. 运行 `npm run lint`、`npm run build` 和 `cargo test --manifest-path src-tauri/Cargo.toml --locked`。
-5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.1.2`。
+5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.2.0`。
 
 ## 安装后
 
@@ -27,7 +27,7 @@ Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windo
 ## 说明
 
 - GitHub Releases 是官方分发渠道。
-- `v1.1.2` 只发布 macOS Apple Silicon DMG 资产。
+- `v1.2.0` 只发布 macOS Apple Silicon DMG 资产。
 - 任何本地构建的 Windows setup `.exe` 仍是测试阶段的 NSIS 安装包。
 - Windows 安装包不会安装 Codex CLI，也不会创建 Codex 使用历史。
 - Windows 稳定支持、Windows code signing 和自动更新交付目前都不承诺。

--- a/docs/zh-CN/installing-on-windows.md
+++ b/docs/zh-CN/installing-on-windows.md
@@ -2,7 +2,7 @@
 
 ## Windows 测试阶段状态
 
-`v1.2.0` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
+`v1.2.2` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
 
 Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windows 安装包，除非该版本单独配置了 Windows code signing，否则安装包默认未签名，Windows SmartScreen 可能会提示发布者未知。
 
@@ -12,7 +12,7 @@ Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windo
 2. 安装 Windows Tauri 前置依赖。
 3. 运行 `npm ci`。
 4. 运行 `npm run lint`、`npm run build` 和 `cargo test --manifest-path src-tauri/Cargo.toml --locked`。
-5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.2.0`。
+5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.2.2`。
 
 ## 安装后
 
@@ -27,7 +27,7 @@ Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windo
 ## 说明
 
 - GitHub Releases 是官方分发渠道。
-- `v1.2.0` 只发布 macOS Apple Silicon DMG 资产。
+- `v1.2.2` 只发布 macOS Apple Silicon DMG 资产。
 - 任何本地构建的 Windows setup `.exe` 仍是测试阶段的 NSIS 安装包。
 - Windows 安装包不会安装 Codex CLI，也不会创建 Codex 使用历史。
 - Windows 稳定支持、Windows code signing 和自动更新交付目前都不承诺。

--- a/docs/zh-CN/packaging-and-release.md
+++ b/docs/zh-CN/packaging-and-release.md
@@ -6,9 +6,9 @@
 
 当前稳定公开打包资产为：
 
-- 已签名的 **macOS Apple Silicon DMG**
+- 已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**
 
-`v1.1.2` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
+`v1.2.0` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
 
 - 未签名的 **Windows NSIS setup EXE**，仅用于本地兼容性测试和早期验证
 
@@ -28,8 +28,8 @@
 当前面向公开发布的目标流程是：
 
 1. 确认公开品牌文案和文档已经准备完成。
-2. 构建已签名的 macOS Apple Silicon DMG。
-3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.1.2` 不发布 Windows 安装包。
+2. 构建并完成 macOS Apple Silicon DMG 的 notarization 与 staple。
+3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.2.0` 不发布 Windows 安装包。
 4. 通过 GitHub Releases 发布这些安装资产。
 5. 附上对应版本的发布说明。
 
@@ -39,15 +39,15 @@
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.2
-./scripts/release/publish-github-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.0
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
-这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.1.2` 不上传 Windows EXE 资产。
+这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，提交 Apple notarization，执行 staple，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.2.0` 不上传 Windows EXE 资产。
 
 ## 平台隔离规则
 
@@ -76,8 +76,8 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 
 - 为稳定版本创建 Git tag
 - 基于该 tag 创建 GitHub Release
-- 上传已签名的 Apple Silicon DMG
-- `v1.1.2` 不上传 Windows NSIS setup EXE
+- 上传已签名、完成 notarization 并已 staple 的 Apple Silicon DMG
+- `v1.2.0` 不上传 Windows NSIS setup EXE
 - 附上该版本对应的发布说明
 - 发布后再次验证下载与安装流程
 
@@ -88,9 +88,9 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 面向外部文档和公告时，请保持以下表述一致：
 
 - 官方分发渠道：GitHub Releases
-- 稳定发布资产：已签名的 macOS Apple Silicon DMG
-- Windows 安装包：`v1.1.2` 暂缓发布
-- 当前稳定版本线：`v1.1.2`
+- 稳定发布资产：已签名并完成 Apple notarization 的 macOS Apple Silicon DMG
+- Windows 安装包：`v1.2.0` 暂缓发布
+- 当前稳定版本线：`v1.2.0`
 
 ## 相关文档
 
@@ -98,4 +98,4 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [发布 Runbook](./release-runbook.md)
-- [v1.1.2 发布说明](./release-notes-v1.1.2.md)
+- [v1.2.0 发布说明](./release-notes-v1.2.0.md)

--- a/docs/zh-CN/packaging-and-release.md
+++ b/docs/zh-CN/packaging-and-release.md
@@ -8,7 +8,7 @@
 
 - 已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**
 
-`v1.2.0` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
+`v1.2.2` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
 
 - 未签名的 **Windows NSIS setup EXE**，仅用于本地兼容性测试和早期验证
 
@@ -29,7 +29,7 @@
 
 1. 确认公开品牌文案和文档已经准备完成。
 2. 构建并完成 macOS Apple Silicon DMG 的 notarization 与 staple。
-3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.2.0` 不发布 Windows 安装包。
+3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.2.2` 不发布 Windows 安装包。
 4. 通过 GitHub Releases 发布这些安装资产。
 5. 附上对应版本的发布说明。
 
@@ -39,15 +39,15 @@
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.2.0
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
-这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，提交 Apple notarization，执行 staple，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.2.0` 不上传 Windows EXE 资产。
+这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，提交 Apple notarization，执行 staple，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.2.2` 不上传 Windows EXE 资产。
 
 ## 平台隔离规则
 
@@ -77,7 +77,7 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 - 为稳定版本创建 Git tag
 - 基于该 tag 创建 GitHub Release
 - 上传已签名、完成 notarization 并已 staple 的 Apple Silicon DMG
-- `v1.2.0` 不上传 Windows NSIS setup EXE
+- `v1.2.2` 不上传 Windows NSIS setup EXE
 - 附上该版本对应的发布说明
 - 发布后再次验证下载与安装流程
 
@@ -89,8 +89,8 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 
 - 官方分发渠道：GitHub Releases
 - 稳定发布资产：已签名并完成 Apple notarization 的 macOS Apple Silicon DMG
-- Windows 安装包：`v1.2.0` 暂缓发布
-- 当前稳定版本线：`v1.2.0`
+- Windows 安装包：`v1.2.2` 暂缓发布
+- 当前稳定版本线：`v1.2.2`
 
 ## 相关文档
 
@@ -98,4 +98,4 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [发布 Runbook](./release-runbook.md)
-- [v1.2.0 发布说明](./release-notes-v1.2.0.md)
+- [v1.2.2 发布说明](./release-notes-v1.2.2.md)

--- a/docs/zh-CN/release-notes-v1.2.0.md
+++ b/docs/zh-CN/release-notes-v1.2.0.md
@@ -1,0 +1,41 @@
+# Codex Pacer v1.2.0
+
+## 概要
+
+1.2.0 主要改善后台刷新稳定性和资源占用。token 统计与在线额度现在由独立 worker 刷新：本地扫描变慢时不会阻塞在线额度，请求在线额度时也不会延迟 token 导入。
+
+导入器现在只读取增长中 session 文件已经写完整的尾部内容。usage 与 quota 历史改为原位追加或校正，不再反复重建未变化的数据。菜单栏数值直接通过 SQLite 聚合计算，渲染时不必把大量历史记录加载到内存。
+
+## 本次更新
+
+- 新增 GPT-5.6 Sol、Terra 和 Luna 识别及内置 Standard API 等价值 pricing
+- macOS 可以自动发现 ChatGPT 桌面应用内置的 Codex CLI
+- token 与在线额度分别调度刷新、重试和 freshness 状态
+- 前端不再轮询刷新状态，改为接收后端事件
+- 增长中的 JSONL session 文件使用持久化解析检查点
+- 减少 usage 与 quota 历史的数据库重复写入
+- 时间戳迁移改为小批量、可续跑的后台任务
+- 修复 fork 和嵌套 fork 的 token 归属，包括单快照和父文件暂时不可用的情况
+- 修复旧刷新结果覆盖新结果、listener 启动竞态、退出竞态和重试丢失
+- 修复 JSONL 最后一条记录完整但没有换行符时被永久跳过的问题
+- 减少 macOS 刷新后的临时内存滞留和 spool 文件体积
+
+## 从 1.1.1 或 1.1.2 升级
+
+直接覆盖安装 1.2.0 即可，不需要先卸载旧版本，也不要删除旧数据库。
+
+Codex Pacer 的应用名称、bundle identifier 和本地数据位置保持不变。首次启动时，应用会在原数据库上增加新字段和索引。已有 conversation、token usage、quota 样本、订阅设置、菜单栏偏好和自定义 Codex 路径都会保留。
+
+旧记录的时间戳会由一个小批量、可续跑的后台任务补齐。这个任务运行期间，token 与在线额度仍会分别刷新。兼容性测试使用 1.1.1 和 1.1.2 的原始 schema 建库并写入用户数据，再升级到 1.2.0，检查保存值和数据库完整性。
+
+## 性能验证
+
+release 构建的本地重启测试中，没有再出现此前启动和每次刷新约 53 MiB 的写入突发。清空开发缓存后启动 75 秒（包含一次后台刷新）共写入 1.68 MiB。四分钟采样平均占用约 1.53% 单核 CPU，读取 0.18 MiB、写入 5.30 MiB；刷新结束后的物理内存回落到约 136–142 MiB。
+
+这些数字来自本次 release 测试机器和数据集，实际结果会随 session 历史和刷新活动变化。
+
+## 发布形式
+
+公开 macOS 资产是通过 GitHub Releases 分发的 Apple Silicon DMG，并附带 SHA-256 checksum。发布前会完成 Developer ID 签名、Apple notarization、staple 和 Gatekeeper 检查。
+
+本版本仍暂缓发布 Windows 安装包。

--- a/docs/zh-CN/release-notes-v1.2.2.md
+++ b/docs/zh-CN/release-notes-v1.2.2.md
@@ -1,0 +1,38 @@
+# Codex Pacer v1.2.2
+
+## 概要
+
+1.2.2 修复了大型 Codex 历史记录下反复大量读取磁盘的问题。常规的一分钟自动刷新现在只检查 active、发生变化或等待修复的少量文件，不再遍历全部 archive。Dashboard 与额度查询只读取所选窗口，对话历史也改为分页加载。
+
+这个版本同时适配不再提供 5 小时额度的 Codex 账号。程序默认打开 7 天视图，保留 7 天额度，并用同一个 7 天窗口计算菜单栏的 API 等价值。
+
+## 本次更新
+
+- 默认打开当前 7 天窗口
+- 没有 5 小时额度时仍正常显示 7 天额度
+- 菜单栏 API 等价值自动改用当前 7 天窗口
+- 常规扫描使用增量发现和持久化解析检查点
+- archived session 改由受限的维护任务校正，不再每次自动刷新都遍历
+- 额度趋势只查询精确的归一化窗口，并在每个图表时间段保留一个点
+- overview 数据使用缓存，并在 usage、quota 或订阅设置变化时立即失效
+- 对话列表使用 SQL 分页，选中对话后才读取 turn 详情
+- 移除切换视图和搜索条件时的重复 dashboard 读取
+- 没有 import state 的 pending repair 文件也会被直接重试
+
+## 资源验证
+
+测试时把自动扫描间隔设为一分钟。连续 30 分钟采样中，Codex Pacer 共读取 34.41 MiB，平均占用约 0.14% 单核 CPU，trace 中没有再次出现周期性全量 archive 扫描。另一次对打包应用进行的 130 秒 smoke test 在启动后记录到 4 KiB 读取。
+
+这些数字来自发布测试机器及其本地 Codex 历史。实际结果会受 active session、数据库大小和定期校正任务影响。
+
+## 从 1.2.0 升级
+
+直接覆盖安装 1.2.2 即可。不要卸载旧版本，也不要删除本地数据库。
+
+应用名称、bundle identifier 和数据位置保持不变。已有 conversation、token usage、quota 样本、订阅设置、菜单栏偏好和自定义 Codex 路径都会保留。
+
+## 发布形式
+
+公开 macOS 资产是通过 GitHub Releases 分发的 Apple Silicon DMG，并附带 SHA-256 checksum。发布前会完成 Developer ID 签名、Apple notarization、staple 和 Gatekeeper 检查。
+
+本版本仍暂缓发布 Windows 安装包。

--- a/docs/zh-CN/release-runbook.md
+++ b/docs/zh-CN/release-runbook.md
@@ -4,22 +4,22 @@
 
 本文面向维护者，说明如何生成 **Codex Pacer** 的公开发布资产：
 
-- 已签名的 Apple Silicon DMG
-- Windows 兼容性检查，且 `v1.1.2` 暂缓发布 Windows 安装包
+- 已签名、完成 notarization 并已 staple 的 Apple Silicon DMG
+- Windows 兼容性检查，且 `v1.2.0` 暂缓发布 Windows 安装包
 - 通过 GitHub Releases 分发
 
 本地发布入口：
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
-macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.2` 上传 DMG 与 checksum。`v1.1.2` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
+macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.0` 上传 DMG 与 checksum。`v1.2.0` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
 
 ## macOS 发布要求
 
@@ -44,7 +44,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 ## macOS 构建
 
 ```bash
-./scripts/release/build-macos-release.sh 1.1.2
+./scripts/release/build-macos-release.sh 1.2.0
 ```
 
 脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，构建 app/dmg，执行 codesign，并写入 `<artifact>.dmg.sha256`。如果配置了 notarization 凭据，脚本还会执行 notarytool、stapling、Gatekeeper 与 stapler 校验；如果未配置，则跳过这些 notarization 专属步骤。
@@ -52,7 +52,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 ## Windows 构建
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.1.2
+.\scripts\release\build-windows-release.ps1 1.2.0
 ```
 
 脚本会校验版本，运行 `npm ci`、lint、前端构建和 Rust 测试，执行 `npm run tauri build -- --ci --bundles nsis -- --locked`，定位生成的 NSIS setup `.exe`，并写入 `<installer>.exe.sha256`。
@@ -98,7 +98,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.1.
 10. 刷新 live quota 数据，确认不会弹出黑色命令行窗口。
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.1.2_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.0_x64-setup.exe"
 ```
 
 ## 相关文档

--- a/docs/zh-CN/release-runbook.md
+++ b/docs/zh-CN/release-runbook.md
@@ -5,21 +5,21 @@
 本文面向维护者，说明如何生成 **Codex Pacer** 的公开发布资产：
 
 - 已签名、完成 notarization 并已 staple 的 Apple Silicon DMG
-- Windows 兼容性检查，且 `v1.2.0` 暂缓发布 Windows 安装包
+- Windows 兼容性检查，且 `v1.2.2` 暂缓发布 Windows 安装包
 - 通过 GitHub Releases 分发
 
 本地发布入口：
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
-macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.0` 上传 DMG 与 checksum。`v1.2.0` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
+macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.2` 上传 DMG 与 checksum。`v1.2.2` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
 
 ## macOS 发布要求
 
@@ -44,7 +44,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.
 ## macOS 构建
 
 ```bash
-./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
 ```
 
 脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，构建 app/dmg，执行 codesign，并写入 `<artifact>.dmg.sha256`。如果配置了 notarization 凭据，脚本还会执行 notarytool、stapling、Gatekeeper 与 stapler 校验；如果未配置，则跳过这些 notarization 专属步骤。
@@ -52,7 +52,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.
 ## Windows 构建
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
 脚本会校验版本，运行 `npm ci`、lint、前端构建和 Rust 测试，执行 `npm run tauri build -- --ci --bundles nsis -- --locked`，定位生成的 NSIS setup `.exe`，并写入 `<installer>.exe.sha256`。
@@ -98,7 +98,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.
 10. 刷新 live quota 数据，确认不会弹出黑色命令行窗口。
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.0_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.2_x64-setup.exe"
 ```
 
 ## 相关文档

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-pacer",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-pacer",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,13 +36,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -61,21 +61,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -92,14 +92,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -109,14 +109,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -136,29 +136,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -198,27 +198,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -228,33 +228,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -262,35 +262,35 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -569,26 +569,28 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -632,9 +634,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -649,9 +651,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -666,9 +668,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -683,9 +685,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -700,9 +702,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
-      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -717,9 +719,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -734,9 +736,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
-      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -751,9 +753,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -768,9 +770,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -785,9 +787,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -802,9 +804,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
-      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -819,9 +821,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -836,9 +838,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
-      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -846,16 +848,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
-      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -870,9 +874,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
-      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -1133,9 +1137,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1455,9 +1459,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1648,9 +1652,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1661,9 +1665,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1672,9 +1676,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -1692,11 +1696,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1716,9 +1720,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true,
       "funding": [
         {
@@ -1991,9 +1995,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2482,10 +2486,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2889,9 +2903,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -2915,11 +2929,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3012,9 +3029,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3025,9 +3042,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -3045,7 +3062,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3186,14 +3203,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
-      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.11"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3202,27 +3219,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
-      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3308,14 +3325,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3476,17 +3493,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
-      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.11",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3502,8 +3519,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-pacer",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-pacer",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "npm run test:issue-1 && npm run test:issue-3",
+    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness",
     "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
     "test:issue-3": "node scripts/test-issue-3-custom-range.mjs",
+    "test:data-freshness": "node scripts/test-data-freshness.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness && npm run test:settings-save",
+    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness && npm run test:refresh-events && npm run test:settings-save",
     "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
     "test:issue-3": "node scripts/test-issue-3-custom-range.mjs",
     "test:data-freshness": "node --experimental-strip-types scripts/test-data-freshness.mjs",
+    "test:refresh-events": "node --experimental-strip-types scripts/test-refresh-events.mjs",
     "test:settings-save": "node --experimental-strip-types scripts/test-settings-save.mjs",
     "preview": "vite preview",
     "tauri": "tauri"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-pacer",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.2.0",
   "type": "module",
   "engines": {
     "node": ">=22.18.0"

--- a/package.json
+++ b/package.json
@@ -3,14 +3,18 @@
   "private": true,
   "version": "1.1.2",
   "type": "module",
+  "engines": {
+    "node": ">=22.18.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness",
+    "test": "npm run test:issue-1 && npm run test:issue-3 && npm run test:data-freshness && npm run test:settings-save",
     "test:issue-1": "node scripts/test-issue-1-view-controls.mjs",
     "test:issue-3": "node scripts/test-issue-3-custom-range.mjs",
-    "test:data-freshness": "node scripts/test-data-freshness.mjs",
+    "test:data-freshness": "node --experimental-strip-types scripts/test-data-freshness.mjs",
+    "test:settings-save": "node --experimental-strip-types scripts/test-settings-save.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-pacer",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.2",
   "type": "module",
   "engines": {
     "node": ">=22.18.0"

--- a/scripts/test-data-freshness.mjs
+++ b/scripts/test-data-freshness.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+
+import {
+  shouldKeepConversationDetail,
+  waitForOverlappingScan,
+} from '../src/app/dataFreshness.ts'
+
+const summary = {
+  rootSessionId: 'root-session',
+  updatedAt: '2026-07-10T08:00:00Z',
+  apiValueUsd: 12.5,
+  subscriptionShare: 0.125,
+}
+
+const cachedDetail = {
+  rootSessionId: 'root-session',
+  updatedAt: summary.updatedAt,
+  apiValueUsd: summary.apiValueUsd,
+  subscriptionShare: summary.apiValueUsd / 100,
+}
+
+assert.equal(
+  shouldKeepConversationDetail(
+    { ...cachedDetail, updatedAt: '2026-07-10T07:59:59Z' },
+    summary,
+    100,
+  ),
+  false,
+  'detail cache should reject an older conversation timestamp',
+)
+
+assert.equal(
+  shouldKeepConversationDetail(
+    { ...cachedDetail, apiValueUsd: summary.apiValueUsd - 0.5 },
+    summary,
+    100,
+  ),
+  false,
+  'detail cache should reject a stale API value',
+)
+
+assert.equal(
+  shouldKeepConversationDetail(cachedDetail, summary, 200),
+  false,
+  'detail cache should reject subscription share derived from an older monthly price',
+)
+
+assert.equal(
+  shouldKeepConversationDetail(
+    {
+      ...cachedDetail,
+      apiValueUsd: summary.apiValueUsd + 1e-10,
+      subscriptionShare: summary.apiValueUsd / 100 + 1e-10,
+    },
+    summary,
+    100,
+  ),
+  true,
+  'detail cache should retain matching derived values within floating-point tolerance',
+)
+
+let scanChecks = 0
+let settleWaits = 0
+await waitForOverlappingScan(
+  async () => {
+    scanChecks += 1
+    return true
+  },
+  async () => {
+    settleWaits += 1
+  },
+)
+
+assert.equal(scanChecks, 1, 'overlapping refresh should check scan state once')
+assert.equal(settleWaits, 1, 'overlapping refresh should wait once for an active scan')
+
+settleWaits = 0
+await waitForOverlappingScan(
+  async () => false,
+  async () => {
+    settleWaits += 1
+  },
+)
+
+assert.equal(settleWaits, 0, 'refresh should not wait when no scan is active')

--- a/scripts/test-data-freshness.mjs
+++ b/scripts/test-data-freshness.mjs
@@ -5,11 +5,8 @@ import { fileURLToPath } from 'node:url'
 
 import {
   loadConversationDetailForGeneration,
-  refreshDashboardAfterBackgroundScan,
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
-  waitForOverlappingScan,
-  waitForScanToSettleUntilCancelled,
 } from '../src/app/dataFreshness.ts'
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
@@ -155,42 +152,6 @@ assert.equal(
   'detail cache should retain matching derived values within floating-point tolerance',
 )
 
-let scanChecks = 0
-let settleWaits = 0
-const settledAfterOverlap = await waitForOverlappingScan(
-  async () => {
-    scanChecks += 1
-    return true
-  },
-  async () => {
-    settleWaits += 1
-    return true
-  },
-)
-
-assert.equal(scanChecks, 1, 'overlapping refresh should check scan state once')
-assert.equal(settleWaits, 1, 'overlapping refresh should wait once for an active scan')
-assert.equal(settledAfterOverlap, true, 'overlapping refresh should report a settled scan')
-
-const timedOutAfterOverlap = await waitForOverlappingScan(
-  async () => true,
-  async () => false,
-)
-
-assert.equal(timedOutAfterOverlap, false, 'overlapping refresh should report a settle timeout')
-
-settleWaits = 0
-const settledWithoutOverlap = await waitForOverlappingScan(
-  async () => false,
-  async () => {
-    settleWaits += 1
-    return true
-  },
-)
-
-assert.equal(settleWaits, 0, 'refresh should not wait when no scan is active')
-assert.equal(settledWithoutOverlap, true, 'refresh should be ready when no scan is active')
-
 let scanAttempts = 0
 let overlapNotices = 0
 const retriedScan = await runScanWithOverlapRetry(
@@ -226,99 +187,3 @@ await assert.rejects(
   'source switch should fail instead of reading the dashboard after a settle timeout',
 )
 assert.equal(scanAttempts, 1, 'source switch should not retry while the old scan is still active')
-
-let dashboardLoads = 0
-await refreshDashboardAfterBackgroundScan(
-  async () => {
-    throw new Error('background refresh failed')
-  },
-  async () => false,
-  async () => true,
-  async () => {
-    dashboardLoads += 1
-  },
-)
-assert.equal(dashboardLoads, 1, 'background refresh errors should still allow a current dashboard load')
-
-dashboardLoads = 0
-await refreshDashboardAfterBackgroundScan(
-  async () => null,
-  async () => true,
-  async () => false,
-  async () => {
-    dashboardLoads += 1
-  },
-)
-assert.equal(dashboardLoads, 0, 'a settle timeout should skip the current background dashboard load')
-
-let cancelled = false
-let releaseWait
-let markWaitStarted
-const waitStarted = new Promise((resolve) => {
-  markWaitStarted = resolve
-})
-const pendingRefresh = refreshDashboardAfterBackgroundScan(
-  async () => null,
-  async () => true,
-  async () => {
-    markWaitStarted()
-    return new Promise((resolve) => {
-      releaseWait = resolve
-    })
-  },
-  async () => {
-    dashboardLoads += 1
-  },
-  () => cancelled,
-)
-
-await waitStarted
-cancelled = true
-releaseWait(true)
-await pendingRefresh
-assert.equal(dashboardLoads, 0, 'effect cleanup should cancel a refresh that was waiting on a scan')
-
-await refreshDashboardAfterBackgroundScan(
-  async () => null,
-  async () => {
-    throw new Error('scan state unavailable')
-  },
-  async () => true,
-  async () => {
-    dashboardLoads += 1
-  },
-)
-assert.equal(dashboardLoads, 0, 'scan-state errors should not load or reject the interval task')
-
-await refreshDashboardAfterBackgroundScan(
-  async () => null,
-  async () => true,
-  async () => {
-    throw new Error('settle state unavailable')
-  },
-  async () => {
-    dashboardLoads += 1
-  },
-)
-assert.equal(dashboardLoads, 0, 'settle errors should not load or reject the interval task')
-
-let bootstrapWaits = 0
-const bootstrapSettled = await waitForScanToSettleUntilCancelled(
-  async () => {
-    bootstrapWaits += 1
-    return bootstrapWaits > 1
-  },
-  () => false,
-)
-assert.equal(bootstrapSettled, true, 'bootstrap should keep waiting after one settle timeout')
-assert.equal(bootstrapWaits, 2, 'bootstrap should retry its settle wait after a timeout')
-
-let bootstrapCancelled = false
-const cancelledBootstrapSettled = await waitForScanToSettleUntilCancelled(
-  async () => {
-    bootstrapCancelled = true
-    return false
-  },
-  () => bootstrapCancelled,
-)
-assert.equal(cancelledBootstrapSettled, false, 'bootstrap should stop retrying after cleanup')

--- a/scripts/test-data-freshness.mjs
+++ b/scripts/test-data-freshness.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
+  loadConversationDetailForGeneration,
   refreshDashboardAfterBackgroundScan,
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
@@ -8,18 +12,107 @@ import {
   waitForScanToSettleUntilCancelled,
 } from '../src/app/dataFreshness.ts'
 
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
+
 const summary = {
   rootSessionId: 'root-session',
+  title: 'Current title',
+  startedAt: '2026-07-10T07:00:00Z',
   updatedAt: '2026-07-10T08:00:00Z',
+  modelIds: ['gpt-5.6-sol', 'gpt-5.6-terra'],
+  inputTokens: 100,
+  cachedInputTokens: 20,
+  outputTokens: 25,
+  reasoningOutputTokens: 5,
+  totalTokens: 125,
+  sessionCount: 2,
+  subagentCount: 1,
+  hasFastMode: true,
   apiValueUsd: 12.5,
   subscriptionShare: 0.125,
+  sourceStates: ['active', 'archived'],
 }
 
 const cachedDetail = {
   rootSessionId: 'root-session',
+  title: summary.title,
+  startedAt: summary.startedAt,
   updatedAt: summary.updatedAt,
+  inputTokens: summary.inputTokens,
+  cachedInputTokens: summary.cachedInputTokens,
+  outputTokens: summary.outputTokens,
+  reasoningOutputTokens: summary.reasoningOutputTokens,
+  totalTokens: summary.totalTokens,
   apiValueUsd: summary.apiValueUsd,
   subscriptionShare: summary.apiValueUsd / 100,
+  multipleAgent: true,
+  sourceStates: ['archived', 'active'],
+  sessions: [
+    { isSubagent: false, fastModeEffective: false },
+    { isSubagent: true, fastModeEffective: true },
+  ],
+  modelBreakdown: [
+    { modelId: 'gpt-5.6-terra' },
+    { modelId: 'gpt-5.6-sol' },
+  ],
+}
+
+assert.equal(
+  shouldKeepConversationDetail(cachedDetail, summary, 100),
+  true,
+  'detail cache should retain a detail whose user-visible summary fields still match',
+)
+
+let detailGeneration = 1
+let releaseStaleDetail
+const staleDetailRequest = loadConversationDetailForGeneration(
+  () =>
+    new Promise((resolve) => {
+      releaseStaleDetail = resolve
+    }),
+  detailGeneration,
+  () => detailGeneration,
+)
+detailGeneration += 1
+releaseStaleDetail({ title: 'Stale title' })
+assert.equal(
+  await staleDetailRequest,
+  null,
+  'a detail response from before dashboard cache reconciliation should be discarded',
+)
+assert.match(
+  appSource,
+  /latestDetailRequestIdRef\.current \+= 1[\s\S]*detailCacheRef\.current = nextDetailCache/,
+  'dashboard reconciliation should invalidate in-flight detail requests before replacing the cache',
+)
+assert.match(
+  appSource,
+  /setDetail\(\(current\)[\s\S]*nextDetailCache\.get\(current\.rootSessionId\)[\s\S]*\? current : null/,
+  'dashboard reconciliation should stop showing a detail that was evicted from the cache',
+)
+
+for (const [label, changedSummary] of [
+  ['root session', { ...summary, rootSessionId: 'different-root' }],
+  ['title', { ...summary, title: 'Updated title' }],
+  ['start timestamp', { ...summary, startedAt: '2026-07-10T07:00:01Z' }],
+  ['model list', { ...summary, modelIds: ['gpt-5.6-sol'] }],
+  ['input tokens', { ...summary, inputTokens: summary.inputTokens + 1 }],
+  ['cached input tokens', { ...summary, cachedInputTokens: summary.cachedInputTokens + 1 }],
+  ['output tokens', { ...summary, outputTokens: summary.outputTokens + 1 }],
+  ['reasoning tokens', { ...summary, reasoningOutputTokens: summary.reasoningOutputTokens + 1 }],
+  ['total tokens', { ...summary, totalTokens: summary.totalTokens + 1 }],
+  ['session count', { ...summary, sessionCount: summary.sessionCount + 1 }],
+  ['subagent count', { ...summary, subagentCount: 0 }],
+  ['fast-mode state', { ...summary, hasFastMode: false }],
+  ['subscription share', { ...summary, subscriptionShare: summary.subscriptionShare + 0.01 }],
+  ['source state', { ...summary, sourceStates: ['archived'] }],
+]) {
+  assert.equal(
+    shouldKeepConversationDetail(cachedDetail, changedSummary, 100),
+    false,
+    `detail cache should reject a stale ${label}`,
+  )
 }
 
 assert.equal(

--- a/scripts/test-data-freshness.mjs
+++ b/scripts/test-data-freshness.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict'
 
 import {
+  refreshDashboardAfterBackgroundScan,
+  runScanWithOverlapRetry,
   shouldKeepConversationDetail,
   waitForOverlappingScan,
+  waitForScanToSettleUntilCancelled,
 } from '../src/app/dataFreshness.ts'
 
 const summary = {
@@ -61,25 +64,168 @@ assert.equal(
 
 let scanChecks = 0
 let settleWaits = 0
-await waitForOverlappingScan(
+const settledAfterOverlap = await waitForOverlappingScan(
   async () => {
     scanChecks += 1
     return true
   },
   async () => {
     settleWaits += 1
+    return true
   },
 )
 
 assert.equal(scanChecks, 1, 'overlapping refresh should check scan state once')
 assert.equal(settleWaits, 1, 'overlapping refresh should wait once for an active scan')
+assert.equal(settledAfterOverlap, true, 'overlapping refresh should report a settled scan')
+
+const timedOutAfterOverlap = await waitForOverlappingScan(
+  async () => true,
+  async () => false,
+)
+
+assert.equal(timedOutAfterOverlap, false, 'overlapping refresh should report a settle timeout')
 
 settleWaits = 0
-await waitForOverlappingScan(
+const settledWithoutOverlap = await waitForOverlappingScan(
   async () => false,
   async () => {
     settleWaits += 1
+    return true
   },
 )
 
 assert.equal(settleWaits, 0, 'refresh should not wait when no scan is active')
+assert.equal(settledWithoutOverlap, true, 'refresh should be ready when no scan is active')
+
+let scanAttempts = 0
+let overlapNotices = 0
+const retriedScan = await runScanWithOverlapRetry(
+  async () => {
+    scanAttempts += 1
+    if (scanAttempts === 1) {
+      throw new Error('A scan is already running.')
+    }
+    return { codexHome: '/tmp/new-home' }
+  },
+  (error) => String(error).includes('already running'),
+  async () => true,
+  () => {
+    overlapNotices += 1
+  },
+)
+
+assert.deepEqual(retriedScan, { codexHome: '/tmp/new-home' })
+assert.equal(scanAttempts, 2, 'source switch should retry a full scan after the old scan settles')
+assert.equal(overlapNotices, 1, 'source switch should report one overlapping scan')
+
+scanAttempts = 0
+await assert.rejects(
+  runScanWithOverlapRetry(
+    async () => {
+      scanAttempts += 1
+      throw new Error('A scan is already running.')
+    },
+    (error) => String(error).includes('already running'),
+    async () => false,
+  ),
+  /did not finish before the timeout/,
+  'source switch should fail instead of reading the dashboard after a settle timeout',
+)
+assert.equal(scanAttempts, 1, 'source switch should not retry while the old scan is still active')
+
+let dashboardLoads = 0
+await refreshDashboardAfterBackgroundScan(
+  async () => {
+    throw new Error('background refresh failed')
+  },
+  async () => false,
+  async () => true,
+  async () => {
+    dashboardLoads += 1
+  },
+)
+assert.equal(dashboardLoads, 1, 'background refresh errors should still allow a current dashboard load')
+
+dashboardLoads = 0
+await refreshDashboardAfterBackgroundScan(
+  async () => null,
+  async () => true,
+  async () => false,
+  async () => {
+    dashboardLoads += 1
+  },
+)
+assert.equal(dashboardLoads, 0, 'a settle timeout should skip the current background dashboard load')
+
+let cancelled = false
+let releaseWait
+let markWaitStarted
+const waitStarted = new Promise((resolve) => {
+  markWaitStarted = resolve
+})
+const pendingRefresh = refreshDashboardAfterBackgroundScan(
+  async () => null,
+  async () => true,
+  async () => {
+    markWaitStarted()
+    return new Promise((resolve) => {
+      releaseWait = resolve
+    })
+  },
+  async () => {
+    dashboardLoads += 1
+  },
+  () => cancelled,
+)
+
+await waitStarted
+cancelled = true
+releaseWait(true)
+await pendingRefresh
+assert.equal(dashboardLoads, 0, 'effect cleanup should cancel a refresh that was waiting on a scan')
+
+await refreshDashboardAfterBackgroundScan(
+  async () => null,
+  async () => {
+    throw new Error('scan state unavailable')
+  },
+  async () => true,
+  async () => {
+    dashboardLoads += 1
+  },
+)
+assert.equal(dashboardLoads, 0, 'scan-state errors should not load or reject the interval task')
+
+await refreshDashboardAfterBackgroundScan(
+  async () => null,
+  async () => true,
+  async () => {
+    throw new Error('settle state unavailable')
+  },
+  async () => {
+    dashboardLoads += 1
+  },
+)
+assert.equal(dashboardLoads, 0, 'settle errors should not load or reject the interval task')
+
+let bootstrapWaits = 0
+const bootstrapSettled = await waitForScanToSettleUntilCancelled(
+  async () => {
+    bootstrapWaits += 1
+    return bootstrapWaits > 1
+  },
+  () => false,
+)
+assert.equal(bootstrapSettled, true, 'bootstrap should keep waiting after one settle timeout')
+assert.equal(bootstrapWaits, 2, 'bootstrap should retry its settle wait after a timeout')
+
+let bootstrapCancelled = false
+const cancelledBootstrapSettled = await waitForScanToSettleUntilCancelled(
+  async () => {
+    bootstrapCancelled = true
+    return false
+  },
+  () => bootstrapCancelled,
+)
+assert.equal(cancelledBootstrapSettled, false, 'bootstrap should stop retrying after cleanup')

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -320,6 +320,17 @@ test('dashboard_startup_does_not_open_and_parse_the_first_conversation_implicitl
   )
 })
 
+test('conversation_entry_load_does_not_repeat_for_query_changes', () => {
+  assert.match(
+    appSource,
+    /if \(!hasBootstrapped \|\| view !== 'conversations'\) return\s+void loadShellRef\.current\(false\)\s+}, \[hasBootstrapped, view\]\)/,
+  )
+  assert.doesNotMatch(
+    appSource,
+    /if \(!hasBootstrapped \|\| view !== 'conversations'\) return\s+void loadShell\(false\)/,
+  )
+})
+
 test('dashboard_reload_preserves_a_later-page_selection_for_the_same_query', () => {
   assert.equal(
     refreshEvents.selectionAfterDashboardReload('root-page-2', 'seven-day-query', 'seven-day-query'),

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -312,12 +312,20 @@ test('popup_wires_latest_request_controller_and_disables_duplicate_manual_refres
 })
 
 test('dashboard_startup_does_not_open_and_parse_the_first_conversation_implicitly', () => {
-  assert.match(
-    appSource,
-    /setSelectedRootSessionId\(\(current\) =>[\s\S]{0,260}\? current[\s\S]{0,80}: null,/,
-  )
+  assert.equal(refreshEvents.selectionAfterDashboardReload(null, null, 'seven-day-query'), null)
   assert.doesNotMatch(
     appSource,
     /setSelectedRootSessionId\([\s\S]{0,320}conversationPage\.items\[0\]/,
+  )
+})
+
+test('dashboard_reload_preserves_a_later-page_selection_for_the_same_query', () => {
+  assert.equal(
+    refreshEvents.selectionAfterDashboardReload('root-page-2', 'seven-day-query', 'seven-day-query'),
+    'root-page-2',
+  )
+  assert.equal(
+    refreshEvents.selectionAfterDashboardReload('root-page-2', 'seven-day-query', 'month-query'),
+    null,
   )
 })

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -310,3 +310,14 @@ test('popup_wires_latest_request_controller_and_disables_duplicate_manual_refres
     /aria-label=\{t\.popup\.actions\.refresh\}[\s\S]{0,220}disabled=\{refreshing\}/,
   )
 })
+
+test('dashboard_startup_does_not_open_and_parse_the_first_conversation_implicitly', () => {
+  assert.match(
+    appSource,
+    /setSelectedRootSessionId\(\(current\) =>[\s\S]{0,260}\? current[\s\S]{0,80}: null,/,
+  )
+  assert.doesNotMatch(
+    appSource,
+    /setSelectedRootSessionId\([\s\S]{0,320}conversationPage\.items\[0\]/,
+  )
+})

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -4,7 +4,9 @@ import { dirname, join } from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
-import { settleRefreshFailure, SurfaceRevisionGate } from '../src/app/refreshEvents.ts'
+import * as refreshEvents from '../src/app/refreshEvents.ts'
+
+const { settleRefreshFailure, SurfaceRevisionGate } = refreshEvents
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
@@ -24,6 +26,28 @@ function completion(refreshRevision, succeeded = true) {
     failure: succeeded ? null : 'refresh failed',
     completedAt: '2026-07-11T00:00:00Z',
   }
+}
+
+function deferred() {
+  let resolve
+  const promise = new Promise((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+function extractFunction(source, signature) {
+  const signatureStart = source.indexOf(signature)
+  assert.notEqual(signatureStart, -1, `missing function: ${signature}`)
+  const bodyStart = source.indexOf(') {', signatureStart) + 2
+  assert.ok(bodyStart > 1, `missing function body: ${signature}`)
+  let depth = 0
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1
+    if (source[index] === '}') depth -= 1
+    if (depth === 0) return source.slice(signatureStart, index + 1)
+  }
+  assert.fail(`unterminated function: ${signature}`)
 }
 
 test('surface_revision_gate_deduplicates_visible_completions', () => {
@@ -117,9 +141,121 @@ test('frontend_refresh_sources_are_event_driven_without_automatic_polling', () =
 })
 
 test('manual_rescan_waits_for_its_ticket_without_loading_dashboard_twice', () => {
-  const handleRescan = appSource.match(/async function handleRescan\(\) \{([\s\S]*?)\n  \}/)?.[1]
-  assert.ok(handleRescan, 'App should retain the manual rescan handler')
+  const handleRescan = extractFunction(appSource, 'async function handleRescan()')
   assert.match(handleRescan, /scanCodexUsage/)
-  assert.doesNotMatch(handleRescan, /loadShell|loadDashboard/)
   assert.match(handleRescan, /finally[\s\S]*setIsBusy\(false\)/)
+})
+
+test('app_manual_reload_decisions_use_completion_only_when_listener_is_ready', () => {
+  const manualDecision = refreshEvents.shouldLoadDashboardAfterManualRefresh
+  const settingsDecision = refreshEvents.shouldLoadDashboardAfterSettingsSave
+
+  assert.equal(typeof manualDecision, 'function')
+  assert.equal(typeof settingsDecision, 'function')
+  assert.equal(manualDecision(true), false, 'a registered listener owns the manual scan reload')
+  assert.equal(manualDecision(false), true, 'a missing listener requires one post-ticket fallback')
+  assert.equal(settingsDecision(true, true), false, 'a source change with a listener must not read twice')
+  assert.equal(settingsDecision(true, false), true, 'a source change without a listener needs a fallback')
+  assert.equal(settingsDecision(false, true), true, 'a normal settings save still needs an explicit read')
+})
+
+test('app_awaits_listener_readiness_and_does_not_bypass_hidden_source_change_defer', () => {
+  const handleRescan = extractFunction(appSource, 'async function handleRescan()')
+  const handleSaveSettings = extractFunction(appSource, 'async function handleSaveSettings(')
+  const rescanReady = handleRescan.indexOf('await refreshCompletionListenerReadyRef.current')
+  const rescanCommand = handleRescan.indexOf('scanCodexUsage(')
+  const settingsReady = handleSaveSettings.indexOf('await refreshCompletionListenerReadyRef.current')
+  const settingsSave = handleSaveSettings.indexOf('saveSettingsWithCodexHomeRollback(')
+
+  assert.ok(rescanReady >= 0 && rescanReady < rescanCommand)
+  assert.ok(settingsReady >= 0 && settingsReady < settingsSave)
+  assert.match(
+    handleRescan,
+    /shouldLoadDashboardAfterManualRefresh\(listenerReady\)[\s\S]*await loadShell\(true\)/,
+  )
+  assert.match(
+    handleSaveSettings,
+    /shouldLoadDashboardAfterSettingsSave\(saved\.codexHomeChanged, listenerReady\)[\s\S]*await loadShell\(true\)/,
+  )
+  assert.match(appSource, /const completionRegistration = listen<RefreshCompletedEvent>/)
+  assert.match(
+    appSource,
+    /refreshCompletionListenerReadyRef\.current = completionRegistration[\s\S]*\.then\([\s\S]*return true[\s\S]*\.catch\([\s\S]*false/,
+  )
+})
+
+test('surface_request_controller_ignores_an_older_response_that_finishes_last', async () => {
+  const Controller = refreshEvents.SurfaceRequestController
+  assert.equal(typeof Controller, 'function')
+  const controller = new Controller()
+  const older = deferred()
+  const newer = deferred()
+  let displayed = 'initial'
+
+  const load = async (pending) => {
+    const claim = controller.claim('passive')
+    const value = await pending
+    if (controller.isLatest(claim)) displayed = value
+    controller.finish(claim)
+  }
+  const olderLoad = load(older.promise)
+  const newerLoad = load(newer.promise)
+
+  newer.resolve('newer snapshot')
+  await newerLoad
+  older.resolve('older snapshot')
+  await olderLoad
+
+  assert.equal(displayed, 'newer snapshot')
+})
+
+test('surface_request_controller_keeps_manual_spinner_single_flight_and_independent', async () => {
+  const Controller = refreshEvents.SurfaceRequestController
+  assert.equal(typeof Controller, 'function')
+  const controller = new Controller()
+  const manual = deferred()
+  const passive = deferred()
+  let displayed = 'existing snapshot'
+  let refreshing = false
+
+  const load = async (kind, pending) => {
+    const claim = controller.claim(kind)
+    if (claim === null) return false
+    refreshing = controller.manualInFlight
+    try {
+      const value = await pending
+      if (controller.isLatest(claim)) displayed = value
+    } finally {
+      controller.finish(claim)
+      refreshing = controller.manualInFlight
+    }
+    return true
+  }
+
+  const manualLoad = load('manual', manual.promise)
+  await Promise.resolve()
+  assert.equal(refreshing, true)
+  assert.equal(controller.claim('manual'), null, 'a second manual request must be rejected synchronously')
+
+  const passiveLoad = load('passive', passive.promise)
+  passive.resolve('newer passive snapshot')
+  await passiveLoad
+  assert.equal(displayed, 'newer passive snapshot')
+  assert.equal(refreshing, true, 'a passive completion must not clear a manual spinner')
+
+  manual.resolve('older forced snapshot')
+  await manualLoad
+  assert.equal(displayed, 'newer passive snapshot')
+  assert.equal(refreshing, false)
+})
+
+test('popup_wires_latest_request_controller_and_disables_duplicate_manual_refresh', () => {
+  assert.match(popupSource, /useRef\(new SurfaceRequestController\(\)\)/)
+  assert.match(popupSource, /\.claim\(forceRefresh \? 'manual' : 'passive'\)/)
+  assert.match(popupSource, /\.isLatest\(claim\)/)
+  assert.match(popupSource, /\.finish\(claim\)/)
+  assert.match(
+    popupSource,
+    /aria-label=\{t\.popup\.actions\.refresh\}[\s\S]{0,220}disabled=\{refreshing\}/,
+  )
 })

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { settleRefreshFailure, SurfaceRevisionGate } from '../src/app/refreshEvents.ts'
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
+const popupSource = readFileSync(join(repoRoot, 'src/menu-bar-popup/MenuBarPopup.tsx'), 'utf8')
+const apiSource = readFileSync(join(repoRoot, 'src/app/api.ts'), 'utf8')
+const dataFreshnessSource = readFileSync(join(repoRoot, 'src/app/dataFreshness.ts'), 'utf8')
+
+function completion(refreshRevision, succeeded = true) {
+  return {
+    refreshRevision,
+    lane: 'token',
+    generation: refreshRevision,
+    usageRevision: refreshRevision,
+    quotaRevision: 0,
+    sourceGeneration: 1,
+    succeeded,
+    failure: succeeded ? null : 'refresh failed',
+    completedAt: '2026-07-11T00:00:00Z',
+  }
+}
+
+test('surface_revision_gate_deduplicates_visible_completions', () => {
+  const gate = new SurfaceRevisionGate()
+
+  assert.equal(gate.accept(completion(1), true), 'reload')
+  assert.equal(gate.accept(completion(1), true), 'ignore')
+})
+
+test('surface_revision_gate_keeps_only_latest_hidden_revision_until_visible', () => {
+  const gate = new SurfaceRevisionGate()
+
+  assert.equal(gate.accept(completion(1), true), 'reload')
+  assert.equal(gate.accept(completion(2), false), 'defer')
+  assert.equal(gate.accept(completion(3), false), 'defer')
+  assert.equal(gate.onVisible(), 'reload')
+  assert.equal(gate.onVisible(), 'ignore')
+})
+
+test('failed_completion_does_not_reload_data', () => {
+  const gate = new SurfaceRevisionGate()
+  const previousData = Object.freeze({ cards: ['existing-card'], sourceTimestamp: '2026-07-10T00:00:00Z' })
+  const currentSurface = { data: previousData, reloads: 0 }
+
+  const decision = gate.accept(completion(1, false), true)
+  const nextSurface =
+    decision === 'reload'
+      ? { data: { cards: ['replacement-card'], sourceTimestamp: null }, reloads: 1 }
+      : currentSurface
+
+  assert.equal(decision, 'ignore')
+  assert.strictEqual(nextSurface.data, previousData)
+  assert.equal(nextSurface.reloads, 0)
+})
+
+test('manual_waiter_failure_clears_refreshing_and_keeps_previous_data', () => {
+  const previousData = Object.freeze({ cards: ['existing-card'], sourceTimestamp: '2026-07-10T00:00:00Z' })
+  const failed = settleRefreshFailure(
+    {
+      data: previousData,
+      loading: false,
+      refreshing: true,
+      error: null,
+    },
+    new Error('coordinator ticket failed'),
+  )
+
+  assert.strictEqual(failed.data, previousData)
+  assert.equal(failed.loading, false)
+  assert.equal(failed.refreshing, false)
+  assert.equal(failed.error, null, 'existing cards should remain the display state instead of an error replacement')
+
+  const firstLoadFailure = settleRefreshFailure(
+    {
+      data: null,
+      loading: true,
+      refreshing: false,
+      error: null,
+    },
+    new Error('initial snapshot failed'),
+  )
+  assert.match(firstLoadFailure.error ?? '', /initial snapshot failed/)
+})
+
+test('frontend_refresh_sources_are_event_driven_without_automatic_polling', () => {
+  assert.doesNotMatch(appSource, /setInterval/)
+  assert.doesNotMatch(popupSource, /setInterval/)
+  assert.doesNotMatch(appSource, /refreshBackgroundData/)
+  assert.doesNotMatch(apiSource, /refreshBackgroundData/)
+  assert.doesNotMatch(dataFreshnessSource, /refreshDashboardAfterBackgroundScan/)
+  assert.doesNotMatch(dataFreshnessSource, /waitForScanToSettleUntilCancelled/)
+  assert.doesNotMatch(appSource, /getLiveRateLimits/)
+  assert.doesNotMatch(appSource, /setLoadedQueryKey\(null\)/)
+
+  assert.match(appSource, /codex-counter:\/\/refresh-completed/)
+  assert.match(appSource, /SurfaceRevisionGate/)
+  assert.match(appSource, /getCurrentWindow\(\)\.isVisible\(\)/)
+  assert.match(appSource, /onFocusChanged/)
+  assert.match(appSource, /visibilitychange/)
+
+  assert.equal(
+    popupSource.match(/codex-counter:\/\/menu-bar-popup-refresh/g)?.length,
+    1,
+    'Popup should have one dedicated refresh listener',
+  )
+  assert.match(
+    popupSource,
+    /listen\('codex-counter:\/\/menu-bar-popup-refresh'[\s\S]{0,220}loadSnapshot\(false\)/,
+  )
+  assert.doesNotMatch(popupSource, /codex-counter:\/\/refresh-completed/)
+})
+
+test('manual_rescan_waits_for_its_ticket_without_loading_dashboard_twice', () => {
+  const handleRescan = appSource.match(/async function handleRescan\(\) \{([\s\S]*?)\n  \}/)?.[1]
+  assert.ok(handleRescan, 'App should retain the manual rescan handler')
+  assert.match(handleRescan, /scanCodexUsage/)
+  assert.doesNotMatch(handleRescan, /loadShell|loadDashboard/)
+  assert.match(handleRescan, /finally[\s\S]*setIsBusy\(false\)/)
+})

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -50,6 +50,14 @@ function extractFunction(source, signature) {
   assert.fail(`unterminated function: ${signature}`)
 }
 
+function enclosingEffect(source, needle) {
+  const needleIndex = source.indexOf(needle)
+  assert.notEqual(needleIndex, -1, `missing effect content: ${needle}`)
+  const layoutEffectIndex = source.lastIndexOf('useLayoutEffect(() => {', needleIndex)
+  const passiveEffectIndex = source.lastIndexOf('useEffect(() => {', needleIndex)
+  return layoutEffectIndex > passiveEffectIndex ? 'layout' : 'passive'
+}
+
 test('surface_revision_gate_deduplicates_visible_completions', () => {
   const gate = new SurfaceRevisionGate()
 
@@ -171,17 +179,60 @@ test('app_awaits_listener_readiness_and_does_not_bypass_hidden_source_change_def
   assert.ok(settingsReady >= 0 && settingsReady < settingsSave)
   assert.match(
     handleRescan,
-    /shouldLoadDashboardAfterManualRefresh\(listenerReady\)[\s\S]*await loadShell\(true\)/,
+    /shouldLoadDashboardAfterManualRefresh\(listenerReady\)[\s\S]*await loadShellRef\.current\(true\)/,
   )
   assert.match(
     handleSaveSettings,
-    /shouldLoadDashboardAfterSettingsSave\(saved\.codexHomeChanged, listenerReady\)[\s\S]*await loadShell\(true\)/,
+    /shouldLoadDashboardAfterSettingsSave\(saved\.codexHomeChanged, listenerReady\)[\s\S]*await loadShellRef\.current\(true\)/,
   )
+  assert.doesNotMatch(handleRescan, /await loadShell\(true\)/)
+  assert.doesNotMatch(handleSaveSettings, /await loadShell\(true\)/)
   assert.match(appSource, /const completionRegistration = listen<RefreshCompletedEvent>/)
   assert.match(
     appSource,
     /refreshCompletionListenerReadyRef\.current = completionRegistration[\s\S]*\.then\([\s\S]*return true[\s\S]*\.catch\([\s\S]*false/,
   )
+})
+
+test('app_commits_listener_readiness_and_latest_loader_before_browser_interaction', () => {
+  assert.equal(
+    enclosingEffect(appSource, 'loadShellRef.current = loadShell'),
+    'layout',
+    'query changes must update the latest loader before paint',
+  )
+  assert.equal(
+    enclosingEffect(appSource, 'const completionRegistration = listen<RefreshCompletedEvent>'),
+    'layout',
+    'manual actions must see the real registration promise before paint',
+  )
+})
+
+test('manual_fallback_after_a_pending_ticket_uses_the_latest_loader_once', async () => {
+  const handleRescan = extractFunction(appSource, 'async function handleRescan()')
+  assert.match(handleRescan, /await loadShellRef\.current\(true\)/)
+  const ticket = deferred()
+  const calls = []
+  const loaderRef = {
+    current: async (quiet) => {
+      calls.push(['old query', quiet])
+    },
+  }
+  const runManual = async () => {
+    const listenerReady = await Promise.resolve(false)
+    await ticket.promise
+    if (refreshEvents.shouldLoadDashboardAfterManualRefresh(listenerReady)) {
+      await loaderRef.current(true)
+    }
+  }
+
+  const pending = runManual()
+  loaderRef.current = async (quiet) => {
+    calls.push(['latest query', quiet])
+  }
+  ticket.resolve()
+  await pending
+
+  assert.deepEqual(calls, [['latest query', true]])
 })
 
 test('surface_request_controller_ignores_an_older_response_that_finishes_last', async () => {

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -132,7 +132,8 @@ test('frontend_refresh_sources_are_event_driven_without_automatic_polling', () =
 
   assert.match(appSource, /codex-counter:\/\/refresh-completed/)
   assert.match(appSource, /SurfaceRevisionGate/)
-  assert.match(appSource, /getCurrentWindow\(\)\.isVisible\(\)/)
+  assert.match(appSource, /appWindow\.isVisible\(\)/)
+  assert.match(appSource, /appWindow\.isFocused\(\)/)
   assert.match(appSource, /onFocusChanged/)
   assert.match(appSource, /visibilitychange/)
 

--- a/scripts/test-settings-save.mjs
+++ b/scripts/test-settings-save.mjs
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  closeSettingsPanelIfIdle,
+  saveSettingsWithCodexHomeRollback,
+} from '../src/app/settingsSave.ts'
+
+const previousSyncSettings = { codexHome: '/tmp/codex-home-a', interval: 5 }
+const nextSyncSettings = { codexHome: '/tmp/missing-codex-home', interval: 10 }
+const previousSubscriptionProfile = { planType: 'plus', monthlyPrice: 20 }
+const nextSubscriptionProfile = { planType: 'pro', monthlyPrice: 200 }
+
+let storedSyncSettings = previousSyncSettings
+let storedSubscriptionProfile = previousSubscriptionProfile
+const calls = []
+
+await assert.rejects(
+  saveSettingsWithCodexHomeRollback({
+    previousSyncSettings,
+    nextSyncSettings,
+    previousSubscriptionProfile,
+    nextSubscriptionProfile,
+    updateSyncSettings: async (settings) => {
+      calls.push(`sync:${settings.codexHome}`)
+      storedSyncSettings = settings
+      return settings
+    },
+    updateSubscriptionProfile: async (profile) => {
+      calls.push(`profile:${profile.planType}`)
+      storedSubscriptionProfile = profile
+      return profile
+    },
+    scanCodexHome: async (codexHome) => {
+      calls.push(`scan:${codexHome}`)
+      if (codexHome === nextSyncSettings.codexHome) {
+        throw new Error(`Codex home is not an existing directory: ${codexHome}`)
+      }
+    },
+  }),
+  /not an existing directory/,
+  'an invalid Codex home should reject the settings save',
+)
+
+assert.deepEqual(
+  storedSyncSettings,
+  previousSyncSettings,
+  'an invalid Codex home should restore the previously persisted sync settings',
+)
+assert.deepEqual(
+  storedSubscriptionProfile,
+  previousSubscriptionProfile,
+  'a failed settings save should restore the previous subscription profile',
+)
+assert.deepEqual(
+  calls,
+  [
+    'sync:/tmp/missing-codex-home',
+    'profile:pro',
+    'scan:/tmp/missing-codex-home',
+    'sync:/tmp/codex-home-a',
+    'profile:plus',
+    'scan:/tmp/codex-home-a',
+  ],
+  'an invalid source should restore both settings and rescan the restored source for freshness',
+)
+
+calls.length = 0
+const validResult = await saveSettingsWithCodexHomeRollback({
+  previousSyncSettings,
+  nextSyncSettings: { ...nextSyncSettings, codexHome: '/tmp/codex-home-b' },
+  previousSubscriptionProfile,
+  nextSubscriptionProfile,
+  updateSyncSettings: async (settings) => {
+    calls.push(`sync:${settings.codexHome}`)
+    return settings
+  },
+  updateSubscriptionProfile: async (profile) => {
+    calls.push(`profile:${profile.planType}`)
+    return profile
+  },
+  scanCodexHome: async (codexHome) => {
+    calls.push(`scan:${codexHome}`)
+  },
+})
+
+assert.equal(validResult.codexHomeChanged, true)
+assert.equal(validResult.syncSettings.codexHome, '/tmp/codex-home-b')
+assert.deepEqual(
+  calls,
+  ['sync:/tmp/codex-home-b', 'profile:pro', 'scan:/tmp/codex-home-b'],
+  'a valid source change should be scanned after persistence so it is authoritative',
+)
+
+calls.length = 0
+const unchangedResult = await saveSettingsWithCodexHomeRollback({
+  previousSyncSettings,
+  nextSyncSettings: { ...previousSyncSettings, interval: 15 },
+  previousSubscriptionProfile,
+  nextSubscriptionProfile,
+  updateSyncSettings: async (settings) => {
+    calls.push(`sync:${settings.codexHome}`)
+    return settings
+  },
+  updateSubscriptionProfile: async (profile) => {
+    calls.push(`profile:${profile.planType}`)
+    return profile
+  },
+  scanCodexHome: async () => {
+    calls.push('unexpected-scan')
+  },
+})
+
+assert.equal(unchangedResult.codexHomeChanged, false)
+assert.deepEqual(
+  calls,
+  ['sync:/tmp/codex-home-a', 'profile:pro'],
+  'saving unrelated settings should not trigger a Codex home scan',
+)
+
+calls.length = 0
+storedSubscriptionProfile = previousSubscriptionProfile
+storedSyncSettings = previousSyncSettings
+await assert.rejects(
+  saveSettingsWithCodexHomeRollback({
+    previousSyncSettings,
+    nextSyncSettings: { ...previousSyncSettings, interval: 30 },
+    previousSubscriptionProfile,
+    nextSubscriptionProfile,
+    updateSyncSettings: async (settings) => {
+      calls.push(`sync:${settings.interval}`)
+      storedSyncSettings = settings
+      return settings
+    },
+    updateSubscriptionProfile: async () => {
+      calls.push('profile:failed')
+      throw new Error('profile save failed')
+    },
+    scanCodexHome: async () => {
+      calls.push('unexpected-scan')
+    },
+  }),
+  /profile save failed/,
+)
+assert.deepEqual(storedSyncSettings, previousSyncSettings)
+assert.deepEqual(storedSubscriptionProfile, previousSubscriptionProfile)
+assert.deepEqual(
+  calls,
+  ['sync:30', 'profile:failed', 'sync:5'],
+  'a later persistence failure should restore sync settings saved earlier in the operation',
+)
+
+let closeCount = 0
+assert.equal(closeSettingsPanelIfIdle(true, () => (closeCount += 1)), false)
+assert.equal(closeCount, 0, 'the settings modal should stay open while validation is pending')
+assert.equal(closeSettingsPanelIfIdle(false, () => (closeCount += 1)), true)
+assert.equal(closeCount, 1, 'the settings modal should close normally while idle')
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const appSource = readFileSync(join(repoRoot, 'src/App.tsx'), 'utf8')
+const panelSource = readFileSync(join(repoRoot, 'src/components/SettingsPanel.tsx'), 'utf8')
+const i18nSource = readFileSync(join(repoRoot, 'src/app/i18n.ts'), 'utf8')
+const packageMetadata = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'))
+const readmeSource = readFileSync(join(repoRoot, 'README.md'), 'utf8')
+const chineseReadmeSource = readFileSync(join(repoRoot, 'README.zh-CN.md'), 'utf8')
+const englishGettingStarted = readFileSync(join(repoRoot, 'docs/en/getting-started.md'), 'utf8')
+const chineseGettingStarted = readFileSync(join(repoRoot, 'docs/zh-CN/getting-started.md'), 'utf8')
+
+assert.match(
+  appSource,
+  /saveSettingsWithCodexHomeRollback\([\s\S]*scanCodexHome:[\s\S]*runScanWithOverlapRetry/,
+  'settings save should validate the persisted Codex home through a tracked scan that can reject',
+)
+assert.doesNotMatch(
+  appSource,
+  /await loadShell\(codexHomeChanged\)/,
+  'settings save should not rely on loadShell, which handles dashboard errors internally, to validate a source',
+)
+assert.match(
+  panelSource,
+  /catch \(error\)[\s\S]*setSaveError\(t\.status\.settingsSaveFailed\(String\(error\)\)\)/,
+  'the settings panel should keep the modal open and show save failures',
+)
+assert.match(
+  panelSource,
+  /const handleClose = \(\) => closeSettingsPanelIfIdle\(saving, onClose\)/,
+  'all settings close paths should share the saving guard',
+)
+assert.match(
+  panelSource,
+  /modal-backdrop" onClick=\{handleClose\}[\s\S]*disabled=\{saving\}[\s\S]*onClick=\{handleClose\}[\s\S]*disabled=\{saving\}[\s\S]*onClick=\{handleClose\}/,
+  'backdrop, Close, and Cancel should keep the modal open while a save is pending',
+)
+assert.match(
+  panelSource,
+  /className="settings-save-error" role="alert"/,
+  'settings save failures should be exposed as an accessible inline alert',
+)
+assert.match(i18nSource, /settingsSaveFailed: \(error: string\) => string/)
+assert.match(i18nSource, /settingsSaveFailed: \(error\) => `设置未保存：\$\{error\}`/)
+assert.match(i18nSource, /settingsSaveFailed: \(error\) => `Settings were not saved: \$\{error\}`/)
+assert.equal(
+  packageMetadata.engines?.node,
+  '>=22.18.0',
+  'package metadata should enforce the Node runtime required for direct TypeScript test imports',
+)
+assert.match(packageMetadata.scripts['test:data-freshness'], /node --experimental-strip-types /)
+assert.match(packageMetadata.scripts['test:settings-save'], /node --experimental-strip-types /)
+for (const [label, source] of [
+  ['README', readmeSource],
+  ['Chinese README', chineseReadmeSource],
+  ['English getting started guide', englishGettingStarted],
+  ['Chinese getting started guide', chineseGettingStarted],
+]) {
+  assert.match(source, /Node\.js 22\.18\+/, `${label} should document the Node 22.18 minimum`)
+  assert.doesNotMatch(source, /Node\.js 20\+/, `${label} should not advertise an incompatible Node 20 runtime`)
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-pacer"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-pacer"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -575,6 +575,8 @@ dependencies = [
  "chrono",
  "dirs",
  "log",
+ "objc2",
+ "objc2-foundation",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2447,6 +2449,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -574,6 +574,7 @@ version = "1.2.0"
 dependencies = [
  "chrono",
  "dirs",
+ "flate2",
  "log",
  "objc2",
  "objc2-foundation",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "dirs",
  "flate2",
  "log",
+ "mimalloc",
  "objc2",
  "objc2-foundation",
  "rusqlite",
@@ -2132,6 +2133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2252,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-pacer"
-version = "1.2.0"
+version = "1.2.2"
 description = "Codex Pacer desktop analytics"
 authors = ["Codex"]
 license = ""

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2.5.6", features = [] }
 [dependencies]
 chrono = { version = "0.4.42", features = ["serde"] }
 dirs = "6.0.0"
+flate2 = "1.1.9"
 log = "0.4"
 objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", features = ["NSProcessInfo", "NSString"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.42", features = ["serde"] }
 dirs = "6.0.0"
 flate2 = "1.1.9"
 log = "0.4"
+mimalloc = "0.1.52"
 objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", features = ["NSProcessInfo", "NSString"] }
 rusqlite = { version = "0.37.0", features = ["bundled", "chrono"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ tauri-build = { version = "2.5.6", features = [] }
 chrono = { version = "0.4.42", features = ["serde"] }
 dirs = "6.0.0"
 log = "0.4"
+objc2 = "0.6.4"
+objc2-foundation = { version = "0.3.2", features = ["NSProcessInfo", "NSString"] }
 rusqlite = { version = "0.37.0", features = ["bundled", "chrono"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,12 +28,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "2.10.3", features = ["tray-icon"] }
 tauri-plugin-log = "2"
+tempfile = "3.23.0"
 tokio = { version = "1.48.0", features = ["time"] }
 ureq = "2.12.1"
 walkdir = "2.5.0"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2"
-
-[dev-dependencies]
-tempfile = "3.23.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-pacer"
-version = "1.1.2"
+version = "1.2.0"
 description = "Codex Pacer desktop analytics"
 authors = ["Codex"]
 license = ""

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -3,6 +3,9 @@ CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp)
 CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_ms
   ON usage_events(timestamp_ms, id)
   WHERE timestamp_ms IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_value
+  ON usage_events(timestamp_ms, value_usd)
+  WHERE timestamp_ms IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_usage_events_missing_timestamp_ms
   ON usage_events(id)
   WHERE timestamp_ms IS NULL;
@@ -10,6 +13,11 @@ CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
 CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
+CREATE INDEX IF NOT EXISTS idx_import_state_source_bucket ON import_state(source_bucket);
+CREATE INDEX IF NOT EXISTS idx_import_state_incomplete_archived_tail
+  ON import_state(source_path)
+  WHERE source_bucket = 'archived'
+    AND parser_completed_offset < file_size;
 CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
   ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
 CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_window_ms

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -3,6 +3,9 @@ CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp)
 CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_ms
   ON usage_events(timestamp_ms, id)
   WHERE timestamp_ms IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_usage_events_missing_timestamp_ms
+  ON usage_events(id)
+  WHERE timestamp_ms IS NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -16,3 +16,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
   ON rate_limit_samples(
     bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
   );
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_owner
+  ON rate_limit_samples(source_kind, source_session_id, bucket, sample_timestamp_ms, id);
+CREATE INDEX IF NOT EXISTS idx_latest_rate_limits_lookup
+  ON latest_rate_limits(bucket, source_kind, sample_timestamp_ms DESC, source_session_id);

--- a/src-tauri/sql/indexes.sql
+++ b/src-tauri/sql/indexes.sql
@@ -1,11 +1,17 @@
 CREATE INDEX IF NOT EXISTS idx_usage_events_session_id ON usage_events(session_id);
 CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp_ms
+  ON usage_events(timestamp_ms, id)
+  WHERE timestamp_ms IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
 CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
 CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
   ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_window_ms
+  ON rate_limit_samples(bucket, window_start_ms, resets_at_ms, sample_timestamp_ms, id)
+  WHERE window_start_ms IS NOT NULL AND resets_at_ms IS NOT NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
   ON rate_limit_samples(
     bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at

--- a/src-tauri/sql/queries/rate_limit_windows.sql
+++ b/src-tauri/sql/queries/rate_limit_windows.sql
@@ -1,5 +1,0 @@
-SELECT window_start, resets_at
-FROM rate_limit_samples
-WHERE bucket = ?1
-GROUP BY window_start, resets_at
-ORDER BY window_start DESC, resets_at DESC

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -96,6 +96,7 @@ CREATE TABLE IF NOT EXISTS sync_settings (
   menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
   last_scan_started_at TEXT,
   last_scan_completed_at TEXT,
+  last_full_scan_completed_at TEXT,
   updated_at TEXT NOT NULL
 );
 

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -97,6 +97,7 @@ CREATE TABLE IF NOT EXISTS sync_settings (
   last_scan_started_at TEXT,
   last_scan_completed_at TEXT,
   last_full_scan_completed_at TEXT,
+  last_scan_codex_home TEXT,
   updated_at TEXT NOT NULL
 );
 

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -110,6 +110,7 @@ CREATE TABLE IF NOT EXISTS import_state (
   file_size INTEGER NOT NULL,
   file_mtime_ms INTEGER NOT NULL,
   parser_checkpoint TEXT,
+  parser_completed_offset INTEGER,
   last_imported_at TEXT NOT NULL
 );
 

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -109,6 +109,7 @@ CREATE TABLE IF NOT EXISTS import_state (
   source_bucket TEXT NOT NULL,
   file_size INTEGER NOT NULL,
   file_mtime_ms INTEGER NOT NULL,
+  parser_checkpoint TEXT,
   last_imported_at TEXT NOT NULL
 );
 

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -161,3 +161,22 @@ CREATE TABLE IF NOT EXISTS rate_limit_samples (
   remaining_percent INTEGER NOT NULL,
   created_at TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS latest_rate_limits (
+  source_kind TEXT NOT NULL,
+  source_session_id TEXT NOT NULL DEFAULT '',
+  bucket TEXT NOT NULL,
+  sample_timestamp TEXT NOT NULL,
+  sample_timestamp_ms INTEGER NOT NULL,
+  limit_id TEXT NOT NULL DEFAULT '',
+  limit_name TEXT NOT NULL DEFAULT '',
+  plan_type TEXT NOT NULL DEFAULT '',
+  window_start TEXT NOT NULL,
+  window_start_ms INTEGER NOT NULL,
+  resets_at TEXT NOT NULL,
+  resets_at_ms INTEGER NOT NULL,
+  used_percent INTEGER NOT NULL,
+  remaining_percent INTEGER NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (source_kind, source_session_id, bucket)
+);

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -72,6 +72,7 @@ CREATE TABLE IF NOT EXISTS session_overrides (
 CREATE TABLE IF NOT EXISTS sync_settings (
   singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
   sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
+  scan_commit_revision INTEGER NOT NULL DEFAULT 0,
   codex_home TEXT,
   auto_scan_enabled INTEGER NOT NULL,
   auto_scan_interval_minutes INTEGER NOT NULL,

--- a/src-tauri/sql/schema.sql
+++ b/src-tauri/sql/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS usage_events (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   session_id TEXT NOT NULL,
   timestamp TEXT NOT NULL,
+  timestamp_ms INTEGER,
   model_id TEXT NOT NULL,
   input_tokens INTEGER NOT NULL,
   cached_input_tokens INTEGER NOT NULL,
@@ -116,6 +117,24 @@ CREATE TABLE IF NOT EXISTS data_repairs (
   completed_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS data_repair_progress (
+  repair_key TEXT NOT NULL,
+  stream_key TEXT NOT NULL,
+  progress_value INTEGER NOT NULL,
+  PRIMARY KEY (repair_key, stream_key)
+);
+
+CREATE TABLE IF NOT EXISTS data_repair_quarantine (
+  repair_key TEXT NOT NULL,
+  table_name TEXT NOT NULL,
+  row_id INTEGER NOT NULL,
+  column_name TEXT NOT NULL,
+  raw_value TEXT NOT NULL,
+  error_message TEXT NOT NULL,
+  quarantined_at TEXT NOT NULL,
+  PRIMARY KEY (repair_key, table_name, row_id, column_name)
+);
+
 CREATE TABLE IF NOT EXISTS data_repair_pending_files (
   repair_key TEXT NOT NULL,
   source_path TEXT NOT NULL,
@@ -130,11 +149,14 @@ CREATE TABLE IF NOT EXISTS rate_limit_samples (
   source_session_id TEXT NOT NULL DEFAULT '',
   bucket TEXT NOT NULL,
   sample_timestamp TEXT NOT NULL,
+  sample_timestamp_ms INTEGER,
   limit_id TEXT NOT NULL DEFAULT '',
   limit_name TEXT NOT NULL DEFAULT '',
   plan_type TEXT NOT NULL DEFAULT '',
   window_start TEXT NOT NULL,
+  window_start_ms INTEGER,
   resets_at TEXT NOT NULL,
+  resets_at_ms INTEGER,
   used_percent INTEGER NOT NULL,
   remaining_percent INTEGER NOT NULL,
   created_at TEXT NOT NULL

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -93,6 +93,25 @@ fn ensure_import_state_schema(conn: &Connection) -> rusqlite::Result<()> {
     if !columns.iter().any(|column| column == "parser_checkpoint") {
         conn.execute("ALTER TABLE import_state ADD COLUMN parser_checkpoint TEXT", [])?;
     }
+    if !columns
+        .iter()
+        .any(|column| column == "parser_completed_offset")
+    {
+        conn.execute(
+            "ALTER TABLE import_state ADD COLUMN parser_completed_offset INTEGER",
+            [],
+        )?;
+        conn.execute(
+            "
+            UPDATE import_state
+            SET parser_completed_offset = CAST(
+              json_extract(parser_checkpoint, '$.completed_offset') AS INTEGER
+            )
+            WHERE parser_checkpoint IS NOT NULL
+            ",
+            [],
+        )?;
+    }
     Ok(())
 }
 
@@ -194,6 +213,9 @@ mod tests {
             .collect::<rusqlite::Result<Vec<_>>>()
             .expect("collect columns");
         assert!(columns.iter().any(|column| column == "parser_checkpoint"));
+        assert!(columns
+            .iter()
+            .any(|column| column == "parser_completed_offset"));
     }
 
     #[test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -151,6 +151,61 @@ mod tests {
     }
 
     #[test]
+    fn init_db_adds_resolved_scan_source_to_existing_sync_settings() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+
+        conn.execute_batch(
+            "
+        CREATE TABLE sync_settings (
+          singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+          codex_home TEXT,
+          auto_scan_enabled INTEGER NOT NULL,
+          auto_scan_interval_minutes INTEGER NOT NULL,
+          last_scan_started_at TEXT,
+          last_scan_completed_at TEXT,
+          updated_at TEXT NOT NULL
+        );
+
+        INSERT INTO sync_settings (
+          singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
+          last_scan_started_at, last_scan_completed_at, updated_at
+        )
+        VALUES (
+          1, NULL, 1, 5,
+          '2026-07-09T23:00:00Z', '2026-07-09T23:01:00Z',
+          '2026-07-10T00:00:00Z'
+        );
+        ",
+        )
+        .expect("seed legacy schema");
+
+        init_db(&conn).expect("migrate schema");
+
+        let (resolved_source, started, completed, full_completed): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "
+                SELECT last_scan_codex_home, last_scan_started_at,
+                       last_scan_completed_at, last_full_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("load resolved scan source");
+
+        assert_eq!(resolved_source, None);
+        assert_eq!(started, None);
+        assert_eq!(completed, None);
+        assert_eq!(full_completed, None);
+    }
+
+    #[test]
     fn sync_settings_tracks_last_full_scan_completion() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
         init_db(&conn).expect("init database");
@@ -163,6 +218,104 @@ mod tests {
             get_last_full_scan_completed(&conn).expect("load saved value"),
             Some("2026-03-27T00:00:00Z".to_string())
         );
+    }
+
+    #[test]
+    fn scan_freshness_tracks_resolved_source_when_default_selector_moves() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let first = set_last_scan_started_for_source(
+            &conn,
+            "2026-07-10T00:00:00Z",
+            None,
+            "/tmp/codex-home-a",
+        )
+        .expect("start first scan");
+        assert!(first.recorded);
+        assert!(first.source_changed);
+
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-10T00:01:00Z",
+            None,
+            "/tmp/codex-home-a",
+            true,
+        )
+        .expect("complete first scan"));
+
+        let second = set_last_scan_started_for_source(
+            &conn,
+            "2026-07-10T01:00:00Z",
+            None,
+            "/tmp/codex-home-b",
+        )
+        .expect("start second scan");
+        assert!(second.recorded);
+        assert!(second.source_changed);
+        assert!(second.full_scan_required);
+
+        let (resolved_source, started, completed, full_completed): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "
+                SELECT last_scan_codex_home, last_scan_started_at,
+                       last_scan_completed_at, last_full_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("load moved scan source");
+
+        assert_eq!(resolved_source.as_deref(), Some("/tmp/codex-home-b"));
+        assert_eq!(started.as_deref(), Some("2026-07-10T01:00:00Z"));
+        assert_eq!(completed, None);
+        assert_eq!(full_completed, None);
+
+        let retry = set_last_scan_started_for_source(
+            &conn,
+            "2026-07-10T01:00:30Z",
+            None,
+            "/tmp/codex-home-b",
+        )
+        .expect("retry second scan");
+        assert!(retry.recorded);
+        assert!(!retry.source_changed);
+        assert!(retry.full_scan_required);
+
+        assert!(!set_scan_completed_for_source(
+            &conn,
+            "2026-07-10T01:01:00Z",
+            None,
+            "/tmp/codex-home-a",
+            true,
+        )
+        .expect("reject completion from first source"));
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-10T01:02:00Z",
+            None,
+            "/tmp/codex-home-b",
+            true,
+        )
+        .expect("complete second scan"));
+
+        let next = set_last_scan_started_for_source(
+            &conn,
+            "2026-07-10T02:00:00Z",
+            None,
+            "/tmp/codex-home-b",
+        )
+        .expect("start next incremental scan");
+        assert!(next.recorded);
+        assert!(!next.source_changed);
+        assert!(!next.full_scan_required);
     }
 
     #[test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -16,7 +16,11 @@ pub use epoch_backfill::{
     backfill_epoch_batch, backfill_epoch_batch_cancellable, epoch_backfill_pending,
     parse_epoch_millis, EpochBackfillProgress,
 };
-pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
+#[allow(unused_imports)]
+pub use rate_limit_samples::{
+    append_session_rate_limit_samples, insert_live_rate_limit_snapshot, load_latest_rate_limits,
+    replace_session_rate_limit_samples, RateLimitWriteStats,
+};
 pub use subscriptions::{
     canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
 };

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -14,10 +14,13 @@ pub use subscriptions::{
 };
 pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
-    set_last_scan_started_for_source, set_scan_completed_for_source,
+    set_scan_completed_for_source,
+};
+pub(crate) use sync_settings::{
+    preview_scan_freshness_for_source, set_last_scan_started_for_source_in_transaction,
 };
 #[cfg(test)]
-pub use sync_settings::set_last_full_scan_completed;
+pub use sync_settings::{set_last_full_scan_completed, set_last_scan_started_for_source};
 
 pub fn now_utc_string() -> String {
     Utc::now().to_rfc3339()
@@ -99,6 +102,41 @@ mod tests {
     use crate::models::{SubscriptionProfile, SyncSettings};
 
     #[test]
+    fn init_db_adds_scan_commit_revision_to_existing_sync_settings() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        conn.execute_batch(
+            "
+            CREATE TABLE sync_settings (
+              singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+              codex_home TEXT,
+              auto_scan_enabled INTEGER NOT NULL,
+              auto_scan_interval_minutes INTEGER NOT NULL,
+              last_scan_started_at TEXT,
+              last_scan_completed_at TEXT,
+              updated_at TEXT NOT NULL
+            );
+            INSERT INTO sync_settings (
+              singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
+              last_scan_started_at, last_scan_completed_at, updated_at
+            )
+            VALUES (1, NULL, 1, 5, NULL, NULL, '2026-07-10T00:00:00Z');
+            ",
+        )
+        .expect("seed legacy schema");
+
+        init_db(&conn).expect("migrate schema");
+        let revision: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load scan commit revision");
+
+        assert_eq!(revision, 0);
+    }
+
+    #[test]
     fn init_db_adds_menu_bar_flag_to_existing_sync_settings() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
 
@@ -146,7 +184,9 @@ mod tests {
         );
         assert!(settings.menu_bar_popup_show_reset_timeline);
         assert!(settings.menu_bar_popup_show_actions);
-        assert!(get_last_full_scan_completed(&conn).expect("load last full scan").is_none());
+        assert!(get_last_full_scan_completed(&conn)
+            .expect("load last full scan")
+            .is_none());
         assert!(!settings.hide_dock_icon_when_menu_bar_visible);
     }
 
@@ -210,9 +250,12 @@ mod tests {
         let conn = Connection::open_in_memory().expect("open in-memory database");
         init_db(&conn).expect("init database");
 
-        assert!(get_last_full_scan_completed(&conn).expect("load initial value").is_none());
+        assert!(get_last_full_scan_completed(&conn)
+            .expect("load initial value")
+            .is_none());
 
-        set_last_full_scan_completed(&conn, "2026-03-27T00:00:00Z").expect("set full scan timestamp");
+        set_last_full_scan_completed(&conn, "2026-03-27T00:00:00Z")
+            .expect("set full scan timestamp");
 
         assert_eq!(
             get_last_full_scan_completed(&conn).expect("load saved value"),

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -241,6 +241,7 @@ mod tests {
             None,
             "/tmp/codex-home-a",
             true,
+            false,
         )
         .expect("complete first scan"));
 
@@ -295,6 +296,7 @@ mod tests {
             None,
             "/tmp/codex-home-a",
             true,
+            false,
         )
         .expect("reject completion from first source"));
         assert!(set_scan_completed_for_source(
@@ -303,6 +305,7 @@ mod tests {
             None,
             "/tmp/codex-home-b",
             true,
+            false,
         )
         .expect("complete second scan"));
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -873,6 +873,183 @@ mod tests {
         assert_eq!(settings.live_quota_refresh_interval_seconds, 600);
     }
 
+    fn assert_release_upgrade_preserves_user_data(legacy_schema: &str) {
+        let conn = Connection::open_in_memory().expect("open legacy release database");
+        conn.execute_batch(legacy_schema)
+            .expect("install historical release schema");
+        conn.execute_batch(
+            "
+            INSERT INTO sessions (
+              session_id, root_session_id, title, source_state,
+              created_at, imported_at
+            ) VALUES (
+              'legacy-session', 'legacy-session', 'Legacy conversation', 'active',
+              '2026-04-01T00:00:00Z', '2026-04-01T00:01:00Z'
+            );
+            INSERT INTO conversation_links (
+              session_id, root_session_id, parent_session_id, depth
+            ) VALUES ('legacy-session', 'legacy-session', NULL, 0);
+            INSERT INTO usage_events (
+              session_id, timestamp, model_id,
+              input_tokens, cached_input_tokens, output_tokens,
+              reasoning_output_tokens, total_tokens, value_usd,
+              fast_mode_auto, fast_mode_effective
+            ) VALUES (
+              'legacy-session', '2026-04-01T00:02:00Z', 'gpt-5.4',
+              100, 20, 25, 0, 125, 0.42, 0, 0
+            );
+            INSERT INTO pricing_catalog (
+              model_id, display_name,
+              input_price_per_million, cached_input_price_per_million,
+              output_price_per_million, effective_model_id,
+              is_official, note, source_url, updated_at
+            ) VALUES (
+              'legacy-model', 'Legacy model', 1.0, 0.1, 2.0,
+              'legacy-model', 1, 'release fixture',
+              'https://example.invalid/pricing', '2026-04-01T00:00:00Z'
+            );
+            INSERT INTO subscription_profile (
+              singleton_id, plan_type, currency,
+              monthly_price, billing_anchor_day, updated_at
+            ) VALUES (1, 'pro', 'USD', 42.0, 9, '2026-04-01T00:00:00Z');
+            INSERT INTO session_overrides (
+              session_id, fast_mode_override, updated_at
+            ) VALUES ('legacy-session', 1, '2026-04-01T00:00:00Z');
+            INSERT INTO sync_settings (
+              singleton_id, codex_home, auto_scan_enabled,
+              auto_scan_interval_minutes, last_scan_started_at,
+              last_scan_completed_at, updated_at
+            ) VALUES (
+              1, '/legacy/codex-home', 1, 17,
+              '2026-04-01T00:03:00Z', '2026-04-01T00:04:00Z',
+              '2026-04-01T00:05:00Z'
+            );
+            INSERT INTO import_state (
+              source_path, session_id, source_bucket,
+              file_size, file_mtime_ms, last_imported_at
+            ) VALUES (
+              '/legacy/session.jsonl', 'legacy-session', 'active',
+              512, 1775000000000, '2026-04-01T00:05:00Z'
+            );
+            INSERT INTO rate_limit_samples (
+              source_kind, source_session_id, bucket,
+              sample_timestamp, limit_id, limit_name, plan_type,
+              window_start, resets_at, used_percent,
+              remaining_percent, created_at
+            ) VALUES (
+              'session', 'legacy-session', 'five_hour',
+              '2026-04-01T00:06:00Z', 'legacy-limit', 'Legacy limit', 'pro',
+              '2026-04-01T00:00:00Z', '2026-04-01T05:00:00Z',
+              25, 75, '2026-04-01T00:06:00Z'
+            );
+            ",
+        )
+        .expect("seed historical user data");
+
+        init_db(&conn).expect("upgrade historical release database");
+        let progress = backfill_epoch_batch(&conn, 1_000)
+            .expect("backfill historical epoch values");
+        assert!(progress.complete);
+        init_db(&conn).expect("repeat upgrade idempotently");
+
+        let session: (String, String) = conn
+            .query_row(
+                "SELECT title, source_state FROM sessions WHERE session_id = 'legacy-session'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("load preserved session");
+        assert_eq!(session, ("Legacy conversation".to_string(), "active".to_string()));
+
+        let usage: (i64, i64, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT COUNT(*), total_tokens, timestamp_ms
+                FROM usage_events
+                WHERE session_id = 'legacy-session'
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load preserved usage");
+        assert_eq!(usage.0, 1);
+        assert_eq!(usage.1, 125);
+        assert!(usage.2.is_some());
+
+        let quota: (i64, i64, i64, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT COUNT(*), used_percent, remaining_percent, sample_timestamp_ms
+                FROM rate_limit_samples
+                WHERE source_session_id = 'legacy-session'
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("load preserved quota");
+        assert_eq!((quota.0, quota.1, quota.2), (1, 25, 75));
+        assert!(quota.3.is_some());
+
+        let profile = get_subscription_profile(&conn).expect("load preserved subscription");
+        assert_eq!(profile.plan_type, "pro");
+        assert_eq!(profile.monthly_price, 42.0);
+        assert_eq!(profile.billing_anchor_day, 9);
+
+        let settings = get_sync_settings(&conn).expect("load preserved settings");
+        assert_eq!(settings.codex_home.as_deref(), Some("/legacy/codex-home"));
+        assert_eq!(settings.auto_scan_interval_minutes, 17);
+
+        let import_state: (i64, Option<String>) = conn
+            .query_row(
+                "
+                SELECT file_size, parser_checkpoint
+                FROM import_state
+                WHERE source_path = '/legacy/session.jsonl'
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("load preserved import state");
+        assert_eq!(import_state, (512, None));
+
+        let repair_tables: i64 = conn
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM sqlite_master
+                WHERE type = 'table'
+                  AND name IN (
+                    'data_repair_progress',
+                    'data_repair_quarantine',
+                    'latest_rate_limits'
+                  )
+                ",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load upgraded tables");
+        assert_eq!(repair_tables, 3);
+
+        let integrity: String = conn
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .expect("check upgraded database integrity");
+        assert_eq!(integrity, "ok");
+    }
+
+    #[test]
+    fn upgrades_v1_1_1_database_without_losing_user_data() {
+        assert_release_upgrade_preserves_user_data(include_str!(
+            "../tests/fixtures/v1.1.1-schema.sql"
+        ));
+    }
+
+    #[test]
+    fn upgrades_v1_1_2_database_without_losing_user_data() {
+        assert_release_upgrade_preserves_user_data(include_str!(
+            "../tests/fixtures/v1.1.2-schema.sql"
+        ));
+    }
+
     #[test]
     fn subscription_profile_is_normalized_to_usd() {
         let conn = Connection::open_in_memory().expect("open in-memory database");

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -438,6 +438,291 @@ mod tests {
     }
 
     #[test]
+    fn settings_save_does_not_overwrite_newer_scan_freshness() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let mut stale_settings = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save initial settings");
+
+        set_last_scan_started_for_source(
+            &conn,
+            "2026-07-11T01:00:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/codex-home-a",
+        )
+        .expect("record newer scan start");
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-11T01:01:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/codex-home-a",
+            true,
+            false,
+        )
+        .expect("record newer scan completion"));
+
+        stale_settings.auto_scan_interval_minutes = 17;
+        save_sync_settings(&conn, &stale_settings).expect("save stale config snapshot");
+
+        let saved = get_sync_settings(&conn).expect("reload settings");
+        assert_eq!(
+            saved.last_scan_started_at.as_deref(),
+            Some("2026-07-11T01:00:00Z")
+        );
+        assert_eq!(
+            saved.last_scan_completed_at.as_deref(),
+            Some("2026-07-11T01:01:00Z")
+        );
+    }
+
+    #[test]
+    fn home_change_clears_all_scan_freshness_in_one_transaction() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let settings = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save first Codex home");
+        set_last_scan_started_for_source(
+            &conn,
+            "2026-07-11T02:00:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/resolved-home-a",
+        )
+        .expect("record scan start");
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-11T02:01:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/resolved-home-a",
+            true,
+            false,
+        )
+        .expect("record full scan completion"));
+        let revision_before: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load revision before home change");
+
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-b".to_string()),
+                ..settings
+            },
+        )
+        .expect("change Codex home");
+
+        let (started, completed, full_completed, resolved_home, revision): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i64,
+        ) = conn
+            .query_row(
+                "
+                SELECT last_scan_started_at, last_scan_completed_at,
+                       last_full_scan_completed_at, last_scan_codex_home,
+                       scan_commit_revision
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .expect("load freshness after home change");
+
+        assert_eq!(
+            (started, completed, full_completed, resolved_home),
+            (None, None, None, None)
+        );
+        assert_eq!(revision, revision_before + 1);
+    }
+
+    #[test]
+    fn codex_home_aba_advances_scan_commit_revision() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let initial_revision: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load initial revision");
+        let settings_a = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save home A");
+        let revision_a: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load home A revision");
+        let settings_b = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-b".to_string()),
+                ..settings_a
+            },
+        )
+        .expect("save home B");
+        let revision_b: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load home B revision");
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..settings_b
+            },
+        )
+        .expect("return to home A");
+        let final_revision: i64 = conn
+            .query_row(
+                "SELECT scan_commit_revision FROM sync_settings WHERE singleton_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("load final revision");
+
+        assert_eq!(revision_a, initial_revision + 1);
+        assert_eq!(revision_b, revision_a + 1);
+        assert_eq!(final_revision, revision_b + 1);
+    }
+
+    #[test]
+    fn unchanged_home_config_save_preserves_revision_and_hidden_freshness_columns() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        let mut settings = save_sync_settings(
+            &conn,
+            &SyncSettings {
+                codex_home: Some("/tmp/codex-home-a".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save Codex home");
+        set_last_scan_started_for_source(
+            &conn,
+            "2026-07-11T03:00:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/resolved-home-a",
+        )
+        .expect("record scan start");
+        assert!(set_scan_completed_for_source(
+            &conn,
+            "2026-07-11T03:01:00Z",
+            Some("/tmp/codex-home-a"),
+            "/tmp/resolved-home-a",
+            true,
+            false,
+        )
+        .expect("record full scan completion"));
+        conn.execute(
+            "UPDATE sync_settings SET scan_commit_revision = 41 WHERE singleton_id = 1",
+            [],
+        )
+        .expect("seed revision");
+        let before: (i64, Option<String>, Option<String>) = conn
+            .query_row(
+                "
+                SELECT scan_commit_revision, last_scan_codex_home,
+                       last_full_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load hidden freshness before save");
+
+        settings.auto_scan_interval_minutes = 19;
+        save_sync_settings(&conn, &settings).expect("save unchanged-home config");
+
+        let after: (i64, Option<String>, Option<String>) = conn
+            .query_row(
+                "
+                SELECT scan_commit_revision, last_scan_codex_home,
+                       last_full_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load hidden freshness after save");
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn settings_insert_ignores_payload_freshness() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+        conn.execute("DELETE FROM sync_settings WHERE singleton_id = 1", [])
+            .expect("remove singleton to exercise insert path");
+
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                last_scan_started_at: Some("stale-start".to_string()),
+                last_scan_completed_at: Some("stale-complete".to_string()),
+                ..SyncSettings::default()
+            },
+        )
+        .expect("insert settings singleton");
+
+        let freshness: (Option<String>, Option<String>) = conn
+            .query_row(
+                "
+                SELECT last_scan_started_at, last_scan_completed_at
+                FROM sync_settings
+                WHERE singleton_id = 1
+                ",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("load inserted freshness");
+        assert_eq!(freshness, (None, None));
+    }
+
+    #[test]
     fn init_db_migrates_old_default_refresh_and_disables_legacy_fast_mode_once() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -28,7 +28,7 @@ pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
     set_scan_completed_for_source,
 };
-pub use usage_events::{insert_usage_events, NewUsageEvent};
+pub use usage_events::{replace_session_usage_events, NewUsageEvent};
 pub(crate) use sync_settings::{
     preview_scan_freshness_for_source, set_last_scan_started_for_source_in_transaction,
 };

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -12,7 +12,10 @@ mod sync_settings;
 mod usage_events;
 
 #[allow(unused_imports)]
-pub use epoch_backfill::{backfill_epoch_batch, parse_epoch_millis, EpochBackfillProgress};
+pub use epoch_backfill::{
+    backfill_epoch_batch, backfill_epoch_batch_cancellable, epoch_backfill_pending,
+    parse_epoch_millis, EpochBackfillProgress,
+};
 pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
 pub use subscriptions::{
     canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
@@ -45,8 +48,21 @@ pub fn i64_to_bool(value: i64) -> bool {
 }
 
 pub fn open_connection(db_path: &Path) -> rusqlite::Result<Connection> {
+    open_connection_with_busy_timeout(db_path, Duration::from_secs(10))
+}
+
+pub(crate) fn open_epoch_maintenance_connection(
+    db_path: &Path,
+) -> rusqlite::Result<Connection> {
+    open_connection_with_busy_timeout(db_path, Duration::from_millis(200))
+}
+
+fn open_connection_with_busy_timeout(
+    db_path: &Path,
+    busy_timeout: Duration,
+) -> rusqlite::Result<Connection> {
     let conn = Connection::open(db_path)?;
-    conn.busy_timeout(Duration::from_secs(10))?;
+    conn.busy_timeout(busy_timeout)?;
     conn.pragma_update(None, "foreign_keys", "ON")?;
     conn.pragma_update(None, "journal_mode", "WAL")?;
     conn.pragma_update(None, "synchronous", "NORMAL")?;
@@ -107,6 +123,32 @@ fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {
 mod tests {
     use super::*;
     use crate::models::{SubscriptionProfile, SyncSettings};
+
+    #[test]
+    fn epoch_maintenance_connection_uses_short_busy_timeout_and_normal_pragmas() {
+        let directory = tempfile::tempdir().expect("create maintenance connection directory");
+        let path = directory.path().join("maintenance.sqlite3");
+
+        let conn = open_epoch_maintenance_connection(&path)
+            .expect("open epoch maintenance connection");
+
+        let busy_timeout: i64 = conn
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .expect("read busy timeout");
+        let foreign_keys: i64 = conn
+            .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+            .expect("read foreign key mode");
+        let journal_mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .expect("read journal mode");
+        let synchronous: i64 = conn
+            .query_row("PRAGMA synchronous", [], |row| row.get(0))
+            .expect("read synchronous mode");
+        assert_eq!(busy_timeout, 200);
+        assert_eq!(foreign_keys, 1);
+        assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
+        assert_eq!(synchronous, 1, "SQLite NORMAL synchronous mode");
+    }
 
     #[test]
     fn init_db_adds_scan_commit_revision_to_existing_sync_settings() {

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -28,7 +28,9 @@ pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
     set_scan_completed_for_source,
 };
-pub use usage_events::{replace_session_usage_events, NewUsageEvent};
+pub use usage_events::{
+    append_session_usage_events, replace_session_usage_events, NewUsageEvent,
+};
 pub(crate) use sync_settings::{
     preview_scan_freshness_for_source, set_last_scan_started_for_source_in_transaction,
 };
@@ -75,10 +77,22 @@ fn open_connection_with_busy_timeout(
 
 pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(include_str!("../sql/schema.sql"))?;
+    ensure_import_state_schema(conn)?;
     epoch_backfill::ensure_epoch_schema(conn)?;
     sync_settings::ensure_sync_settings_schema(conn)?;
     ensure_singletons(conn)?;
     conn.execute_batch(include_str!("../sql/indexes.sql"))?;
+    Ok(())
+}
+
+fn ensure_import_state_schema(conn: &Connection) -> rusqlite::Result<()> {
+    let mut statement = conn.prepare("PRAGMA table_info(import_state)")?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if !columns.iter().any(|column| column == "parser_checkpoint") {
+        conn.execute("ALTER TABLE import_state ADD COLUMN parser_checkpoint TEXT", [])?;
+    }
     Ok(())
 }
 
@@ -152,6 +166,34 @@ mod tests {
         assert_eq!(foreign_keys, 1);
         assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
         assert_eq!(synchronous, 1, "SQLite NORMAL synchronous mode");
+    }
+
+    #[test]
+    fn init_db_adds_parser_checkpoint_to_legacy_import_state() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        conn.execute_batch(
+            "
+            CREATE TABLE import_state (
+              source_path TEXT PRIMARY KEY,
+              session_id TEXT,
+              source_bucket TEXT NOT NULL,
+              file_size INTEGER NOT NULL,
+              file_mtime_ms INTEGER NOT NULL,
+              last_imported_at TEXT NOT NULL
+            );
+            ",
+        )
+        .expect("seed legacy import state");
+
+        init_db(&conn).expect("migrate database");
+        let columns = conn
+            .prepare("PRAGMA table_info(import_state)")
+            .expect("prepare column query")
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query columns")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect columns");
+        assert!(columns.iter().any(|column| column == "parser_checkpoint"));
     }
 
     #[test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -4,10 +4,14 @@ use std::time::Duration;
 use chrono::Utc;
 use rusqlite::{params, Connection};
 
+#[allow(dead_code)]
+mod epoch_backfill;
 mod rate_limit_samples;
 mod subscriptions;
 mod sync_settings;
 
+#[allow(unused_imports)]
+pub use epoch_backfill::{backfill_epoch_batch, parse_epoch_millis, EpochBackfillProgress};
 pub use rate_limit_samples::{insert_live_rate_limit_snapshot, replace_session_rate_limit_samples};
 pub use subscriptions::{
     canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
@@ -49,6 +53,7 @@ pub fn open_connection(db_path: &Path) -> rusqlite::Result<Connection> {
 
 pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(include_str!("../sql/schema.sql"))?;
+    epoch_backfill::ensure_epoch_schema(conn)?;
     sync_settings::ensure_sync_settings_schema(conn)?;
     ensure_singletons(conn)?;
     conn.execute_batch(include_str!("../sql/indexes.sql"))?;

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -9,6 +9,7 @@ mod epoch_backfill;
 mod rate_limit_samples;
 mod subscriptions;
 mod sync_settings;
+mod usage_events;
 
 #[allow(unused_imports)]
 pub use epoch_backfill::{backfill_epoch_batch, parse_epoch_millis, EpochBackfillProgress};
@@ -20,6 +21,7 @@ pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
     set_scan_completed_for_source,
 };
+pub use usage_events::{insert_usage_events, NewUsageEvent};
 pub(crate) use sync_settings::{
     preview_scan_freshness_for_source, set_last_scan_started_for_source_in_transaction,
 };

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -14,8 +14,10 @@ pub use subscriptions::{
 };
 pub use sync_settings::{
     get_last_full_scan_completed, get_sync_settings, save_sync_settings,
-    set_last_full_scan_completed, set_last_scan_completed, set_last_scan_started,
+    set_last_scan_started_for_source, set_scan_completed_for_source,
 };
+#[cfg(test)]
+pub use sync_settings::set_last_full_scan_completed;
 
 pub fn now_utc_string() -> String {
     Utc::now().to_rfc3339()

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -13,7 +13,8 @@ pub use subscriptions::{
     canonical_subscription_currency, get_subscription_profile, save_subscription_profile,
 };
 pub use sync_settings::{
-    get_sync_settings, save_sync_settings, set_last_scan_completed, set_last_scan_started,
+    get_last_full_scan_completed, get_sync_settings, save_sync_settings,
+    set_last_full_scan_completed, set_last_scan_completed, set_last_scan_started,
 };
 
 pub fn now_utc_string() -> String {
@@ -79,9 +80,9 @@ fn ensure_singletons(conn: &Connection) -> rusqlite::Result<()> {
       menu_bar_speed_fast_emoji, menu_bar_speed_slow_emoji,
       menu_bar_popup_enabled, menu_bar_popup_modules,
       menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
-      last_scan_started_at, last_scan_completed_at, updated_at
+      last_scan_started_at, last_scan_completed_at, last_full_scan_completed_at, updated_at
     )
-    VALUES (1, 2, NULL, 1, 5, 300, 0, 0, 1, 1, 0, 'remaining_percent', 'five_hour', 'day', 1, 85, 115, '🟢', '🔥', '🐢', 1, ?2, 1, 1, NULL, NULL, ?1)
+    VALUES (1, 2, NULL, 1, 5, 300, 0, 0, 1, 1, 0, 'remaining_percent', 'five_hour', 'day', 1, 85, 115, '🟢', '🔥', '🐢', 1, ?2, 1, 1, NULL, NULL, NULL, ?1)
     ON CONFLICT(singleton_id) DO NOTHING
     ",
         params![now, sync_settings::default_menu_bar_popup_modules_json()],
@@ -143,7 +144,23 @@ mod tests {
         );
         assert!(settings.menu_bar_popup_show_reset_timeline);
         assert!(settings.menu_bar_popup_show_actions);
+        assert!(get_last_full_scan_completed(&conn).expect("load last full scan").is_none());
         assert!(!settings.hide_dock_icon_when_menu_bar_visible);
+    }
+
+    #[test]
+    fn sync_settings_tracks_last_full_scan_completion() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        assert!(get_last_full_scan_completed(&conn).expect("load initial value").is_none());
+
+        set_last_full_scan_completed(&conn, "2026-03-27T00:00:00Z").expect("set full scan timestamp");
+
+        assert_eq!(
+            get_last_full_scan_completed(&conn).expect("load saved value"),
+            Some("2026-03-27T00:00:00Z".to_string())
+        );
     }
 
     #[test]
@@ -200,6 +217,26 @@ mod tests {
     }
 
     #[test]
+    fn save_sync_settings_honors_long_background_refresh_intervals() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("init database");
+
+        save_sync_settings(
+            &conn,
+            &SyncSettings {
+                auto_scan_interval_minutes: 180,
+                ..SyncSettings::default()
+            },
+        )
+        .expect("save settings");
+
+        let settings = get_sync_settings(&conn).expect("load settings");
+
+        assert_eq!(settings.auto_scan_interval_minutes, 180);
+        assert_eq!(settings.live_quota_refresh_interval_seconds, 10800);
+    }
+
+    #[test]
     fn init_db_migrates_old_default_refresh_and_disables_legacy_fast_mode_once() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
 
@@ -241,7 +278,8 @@ mod tests {
         save_sync_settings(
             &conn,
             &SyncSettings {
-                live_quota_refresh_interval_seconds: 600,
+                auto_scan_interval_minutes: 10,
+                live_quota_refresh_interval_seconds: 60,
                 ..SyncSettings::default()
             },
         )
@@ -250,6 +288,7 @@ mod tests {
         init_db(&conn).expect("run init again");
         let settings = get_sync_settings(&conn).expect("reload settings");
 
+        assert_eq!(settings.auto_scan_interval_minutes, 10);
         assert_eq!(settings.live_quota_refresh_interval_seconds, 600);
     }
 

--- a/src-tauri/src/database/epoch_backfill.rs
+++ b/src-tauri/src/database/epoch_backfill.rs
@@ -1,5 +1,6 @@
 use chrono::DateTime;
 use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::now_utc_string;
 
@@ -13,6 +14,15 @@ pub struct EpochBackfillProgress {
     pub usage_rows_updated: usize,
     pub quota_rows_updated: usize,
     pub complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EpochBackfillCancellationPoint {
+    Transaction,
+    UsageRow,
+    QuotaRow,
+    CompletionMarker,
+    Commit,
 }
 
 struct UsageEpochRow {
@@ -69,23 +79,48 @@ pub fn backfill_epoch_batch(
     conn: &Connection,
     batch_size: usize,
 ) -> rusqlite::Result<EpochBackfillProgress> {
+    backfill_epoch_batch_with_cancel_check(conn, batch_size, |_| false)
+        .map(|progress| progress.expect("non-cancellable epoch backfill returns progress"))
+}
+
+pub fn backfill_epoch_batch_cancellable(
+    conn: &Connection,
+    batch_size: usize,
+    cancelled: &AtomicBool,
+) -> rusqlite::Result<Option<EpochBackfillProgress>> {
+    backfill_epoch_batch_with_cancel_check(conn, batch_size, |_| {
+        cancelled.load(Ordering::Acquire)
+    })
+}
+
+fn backfill_epoch_batch_with_cancel_check(
+    conn: &Connection,
+    batch_size: usize,
+    mut is_cancelled: impl FnMut(EpochBackfillCancellationPoint) -> bool,
+) -> rusqlite::Result<Option<EpochBackfillProgress>> {
+    if is_cancelled(EpochBackfillCancellationPoint::Transaction) {
+        return Ok(None);
+    }
     let batch_size = batch_size.min(MAX_BATCH_SIZE);
     if batch_size == 0 {
-        return Ok(EpochBackfillProgress {
+        return Ok(Some(EpochBackfillProgress {
             usage_rows_updated: 0,
             quota_rows_updated: 0,
             complete: repair_is_complete(conn)?,
-        });
+        }));
     }
 
     let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     if repair_is_complete(&transaction)? {
+        if is_cancelled(EpochBackfillCancellationPoint::Commit) {
+            return Ok(None);
+        }
         transaction.commit()?;
-        return Ok(EpochBackfillProgress {
+        return Ok(Some(EpochBackfillProgress {
             usage_rows_updated: 0,
             quota_rows_updated: 0,
             complete: true,
-        });
+        }));
     }
 
     ensure_cursor(&transaction, USAGE_STREAM)?;
@@ -96,6 +131,9 @@ pub fn backfill_epoch_batch(
     let usage_rows_updated = usage_rows.len();
     let usage_exhausted = usage_rows_updated < batch_size;
     for row in &usage_rows {
+        if is_cancelled(EpochBackfillCancellationPoint::UsageRow) {
+            return Ok(None);
+        }
         migrate_usage_row(&transaction, row)?;
     }
     if let Some(last_row) = usage_rows.last() {
@@ -109,6 +147,9 @@ pub fn backfill_epoch_batch(
         let rows_updated = quota_rows.len();
         let exhausted = rows_updated < remaining;
         for row in &quota_rows {
+            if is_cancelled(EpochBackfillCancellationPoint::QuotaRow) {
+                return Ok(None);
+            }
             migrate_quota_row(&transaction, row)?;
         }
         if let Some(last_row) = quota_rows.last() {
@@ -121,6 +162,9 @@ pub fn backfill_epoch_batch(
 
     let complete = usage_exhausted && quota_exhausted;
     if complete {
+        if is_cancelled(EpochBackfillCancellationPoint::CompletionMarker) {
+            return Ok(None);
+        }
         transaction.execute(
             "
             INSERT INTO data_repairs (repair_key, completed_at)
@@ -130,23 +174,30 @@ pub fn backfill_epoch_batch(
             params![REPAIR_KEY, now_utc_string()],
         )?;
     }
+    if is_cancelled(EpochBackfillCancellationPoint::Commit) {
+        return Ok(None);
+    }
     transaction.commit()?;
 
-    Ok(EpochBackfillProgress {
+    Ok(Some(EpochBackfillProgress {
         usage_rows_updated,
         quota_rows_updated,
         complete,
-    })
+    }))
 }
 
 fn repair_is_complete(conn: &Connection) -> rusqlite::Result<bool> {
+    epoch_backfill_pending(conn).map(|pending| !pending)
+}
+
+pub fn epoch_backfill_pending(conn: &Connection) -> rusqlite::Result<bool> {
     conn.query_row(
         "SELECT 1 FROM data_repairs WHERE repair_key = ?1",
         params![REPAIR_KEY],
         |_| Ok(()),
     )
     .optional()
-    .map(|value| value.is_some())
+    .map(|value| value.is_none())
 }
 
 fn ensure_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::Result<()> {
@@ -391,14 +442,64 @@ fn quarantine_value(
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use rusqlite::{params, Connection};
     use tempfile::tempdir;
 
-    use super::{backfill_epoch_batch, parse_epoch_millis};
+    use super::{
+        backfill_epoch_batch, backfill_epoch_batch_cancellable,
+        backfill_epoch_batch_with_cancel_check, epoch_backfill_pending,
+        EpochBackfillCancellationPoint, parse_epoch_millis,
+    };
     use crate::database::init_db;
 
     const REPAIR_KEY: &str = "epoch_timestamp_backfill_v1";
+
+    fn assert_repair_transaction_is_empty(conn: &Connection) {
+        let usage_epochs: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM usage_events WHERE timestamp_ms IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count usage epochs");
+        let quota_epochs: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM rate_limit_samples WHERE sample_timestamp_ms IS NOT NULL OR window_start_ms IS NOT NULL OR resets_at_ms IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count quota epochs");
+        let cursors: i64 = conn
+            .query_row("SELECT COUNT(*) FROM data_repair_progress", [], |row| row.get(0))
+            .expect("count repair cursors");
+        let quarantine: i64 = conn
+            .query_row("SELECT COUNT(*) FROM data_repair_quarantine", [], |row| row.get(0))
+            .expect("count quarantine rows");
+        let completion: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count completion markers");
+        assert_eq!((usage_epochs, quota_epochs, cursors, quarantine, completion), (0, 0, 0, 0, 0));
+    }
+
+    fn assert_cancel_at(point: EpochBackfillCancellationPoint, seed: impl FnOnce(&Connection)) {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        seed(&conn);
+
+        let outcome = backfill_epoch_batch_with_cancel_check(&conn, 1_000, |observed| {
+            observed == point
+        })
+        .expect("cancel bounded epoch repair");
+
+        assert!(outcome.is_none(), "cancelled repair returns no progress");
+        assert_repair_transaction_is_empty(&conn);
+    }
 
     fn create_legacy_epoch_tables(conn: &Connection) {
         conn.execute_batch(
@@ -539,6 +640,75 @@ mod tests {
             )
             .expect("load migrated quota sample");
         assert_eq!(quota_epochs, (None, None, None));
+    }
+
+    #[test]
+    fn epoch_backfill_pending_reads_only_completion_marker() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        conn.execute_batch(
+            "
+            DROP TABLE usage_events;
+            DROP TABLE rate_limit_samples;
+            DROP TABLE data_repair_progress;
+            DROP TABLE data_repair_quarantine;
+            ",
+        )
+        .expect("remove every repair history source");
+
+        assert!(epoch_backfill_pending(&conn).expect("read pending marker"));
+        conn.execute(
+            "INSERT INTO data_repairs (repair_key, completed_at) VALUES (?1, ?2)",
+            params![REPAIR_KEY, "2026-07-11T00:00:00Z"],
+        )
+        .expect("mark repair complete");
+        assert!(!epoch_backfill_pending(&conn).expect("read completed marker"));
+    }
+
+    #[test]
+    fn pre_cancelled_epoch_backfill_does_not_open_a_transaction() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        insert_usage(&conn, "2026-07-10T03:00:00Z");
+        let cancelled = AtomicBool::new(true);
+
+        let outcome = backfill_epoch_batch_cancellable(&conn, 1_000, &cancelled)
+            .expect("observe pre-cancelled repair");
+
+        assert!(outcome.is_none());
+        assert!(cancelled.load(Ordering::Acquire));
+        assert_repair_transaction_is_empty(&conn);
+    }
+
+    #[test]
+    fn epoch_backfill_cancellation_before_usage_mutation_rolls_back_everything() {
+        assert_cancel_at(EpochBackfillCancellationPoint::UsageRow, |conn| {
+            insert_usage(conn, "2026-07-10T03:00:00Z");
+        });
+    }
+
+    #[test]
+    fn epoch_backfill_cancellation_before_quota_mutation_rolls_back_everything() {
+        assert_cancel_at(EpochBackfillCancellationPoint::QuotaRow, |conn| {
+            insert_usage(conn, "malformed-usage");
+            insert_quota(conn, "2026-07-10T03:00:00Z");
+        });
+    }
+
+    #[test]
+    fn epoch_backfill_cancellation_before_completion_marker_rolls_back_everything() {
+        assert_cancel_at(EpochBackfillCancellationPoint::CompletionMarker, |conn| {
+            insert_usage(conn, "malformed-usage");
+            insert_quota(conn, "malformed-quota");
+        });
+    }
+
+    #[test]
+    fn epoch_backfill_cancellation_before_commit_rolls_back_everything() {
+        assert_cancel_at(EpochBackfillCancellationPoint::Commit, |conn| {
+            insert_usage(conn, "malformed-usage");
+            insert_quota(conn, "malformed-quota");
+        });
     }
 
     #[test]

--- a/src-tauri/src/database/epoch_backfill.rs
+++ b/src-tauri/src/database/epoch_backfill.rs
@@ -785,11 +785,7 @@ mod tests {
                     FROM sqlite_master
                     WHERE type = 'index'
                       AND sql IS NOT NULL
-                      AND (
-                        sql LIKE '%timestamp_ms%'
-                        OR sql LIKE '%window_start_ms%'
-                        OR sql LIKE '%resets_at_ms%'
-                      )
+                      AND name IN ('idx_rate_limit_samples_window_ms', 'idx_usage_events_timestamp_ms')
                     ORDER BY name
                     ",
                 )

--- a/src-tauri/src/database/epoch_backfill.rs
+++ b/src-tauri/src/database/epoch_backfill.rs
@@ -1,0 +1,1103 @@
+use chrono::DateTime;
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+
+use super::now_utc_string;
+
+const REPAIR_KEY: &str = "epoch_timestamp_backfill_v1";
+const USAGE_STREAM: &str = "usage_events";
+const QUOTA_STREAM: &str = "rate_limit_samples";
+const MAX_BATCH_SIZE: usize = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EpochBackfillProgress {
+    pub usage_rows_updated: usize,
+    pub quota_rows_updated: usize,
+    pub complete: bool,
+}
+
+struct UsageEpochRow {
+    id: i64,
+    timestamp: String,
+    timestamp_ms: Option<i64>,
+}
+
+struct QuotaEpochRow {
+    id: i64,
+    sample_timestamp: String,
+    sample_timestamp_ms: Option<i64>,
+    window_start: String,
+    window_start_ms: Option<i64>,
+    resets_at: String,
+    resets_at_ms: Option<i64>,
+}
+
+pub(super) fn ensure_epoch_schema(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_integer_column(conn, "usage_events", "timestamp_ms")?;
+    ensure_integer_column(conn, "rate_limit_samples", "sample_timestamp_ms")?;
+    ensure_integer_column(conn, "rate_limit_samples", "window_start_ms")?;
+    ensure_integer_column(conn, "rate_limit_samples", "resets_at_ms")?;
+    Ok(())
+}
+
+fn ensure_integer_column(
+    conn: &Connection,
+    table_name: &str,
+    column_name: &str,
+) -> rusqlite::Result<()> {
+    let mut statement = conn.prepare(&format!("PRAGMA table_info({table_name})"))?;
+    let mut rows = statement.query([])?;
+    while let Some(row) = rows.next()? {
+        if row.get::<_, String>(1)? == column_name {
+            return Ok(());
+        }
+    }
+    drop(rows);
+    drop(statement);
+
+    conn.execute_batch(&format!(
+        "ALTER TABLE {table_name} ADD COLUMN {column_name} INTEGER"
+    ))
+}
+
+pub fn parse_epoch_millis(value: &str) -> Result<i64, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.timestamp_millis())
+        .map_err(|error| error.to_string())
+}
+
+pub fn backfill_epoch_batch(
+    conn: &Connection,
+    batch_size: usize,
+) -> rusqlite::Result<EpochBackfillProgress> {
+    let batch_size = batch_size.min(MAX_BATCH_SIZE);
+    if batch_size == 0 {
+        return Ok(EpochBackfillProgress {
+            usage_rows_updated: 0,
+            quota_rows_updated: 0,
+            complete: repair_is_complete(conn)?,
+        });
+    }
+
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    if repair_is_complete(&transaction)? {
+        transaction.commit()?;
+        return Ok(EpochBackfillProgress {
+            usage_rows_updated: 0,
+            quota_rows_updated: 0,
+            complete: true,
+        });
+    }
+
+    ensure_cursor(&transaction, USAGE_STREAM)?;
+    ensure_cursor(&transaction, QUOTA_STREAM)?;
+
+    let usage_cursor = load_cursor(&transaction, USAGE_STREAM)?;
+    let usage_rows = load_usage_rows(&transaction, usage_cursor, batch_size)?;
+    let usage_rows_updated = usage_rows.len();
+    let usage_exhausted = usage_rows_updated < batch_size;
+    for row in &usage_rows {
+        migrate_usage_row(&transaction, row)?;
+    }
+    if let Some(last_row) = usage_rows.last() {
+        save_cursor(&transaction, USAGE_STREAM, last_row.id)?;
+    }
+
+    let remaining = batch_size - usage_rows_updated;
+    let (quota_rows_updated, quota_exhausted) = if usage_exhausted {
+        let quota_cursor = load_cursor(&transaction, QUOTA_STREAM)?;
+        let quota_rows = load_quota_rows(&transaction, quota_cursor, remaining)?;
+        let rows_updated = quota_rows.len();
+        let exhausted = rows_updated < remaining;
+        for row in &quota_rows {
+            migrate_quota_row(&transaction, row)?;
+        }
+        if let Some(last_row) = quota_rows.last() {
+            save_cursor(&transaction, QUOTA_STREAM, last_row.id)?;
+        }
+        (rows_updated, exhausted)
+    } else {
+        (0, false)
+    };
+
+    let complete = usage_exhausted && quota_exhausted;
+    if complete {
+        transaction.execute(
+            "
+            INSERT INTO data_repairs (repair_key, completed_at)
+            VALUES (?1, ?2)
+            ON CONFLICT(repair_key) DO NOTHING
+            ",
+            params![REPAIR_KEY, now_utc_string()],
+        )?;
+    }
+    transaction.commit()?;
+
+    Ok(EpochBackfillProgress {
+        usage_rows_updated,
+        quota_rows_updated,
+        complete,
+    })
+}
+
+fn repair_is_complete(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT 1 FROM data_repairs WHERE repair_key = ?1",
+        params![REPAIR_KEY],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|value| value.is_some())
+}
+
+fn ensure_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::Result<()> {
+    transaction.execute(
+        "
+        INSERT INTO data_repair_progress (repair_key, stream_key, progress_value)
+        VALUES (?1, ?2, 0)
+        ON CONFLICT(repair_key, stream_key) DO NOTHING
+        ",
+        params![REPAIR_KEY, stream_key],
+    )?;
+    Ok(())
+}
+
+fn load_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::Result<i64> {
+    transaction.query_row(
+        "
+        SELECT progress_value
+        FROM data_repair_progress
+        WHERE repair_key = ?1 AND stream_key = ?2
+        ",
+        params![REPAIR_KEY, stream_key],
+        |row| row.get(0),
+    )
+}
+
+fn save_cursor(
+    transaction: &Transaction<'_>,
+    stream_key: &str,
+    progress_value: i64,
+) -> rusqlite::Result<()> {
+    transaction.execute(
+        "
+        UPDATE data_repair_progress
+        SET progress_value = ?3
+        WHERE repair_key = ?1 AND stream_key = ?2
+        ",
+        params![REPAIR_KEY, stream_key, progress_value],
+    )?;
+    Ok(())
+}
+
+fn load_usage_rows(
+    transaction: &Transaction<'_>,
+    cursor: i64,
+    limit: usize,
+) -> rusqlite::Result<Vec<UsageEpochRow>> {
+    let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+    let mut statement = transaction.prepare(
+        "
+        SELECT id, timestamp, timestamp_ms
+        FROM usage_events
+        WHERE id > ?1
+        ORDER BY id
+        LIMIT ?2
+        ",
+    )?;
+    let rows = statement
+        .query_map(params![cursor, limit], |row| {
+            Ok(UsageEpochRow {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                timestamp_ms: row.get(2)?,
+            })
+        })?
+        .collect();
+    rows
+}
+
+fn load_quota_rows(
+    transaction: &Transaction<'_>,
+    cursor: i64,
+    limit: usize,
+) -> rusqlite::Result<Vec<QuotaEpochRow>> {
+    let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+    let mut statement = transaction.prepare(
+        "
+        SELECT id,
+               sample_timestamp, sample_timestamp_ms,
+               window_start, window_start_ms,
+               resets_at, resets_at_ms
+        FROM rate_limit_samples
+        WHERE id > ?1
+        ORDER BY id
+        LIMIT ?2
+        ",
+    )?;
+    let rows = statement
+        .query_map(params![cursor, limit], |row| {
+            Ok(QuotaEpochRow {
+                id: row.get(0)?,
+                sample_timestamp: row.get(1)?,
+                sample_timestamp_ms: row.get(2)?,
+                window_start: row.get(3)?,
+                window_start_ms: row.get(4)?,
+                resets_at: row.get(5)?,
+                resets_at_ms: row.get(6)?,
+            })
+        })?
+        .collect();
+    rows
+}
+
+fn migrate_usage_row(
+    transaction: &Transaction<'_>,
+    row: &UsageEpochRow,
+) -> rusqlite::Result<()> {
+    if row.timestamp_ms.is_some() {
+        return Ok(());
+    }
+
+    match parse_epoch_millis(&row.timestamp) {
+        Ok(timestamp_ms) => {
+            transaction.execute(
+                "
+                UPDATE usage_events
+                SET timestamp_ms = ?1
+                WHERE id = ?2 AND timestamp_ms IS NULL
+                ",
+                params![timestamp_ms, row.id],
+            )?;
+        }
+        Err(error) => quarantine_value(
+            transaction,
+            "usage_events",
+            row.id,
+            "timestamp",
+            &row.timestamp,
+            &error,
+        )?,
+    }
+    Ok(())
+}
+
+fn migrate_quota_row(
+    transaction: &Transaction<'_>,
+    row: &QuotaEpochRow,
+) -> rusqlite::Result<()> {
+    let sample_timestamp_ms = parse_missing_value(
+        transaction,
+        "rate_limit_samples",
+        row.id,
+        "sample_timestamp",
+        &row.sample_timestamp,
+        row.sample_timestamp_ms,
+    )?;
+    let window_start_ms = parse_missing_value(
+        transaction,
+        "rate_limit_samples",
+        row.id,
+        "window_start",
+        &row.window_start,
+        row.window_start_ms,
+    )?;
+    let resets_at_ms = parse_missing_value(
+        transaction,
+        "rate_limit_samples",
+        row.id,
+        "resets_at",
+        &row.resets_at,
+        row.resets_at_ms,
+    )?;
+
+    if sample_timestamp_ms.is_none() && window_start_ms.is_none() && resets_at_ms.is_none() {
+        return Ok(());
+    }
+
+    transaction.execute(
+        "
+        UPDATE rate_limit_samples
+        SET sample_timestamp_ms = COALESCE(sample_timestamp_ms, ?1),
+            window_start_ms = COALESCE(window_start_ms, ?2),
+            resets_at_ms = COALESCE(resets_at_ms, ?3)
+        WHERE id = ?4
+        ",
+        params![sample_timestamp_ms, window_start_ms, resets_at_ms, row.id],
+    )?;
+    Ok(())
+}
+
+fn parse_missing_value(
+    transaction: &Transaction<'_>,
+    table_name: &str,
+    row_id: i64,
+    column_name: &str,
+    raw_value: &str,
+    current_value: Option<i64>,
+) -> rusqlite::Result<Option<i64>> {
+    if current_value.is_some() {
+        return Ok(None);
+    }
+
+    match parse_epoch_millis(raw_value) {
+        Ok(value) => Ok(Some(value)),
+        Err(error) => {
+            quarantine_value(
+                transaction,
+                table_name,
+                row_id,
+                column_name,
+                raw_value,
+                &error,
+            )?;
+            Ok(None)
+        }
+    }
+}
+
+fn quarantine_value(
+    transaction: &Transaction<'_>,
+    table_name: &str,
+    row_id: i64,
+    column_name: &str,
+    raw_value: &str,
+    error_message: &str,
+) -> rusqlite::Result<()> {
+    transaction.execute(
+        "
+        INSERT INTO data_repair_quarantine (
+          repair_key, table_name, row_id, column_name,
+          raw_value, error_message, quarantined_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        ON CONFLICT(repair_key, table_name, row_id, column_name) DO UPDATE SET
+          raw_value = excluded.raw_value,
+          error_message = excluded.error_message,
+          quarantined_at = excluded.quarantined_at
+        ",
+        params![
+            REPAIR_KEY,
+            table_name,
+            row_id,
+            column_name,
+            raw_value,
+            error_message,
+            now_utc_string()
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use rusqlite::{params, Connection};
+    use tempfile::tempdir;
+
+    use super::{backfill_epoch_batch, parse_epoch_millis};
+    use crate::database::init_db;
+
+    const REPAIR_KEY: &str = "epoch_timestamp_backfill_v1";
+
+    fn create_legacy_epoch_tables(conn: &Connection) {
+        conn.execute_batch(
+            "
+            CREATE TABLE usage_events (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              timestamp TEXT NOT NULL,
+              model_id TEXT NOT NULL,
+              input_tokens INTEGER NOT NULL,
+              cached_input_tokens INTEGER NOT NULL,
+              output_tokens INTEGER NOT NULL,
+              reasoning_output_tokens INTEGER NOT NULL,
+              total_tokens INTEGER NOT NULL,
+              value_usd REAL NOT NULL,
+              fast_mode_auto INTEGER NOT NULL,
+              fast_mode_effective INTEGER NOT NULL
+            );
+
+            CREATE TABLE rate_limit_samples (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              source_kind TEXT NOT NULL,
+              source_session_id TEXT NOT NULL DEFAULT '',
+              bucket TEXT NOT NULL,
+              sample_timestamp TEXT NOT NULL,
+              limit_id TEXT NOT NULL DEFAULT '',
+              limit_name TEXT NOT NULL DEFAULT '',
+              plan_type TEXT NOT NULL DEFAULT '',
+              window_start TEXT NOT NULL,
+              resets_at TEXT NOT NULL,
+              used_percent INTEGER NOT NULL,
+              remaining_percent INTEGER NOT NULL,
+              created_at TEXT NOT NULL
+            );
+            ",
+        )
+        .expect("create legacy epoch tables");
+    }
+
+    fn insert_usage(conn: &Connection, timestamp: &str) -> i64 {
+        conn.execute(
+            "
+            INSERT INTO usage_events (
+              session_id, timestamp, model_id,
+              input_tokens, cached_input_tokens, output_tokens,
+              reasoning_output_tokens, total_tokens, value_usd,
+              fast_mode_auto, fast_mode_effective
+            )
+            VALUES ('session', ?1, 'gpt-5', 1, 0, 1, 0, 2, 0.01, 0, 0)
+            ",
+            params![timestamp],
+        )
+        .expect("insert usage event");
+        conn.last_insert_rowid()
+    }
+
+    fn insert_quota(conn: &Connection, timestamp: &str) -> i64 {
+        insert_quota_fields(conn, timestamp, timestamp, timestamp)
+    }
+
+    fn insert_quota_fields(
+        conn: &Connection,
+        sample_timestamp: &str,
+        window_start: &str,
+        resets_at: &str,
+    ) -> i64 {
+        conn.execute(
+            "
+            INSERT INTO rate_limit_samples (
+              source_kind, source_session_id, bucket,
+              sample_timestamp, limit_id, limit_name, plan_type,
+              window_start, resets_at, used_percent, remaining_percent, created_at
+            )
+            VALUES (
+              'session', '', 'five_hour',
+              ?1, '', '', 'plus',
+              ?2, ?3, 25, 75, ?1
+            )
+            ",
+            params![sample_timestamp, window_start, resets_at],
+        )
+        .expect("insert quota sample");
+        conn.last_insert_rowid()
+    }
+
+    fn column_names(conn: &Connection, table: &str) -> Vec<String> {
+        let mut statement = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .expect("prepare table info");
+        statement
+            .query_map([], |row| row.get(1))
+            .expect("query table info")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect column names")
+    }
+
+    fn open_initialized(path: &Path) -> Connection {
+        let conn = Connection::open(path).expect("open database");
+        init_db(&conn).expect("initialize database");
+        conn
+    }
+
+    #[test]
+    fn init_db_adds_epoch_columns_without_updating_history() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        create_legacy_epoch_tables(&conn);
+        let usage_id = insert_usage(&conn, "2026-07-10T10:00:00+08:00");
+        let quota_id = insert_quota(&conn, "2026-07-10T03:00:01Z");
+
+        init_db(&conn).expect("migrate legacy database");
+
+        let usage_columns = column_names(&conn, "usage_events");
+        assert!(usage_columns.iter().any(|name| name == "timestamp_ms"));
+        let quota_columns = column_names(&conn, "rate_limit_samples");
+        for expected in ["sample_timestamp_ms", "window_start_ms", "resets_at_ms"] {
+            assert!(quota_columns.iter().any(|name| name == expected));
+        }
+
+        let (usage_timestamp, usage_epoch): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT timestamp, timestamp_ms FROM usage_events WHERE id = ?1",
+                params![usage_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("load migrated usage event");
+        assert_eq!(usage_timestamp, "2026-07-10T10:00:00+08:00");
+        assert_eq!(usage_epoch, None);
+
+        let quota_epochs: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![quota_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load migrated quota sample");
+        assert_eq!(quota_epochs, (None, None, None));
+    }
+
+    #[test]
+    fn epoch_schema_omits_large_missing_indexes() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+
+        let epoch_indexes: Vec<(String, String)> = {
+            let mut statement = conn
+                .prepare(
+                    "
+                    SELECT name, sql
+                    FROM sqlite_master
+                    WHERE type = 'index'
+                      AND sql IS NOT NULL
+                      AND (
+                        sql LIKE '%timestamp_ms%'
+                        OR sql LIKE '%window_start_ms%'
+                        OR sql LIKE '%resets_at_ms%'
+                      )
+                    ORDER BY name
+                    ",
+                )
+                .expect("prepare epoch index query");
+            statement
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query epoch indexes")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("collect epoch indexes")
+        };
+
+        assert_eq!(
+            epoch_indexes
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "idx_rate_limit_samples_window_ms",
+                "idx_usage_events_timestamp_ms"
+            ]
+        );
+        assert!(epoch_indexes.iter().all(|(_, sql)| {
+            let normalized = sql.to_ascii_lowercase();
+            normalized.contains(" where ") && !normalized.contains(" is null")
+        }));
+    }
+
+    #[test]
+    fn epoch_parser_orders_mixed_offsets_by_instant() {
+        let earlier = parse_epoch_millis("2026-07-10T10:00:00+08:00")
+            .expect("parse timestamp with positive offset");
+        let later = parse_epoch_millis("2026-07-10T03:00:01Z")
+            .expect("parse timestamp in UTC");
+
+        assert!(earlier < later);
+    }
+
+    #[test]
+    fn backfill_updates_at_most_requested_batch_size() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        for second in 0..4 {
+            insert_usage(&conn, &format!("2026-07-10T03:00:0{second}Z"));
+            insert_quota(&conn, &format!("2026-07-10T04:00:0{second}Z"));
+        }
+
+        let progress = backfill_epoch_batch(&conn, 3).expect("backfill one bounded batch");
+
+        assert_eq!(progress.usage_rows_updated + progress.quota_rows_updated, 3);
+        assert!(!progress.complete);
+        let usage_migrated: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM usage_events WHERE timestamp_ms IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count migrated usage rows");
+        let quota_migrated: i64 = conn
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM rate_limit_samples
+                WHERE sample_timestamp_ms IS NOT NULL
+                  AND window_start_ms IS NOT NULL
+                  AND resets_at_ms IS NOT NULL
+                ",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count migrated quota rows");
+        assert_eq!(usage_migrated + quota_migrated, 3);
+    }
+
+    #[test]
+    fn backfill_caps_oversized_batches_at_one_thousand_rows() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        for _ in 0..1_001 {
+            insert_usage(&conn, "2026-07-10T03:00:00Z");
+        }
+
+        let progress =
+            backfill_epoch_batch(&conn, 1_001).expect("backfill oversized requested batch");
+
+        assert_eq!(progress.usage_rows_updated + progress.quota_rows_updated, 1_000);
+        assert!(!progress.complete);
+    }
+
+    #[test]
+    fn backfill_zero_batch_does_not_complete_unfinished_repair() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        insert_usage(&conn, "2026-07-10T03:00:00Z");
+
+        let progress = backfill_epoch_batch(&conn, 0).expect("run zero-sized batch");
+
+        assert_eq!(progress.usage_rows_updated, 0);
+        assert_eq!(progress.quota_rows_updated, 0);
+        assert!(!progress.complete);
+        let completion_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count completion markers");
+        assert_eq!(completion_count, 0);
+    }
+
+    #[test]
+    fn epoch_backfill_resumes_from_durable_cursors_after_restart() {
+        let directory = tempdir().expect("create temporary directory");
+        let db_path = directory.path().join("epoch-resume.sqlite3");
+        let conn = open_initialized(&db_path);
+        let first_id = insert_usage(&conn, "2026-07-10T03:00:00Z");
+        let second_id = insert_usage(&conn, "2026-07-10T03:00:01Z");
+        insert_usage(&conn, "2026-07-10T03:00:02Z");
+
+        let first = backfill_epoch_batch(&conn, 1).expect("run first batch");
+        assert_eq!(first.usage_rows_updated, 1);
+        conn.execute(
+            "UPDATE usage_events SET timestamp_ms = NULL WHERE id = ?1",
+            params![first_id],
+        )
+        .expect("clear migrated value behind durable cursor");
+        drop(conn);
+
+        let reopened = open_initialized(&db_path);
+        let second = backfill_epoch_batch(&reopened, 1).expect("resume after restart");
+
+        assert_eq!(second.usage_rows_updated, 1);
+        let first_epoch: Option<i64> = reopened
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![first_id],
+                |row| row.get(0),
+            )
+            .expect("load first epoch");
+        let second_epoch: Option<i64> = reopened
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![second_id],
+                |row| row.get(0),
+            )
+            .expect("load second epoch");
+        assert_eq!(first_epoch, None);
+        assert!(second_epoch.is_some());
+        let cursor: i64 = reopened
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'usage_events'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load durable usage cursor");
+        assert_eq!(cursor, second_id);
+    }
+
+    #[test]
+    fn malformed_epoch_is_quarantined_without_blocking_later_rows() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        let malformed_id = insert_usage(&conn, "not-a-timestamp");
+        let valid_id = insert_usage(&conn, "2026-07-10T03:00:01Z");
+
+        let progress = backfill_epoch_batch(&conn, 10).expect("backfill malformed row");
+
+        assert!(progress.complete);
+        let malformed_epoch: Option<i64> = conn
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![malformed_id],
+                |row| row.get(0),
+            )
+            .expect("load malformed epoch");
+        let valid_epoch: Option<i64> = conn
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![valid_id],
+                |row| row.get(0),
+            )
+            .expect("load valid epoch");
+        assert_eq!(malformed_epoch, None);
+        assert_eq!(
+            valid_epoch,
+            Some(parse_epoch_millis("2026-07-10T03:00:01Z").expect("parse expected epoch"))
+        );
+        let quarantined: (String, i64, String, String) = conn
+            .query_row(
+                "
+                SELECT table_name, row_id, column_name, raw_value
+                FROM data_repair_quarantine
+                WHERE repair_key = ?1
+                ",
+                params![REPAIR_KEY],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("load quarantine row");
+        assert_eq!(
+            quarantined,
+            (
+                "usage_events".to_string(),
+                malformed_id,
+                "timestamp".to_string(),
+                "not-a-timestamp".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn malformed_quota_epochs_are_quarantined_per_column_without_blocking_later_rows() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        let partial_id = insert_quota_fields(
+            &conn,
+            "bad-sample",
+            "2026-07-10T05:00:00Z",
+            "2026-07-10T10:00:00Z",
+        );
+        let malformed_id =
+            insert_quota_fields(&conn, "bad-sample-2", "bad-window", "bad-reset");
+        let valid_id = insert_quota_fields(
+            &conn,
+            "2026-07-10T06:00:00Z",
+            "2026-07-10T06:00:00Z",
+            "2026-07-10T11:00:00Z",
+        );
+
+        let progress = backfill_epoch_batch(&conn, 10).expect("backfill quota rows");
+
+        assert!(progress.complete);
+        let partial_epochs: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![partial_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load partially malformed quota epochs");
+        assert_eq!(partial_epochs.0, None);
+        assert_eq!(
+            partial_epochs.1,
+            Some(parse_epoch_millis("2026-07-10T05:00:00Z").expect("parse window"))
+        );
+        assert_eq!(
+            partial_epochs.2,
+            Some(parse_epoch_millis("2026-07-10T10:00:00Z").expect("parse reset"))
+        );
+
+        let malformed_epochs: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![malformed_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load malformed quota epochs");
+        assert_eq!(malformed_epochs, (None, None, None));
+
+        let valid_epochs: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![valid_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load valid quota epochs");
+        assert!(valid_epochs.0.is_some());
+        assert!(valid_epochs.1.is_some());
+        assert!(valid_epochs.2.is_some());
+
+        let quarantine_rows: Vec<(i64, String, String)> = {
+            let mut statement = conn
+                .prepare(
+                    "
+                    SELECT row_id, column_name, raw_value
+                    FROM data_repair_quarantine
+                    WHERE repair_key = ?1 AND table_name = 'rate_limit_samples'
+                    ORDER BY row_id, column_name
+                    ",
+                )
+                .expect("prepare quota quarantine query");
+            statement
+                .query_map(params![REPAIR_KEY], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })
+                .expect("query quota quarantine")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("collect quota quarantine")
+        };
+        assert_eq!(
+            quarantine_rows,
+            vec![
+                (partial_id, "sample_timestamp".to_string(), "bad-sample".to_string()),
+                (malformed_id, "resets_at".to_string(), "bad-reset".to_string()),
+                (
+                    malformed_id,
+                    "sample_timestamp".to_string(),
+                    "bad-sample-2".to_string()
+                ),
+                (
+                    malformed_id,
+                    "window_start".to_string(),
+                    "bad-window".to_string()
+                )
+            ]
+        );
+        let quota_cursor: i64 = conn
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'rate_limit_samples'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load durable quota cursor");
+        assert_eq!(quota_cursor, valid_id);
+    }
+
+    #[test]
+    fn quota_backfill_skips_updates_when_no_epoch_value_can_change() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        let populated_id = insert_quota(&conn, "2026-07-10T05:00:00Z");
+        conn.execute(
+            "
+            UPDATE rate_limit_samples
+            SET sample_timestamp_ms = 1, window_start_ms = 2, resets_at_ms = 3
+            WHERE id = ?1
+            ",
+            params![populated_id],
+        )
+        .expect("prepopulate epoch fields");
+        insert_quota_fields(&conn, "bad-sample", "bad-window", "bad-reset");
+        conn.execute_batch(
+            "
+            CREATE TRIGGER reject_noop_quota_update
+            BEFORE UPDATE ON rate_limit_samples
+            BEGIN
+              SELECT RAISE(ABORT, 'unexpected quota update');
+            END;
+            ",
+        )
+        .expect("install quota update guard");
+
+        let progress = backfill_epoch_batch(&conn, 10).expect("backfill no-op quota rows");
+
+        assert!(progress.complete);
+        assert_eq!(progress.quota_rows_updated, 2);
+        let populated_epochs: (i64, i64, i64) = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE id = ?1
+                ",
+                params![populated_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("load prepopulated epochs");
+        assert_eq!(populated_epochs, (1, 2, 3));
+        let quarantined: i64 = conn
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM data_repair_quarantine
+                WHERE repair_key = ?1 AND table_name = 'rate_limit_samples'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count malformed quota fields");
+        assert_eq!(quarantined, 3);
+    }
+
+    #[test]
+    fn epoch_backfill_rolls_back_rows_quarantine_cursors_and_completion_together() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        let malformed_id = insert_usage(&conn, "bad-timestamp");
+        let valid_id = insert_usage(&conn, "2026-07-10T03:00:01Z");
+        conn.execute_batch(
+            "
+            CREATE TRIGGER fail_epoch_completion
+            BEFORE INSERT ON data_repairs
+            WHEN NEW.repair_key = 'epoch_timestamp_backfill_v1'
+            BEGIN
+              SELECT RAISE(ABORT, 'injected completion failure');
+            END;
+            ",
+        )
+        .expect("install completion failure trigger");
+
+        let error = backfill_epoch_batch(&conn, 10).expect_err("inject transaction failure");
+
+        assert!(error.to_string().contains("injected completion failure"));
+        for row_id in [malformed_id, valid_id] {
+            let epoch: Option<i64> = conn
+                .query_row(
+                    "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                    params![row_id],
+                    |row| row.get(0),
+                )
+                .expect("load rolled-back usage epoch");
+            assert_eq!(epoch, None);
+        }
+        let quarantine_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM data_repair_quarantine", [], |row| {
+                row.get(0)
+            })
+            .expect("count rolled-back quarantine rows");
+        assert_eq!(quarantine_count, 0);
+        let cursor_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM data_repair_progress", [], |row| {
+                row.get(0)
+            })
+            .expect("count rolled-back cursors");
+        assert_eq!(cursor_count, 0);
+        let completion_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count rolled-back completion markers");
+        assert_eq!(completion_count, 0);
+    }
+
+    #[test]
+    fn epoch_backfill_completion_is_idempotent() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        insert_usage(&conn, "2026-07-10T03:00:00Z");
+        insert_quota(&conn, "2026-07-10T04:00:00Z");
+
+        let first = backfill_epoch_batch(&conn, 10).expect("complete backfill");
+        assert!(first.complete);
+        let completed_at: String = conn
+            .query_row(
+                "SELECT completed_at FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load completion time");
+        let cursor_snapshot: Vec<(String, i64)> = {
+            let mut statement = conn
+                .prepare(
+                    "
+                    SELECT stream_key, progress_value
+                    FROM data_repair_progress
+                    WHERE repair_key = ?1
+                    ORDER BY stream_key
+                    ",
+                )
+                .expect("prepare cursor snapshot");
+            statement
+                .query_map(params![REPAIR_KEY], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query cursor snapshot")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("collect cursor snapshot")
+        };
+
+        let second = backfill_epoch_batch(&conn, 10).expect("rerun completed backfill");
+
+        assert!(second.complete);
+        assert_eq!(second.usage_rows_updated, 0);
+        assert_eq!(second.quota_rows_updated, 0);
+        let completion_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("count completion rows");
+        assert_eq!(completion_rows, 1);
+        let rerun_completed_at: String = conn
+            .query_row(
+                "SELECT completed_at FROM data_repairs WHERE repair_key = ?1",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("reload completion time");
+        assert_eq!(rerun_completed_at, completed_at);
+        let rerun_cursor_snapshot: Vec<(String, i64)> = {
+            let mut statement = conn
+                .prepare(
+                    "
+                    SELECT stream_key, progress_value
+                    FROM data_repair_progress
+                    WHERE repair_key = ?1
+                    ORDER BY stream_key
+                    ",
+                )
+                .expect("prepare rerun cursor snapshot");
+            statement
+                .query_map(params![REPAIR_KEY], |row| Ok((row.get(0)?, row.get(1)?)))
+                .expect("query rerun cursor snapshot")
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .expect("collect rerun cursor snapshot")
+        };
+        assert_eq!(rerun_cursor_snapshot, cursor_snapshot);
+    }
+
+    #[test]
+    fn integrity_check_is_ok_after_epoch_migration() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        create_legacy_epoch_tables(&conn);
+        insert_usage(&conn, "2026-07-10T03:00:00Z");
+        insert_usage(&conn, "malformed");
+        insert_quota(&conn, "2026-07-10T04:00:00Z");
+        init_db(&conn).expect("migrate legacy database");
+
+        let mut complete = false;
+        for _ in 0..10 {
+            complete = backfill_epoch_batch(&conn, 1)
+                .expect("run bounded migration batch")
+                .complete;
+            if complete {
+                break;
+            }
+        }
+        assert!(complete);
+        let integrity: String = conn
+            .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+            .expect("run integrity check");
+        assert_eq!(integrity, "ok");
+    }
+}

--- a/src-tauri/src/database/epoch_backfill.rs
+++ b/src-tauri/src/database/epoch_backfill.rs
@@ -7,6 +7,10 @@ use super::now_utc_string;
 const REPAIR_KEY: &str = "epoch_timestamp_backfill_v1";
 const USAGE_STREAM: &str = "usage_events";
 const QUOTA_STREAM: &str = "rate_limit_samples";
+// Production writers populate epoch fields, so a repair must not chase rows
+// appended after it starts.
+const USAGE_HIGH_WATER_STREAM: &str = "usage_events_high_water";
+const QUOTA_HIGH_WATER_STREAM: &str = "rate_limit_samples_high_water";
 const MAX_BATCH_SIZE: usize = 1_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,9 +129,25 @@ fn backfill_epoch_batch_with_cancel_check(
 
     ensure_cursor(&transaction, USAGE_STREAM)?;
     ensure_cursor(&transaction, QUOTA_STREAM)?;
+    ensure_high_water(
+        &transaction,
+        USAGE_HIGH_WATER_STREAM,
+        "SELECT COALESCE(MAX(id), 0) FROM usage_events",
+    )?;
+    ensure_high_water(
+        &transaction,
+        QUOTA_HIGH_WATER_STREAM,
+        "SELECT COALESCE(MAX(id), 0) FROM rate_limit_samples",
+    )?;
 
     let usage_cursor = load_cursor(&transaction, USAGE_STREAM)?;
-    let usage_rows = load_usage_rows(&transaction, usage_cursor, batch_size)?;
+    let usage_high_water = load_cursor(&transaction, USAGE_HIGH_WATER_STREAM)?;
+    let usage_rows = load_usage_rows(
+        &transaction,
+        usage_cursor,
+        usage_high_water,
+        batch_size,
+    )?;
     let usage_rows_updated = usage_rows.len();
     let usage_exhausted = usage_rows_updated < batch_size;
     for row in &usage_rows {
@@ -143,7 +163,13 @@ fn backfill_epoch_batch_with_cancel_check(
     let remaining = batch_size - usage_rows_updated;
     let (quota_rows_updated, quota_exhausted) = if usage_exhausted {
         let quota_cursor = load_cursor(&transaction, QUOTA_STREAM)?;
-        let quota_rows = load_quota_rows(&transaction, quota_cursor, remaining)?;
+        let quota_high_water = load_cursor(&transaction, QUOTA_HIGH_WATER_STREAM)?;
+        let quota_rows = load_quota_rows(
+            &transaction,
+            quota_cursor,
+            quota_high_water,
+            remaining,
+        )?;
         let rows_updated = quota_rows.len();
         let exhausted = rows_updated < remaining;
         for row in &quota_rows {
@@ -212,6 +238,39 @@ fn ensure_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::R
     Ok(())
 }
 
+fn ensure_high_water(
+    transaction: &Transaction<'_>,
+    stream_key: &str,
+    max_id_sql: &str,
+) -> rusqlite::Result<()> {
+    let exists = transaction
+        .query_row(
+            "
+            SELECT 1
+            FROM data_repair_progress
+            WHERE repair_key = ?1 AND stream_key = ?2
+            ",
+            params![REPAIR_KEY, stream_key],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    if exists {
+        return Ok(());
+    }
+
+    let high_water = transaction.query_row(max_id_sql, [], |row| row.get::<_, i64>(0))?;
+    transaction.execute(
+        "
+        INSERT INTO data_repair_progress (repair_key, stream_key, progress_value)
+        VALUES (?1, ?2, ?3)
+        ON CONFLICT(repair_key, stream_key) DO NOTHING
+        ",
+        params![REPAIR_KEY, stream_key, high_water],
+    )?;
+    Ok(())
+}
+
 fn load_cursor(transaction: &Transaction<'_>, stream_key: &str) -> rusqlite::Result<i64> {
     transaction.query_row(
         "
@@ -243,6 +302,7 @@ fn save_cursor(
 fn load_usage_rows(
     transaction: &Transaction<'_>,
     cursor: i64,
+    high_water: i64,
     limit: usize,
 ) -> rusqlite::Result<Vec<UsageEpochRow>> {
     let limit = i64::try_from(limit).unwrap_or(i64::MAX);
@@ -250,13 +310,13 @@ fn load_usage_rows(
         "
         SELECT id, timestamp, timestamp_ms
         FROM usage_events
-        WHERE id > ?1
+        WHERE id > ?1 AND id <= ?2
         ORDER BY id
-        LIMIT ?2
+        LIMIT ?3
         ",
     )?;
     let rows = statement
-        .query_map(params![cursor, limit], |row| {
+        .query_map(params![cursor, high_water, limit], |row| {
             Ok(UsageEpochRow {
                 id: row.get(0)?,
                 timestamp: row.get(1)?,
@@ -270,6 +330,7 @@ fn load_usage_rows(
 fn load_quota_rows(
     transaction: &Transaction<'_>,
     cursor: i64,
+    high_water: i64,
     limit: usize,
 ) -> rusqlite::Result<Vec<QuotaEpochRow>> {
     let limit = i64::try_from(limit).unwrap_or(i64::MAX);
@@ -280,13 +341,13 @@ fn load_quota_rows(
                window_start, window_start_ms,
                resets_at, resets_at_ms
         FROM rate_limit_samples
-        WHERE id > ?1
+        WHERE id > ?1 AND id <= ?2
         ORDER BY id
-        LIMIT ?2
+        LIMIT ?3
         ",
     )?;
     let rows = statement
-        .query_map(params![cursor, limit], |row| {
+        .query_map(params![cursor, high_water, limit], |row| {
             Ok(QuotaEpochRow {
                 id: row.get(0)?,
                 sample_timestamp: row.get(1)?,
@@ -888,6 +949,166 @@ mod tests {
             )
             .expect("load durable usage cursor");
         assert_eq!(cursor, second_id);
+    }
+
+    #[test]
+    fn backfill_completion_ignores_new_epoch_rows_beyond_initial_high_water() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        init_db(&conn).expect("initialize database");
+        insert_quota(&conn, "2026-07-10T03:00:00Z");
+        let malformed_id =
+            insert_quota_fields(&conn, "bad-sample", "bad-window", "bad-reset");
+
+        let first = backfill_epoch_batch(&conn, 1).expect("backfill initial quota row");
+        assert!(!first.complete);
+        assert_eq!(first.quota_rows_updated, 1);
+
+        let mut progress = first;
+        for minute in 1..=4 {
+            let appended_id = insert_quota(
+                &conn,
+                &format!("2026-07-10T03:0{minute}:00Z"),
+            );
+            conn.execute(
+                "
+                UPDATE rate_limit_samples
+                SET sample_timestamp_ms = 1, window_start_ms = 1, resets_at_ms = 1
+                WHERE id = ?1
+                ",
+                params![appended_id],
+            )
+            .expect("simulate an epoch-aware production append");
+            progress = backfill_epoch_batch(&conn, 1).expect("continue bounded legacy repair");
+            if progress.complete {
+                break;
+            }
+        }
+
+        assert!(
+            progress.complete,
+            "repair chased epoch-aware rows beyond its initial high-water"
+        );
+        let high_water: i64 = conn
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'rate_limit_samples_high_water'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load quota high-water");
+        assert_eq!(high_water, malformed_id);
+        let quarantined: i64 = conn
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM data_repair_quarantine
+                WHERE repair_key = ?1 AND table_name = 'rate_limit_samples'
+                  AND row_id = ?2
+                ",
+                params![REPAIR_KEY, malformed_id],
+                |row| row.get(0),
+            )
+            .expect("count malformed quota fields");
+        assert_eq!(quarantined, 3);
+        assert!(!epoch_backfill_pending(&conn).expect("read completion marker"));
+    }
+
+    #[test]
+    fn legacy_cursor_upgrade_persists_high_water_across_restart() {
+        let directory = tempdir().expect("create temporary directory");
+        let db_path = directory.path().join("epoch-high-water-upgrade.sqlite3");
+        let conn = open_initialized(&db_path);
+        let processed_id = insert_usage(&conn, "2026-07-10T03:00:00Z");
+        conn.execute(
+            "UPDATE usage_events SET timestamp_ms = 1 WHERE id = ?1",
+            params![processed_id],
+        )
+        .expect("simulate an already processed legacy row");
+        let valid_id = insert_usage(&conn, "2026-07-10T03:00:01Z");
+        let malformed_id = insert_usage(&conn, "bad-timestamp");
+        conn.execute(
+            "
+            INSERT INTO data_repair_progress (repair_key, stream_key, progress_value)
+            VALUES (?1, 'usage_events', ?2)
+            ",
+            params![REPAIR_KEY, processed_id],
+        )
+        .expect("seed legacy cursor without high-water");
+
+        let first = backfill_epoch_batch(&conn, 1).expect("upgrade legacy repair progress");
+
+        assert!(!first.complete);
+        let captured_high_water: i64 = conn
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'usage_events_high_water'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load captured usage high-water");
+        assert_eq!(captured_high_water, malformed_id);
+        let valid_epoch: Option<i64> = conn
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![valid_id],
+                |row| row.get(0),
+            )
+            .expect("load upgraded usage epoch");
+        assert!(valid_epoch.is_some());
+        drop(conn);
+
+        let reopened = open_initialized(&db_path);
+        let appended_id = insert_usage(&reopened, "2026-07-10T03:00:03Z");
+        reopened
+            .execute(
+                "UPDATE usage_events SET timestamp_ms = 1 WHERE id = ?1",
+                params![appended_id],
+            )
+            .expect("append epoch-aware row after captured high-water");
+        let second = backfill_epoch_batch(&reopened, 1).expect("resume bounded repair");
+        assert!(!second.complete);
+        let third = backfill_epoch_batch(&reopened, 1).expect("complete bounded repair");
+
+        assert!(third.complete);
+        let final_cursor: i64 = reopened
+            .query_row(
+                "
+                SELECT progress_value
+                FROM data_repair_progress
+                WHERE repair_key = ?1 AND stream_key = 'usage_events'
+                ",
+                params![REPAIR_KEY],
+                |row| row.get(0),
+            )
+            .expect("load final usage cursor");
+        assert_eq!(final_cursor, malformed_id);
+        let quarantine_count: i64 = reopened
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM data_repair_quarantine
+                WHERE repair_key = ?1 AND table_name = 'usage_events' AND row_id = ?2
+                ",
+                params![REPAIR_KEY, malformed_id],
+                |row| row.get(0),
+            )
+            .expect("count quarantined legacy row");
+        assert_eq!(quarantine_count, 1);
+        let appended_epoch: Option<i64> = reopened
+            .query_row(
+                "SELECT timestamp_ms FROM usage_events WHERE id = ?1",
+                params![appended_id],
+                |row| row.get(0),
+            )
+            .expect("load appended epoch-aware row");
+        assert_eq!(appended_epoch, Some(1));
+        assert!(!epoch_backfill_pending(&reopened).expect("read completion marker"));
     }
 
     #[test]

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -1,58 +1,127 @@
 use std::io::{Error as IoError, ErrorKind};
 
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
-use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord};
+use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord, RateLimitWindowSnapshot};
 
 use super::{now_utc_string, parse_epoch_millis};
 
-struct ParsedRateLimitSample<'a> {
-    sample: &'a RateLimitSampleRecord,
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ParsedRateLimitSample {
+    source_kind: String,
+    source_session_id: String,
+    bucket: String,
+    sample_timestamp: String,
     sample_timestamp_ms: i64,
+    limit_id: String,
+    limit_name: String,
+    plan_type: String,
+    window_start: String,
     window_start_ms: i64,
+    resets_at: String,
     resets_at_ms: i64,
+    used_percent: i64,
+    remaining_percent: i64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RateLimitWriteStats {
+    pub observed: usize,
+    pub historical_inserted: usize,
+    pub latest_updated: usize,
 }
 
 pub fn replace_session_rate_limit_samples(
     conn: &Connection,
     session_id: &str,
     samples: &[RateLimitSampleRecord],
-) -> rusqlite::Result<()> {
-    let parsed = parse_rate_limit_samples(samples)?;
-    conn.execute(
-        "
-    DELETE FROM rate_limit_samples
-    WHERE source_kind = 'session' AND source_session_id = ?1
-    ",
-        params![session_id],
-    )?;
-    insert_parsed_rate_limit_samples(conn, &parsed)
+) -> rusqlite::Result<RateLimitWriteStats> {
+    let mut parsed = parse_rate_limit_samples(samples)?;
+    normalize_session_owner(&mut parsed, session_id);
+    let compacted = compact_complete_session_history(&parsed);
+    with_rate_limit_savepoint(conn, |conn| {
+        let mut stats = RateLimitWriteStats {
+            observed: parsed.len(),
+            ..RateLimitWriteStats::default()
+        };
+        if load_session_history(conn, session_id)? != compacted {
+            conn.execute(
+                "DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1",
+                params![session_id],
+            )?;
+            stats.historical_inserted = insert_parsed_rate_limit_samples(conn, &compacted)?;
+        }
+        let buckets = compacted
+            .iter()
+            .map(|sample| sample.bucket.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        for bucket in ["five_hour", "seven_day"] {
+            if !buckets.contains(bucket) {
+                conn.execute(
+                    "DELETE FROM latest_rate_limits WHERE source_kind = 'session' AND source_session_id = ?1 AND bucket = ?2",
+                    params![session_id, bucket],
+                )?;
+            }
+        }
+        for sample in newest_per_owner_bucket(&parsed) {
+            stats.latest_updated += upsert_latest(conn, sample)?;
+        }
+        Ok(stats)
+    })
 }
 
+#[allow(dead_code)]
+pub fn append_session_rate_limit_samples(
+    conn: &Connection,
+    session_id: &str,
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<RateLimitWriteStats> {
+    let mut parsed = parse_rate_limit_samples(samples)?;
+    normalize_session_owner(&mut parsed, session_id);
+    with_rate_limit_savepoint(conn, |conn| append_parsed_samples(conn, &parsed))
+}
+
+#[cfg(test)]
 pub fn insert_rate_limit_samples(
     conn: &Connection,
     samples: &[RateLimitSampleRecord],
 ) -> rusqlite::Result<()> {
     let parsed = parse_rate_limit_samples(samples)?;
-    insert_parsed_rate_limit_samples(conn, &parsed)
+    with_rate_limit_savepoint(conn, |conn| {
+        insert_parsed_rate_limit_samples(conn, &parsed).map(|_| ())
+    })
 }
 
 fn parse_rate_limit_samples(
     samples: &[RateLimitSampleRecord],
-) -> rusqlite::Result<Vec<ParsedRateLimitSample<'_>>> {
+) -> rusqlite::Result<Vec<ParsedRateLimitSample>> {
     let mut parsed = Vec::with_capacity(samples.len());
     for sample in samples {
         parsed.push(ParsedRateLimitSample {
-            sample,
-            sample_timestamp_ms: parse_epoch_field(
-                "sample_timestamp",
-                &sample.sample_timestamp,
-            )?,
+            source_kind: sample.source_kind.clone(),
+            source_session_id: sample.source_session_id.clone().unwrap_or_default(),
+            bucket: sample.bucket.clone(),
+            sample_timestamp: sample.sample_timestamp.clone(),
+            sample_timestamp_ms: parse_epoch_field("sample_timestamp", &sample.sample_timestamp)?,
+            limit_id: sample.limit_id.clone().unwrap_or_default(),
+            limit_name: sample.limit_name.clone().unwrap_or_default(),
+            plan_type: sample.plan_type.clone().unwrap_or_default(),
+            window_start: sample.window_start.clone(),
             window_start_ms: parse_epoch_field("window_start", &sample.window_start)?,
+            resets_at: sample.resets_at.clone(),
             resets_at_ms: parse_epoch_field("resets_at", &sample.resets_at)?,
+            used_percent: sample.used_percent.clamp(0, 100),
+            remaining_percent: sample.remaining_percent.clamp(0, 100),
         });
     }
     Ok(parsed)
+}
+
+fn normalize_session_owner(samples: &mut [ParsedRateLimitSample], session_id: &str) {
+    for sample in samples {
+        sample.source_kind = "session".to_string();
+        sample.source_session_id = session_id.to_string();
+    }
 }
 
 fn parse_epoch_field(field_name: &str, value: &str) -> rusqlite::Result<i64> {
@@ -66,10 +135,10 @@ fn parse_epoch_field(field_name: &str, value: &str) -> rusqlite::Result<i64> {
 
 fn insert_parsed_rate_limit_samples(
     conn: &Connection,
-    samples: &[ParsedRateLimitSample<'_>],
-) -> rusqlite::Result<()> {
+    samples: &[ParsedRateLimitSample],
+) -> rusqlite::Result<usize> {
     if samples.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
     let created_at = now_utc_string();
     let mut stmt = conn.prepare(
@@ -83,34 +152,34 @@ fn insert_parsed_rate_limit_samples(
     ",
     )?;
 
-    for parsed in samples {
-        let sample = parsed.sample;
-        stmt.execute(params![
+    let mut inserted = 0;
+    for sample in samples {
+        inserted += stmt.execute(params![
             sample.source_kind,
-            sample.source_session_id.as_deref().unwrap_or_default(),
+            sample.source_session_id,
             sample.bucket,
             sample.sample_timestamp,
-            parsed.sample_timestamp_ms,
-            sample.limit_id.as_deref().unwrap_or_default(),
-            sample.limit_name.as_deref().unwrap_or_default(),
-            sample.plan_type.as_deref().unwrap_or_default(),
+            sample.sample_timestamp_ms,
+            sample.limit_id,
+            sample.limit_name,
+            sample.plan_type,
             sample.window_start,
-            parsed.window_start_ms,
+            sample.window_start_ms,
             sample.resets_at,
-            parsed.resets_at_ms,
-            sample.used_percent.clamp(0, 100),
-            sample.remaining_percent.clamp(0, 100),
+            sample.resets_at_ms,
+            sample.used_percent,
+            sample.remaining_percent,
             created_at,
         ])?;
     }
 
-    Ok(())
+    Ok(inserted)
 }
 
 pub fn insert_live_rate_limit_snapshot(
     conn: &Connection,
     snapshot: &LiveRateLimitSnapshot,
-) -> rusqlite::Result<()> {
+) -> rusqlite::Result<RateLimitWriteStats> {
     let mut samples = Vec::new();
     for (bucket, window) in [
         ("five_hour", snapshot.primary.as_ref()),
@@ -138,7 +207,387 @@ pub fn insert_live_rate_limit_snapshot(
             remaining_percent: window.remaining_percent,
         });
     }
-    insert_rate_limit_samples(conn, &samples)
+    let parsed = parse_rate_limit_samples(&samples)?;
+    with_rate_limit_savepoint(conn, |conn| append_parsed_samples(conn, &parsed))
+}
+
+fn with_rate_limit_savepoint<T>(
+    conn: &Connection,
+    operation: impl FnOnce(&Connection) -> rusqlite::Result<T>,
+) -> rusqlite::Result<T> {
+    conn.execute_batch("SAVEPOINT codex_pacer_rate_limit_write")?;
+    match operation(conn) {
+        Ok(value) => {
+            conn.execute_batch("RELEASE SAVEPOINT codex_pacer_rate_limit_write")?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT codex_pacer_rate_limit_write; RELEASE SAVEPOINT codex_pacer_rate_limit_write",
+            );
+            Err(error)
+        }
+    }
+}
+
+fn same_window(left: &ParsedRateLimitSample, right: &ParsedRateLimitSample) -> bool {
+    left.window_start_ms == right.window_start_ms && left.resets_at_ms == right.resets_at_ms
+}
+
+fn same_value(left: &ParsedRateLimitSample, right: &ParsedRateLimitSample) -> bool {
+    left.used_percent == right.used_percent && left.remaining_percent == right.remaining_percent
+}
+
+fn same_history_point(left: &ParsedRateLimitSample, right: &ParsedRateLimitSample) -> bool {
+    left.source_kind == right.source_kind
+        && left.source_session_id == right.source_session_id
+        && left.bucket == right.bucket
+        && left.sample_timestamp_ms == right.sample_timestamp_ms
+        && left.limit_id == right.limit_id
+        && left.limit_name == right.limit_name
+        && left.plan_type == right.plan_type
+        && same_window(left, right)
+        && same_value(left, right)
+}
+
+fn grouped_sorted(samples: &[ParsedRateLimitSample]) -> Vec<Vec<ParsedRateLimitSample>> {
+    let mut ordered = samples.to_vec();
+    ordered.sort_by(|left, right| {
+        (
+            &left.source_kind,
+            &left.source_session_id,
+            &left.bucket,
+            left.sample_timestamp_ms,
+        )
+            .cmp(&(
+                &right.source_kind,
+                &right.source_session_id,
+                &right.bucket,
+                right.sample_timestamp_ms,
+            ))
+    });
+    let mut groups: Vec<Vec<ParsedRateLimitSample>> = Vec::new();
+    for sample in ordered {
+        if groups
+            .last()
+            .and_then(|group| group.first())
+            .is_some_and(|first| {
+                first.source_kind == sample.source_kind
+                    && first.source_session_id == sample.source_session_id
+                    && first.bucket == sample.bucket
+            })
+        {
+            groups.last_mut().expect("group exists").push(sample);
+        } else {
+            groups.push(vec![sample]);
+        }
+    }
+    groups
+}
+
+fn compact_complete_session_history(
+    samples: &[ParsedRateLimitSample],
+) -> Vec<ParsedRateLimitSample> {
+    let mut compacted = Vec::new();
+    for group in grouped_sorted(samples) {
+        let Some(first) = group.first() else { continue };
+        compacted.push(first.clone());
+        let mut previous = first;
+        for sample in group.iter().skip(1) {
+            if !same_window(previous, sample) || !same_value(previous, sample) {
+                compacted.push(sample.clone());
+            }
+            previous = sample;
+        }
+        if let Some(last) = group.last() {
+            if compacted
+                .last()
+                .map_or(true, |point| !same_history_point(point, last))
+            {
+                compacted.push(last.clone());
+            }
+        }
+    }
+    compacted
+}
+
+fn newest_per_owner_bucket(samples: &[ParsedRateLimitSample]) -> Vec<&ParsedRateLimitSample> {
+    grouped_sorted(samples)
+        .iter()
+        .filter_map(|group| group.last())
+        .map(|sample| {
+            samples
+                .iter()
+                .find(|candidate| same_history_point(candidate, sample))
+                .expect("newest sample belongs to input")
+        })
+        .collect()
+}
+
+fn append_parsed_samples(
+    conn: &Connection,
+    samples: &[ParsedRateLimitSample],
+) -> rusqlite::Result<RateLimitWriteStats> {
+    let mut stats = RateLimitWriteStats {
+        observed: samples.len(),
+        ..RateLimitWriteStats::default()
+    };
+    for group in grouped_sorted(samples) {
+        let Some(first) = group.first() else { continue };
+        let mut previous = load_latest_owner_bucket(
+            conn,
+            &first.source_kind,
+            &first.source_session_id,
+            &first.bucket,
+        )?;
+        let mut history = Vec::new();
+        for sample in &group {
+            if previous
+                .as_ref()
+                .is_some_and(|current| sample.sample_timestamp_ms < current.sample_timestamp_ms)
+            {
+                continue;
+            }
+            match previous.as_ref() {
+                None => history.push(sample.clone()),
+                Some(current) if !same_window(current, sample) => {
+                    history.push(current.clone());
+                    history.push(sample.clone());
+                }
+                Some(current) if !same_value(current, sample) => history.push(sample.clone()),
+                Some(_) => {}
+            }
+            previous = Some(sample.clone());
+        }
+        history.dedup_by(|left, right| same_history_point(left, right));
+        stats.historical_inserted += insert_parsed_rate_limit_samples(conn, &history)?;
+        if let Some(latest) = previous.as_ref() {
+            stats.latest_updated += upsert_latest(conn, latest)?;
+        }
+    }
+    Ok(stats)
+}
+
+fn upsert_latest(conn: &Connection, sample: &ParsedRateLimitSample) -> rusqlite::Result<usize> {
+    conn.execute(
+        "
+        INSERT INTO latest_rate_limits (
+          source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+          limit_id, limit_name, plan_type, window_start, window_start_ms,
+          resets_at, resets_at_ms, used_percent, remaining_percent, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+        ON CONFLICT(source_kind, source_session_id, bucket) DO UPDATE SET
+          sample_timestamp = excluded.sample_timestamp,
+          sample_timestamp_ms = excluded.sample_timestamp_ms,
+          limit_id = excluded.limit_id,
+          limit_name = excluded.limit_name,
+          plan_type = excluded.plan_type,
+          window_start = excluded.window_start,
+          window_start_ms = excluded.window_start_ms,
+          resets_at = excluded.resets_at,
+          resets_at_ms = excluded.resets_at_ms,
+          used_percent = excluded.used_percent,
+          remaining_percent = excluded.remaining_percent,
+          updated_at = excluded.updated_at
+        WHERE excluded.sample_timestamp_ms >= latest_rate_limits.sample_timestamp_ms
+          AND (
+            excluded.sample_timestamp_ms <> latest_rate_limits.sample_timestamp_ms
+            OR excluded.limit_id <> latest_rate_limits.limit_id
+            OR excluded.limit_name <> latest_rate_limits.limit_name
+            OR excluded.plan_type <> latest_rate_limits.plan_type
+            OR excluded.window_start_ms <> latest_rate_limits.window_start_ms
+            OR excluded.resets_at_ms <> latest_rate_limits.resets_at_ms
+            OR excluded.used_percent <> latest_rate_limits.used_percent
+            OR excluded.remaining_percent <> latest_rate_limits.remaining_percent
+          )
+        ",
+        params![
+            sample.source_kind,
+            sample.source_session_id,
+            sample.bucket,
+            sample.sample_timestamp,
+            sample.sample_timestamp_ms,
+            sample.limit_id,
+            sample.limit_name,
+            sample.plan_type,
+            sample.window_start,
+            sample.window_start_ms,
+            sample.resets_at,
+            sample.resets_at_ms,
+            sample.used_percent,
+            sample.remaining_percent,
+            now_utc_string(),
+        ],
+    )
+}
+
+fn load_latest_owner_bucket(
+    conn: &Connection,
+    source_kind: &str,
+    source_session_id: &str,
+    bucket: &str,
+) -> rusqlite::Result<Option<ParsedRateLimitSample>> {
+    conn.query_row(
+        "
+        SELECT source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+               limit_id, limit_name, plan_type, window_start, window_start_ms,
+               resets_at, resets_at_ms, used_percent, remaining_percent
+        FROM latest_rate_limits
+        WHERE source_kind = ?1 AND source_session_id = ?2 AND bucket = ?3
+        ",
+        params![source_kind, source_session_id, bucket],
+        parsed_sample_from_row,
+    )
+    .optional()
+}
+
+fn parsed_sample_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ParsedRateLimitSample> {
+    Ok(ParsedRateLimitSample {
+        source_kind: row.get(0)?,
+        source_session_id: row.get(1)?,
+        bucket: row.get(2)?,
+        sample_timestamp: row.get(3)?,
+        sample_timestamp_ms: row.get(4)?,
+        limit_id: row.get(5)?,
+        limit_name: row.get(6)?,
+        plan_type: row.get(7)?,
+        window_start: row.get(8)?,
+        window_start_ms: row.get(9)?,
+        resets_at: row.get(10)?,
+        resets_at_ms: row.get(11)?,
+        used_percent: row.get(12)?,
+        remaining_percent: row.get(13)?,
+    })
+}
+
+fn load_session_history(
+    conn: &Connection,
+    session_id: &str,
+) -> rusqlite::Result<Vec<ParsedRateLimitSample>> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+               limit_id, limit_name, plan_type, window_start, window_start_ms,
+               resets_at, resets_at_ms, used_percent, remaining_percent
+        FROM rate_limit_samples
+        WHERE source_kind = 'session' AND source_session_id = ?1
+        ORDER BY bucket, sample_timestamp_ms, id
+        ",
+    )?;
+    let rows = stmt.query_map(params![session_id], |row| {
+        Ok(ParsedRateLimitSample {
+            source_kind: row.get(0)?,
+            source_session_id: row.get(1)?,
+            bucket: row.get(2)?,
+            sample_timestamp: row.get(3)?,
+            sample_timestamp_ms: row.get::<_, Option<i64>>(4)?.unwrap_or(i64::MIN),
+            limit_id: row.get(5)?,
+            limit_name: row.get(6)?,
+            plan_type: row.get(7)?,
+            window_start: row.get(8)?,
+            window_start_ms: row.get::<_, Option<i64>>(9)?.unwrap_or(i64::MIN),
+            resets_at: row.get(10)?,
+            resets_at_ms: row.get::<_, Option<i64>>(11)?.unwrap_or(i64::MIN),
+            used_percent: row.get(12)?,
+            remaining_percent: row.get(13)?,
+        })
+    })?;
+    rows.collect()
+}
+
+#[derive(Clone)]
+struct LatestWindow {
+    owner: (String, String),
+    sample: ParsedRateLimitSample,
+}
+
+fn load_latest_window(
+    conn: &Connection,
+    bucket: &str,
+    source_kind: Option<&str>,
+) -> rusqlite::Result<Option<LatestWindow>> {
+    conn.query_row(
+        "
+        SELECT source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+               limit_id, limit_name, plan_type, window_start, window_start_ms,
+               resets_at, resets_at_ms, used_percent, remaining_percent
+        FROM latest_rate_limits
+        WHERE bucket = ?1 AND (?2 IS NULL OR source_kind = ?2)
+        ORDER BY sample_timestamp_ms DESC, rowid DESC
+        LIMIT 1
+        ",
+        params![bucket, source_kind],
+        |row| {
+            let sample = parsed_sample_from_row(row)?;
+            Ok(LatestWindow {
+                owner: (sample.source_kind.clone(), sample.source_session_id.clone()),
+                sample,
+            })
+        },
+    )
+    .optional()
+}
+
+pub fn load_latest_rate_limits(
+    conn: &Connection,
+    source_kind: Option<&str>,
+) -> rusqlite::Result<Option<LiveRateLimitSnapshot>> {
+    let mut primary = load_latest_window(conn, "five_hour", source_kind)?;
+    let mut secondary = load_latest_window(conn, "seven_day", source_kind)?;
+    let newest = match (primary.as_ref(), secondary.as_ref()) {
+        (Some(left), Some(right)) => {
+            if right.sample.sample_timestamp_ms > left.sample.sample_timestamp_ms {
+                right
+            } else {
+                left
+            }
+        }
+        (Some(left), None) => left,
+        (None, Some(right)) => right,
+        (None, None) => return Ok(None),
+    };
+    let newest_owner = newest.owner.clone();
+    let newest_timestamp = newest.sample.sample_timestamp_ms;
+    if primary.as_ref().is_some_and(|window| {
+        window.owner != newest_owner || window.sample.sample_timestamp_ms != newest_timestamp
+    }) {
+        primary = None;
+    }
+    if secondary.as_ref().is_some_and(|window| {
+        window.owner != newest_owner || window.sample.sample_timestamp_ms != newest_timestamp
+    }) {
+        secondary = None;
+    }
+    let reference = primary
+        .as_ref()
+        .or(secondary.as_ref())
+        .expect("latest window exists");
+    let limit_id =
+        (!reference.sample.limit_id.is_empty()).then(|| reference.sample.limit_id.clone());
+    let limit_name =
+        (!reference.sample.limit_name.is_empty()).then(|| reference.sample.limit_name.clone());
+    let plan_type =
+        (!reference.sample.plan_type.is_empty()).then(|| reference.sample.plan_type.clone());
+    let fetched_at = reference.sample.sample_timestamp.clone();
+    let window_snapshot = |window: LatestWindow| RateLimitWindowSnapshot {
+        used_percent: window.sample.used_percent,
+        remaining_percent: window.sample.remaining_percent,
+        window_duration_mins: Some(
+            (window.sample.resets_at_ms - window.sample.window_start_ms)
+                .div_euclid(60_000)
+                .max(0),
+        ),
+        resets_at: Some(window.sample.resets_at),
+        window_start: Some(window.sample.window_start),
+    };
+    Ok(Some(LiveRateLimitSnapshot {
+        limit_id,
+        limit_name,
+        plan_type,
+        primary: primary.map(window_snapshot),
+        secondary: secondary.map(window_snapshot),
+        fetched_at,
+    }))
 }
 
 #[cfg(test)]
@@ -146,13 +595,11 @@ mod tests {
     use rusqlite::Connection;
 
     use crate::database::{init_db, parse_epoch_millis};
-    use crate::models::{
-        LiveRateLimitSnapshot, RateLimitSampleRecord, RateLimitWindowSnapshot,
-    };
+    use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord, RateLimitWindowSnapshot};
 
     use super::{
-        insert_live_rate_limit_snapshot, insert_rate_limit_samples,
-        replace_session_rate_limit_samples,
+        append_session_rate_limit_samples, insert_live_rate_limit_snapshot,
+        insert_rate_limit_samples, load_latest_rate_limits, replace_session_rate_limit_samples,
     };
 
     fn session_sample(
@@ -173,6 +620,346 @@ mod tests {
             used_percent: 25,
             remaining_percent: 75,
         }
+    }
+
+    fn live_snapshot(
+        fetched_at: &str,
+        primary_used: i64,
+        secondary_used: i64,
+        primary_window_start: &str,
+        primary_resets_at: &str,
+    ) -> LiveRateLimitSnapshot {
+        LiveRateLimitSnapshot {
+            limit_id: Some("codex".to_string()),
+            limit_name: Some("Codex".to_string()),
+            plan_type: Some("pro".to_string()),
+            primary: Some(RateLimitWindowSnapshot {
+                used_percent: primary_used,
+                remaining_percent: 100 - primary_used,
+                window_duration_mins: Some(300),
+                window_start: Some(primary_window_start.to_string()),
+                resets_at: Some(primary_resets_at.to_string()),
+            }),
+            secondary: Some(RateLimitWindowSnapshot {
+                used_percent: secondary_used,
+                remaining_percent: 100 - secondary_used,
+                window_duration_mins: Some(10_080),
+                window_start: Some("2026-07-06T00:00:00Z".to_string()),
+                resets_at: Some("2026-07-13T00:00:00Z".to_string()),
+            }),
+            fetched_at: fetched_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn repeated_live_percent_updates_latest_without_growing_history() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let first = live_snapshot(
+            "2026-07-10T10:00:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        let repeated = live_snapshot(
+            "2026-07-10T10:05:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+
+        let first_stats = insert_live_rate_limit_snapshot(&conn, &first).expect("insert first");
+        let repeated_stats =
+            insert_live_rate_limit_snapshot(&conn, &repeated).expect("insert repeated");
+
+        assert_eq!(first_stats.historical_inserted, 2);
+        assert_eq!(first_stats.latest_updated, 2);
+        assert_eq!(repeated_stats.historical_inserted, 0);
+        assert_eq!(repeated_stats.latest_updated, 2);
+        let history_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| {
+                row.get(0)
+            })
+            .expect("count history");
+        let latest_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM latest_rate_limits", [], |row| {
+                row.get(0)
+            })
+            .expect("count latest");
+        assert_eq!(history_count, 2);
+        assert_eq!(latest_count, 2);
+        assert_eq!(
+            load_latest_rate_limits(&conn, Some("live"))
+                .expect("load latest")
+                .expect("latest snapshot")
+                .fetched_at,
+            repeated.fetched_at
+        );
+    }
+
+    #[test]
+    fn changed_percent_adds_one_history_point() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let first = live_snapshot(
+            "2026-07-10T10:00:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        let changed = live_snapshot(
+            "2026-07-10T10:05:00Z",
+            41,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        insert_live_rate_limit_snapshot(&conn, &first).expect("insert first");
+
+        let stats = insert_live_rate_limit_snapshot(&conn, &changed).expect("insert changed");
+
+        assert_eq!(stats.historical_inserted, 1);
+        assert_eq!(stats.latest_updated, 2);
+        let history_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| {
+                row.get(0)
+            })
+            .expect("count history");
+        assert_eq!(history_count, 3);
+    }
+
+    #[test]
+    fn new_window_keeps_previous_close_and_new_start() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let mut first = live_snapshot(
+            "2026-07-10T10:00:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        first.secondary = None;
+        let mut close = first.clone();
+        close.fetched_at = "2026-07-10T12:59:00Z".to_string();
+        let mut next = live_snapshot(
+            "2026-07-10T13:00:00Z",
+            0,
+            20,
+            "2026-07-10T13:00:00Z",
+            "2026-07-10T18:00:00Z",
+        );
+        next.secondary = None;
+        insert_live_rate_limit_snapshot(&conn, &first).expect("insert first");
+        insert_live_rate_limit_snapshot(&conn, &close).expect("observe close");
+
+        let stats = insert_live_rate_limit_snapshot(&conn, &next).expect("insert next window");
+
+        assert_eq!(stats.historical_inserted, 2);
+        let timestamps = conn
+            .prepare(
+                "SELECT sample_timestamp FROM rate_limit_samples ORDER BY sample_timestamp_ms, id",
+            )
+            .expect("prepare timestamps")
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("query timestamps")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect timestamps");
+        assert_eq!(
+            timestamps,
+            vec![
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T12:59:00Z",
+                "2026-07-10T13:00:00Z"
+            ]
+        );
+    }
+
+    #[test]
+    fn session_batch_keeps_first_change_and_last() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let mut samples = vec![
+            session_sample(
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:01:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:02:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:03:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+        ];
+        samples[2].used_percent = 26;
+        samples[2].remaining_percent = 74;
+        samples[3].used_percent = 26;
+        samples[3].remaining_percent = 74;
+
+        let stats = replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("replace session samples");
+
+        assert_eq!(stats.observed, 4);
+        assert_eq!(stats.historical_inserted, 3);
+        let timestamps = conn
+            .prepare(
+                "SELECT sample_timestamp FROM rate_limit_samples ORDER BY sample_timestamp_ms, id",
+            )
+            .expect("prepare timestamps")
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("query timestamps")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect timestamps");
+        assert_eq!(
+            timestamps,
+            vec![
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T10:02:00Z",
+                "2026-07-10T10:03:00Z"
+            ]
+        );
+    }
+
+    #[test]
+    fn repeated_session_replace_performs_zero_semantic_writes() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let samples = vec![
+            session_sample(
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:01:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+        ];
+        replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("insert session samples");
+        let changes_before = conn.total_changes();
+
+        let stats = replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("repeat session samples");
+
+        assert_eq!(stats.historical_inserted, 0);
+        assert_eq!(stats.latest_updated, 0);
+        assert_eq!(conn.total_changes(), changes_before);
+    }
+
+    #[test]
+    fn latest_quota_uses_epoch_order() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let newer = live_snapshot(
+            "2026-07-10T03:00:01Z",
+            41,
+            20,
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T07:00:00Z",
+        );
+        let older = live_snapshot(
+            "2026-07-10T10:00:00+08:00",
+            40,
+            20,
+            "2026-07-10T09:00:00+08:00",
+            "2026-07-10T14:00:00+08:00",
+        );
+        insert_live_rate_limit_snapshot(&conn, &newer).expect("insert newer");
+        insert_live_rate_limit_snapshot(&conn, &older).expect("insert older later");
+
+        let latest = load_latest_rate_limits(&conn, Some("live"))
+            .expect("load latest")
+            .expect("latest snapshot");
+
+        assert_eq!(latest.fetched_at, newer.fetched_at);
+        assert_eq!(latest.primary.map(|window| window.used_percent), Some(41));
+    }
+
+    #[test]
+    fn latest_lookup_does_not_scan_history() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let snapshot = live_snapshot(
+            "2026-07-10T10:00:00Z",
+            40,
+            20,
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        insert_live_rate_limit_snapshot(&conn, &snapshot).expect("insert snapshot");
+        conn.execute_batch("DROP TABLE rate_limit_samples")
+            .expect("drop history table");
+
+        let latest = load_latest_rate_limits(&conn, Some("live"))
+            .expect("load latest without history")
+            .expect("latest snapshot");
+
+        assert_eq!(latest.fetched_at, snapshot.fetched_at);
+    }
+
+    #[test]
+    fn session_latest_rows_are_owned_independently() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let first = session_sample(
+            "2026-07-10T10:00:00Z",
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        let mut second = first.clone();
+        second.source_session_id = Some("session-2".to_string());
+        second.sample_timestamp = "2026-07-10T10:01:00Z".to_string();
+        append_session_rate_limit_samples(&conn, "session-1", &[first])
+            .expect("append first session");
+        append_session_rate_limit_samples(&conn, "session-2", &[second])
+            .expect("append second session");
+
+        let owner_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM latest_rate_limits WHERE source_kind = 'session' AND bucket = 'five_hour'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count owners");
+        assert_eq!(owner_count, 2);
+    }
+
+    #[test]
+    fn session_replace_plan_uses_owner_index() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+
+        let details = conn
+            .prepare(
+                "EXPLAIN QUERY PLAN DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1",
+            )
+            .expect("prepare delete plan")
+            .query_map(["session-1"], |row| row.get::<_, String>(3))
+            .expect("query delete plan")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect delete plan");
+
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("idx_rate_limit_samples_owner")),
+            "owner delete must not scan all quota history: {details:?}"
+        );
     }
 
     #[test]
@@ -283,7 +1070,9 @@ mod tests {
 
         assert!(result.is_err());
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| {
+                row.get(0)
+            })
             .expect("count quota samples");
         assert_eq!(count, 0);
     }
@@ -320,5 +1109,35 @@ mod tests {
             )
             .expect("load preserved samples");
         assert_eq!(persisted, (1, existing.sample_timestamp));
+    }
+
+    #[test]
+    fn session_replace_repairs_legacy_null_epoch_rows() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let sample = session_sample(
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T07:00:00Z",
+        );
+        replace_session_rate_limit_samples(&conn, "session-1", &[sample.clone()])
+            .expect("insert initial sample");
+        conn.execute(
+            "UPDATE rate_limit_samples SET sample_timestamp_ms = NULL, window_start_ms = NULL, resets_at_ms = NULL WHERE source_session_id = 'session-1'",
+            [],
+        )
+        .expect("simulate legacy null epochs");
+
+        replace_session_rate_limit_samples(&conn, "session-1", &[sample])
+            .expect("repair legacy session sample");
+
+        let populated: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM rate_limit_samples WHERE source_session_id = 'session-1' AND sample_timestamp_ms IS NOT NULL AND window_start_ms IS NOT NULL AND resets_at_ms IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count populated epochs");
+        assert_eq!(populated, 1);
     }
 }

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -1,14 +1,24 @@
+use std::io::{Error as IoError, ErrorKind};
+
 use rusqlite::{params, Connection};
 
 use crate::models::{LiveRateLimitSnapshot, RateLimitSampleRecord};
 
-use super::now_utc_string;
+use super::{now_utc_string, parse_epoch_millis};
+
+struct ParsedRateLimitSample<'a> {
+    sample: &'a RateLimitSampleRecord,
+    sample_timestamp_ms: i64,
+    window_start_ms: i64,
+    resets_at_ms: i64,
+}
 
 pub fn replace_session_rate_limit_samples(
     conn: &Connection,
     session_id: &str,
     samples: &[RateLimitSampleRecord],
 ) -> rusqlite::Result<()> {
+    let parsed = parse_rate_limit_samples(samples)?;
     conn.execute(
         "
     DELETE FROM rate_limit_samples
@@ -16,35 +26,78 @@ pub fn replace_session_rate_limit_samples(
     ",
         params![session_id],
     )?;
-    insert_rate_limit_samples(conn, samples)
+    insert_parsed_rate_limit_samples(conn, &parsed)
 }
 
 pub fn insert_rate_limit_samples(
     conn: &Connection,
     samples: &[RateLimitSampleRecord],
 ) -> rusqlite::Result<()> {
+    let parsed = parse_rate_limit_samples(samples)?;
+    insert_parsed_rate_limit_samples(conn, &parsed)
+}
+
+fn parse_rate_limit_samples(
+    samples: &[RateLimitSampleRecord],
+) -> rusqlite::Result<Vec<ParsedRateLimitSample<'_>>> {
+    let mut parsed = Vec::with_capacity(samples.len());
+    for sample in samples {
+        parsed.push(ParsedRateLimitSample {
+            sample,
+            sample_timestamp_ms: parse_epoch_field(
+                "sample_timestamp",
+                &sample.sample_timestamp,
+            )?,
+            window_start_ms: parse_epoch_field("window_start", &sample.window_start)?,
+            resets_at_ms: parse_epoch_field("resets_at", &sample.resets_at)?,
+        });
+    }
+    Ok(parsed)
+}
+
+fn parse_epoch_field(field_name: &str, value: &str) -> rusqlite::Result<i64> {
+    parse_epoch_millis(value).map_err(|error| {
+        rusqlite::Error::ToSqlConversionFailure(Box::new(IoError::new(
+            ErrorKind::InvalidData,
+            format!("Invalid rate limit {field_name} {value:?}: {error}"),
+        )))
+    })
+}
+
+fn insert_parsed_rate_limit_samples(
+    conn: &Connection,
+    samples: &[ParsedRateLimitSample<'_>],
+) -> rusqlite::Result<()> {
+    if samples.is_empty() {
+        return Ok(());
+    }
     let created_at = now_utc_string();
     let mut stmt = conn.prepare(
         "
     INSERT OR IGNORE INTO rate_limit_samples (
-      source_kind, source_session_id, bucket, sample_timestamp, limit_id, limit_name, plan_type,
-      window_start, resets_at, used_percent, remaining_percent, created_at
+      source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+      limit_id, limit_name, plan_type, window_start, window_start_ms,
+      resets_at, resets_at_ms, used_percent, remaining_percent, created_at
     )
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
     ",
     )?;
 
-    for sample in samples {
+    for parsed in samples {
+        let sample = parsed.sample;
         stmt.execute(params![
             sample.source_kind,
-            sample.source_session_id.clone().unwrap_or_default(),
+            sample.source_session_id.as_deref().unwrap_or_default(),
             sample.bucket,
             sample.sample_timestamp,
-            sample.limit_id.clone().unwrap_or_default(),
-            sample.limit_name.clone().unwrap_or_default(),
-            sample.plan_type.clone().unwrap_or_default(),
+            parsed.sample_timestamp_ms,
+            sample.limit_id.as_deref().unwrap_or_default(),
+            sample.limit_name.as_deref().unwrap_or_default(),
+            sample.plan_type.as_deref().unwrap_or_default(),
             sample.window_start,
+            parsed.window_start_ms,
             sample.resets_at,
+            parsed.resets_at_ms,
             sample.used_percent.clamp(0, 100),
             sample.remaining_percent.clamp(0, 100),
             created_at,
@@ -86,4 +139,186 @@ pub fn insert_live_rate_limit_snapshot(
         });
     }
     insert_rate_limit_samples(conn, &samples)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use crate::database::{init_db, parse_epoch_millis};
+    use crate::models::{
+        LiveRateLimitSnapshot, RateLimitSampleRecord, RateLimitWindowSnapshot,
+    };
+
+    use super::{
+        insert_live_rate_limit_snapshot, insert_rate_limit_samples,
+        replace_session_rate_limit_samples,
+    };
+
+    fn session_sample(
+        sample_timestamp: &str,
+        window_start: &str,
+        resets_at: &str,
+    ) -> RateLimitSampleRecord {
+        RateLimitSampleRecord {
+            source_kind: "session".to_string(),
+            source_session_id: Some("session-1".to_string()),
+            bucket: "five_hour".to_string(),
+            sample_timestamp: sample_timestamp.to_string(),
+            limit_id: Some("codex".to_string()),
+            limit_name: Some("Codex".to_string()),
+            plan_type: Some("pro".to_string()),
+            window_start: window_start.to_string(),
+            resets_at: resets_at.to_string(),
+            used_percent: 25,
+            remaining_percent: 75,
+        }
+    }
+
+    #[test]
+    fn session_quota_write_populates_all_epoch_fields() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let sample = session_sample(
+            "2026-07-10T10:00:00+08:00",
+            "2026-07-10T09:00:00+08:00",
+            "2026-07-10T14:00:00+08:00",
+        );
+
+        replace_session_rate_limit_samples(&conn, "session-1", &[sample.clone()])
+            .expect("replace session quota samples");
+
+        let epochs = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                ",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .expect("load quota epochs");
+        assert_eq!(
+            epochs,
+            (
+                parse_epoch_millis(&sample.sample_timestamp).expect("parse sample timestamp"),
+                parse_epoch_millis(&sample.window_start).expect("parse window start"),
+                parse_epoch_millis(&sample.resets_at).expect("parse resets at"),
+            )
+        );
+    }
+
+    #[test]
+    fn live_quota_write_populates_all_epoch_fields() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let snapshot = LiveRateLimitSnapshot {
+            limit_id: Some("codex".to_string()),
+            limit_name: Some("Codex".to_string()),
+            plan_type: Some("pro".to_string()),
+            primary: Some(RateLimitWindowSnapshot {
+                used_percent: 10,
+                remaining_percent: 90,
+                window_duration_mins: Some(300),
+                window_start: Some("2026-07-10T02:00:00Z".to_string()),
+                resets_at: Some("2026-07-10T07:00:00Z".to_string()),
+            }),
+            secondary: None,
+            fetched_at: "2026-07-10T10:00:00+08:00".to_string(),
+        };
+
+        insert_live_rate_limit_snapshot(&conn, &snapshot).expect("insert live quota snapshot");
+
+        let epochs = conn
+            .query_row(
+                "
+                SELECT sample_timestamp_ms, window_start_ms, resets_at_ms
+                FROM rate_limit_samples
+                WHERE source_kind = 'live'
+                ",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .expect("load live quota epochs");
+        assert_eq!(
+            epochs,
+            (
+                parse_epoch_millis(&snapshot.fetched_at).expect("parse fetched at"),
+                parse_epoch_millis("2026-07-10T02:00:00Z").expect("parse window start"),
+                parse_epoch_millis("2026-07-10T07:00:00Z").expect("parse resets at"),
+            )
+        );
+    }
+
+    #[test]
+    fn malformed_quota_append_writes_nothing() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let samples = [
+            session_sample(
+                "2026-07-10T02:00:00Z",
+                "2026-07-10T02:00:00Z",
+                "2026-07-10T07:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T02:01:00Z",
+                "invalid-window-start",
+                "2026-07-10T07:01:00Z",
+            ),
+        ];
+
+        let result = insert_rate_limit_samples(&conn, &samples);
+
+        assert!(result.is_err());
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM rate_limit_samples", [], |row| row.get(0))
+            .expect("count quota samples");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn malformed_quota_replace_preserves_existing_session_rows() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let existing = session_sample(
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T02:00:00Z",
+            "2026-07-10T07:00:00Z",
+        );
+        replace_session_rate_limit_samples(&conn, "session-1", &[existing.clone()])
+            .expect("insert existing sample");
+        let malformed = session_sample(
+            "invalid-sample-timestamp",
+            "2026-07-10T02:01:00Z",
+            "2026-07-10T07:01:00Z",
+        );
+
+        let result = replace_session_rate_limit_samples(&conn, "session-1", &[malformed]);
+
+        assert!(result.is_err());
+        let persisted = conn
+            .query_row(
+                "
+                SELECT COUNT(*), MIN(sample_timestamp)
+                FROM rate_limit_samples
+                WHERE source_kind = 'session' AND source_session_id = 'session-1'
+                ",
+                [],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .expect("load preserved samples");
+        assert_eq!(persisted, (1, existing.sample_timestamp));
+    }
 }

--- a/src-tauri/src/database/rate_limit_samples.rs
+++ b/src-tauri/src/database/rate_limit_samples.rs
@@ -28,6 +28,8 @@ struct ParsedRateLimitSample {
 pub struct RateLimitWriteStats {
     pub observed: usize,
     pub historical_inserted: usize,
+    pub historical_updated: usize,
+    pub historical_deleted: usize,
     pub latest_updated: usize,
 }
 
@@ -44,13 +46,7 @@ pub fn replace_session_rate_limit_samples(
             observed: parsed.len(),
             ..RateLimitWriteStats::default()
         };
-        if load_session_history(conn, session_id)? != compacted {
-            conn.execute(
-                "DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1",
-                params![session_id],
-            )?;
-            stats.historical_inserted = insert_parsed_rate_limit_samples(conn, &compacted)?;
-        }
+        reconcile_session_history(conn, session_id, &compacted, &mut stats)?;
         let buckets = compacted
             .iter()
             .map(|sample| sample.bucket.as_str())
@@ -250,6 +246,20 @@ fn same_history_point(left: &ParsedRateLimitSample, right: &ParsedRateLimitSampl
         && same_value(left, right)
 }
 
+fn same_history_point_except_observed_at(
+    left: &ParsedRateLimitSample,
+    right: &ParsedRateLimitSample,
+) -> bool {
+    left.source_kind == right.source_kind
+        && left.source_session_id == right.source_session_id
+        && left.bucket == right.bucket
+        && left.limit_id == right.limit_id
+        && left.limit_name == right.limit_name
+        && left.plan_type == right.plan_type
+        && same_window(left, right)
+        && same_value(left, right)
+}
+
 fn grouped_sorted(samples: &[ParsedRateLimitSample]) -> Vec<Vec<ParsedRateLimitSample>> {
     let mut ordered = samples.to_vec();
     ordered.sort_by(|left, right| {
@@ -295,6 +305,12 @@ fn compact_complete_session_history(
         let mut previous = first;
         for sample in group.iter().skip(1) {
             if !same_window(previous, sample) || !same_value(previous, sample) {
+                if compacted
+                    .last()
+                    .map_or(true, |point| !same_history_point(point, previous))
+                {
+                    compacted.push(previous.clone());
+                }
                 compacted.push(sample.clone());
             }
             previous = sample;
@@ -309,6 +325,85 @@ fn compact_complete_session_history(
         }
     }
     compacted
+}
+
+#[derive(Clone, Debug)]
+struct PersistedRateLimitSample {
+    id: i64,
+    sample: ParsedRateLimitSample,
+}
+
+fn reconcile_session_history(
+    conn: &Connection,
+    session_id: &str,
+    desired: &[ParsedRateLimitSample],
+    stats: &mut RateLimitWriteStats,
+) -> rusqlite::Result<()> {
+    let existing = load_session_history(conn, session_id)?;
+    let desired_groups = grouped_sorted(desired);
+    let desired_buckets = desired_groups
+        .iter()
+        .filter_map(|group| group.first().map(|sample| sample.bucket.clone()))
+        .collect::<std::collections::HashSet<_>>();
+
+    for group in desired_groups {
+        let Some(first) = group.first() else { continue };
+        let existing_group = existing
+            .iter()
+            .filter(|persisted| persisted.sample.bucket == first.bucket)
+            .collect::<Vec<_>>();
+        let matching_prefix = existing_group
+            .iter()
+            .zip(&group)
+            .take_while(|(left, right)| same_history_point(&left.sample, right))
+            .count();
+        if matching_prefix == existing_group.len() && matching_prefix == group.len() {
+            continue;
+        }
+        if matching_prefix == existing_group.len() && existing_group.len() < group.len() {
+            stats.historical_inserted +=
+                insert_parsed_rate_limit_samples(conn, &group[matching_prefix..])?;
+            continue;
+        }
+        if existing_group.len() == group.len()
+            && !group.is_empty()
+            && matching_prefix + 1 == group.len()
+            && same_history_point_except_observed_at(
+                &existing_group.last().expect("existing last").sample,
+                group.last().expect("desired last"),
+            )
+        {
+            let last = group.last().expect("desired last");
+            stats.historical_updated += conn.execute(
+                "UPDATE rate_limit_samples SET sample_timestamp = ?1, sample_timestamp_ms = ?2, created_at = ?3 WHERE id = ?4",
+                params![
+                    last.sample_timestamp,
+                    last.sample_timestamp_ms,
+                    now_utc_string(),
+                    existing_group.last().expect("existing last").id,
+                ],
+            )?;
+            continue;
+        }
+
+        stats.historical_deleted += conn.execute(
+            "DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1 AND bucket = ?2",
+            params![session_id, first.bucket],
+        )?;
+        stats.historical_inserted += insert_parsed_rate_limit_samples(conn, &group)?;
+    }
+
+    let existing_buckets = existing
+        .iter()
+        .map(|persisted| persisted.sample.bucket.clone())
+        .collect::<std::collections::HashSet<_>>();
+    for bucket in existing_buckets.difference(&desired_buckets) {
+        stats.historical_deleted += conn.execute(
+            "DELETE FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1 AND bucket = ?2",
+            params![session_id, bucket],
+        )?;
+    }
+    Ok(())
 }
 
 fn newest_per_owner_bucket(samples: &[ParsedRateLimitSample]) -> Vec<&ParsedRateLimitSample> {
@@ -463,10 +558,10 @@ fn parsed_sample_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ParsedRat
 fn load_session_history(
     conn: &Connection,
     session_id: &str,
-) -> rusqlite::Result<Vec<ParsedRateLimitSample>> {
+) -> rusqlite::Result<Vec<PersistedRateLimitSample>> {
     let mut stmt = conn.prepare(
         "
-        SELECT source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
+        SELECT id, source_kind, source_session_id, bucket, sample_timestamp, sample_timestamp_ms,
                limit_id, limit_name, plan_type, window_start, window_start_ms,
                resets_at, resets_at_ms, used_percent, remaining_percent
         FROM rate_limit_samples
@@ -475,21 +570,24 @@ fn load_session_history(
         ",
     )?;
     let rows = stmt.query_map(params![session_id], |row| {
-        Ok(ParsedRateLimitSample {
-            source_kind: row.get(0)?,
-            source_session_id: row.get(1)?,
-            bucket: row.get(2)?,
-            sample_timestamp: row.get(3)?,
-            sample_timestamp_ms: row.get::<_, Option<i64>>(4)?.unwrap_or(i64::MIN),
-            limit_id: row.get(5)?,
-            limit_name: row.get(6)?,
-            plan_type: row.get(7)?,
-            window_start: row.get(8)?,
-            window_start_ms: row.get::<_, Option<i64>>(9)?.unwrap_or(i64::MIN),
-            resets_at: row.get(10)?,
-            resets_at_ms: row.get::<_, Option<i64>>(11)?.unwrap_or(i64::MIN),
-            used_percent: row.get(12)?,
-            remaining_percent: row.get(13)?,
+        Ok(PersistedRateLimitSample {
+            id: row.get(0)?,
+            sample: ParsedRateLimitSample {
+                source_kind: row.get(1)?,
+                source_session_id: row.get(2)?,
+                bucket: row.get(3)?,
+                sample_timestamp: row.get(4)?,
+                sample_timestamp_ms: row.get::<_, Option<i64>>(5)?.unwrap_or(i64::MIN),
+                limit_id: row.get(6)?,
+                limit_name: row.get(7)?,
+                plan_type: row.get(8)?,
+                window_start: row.get(9)?,
+                window_start_ms: row.get::<_, Option<i64>>(10)?.unwrap_or(i64::MIN),
+                resets_at: row.get(11)?,
+                resets_at_ms: row.get::<_, Option<i64>>(12)?.unwrap_or(i64::MIN),
+                used_percent: row.get(13)?,
+                remaining_percent: row.get(14)?,
+            },
         })
     })?;
     rows.collect()
@@ -779,7 +877,7 @@ mod tests {
     }
 
     #[test]
-    fn session_batch_keeps_first_change_and_last() {
+    fn session_batch_keeps_change_boundaries_and_last() {
         let conn = Connection::open_in_memory().expect("open database");
         init_db(&conn).expect("initialize database");
         let mut samples = vec![
@@ -813,7 +911,7 @@ mod tests {
             .expect("replace session samples");
 
         assert_eq!(stats.observed, 4);
-        assert_eq!(stats.historical_inserted, 3);
+        assert_eq!(stats.historical_inserted, 4);
         let timestamps = conn
             .prepare(
                 "SELECT sample_timestamp FROM rate_limit_samples ORDER BY sample_timestamp_ms, id",
@@ -827,6 +925,7 @@ mod tests {
             timestamps,
             vec![
                 "2026-07-10T10:00:00Z",
+                "2026-07-10T10:01:00Z",
                 "2026-07-10T10:02:00Z",
                 "2026-07-10T10:03:00Z"
             ]
@@ -859,6 +958,108 @@ mod tests {
         assert_eq!(stats.historical_inserted, 0);
         assert_eq!(stats.latest_updated, 0);
         assert_eq!(conn.total_changes(), changes_before);
+    }
+
+    #[test]
+    fn growing_same_value_session_updates_only_last_history_point() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let mut samples = vec![
+            session_sample(
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:01:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+        ];
+        replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("insert initial session history");
+        let ids_before = history_ids(&conn, "session-1");
+        samples.push(session_sample(
+            "2026-07-10T10:02:00Z",
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        ));
+
+        let stats = replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("advance final observation");
+
+        assert_eq!(stats.historical_inserted, 0);
+        assert_eq!(stats.historical_updated, 1);
+        assert_eq!(stats.historical_deleted, 0);
+        assert_eq!(history_ids(&conn, "session-1"), ids_before);
+        let timestamps = history_timestamps(&conn, "session-1");
+        assert_eq!(
+            timestamps,
+            vec!["2026-07-10T10:00:00Z", "2026-07-10T10:02:00Z"]
+        );
+    }
+
+    #[test]
+    fn appended_percent_change_preserves_existing_history_ids() {
+        let conn = Connection::open_in_memory().expect("open database");
+        init_db(&conn).expect("initialize database");
+        let mut samples = vec![
+            session_sample(
+                "2026-07-10T10:00:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+            session_sample(
+                "2026-07-10T10:01:00Z",
+                "2026-07-10T08:00:00Z",
+                "2026-07-10T13:00:00Z",
+            ),
+        ];
+        replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("insert initial session history");
+        let ids_before = history_ids(&conn, "session-1");
+        let mut changed = session_sample(
+            "2026-07-10T10:02:00Z",
+            "2026-07-10T08:00:00Z",
+            "2026-07-10T13:00:00Z",
+        );
+        changed.used_percent = 26;
+        changed.remaining_percent = 74;
+        let mut final_sample = changed.clone();
+        final_sample.sample_timestamp = "2026-07-10T10:03:00Z".to_string();
+        samples.extend([changed, final_sample]);
+
+        let stats = replace_session_rate_limit_samples(&conn, "session-1", &samples)
+            .expect("append changed history");
+        let ids_after = history_ids(&conn, "session-1");
+
+        assert_eq!(stats.historical_inserted, 2);
+        assert_eq!(stats.historical_updated, 0);
+        assert_eq!(stats.historical_deleted, 0);
+        assert_eq!(&ids_after[..ids_before.len()], ids_before.as_slice());
+        assert_eq!(ids_after.len(), 4);
+    }
+
+    fn history_ids(conn: &Connection, session_id: &str) -> Vec<i64> {
+        conn.prepare(
+            "SELECT id FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1 ORDER BY bucket, sample_timestamp_ms, id",
+        )
+        .expect("prepare history ids")
+        .query_map([session_id], |row| row.get(0))
+        .expect("query history ids")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("collect history ids")
+    }
+
+    fn history_timestamps(conn: &Connection, session_id: &str) -> Vec<String> {
+        conn.prepare(
+            "SELECT sample_timestamp FROM rate_limit_samples WHERE source_kind = 'session' AND source_session_id = ?1 ORDER BY bucket, sample_timestamp_ms, id",
+        )
+        .expect("prepare history timestamps")
+        .query_map([session_id], |row| row.get(0))
+        .expect("query history timestamps")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("collect history timestamps")
     }
 
     #[test]

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -1,6 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
-#[cfg(test)]
-use rusqlite::{Transaction, TransactionBehavior};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 
 use crate::models::SyncSettings;
 
@@ -428,7 +426,7 @@ pub fn save_sync_settings(
     conn: &Connection,
     settings: &SyncSettings,
 ) -> rusqlite::Result<SyncSettings> {
-    let transaction = conn.unchecked_transaction()?;
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     let current_codex_home = transaction
         .query_row(
             "SELECT codex_home FROM sync_settings WHERE singleton_id = 1",
@@ -440,14 +438,6 @@ pub fn save_sync_settings(
     let codex_home_changed = current_codex_home.as_deref() != settings.codex_home.as_deref();
     let updated_at = now_utc_string();
     let auto_scan_interval_minutes = settings.auto_scan_interval_minutes.max(1);
-    let (last_scan_started_at, last_scan_completed_at) = if codex_home_changed {
-        (None, None)
-    } else {
-        (
-            settings.last_scan_started_at.as_deref(),
-            settings.last_scan_completed_at.as_deref(),
-        )
-    };
     transaction.execute(
     "
     INSERT INTO sync_settings (
@@ -465,7 +455,7 @@ pub fn save_sync_settings(
       menu_bar_popup_show_reset_timeline, menu_bar_popup_show_actions,
       last_scan_started_at, last_scan_completed_at, updated_at
     )
-    VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)
+    VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, NULL, NULL, ?22)
     ON CONFLICT(singleton_id) DO UPDATE SET
       codex_home = excluded.codex_home,
       auto_scan_enabled = excluded.auto_scan_enabled,
@@ -488,8 +478,6 @@ pub fn save_sync_settings(
       menu_bar_popup_modules = excluded.menu_bar_popup_modules,
       menu_bar_popup_show_reset_timeline = excluded.menu_bar_popup_show_reset_timeline,
       menu_bar_popup_show_actions = excluded.menu_bar_popup_show_actions,
-      last_scan_started_at = excluded.last_scan_started_at,
-      last_scan_completed_at = excluded.last_scan_completed_at,
       updated_at = excluded.updated_at
     ",
     params![
@@ -514,8 +502,6 @@ pub fn save_sync_settings(
       serialize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
       bool_to_i64(settings.menu_bar_popup_show_reset_timeline),
       bool_to_i64(settings.menu_bar_popup_show_actions),
-      last_scan_started_at,
-      last_scan_completed_at,
       updated_at,
     ],
     )?;
@@ -534,7 +520,8 @@ fn clear_scan_timestamps(conn: &Connection) -> rusqlite::Result<()> {
     SET last_scan_started_at = NULL,
         last_scan_completed_at = NULL,
         last_full_scan_completed_at = NULL,
-        last_scan_codex_home = NULL
+        last_scan_codex_home = NULL,
+        scan_commit_revision = scan_commit_revision + 1
     WHERE singleton_id = 1
     ",
         [],

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -1,4 +1,6 @@
-use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use rusqlite::{params, Connection, OptionalExtension};
+#[cfg(test)]
+use rusqlite::{Transaction, TransactionBehavior};
 
 use crate::models::SyncSettings;
 
@@ -60,6 +62,19 @@ pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result
             "
       ALTER TABLE sync_settings
       ADD COLUMN sync_settings_schema_version INTEGER NOT NULL DEFAULT 1
+      ",
+            [],
+        )?;
+    }
+
+    if !column_names
+        .iter()
+        .any(|name| name == "scan_commit_revision")
+    {
+        conn.execute(
+            "
+      ALTER TABLE sync_settings
+      ADD COLUMN scan_commit_revision INTEGER NOT NULL DEFAULT 0
       ",
             [],
         )?;
@@ -289,12 +304,15 @@ pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result
         .any(|name| name == "last_full_scan_completed_at")
     {
         conn.execute(
-      "ALTER TABLE sync_settings ADD COLUMN last_full_scan_completed_at TEXT",
-      [],
-    )?;
+            "ALTER TABLE sync_settings ADD COLUMN last_full_scan_completed_at TEXT",
+            [],
+        )?;
     }
 
-    if !column_names.iter().any(|name| name == "last_scan_codex_home") {
+    if !column_names
+        .iter()
+        .any(|name| name == "last_scan_codex_home")
+    {
         let transaction = conn.unchecked_transaction()?;
         transaction.execute(
             "ALTER TABLE sync_settings ADD COLUMN last_scan_codex_home TEXT",
@@ -378,7 +396,9 @@ pub fn get_sync_settings(conn: &Connection) -> rusqlite::Result<SyncSettings> {
                 codex_home: row.get(0)?,
                 auto_scan_enabled: i64_to_bool(row.get::<_, i64>(1)?),
                 auto_scan_interval_minutes,
-                live_quota_refresh_interval_seconds: unified_refresh_interval_seconds(auto_scan_interval_minutes),
+                live_quota_refresh_interval_seconds: unified_refresh_interval_seconds(
+                    auto_scan_interval_minutes,
+                ),
                 hide_dock_icon_when_menu_bar_visible: i64_to_bool(row.get::<_, i64>(4)?),
                 show_menu_bar_logo: i64_to_bool(row.get::<_, i64>(5)?),
                 show_menu_bar_daily_api_value: i64_to_bool(row.get::<_, i64>(6)?),
@@ -529,37 +549,37 @@ pub struct ScanFreshnessStart {
     pub full_scan_required: bool,
 }
 
+#[cfg(test)]
 pub fn set_last_scan_started_for_source(
     conn: &Connection,
     timestamp: &str,
     codex_home_selector: Option<&str>,
     resolved_codex_home: &str,
 ) -> rusqlite::Result<ScanFreshnessStart> {
-    let transaction =
-        Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    let previous_freshness = transaction
-        .query_row(
-            "
-            SELECT last_scan_codex_home, last_full_scan_completed_at
-            FROM sync_settings
-            WHERE singleton_id = 1
-              AND (
-                (codex_home IS NULL AND ?1 IS NULL)
-                OR codex_home = ?1
-              )
-            ",
-            params![codex_home_selector],
-            |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
-        )
-        .optional()?;
-    let Some((previous_source, last_full_scan_completed_at)) = previous_freshness else {
-        transaction.commit()?;
-        return Ok(ScanFreshnessStart::default());
-    };
-    let source_changed = previous_source.as_deref() != Some(resolved_codex_home);
-    let full_scan_required = source_changed || last_full_scan_completed_at.is_none();
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let result = set_last_scan_started_for_source_in_transaction(
+        &transaction,
+        timestamp,
+        codex_home_selector,
+        resolved_codex_home,
+    )?;
+    transaction.commit()?;
+    Ok(result)
+}
 
-    let updated = transaction.execute(
+pub(crate) fn set_last_scan_started_for_source_in_transaction(
+    conn: &Connection,
+    timestamp: &str,
+    codex_home_selector: Option<&str>,
+    resolved_codex_home: &str,
+) -> rusqlite::Result<ScanFreshnessStart> {
+    let preview =
+        preview_scan_freshness_for_source(conn, codex_home_selector, resolved_codex_home)?;
+    if !preview.recorded {
+        return Ok(preview);
+    }
+
+    let updated = conn.execute(
         "
         UPDATE sync_settings
         SET last_scan_started_at = ?1,
@@ -581,12 +601,47 @@ pub fn set_last_scan_started_for_source(
         ",
         params![timestamp, codex_home_selector, resolved_codex_home],
     )?;
-    transaction.commit()?;
-
     Ok(ScanFreshnessStart {
         recorded: updated == 1,
-        source_changed: updated == 1 && source_changed,
-        full_scan_required: updated == 1 && full_scan_required,
+        source_changed: updated == 1 && preview.source_changed,
+        full_scan_required: updated == 1 && preview.full_scan_required,
+    })
+}
+
+pub(crate) fn preview_scan_freshness_for_source(
+    conn: &Connection,
+    codex_home_selector: Option<&str>,
+    resolved_codex_home: &str,
+) -> rusqlite::Result<ScanFreshnessStart> {
+    let previous_freshness = conn
+        .query_row(
+            "
+            SELECT last_scan_codex_home, last_full_scan_completed_at
+            FROM sync_settings
+            WHERE singleton_id = 1
+              AND (
+                (codex_home IS NULL AND ?1 IS NULL)
+                OR codex_home = ?1
+              )
+            ",
+            params![codex_home_selector],
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((previous_source, last_full_scan_completed_at)) = previous_freshness else {
+        return Ok(ScanFreshnessStart::default());
+    };
+    let source_changed = previous_source.as_deref() != Some(resolved_codex_home);
+    let full_scan_required = source_changed || last_full_scan_completed_at.is_none();
+    Ok(ScanFreshnessStart {
+        recorded: true,
+        source_changed,
+        full_scan_required,
     })
 }
 

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -506,28 +506,50 @@ fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
     auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
 
-pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
-    conn.execute(
+pub fn set_last_scan_started_for_source(
+    conn: &Connection,
+    timestamp: &str,
+    codex_home_selector: Option<&str>,
+) -> rusqlite::Result<bool> {
+    let updated = conn.execute(
         "
     UPDATE sync_settings
     SET last_scan_started_at = ?1, updated_at = ?1
     WHERE singleton_id = 1
+      AND (
+        (codex_home IS NULL AND ?2 IS NULL)
+        OR codex_home = ?2
+      )
     ",
-        params![timestamp],
+        params![timestamp, codex_home_selector],
     )?;
-    Ok(())
+    Ok(updated == 1)
 }
 
-pub fn set_last_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
-    conn.execute(
+pub fn set_scan_completed_for_source(
+    conn: &Connection,
+    timestamp: &str,
+    codex_home_selector: Option<&str>,
+    full_scan: bool,
+) -> rusqlite::Result<bool> {
+    let updated = conn.execute(
         "
     UPDATE sync_settings
-    SET last_scan_completed_at = ?1, updated_at = ?1
+    SET last_scan_completed_at = ?1,
+        last_full_scan_completed_at = CASE
+          WHEN ?3 != 0 THEN ?1
+          ELSE last_full_scan_completed_at
+        END,
+        updated_at = ?1
     WHERE singleton_id = 1
+      AND (
+        (codex_home IS NULL AND ?2 IS NULL)
+        OR codex_home = ?2
+      )
     ",
-        params![timestamp],
+        params![timestamp, codex_home_selector, bool_to_i64(full_scan)],
     )?;
-    Ok(())
+    Ok(updated == 1)
 }
 
 pub fn get_last_full_scan_completed(conn: &Connection) -> rusqlite::Result<Option<String>> {
@@ -542,6 +564,7 @@ pub fn get_last_full_scan_completed(conn: &Connection) -> rusqlite::Result<Optio
     )
 }
 
+#[cfg(test)]
 pub fn set_last_full_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
     conn.execute(
         "

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -389,9 +389,27 @@ pub fn save_sync_settings(
     conn: &Connection,
     settings: &SyncSettings,
 ) -> rusqlite::Result<SyncSettings> {
+    let transaction = conn.unchecked_transaction()?;
+    let current_codex_home = transaction
+        .query_row(
+            "SELECT codex_home FROM sync_settings WHERE singleton_id = 1",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+    let codex_home_changed = current_codex_home.as_deref() != settings.codex_home.as_deref();
     let updated_at = now_utc_string();
     let auto_scan_interval_minutes = settings.auto_scan_interval_minutes.max(1);
-    conn.execute(
+    let (last_scan_started_at, last_scan_completed_at) = if codex_home_changed {
+        (None, None)
+    } else {
+        (
+            settings.last_scan_started_at.as_deref(),
+            settings.last_scan_completed_at.as_deref(),
+        )
+    };
+    transaction.execute(
     "
     INSERT INTO sync_settings (
       singleton_id, codex_home, auto_scan_enabled, auto_scan_interval_minutes,
@@ -457,12 +475,31 @@ pub fn save_sync_settings(
       serialize_menu_bar_popup_modules(&settings.menu_bar_popup_modules),
       bool_to_i64(settings.menu_bar_popup_show_reset_timeline),
       bool_to_i64(settings.menu_bar_popup_show_actions),
-      settings.last_scan_started_at,
-      settings.last_scan_completed_at,
+      last_scan_started_at,
+      last_scan_completed_at,
       updated_at,
     ],
     )?;
-    get_sync_settings(conn)
+    if codex_home_changed {
+        clear_scan_timestamps(&transaction)?;
+    }
+    let saved = get_sync_settings(&transaction)?;
+    transaction.commit()?;
+    Ok(saved)
+}
+
+fn clear_scan_timestamps(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET last_scan_started_at = NULL,
+        last_scan_completed_at = NULL,
+        last_full_scan_completed_at = NULL
+    WHERE singleton_id = 1
+    ",
+        [],
+    )?;
+    Ok(())
 }
 
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -284,6 +284,16 @@ pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result
     )?;
     }
 
+    if !column_names
+        .iter()
+        .any(|name| name == "last_full_scan_completed_at")
+    {
+        conn.execute(
+      "ALTER TABLE sync_settings ADD COLUMN last_full_scan_completed_at TEXT",
+      [],
+    )?;
+    }
+
     migrate_sync_settings_defaults_to_minutes(conn)?;
 
     Ok(())
@@ -341,14 +351,15 @@ pub fn get_sync_settings(conn: &Connection) -> rusqlite::Result<SyncSettings> {
            last_scan_started_at, last_scan_completed_at, updated_at
     FROM sync_settings
     WHERE singleton_id = 1
-    ",
+        ",
         [],
         |row| {
+            let auto_scan_interval_minutes = row.get::<_, i64>(2)?.max(1);
             Ok(SyncSettings {
                 codex_home: row.get(0)?,
                 auto_scan_enabled: i64_to_bool(row.get::<_, i64>(1)?),
-                auto_scan_interval_minutes: row.get(2)?,
-                live_quota_refresh_interval_seconds: row.get(3)?,
+                auto_scan_interval_minutes,
+                live_quota_refresh_interval_seconds: unified_refresh_interval_seconds(auto_scan_interval_minutes),
                 hide_dock_icon_when_menu_bar_visible: i64_to_bool(row.get::<_, i64>(4)?),
                 show_menu_bar_logo: i64_to_bool(row.get::<_, i64>(5)?),
                 show_menu_bar_daily_api_value: i64_to_bool(row.get::<_, i64>(6)?),
@@ -379,6 +390,7 @@ pub fn save_sync_settings(
     settings: &SyncSettings,
 ) -> rusqlite::Result<SyncSettings> {
     let updated_at = now_utc_string();
+    let auto_scan_interval_minutes = settings.auto_scan_interval_minutes.max(1);
     conn.execute(
     "
     INSERT INTO sync_settings (
@@ -426,8 +438,8 @@ pub fn save_sync_settings(
     params![
       settings.codex_home,
       bool_to_i64(settings.auto_scan_enabled),
-      settings.auto_scan_interval_minutes.max(1),
-      settings.live_quota_refresh_interval_seconds.clamp(60, 3600),
+      auto_scan_interval_minutes,
+      unified_refresh_interval_seconds(auto_scan_interval_minutes),
       bool_to_i64(settings.hide_dock_icon_when_menu_bar_visible),
       bool_to_i64(settings.show_menu_bar_logo),
       bool_to_i64(settings.show_menu_bar_daily_api_value),
@@ -453,6 +465,10 @@ pub fn save_sync_settings(
     get_sync_settings(conn)
 }
 
+fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
+    auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
+}
+
 pub fn set_last_scan_started(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
     conn.execute(
         "
@@ -470,6 +486,30 @@ pub fn set_last_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::
         "
     UPDATE sync_settings
     SET last_scan_completed_at = ?1, updated_at = ?1
+    WHERE singleton_id = 1
+    ",
+        params![timestamp],
+    )?;
+    Ok(())
+}
+
+pub fn get_last_full_scan_completed(conn: &Connection) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "
+    SELECT last_full_scan_completed_at
+    FROM sync_settings
+    WHERE singleton_id = 1
+    ",
+        [],
+        |row| row.get(0),
+    )
+}
+
+pub fn set_last_full_scan_completed(conn: &Connection, timestamp: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "
+    UPDATE sync_settings
+    SET last_full_scan_completed_at = ?1, updated_at = ?1
     WHERE singleton_id = 1
     ",
         params![timestamp],

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -595,14 +595,17 @@ pub fn set_scan_completed_for_source(
     timestamp: &str,
     codex_home_selector: Option<&str>,
     resolved_codex_home: &str,
-    full_scan: bool,
+    full_scan_completed: bool,
+    full_scan_incomplete: bool,
 ) -> rusqlite::Result<bool> {
+    debug_assert!(!(full_scan_completed && full_scan_incomplete));
     let updated = conn.execute(
         "
         UPDATE sync_settings
         SET last_scan_completed_at = ?1,
             last_full_scan_completed_at = CASE
               WHEN ?4 != 0 THEN ?1
+              WHEN ?5 != 0 THEN NULL
               ELSE last_full_scan_completed_at
             END,
             updated_at = ?1
@@ -617,7 +620,8 @@ pub fn set_scan_completed_for_source(
             timestamp,
             codex_home_selector,
             resolved_codex_home,
-            bool_to_i64(full_scan)
+            bool_to_i64(full_scan_completed),
+            bool_to_i64(full_scan_incomplete)
         ],
     )?;
     Ok(updated == 1)

--- a/src-tauri/src/database/sync_settings.rs
+++ b/src-tauri/src/database/sync_settings.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 
 use crate::models::SyncSettings;
 
@@ -294,6 +294,25 @@ pub(super) fn ensure_sync_settings_schema(conn: &Connection) -> rusqlite::Result
     )?;
     }
 
+    if !column_names.iter().any(|name| name == "last_scan_codex_home") {
+        let transaction = conn.unchecked_transaction()?;
+        transaction.execute(
+            "ALTER TABLE sync_settings ADD COLUMN last_scan_codex_home TEXT",
+            [],
+        )?;
+        transaction.execute(
+            "
+            UPDATE sync_settings
+            SET last_scan_started_at = NULL,
+                last_scan_completed_at = NULL,
+                last_full_scan_completed_at = NULL
+            WHERE singleton_id = 1
+            ",
+            [],
+        )?;
+        transaction.commit()?;
+    }
+
     migrate_sync_settings_defaults_to_minutes(conn)?;
 
     Ok(())
@@ -494,7 +513,8 @@ fn clear_scan_timestamps(conn: &Connection) -> rusqlite::Result<()> {
     UPDATE sync_settings
     SET last_scan_started_at = NULL,
         last_scan_completed_at = NULL,
-        last_full_scan_completed_at = NULL
+        last_full_scan_completed_at = NULL,
+        last_scan_codex_home = NULL
     WHERE singleton_id = 1
     ",
         [],
@@ -502,54 +522,109 @@ fn clear_scan_timestamps(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
-fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
-    auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScanFreshnessStart {
+    pub recorded: bool,
+    pub source_changed: bool,
+    pub full_scan_required: bool,
 }
 
 pub fn set_last_scan_started_for_source(
     conn: &Connection,
     timestamp: &str,
     codex_home_selector: Option<&str>,
-) -> rusqlite::Result<bool> {
-    let updated = conn.execute(
+    resolved_codex_home: &str,
+) -> rusqlite::Result<ScanFreshnessStart> {
+    let transaction =
+        Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let previous_freshness = transaction
+        .query_row(
+            "
+            SELECT last_scan_codex_home, last_full_scan_completed_at
+            FROM sync_settings
+            WHERE singleton_id = 1
+              AND (
+                (codex_home IS NULL AND ?1 IS NULL)
+                OR codex_home = ?1
+              )
+            ",
+            params![codex_home_selector],
+            |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
+        )
+        .optional()?;
+    let Some((previous_source, last_full_scan_completed_at)) = previous_freshness else {
+        transaction.commit()?;
+        return Ok(ScanFreshnessStart::default());
+    };
+    let source_changed = previous_source.as_deref() != Some(resolved_codex_home);
+    let full_scan_required = source_changed || last_full_scan_completed_at.is_none();
+
+    let updated = transaction.execute(
         "
-    UPDATE sync_settings
-    SET last_scan_started_at = ?1, updated_at = ?1
-    WHERE singleton_id = 1
-      AND (
-        (codex_home IS NULL AND ?2 IS NULL)
-        OR codex_home = ?2
-      )
-    ",
-        params![timestamp, codex_home_selector],
+        UPDATE sync_settings
+        SET last_scan_started_at = ?1,
+            last_scan_completed_at = CASE
+              WHEN last_scan_codex_home = ?3 THEN last_scan_completed_at
+              ELSE NULL
+            END,
+            last_full_scan_completed_at = CASE
+              WHEN last_scan_codex_home = ?3 THEN last_full_scan_completed_at
+              ELSE NULL
+            END,
+            last_scan_codex_home = ?3,
+            updated_at = ?1
+        WHERE singleton_id = 1
+          AND (
+            (codex_home IS NULL AND ?2 IS NULL)
+            OR codex_home = ?2
+          )
+        ",
+        params![timestamp, codex_home_selector, resolved_codex_home],
     )?;
-    Ok(updated == 1)
+    transaction.commit()?;
+
+    Ok(ScanFreshnessStart {
+        recorded: updated == 1,
+        source_changed: updated == 1 && source_changed,
+        full_scan_required: updated == 1 && full_scan_required,
+    })
 }
 
 pub fn set_scan_completed_for_source(
     conn: &Connection,
     timestamp: &str,
     codex_home_selector: Option<&str>,
+    resolved_codex_home: &str,
     full_scan: bool,
 ) -> rusqlite::Result<bool> {
     let updated = conn.execute(
         "
-    UPDATE sync_settings
-    SET last_scan_completed_at = ?1,
-        last_full_scan_completed_at = CASE
-          WHEN ?3 != 0 THEN ?1
-          ELSE last_full_scan_completed_at
-        END,
-        updated_at = ?1
-    WHERE singleton_id = 1
-      AND (
-        (codex_home IS NULL AND ?2 IS NULL)
-        OR codex_home = ?2
-      )
-    ",
-        params![timestamp, codex_home_selector, bool_to_i64(full_scan)],
+        UPDATE sync_settings
+        SET last_scan_completed_at = ?1,
+            last_full_scan_completed_at = CASE
+              WHEN ?4 != 0 THEN ?1
+              ELSE last_full_scan_completed_at
+            END,
+            updated_at = ?1
+        WHERE singleton_id = 1
+          AND (
+            (codex_home IS NULL AND ?2 IS NULL)
+            OR codex_home = ?2
+          )
+          AND last_scan_codex_home = ?3
+        ",
+        params![
+            timestamp,
+            codex_home_selector,
+            resolved_codex_home,
+            bool_to_i64(full_scan)
+        ],
     )?;
     Ok(updated == 1)
+}
+
+fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
+    auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
 
 pub fn get_last_full_scan_completed(conn: &Connection) -> rusqlite::Result<Option<String>> {

--- a/src-tauri/src/database/usage_events.rs
+++ b/src-tauri/src/database/usage_events.rs
@@ -1,0 +1,172 @@
+use std::io::{Error as IoError, ErrorKind};
+
+use rusqlite::{params, Connection};
+
+use super::{bool_to_i64, parse_epoch_millis};
+
+pub struct NewUsageEvent<'a> {
+  pub session_id: &'a str,
+  pub model_id: String,
+  pub input_tokens: i64,
+  pub cached_input_tokens: i64,
+  pub output_tokens: i64,
+  pub reasoning_output_tokens: i64,
+  pub total_tokens: i64,
+  pub value_usd: f64,
+  pub fast_mode_auto: bool,
+  pub fast_mode_effective: bool,
+}
+
+pub fn insert_usage_events<'a, Timestamps, EventAt>(
+  conn: &Connection,
+  timestamps: Timestamps,
+  mut event_at: EventAt,
+) -> rusqlite::Result<usize>
+where
+  Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
+  EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
+{
+  let mut timestamp_epochs = Vec::with_capacity(timestamps.len());
+  for timestamp in timestamps.clone() {
+    let timestamp_ms = parse_epoch_millis(timestamp).map_err(|error| {
+      rusqlite::Error::ToSqlConversionFailure(Box::new(IoError::new(
+        ErrorKind::InvalidData,
+        format!("Invalid usage event timestamp {timestamp:?}: {error}"),
+      )))
+    })?;
+    timestamp_epochs.push(timestamp_ms);
+  }
+
+  let mut statement = conn.prepare(
+    "
+    INSERT INTO usage_events (
+      session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens,
+      output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+      fast_mode_auto, fast_mode_effective
+    )
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+    ",
+  )?;
+
+  let mut inserted = 0usize;
+  for (index, (timestamp, timestamp_ms)) in timestamps.zip(timestamp_epochs).enumerate() {
+    let Some(event) = event_at(index) else {
+      continue;
+    };
+    statement.execute(params![
+      event.session_id,
+      timestamp,
+      timestamp_ms,
+      event.model_id,
+      event.input_tokens,
+      event.cached_input_tokens,
+      event.output_tokens,
+      event.reasoning_output_tokens,
+      event.total_tokens,
+      event.value_usd,
+      bool_to_i64(event.fast_mode_auto),
+      bool_to_i64(event.fast_mode_effective),
+    ])?;
+    inserted += 1;
+  }
+
+  Ok(inserted)
+}
+
+#[cfg(test)]
+mod tests {
+  use rusqlite::Connection;
+
+  use crate::database::{init_db, parse_epoch_millis};
+
+  use super::{insert_usage_events, NewUsageEvent};
+
+  fn event<'a>(
+    session_id: &'a str,
+    model_id: &str,
+    total_tokens: i64,
+  ) -> NewUsageEvent<'a> {
+    NewUsageEvent {
+      session_id,
+      model_id: model_id.to_string(),
+      input_tokens: total_tokens,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens,
+      value_usd: 0.0,
+      fast_mode_auto: false,
+      fast_mode_effective: false,
+    }
+  }
+
+  #[test]
+  fn new_usage_event_writes_timestamp_ms() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T10:00:00+08:00"];
+
+    insert_usage_events(
+      &conn,
+      timestamps.iter().copied(),
+      |_| Some(event("session-1", "gpt-5.4", 10)),
+    )
+    .expect("insert usage event");
+
+    let persisted = conn
+      .query_row(
+        "SELECT timestamp, timestamp_ms FROM usage_events",
+        [],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+      )
+      .expect("load usage event");
+    assert_eq!(persisted.0, timestamps[0]);
+    assert_eq!(
+      persisted.1,
+      parse_epoch_millis(timestamps[0]).expect("parse expected timestamp")
+    );
+  }
+
+  #[test]
+  fn usage_event_batch_parses_mixed_offsets_by_instant() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T10:00:00+08:00", "2026-07-10T02:00:01Z"];
+
+    insert_usage_events(
+      &conn,
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("insert usage events");
+
+    let epochs = conn
+      .prepare("SELECT timestamp_ms FROM usage_events ORDER BY id")
+      .expect("prepare epoch query")
+      .query_map([], |row| row.get::<_, i64>(0))
+      .expect("query epochs")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect epochs");
+    assert_eq!(epochs.len(), 2);
+    assert_eq!(epochs[1] - epochs[0], 1_000);
+  }
+
+  #[test]
+  fn malformed_new_usage_batch_writes_nothing() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T02:00:00Z", "not-an-rfc3339-timestamp"];
+
+    let result = insert_usage_events(
+      &conn,
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    );
+
+    assert!(result.is_err());
+    let count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0))
+      .expect("count usage events");
+    assert_eq!(count, 0);
+  }
+}

--- a/src-tauri/src/database/usage_events.rs
+++ b/src-tauri/src/database/usage_events.rs
@@ -114,6 +114,29 @@ where
   }
 }
 
+pub fn append_session_usage_events<'a, Timestamps, EventAt>(
+  conn: &Connection,
+  session_id: &str,
+  timestamps: Timestamps,
+  mut event_at: EventAt,
+) -> rusqlite::Result<UsageEventWriteStats>
+where
+  Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
+  EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
+{
+  let mut prepared = prepare_usage_events(timestamps, &mut event_at)?;
+  for event in &mut prepared {
+    event.session_id = session_id.to_string();
+  }
+  let inserted = insert_prepared_usage_events(conn, &prepared)?;
+  Ok(UsageEventWriteStats {
+    observed: prepared.len(),
+    inserted,
+    deleted: 0,
+    rebuilt: false,
+  })
+}
+
 fn prepare_usage_events<'a, Timestamps, EventAt>(
   timestamps: Timestamps,
   event_at: &mut EventAt,

--- a/src-tauri/src/database/usage_events.rs
+++ b/src-tauri/src/database/usage_events.rs
@@ -17,6 +17,31 @@ pub struct NewUsageEvent<'a> {
   pub fast_mode_effective: bool,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct PreparedUsageEvent {
+  session_id: String,
+  timestamp: String,
+  timestamp_ms: i64,
+  model_id: String,
+  input_tokens: i64,
+  cached_input_tokens: i64,
+  output_tokens: i64,
+  reasoning_output_tokens: i64,
+  total_tokens: i64,
+  value_usd: f64,
+  fast_mode_auto: bool,
+  fast_mode_effective: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct UsageEventWriteStats {
+  pub observed: usize,
+  pub inserted: usize,
+  pub deleted: usize,
+  pub rebuilt: bool,
+}
+
+#[cfg(test)]
 pub fn insert_usage_events<'a, Timestamps, EventAt>(
   conn: &Connection,
   timestamps: Timestamps,
@@ -26,7 +51,78 @@ where
   Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
   EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
 {
-  let mut timestamp_epochs = Vec::with_capacity(timestamps.len());
+  let prepared = prepare_usage_events(timestamps, &mut event_at)?;
+  insert_prepared_usage_events(conn, &prepared)
+}
+
+pub fn replace_session_usage_events<'a, Timestamps, EventAt>(
+  conn: &Connection,
+  session_id: &str,
+  timestamps: Timestamps,
+  mut event_at: EventAt,
+) -> rusqlite::Result<UsageEventWriteStats>
+where
+  Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
+  EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
+{
+  let mut desired = prepare_usage_events(timestamps, &mut event_at)?;
+  for event in &mut desired {
+    event.session_id = session_id.to_string();
+  }
+  let existing = load_session_usage_events(conn, session_id)?;
+  let matching_prefix = existing
+    .iter()
+    .zip(&desired)
+    .take_while(|(left, right)| left == right)
+    .count();
+
+  conn.execute_batch("SAVEPOINT codex_pacer_usage_event_write")?;
+  let result = if matching_prefix == existing.len() {
+    insert_prepared_usage_events(conn, &desired[matching_prefix..]).map(|inserted| {
+      UsageEventWriteStats {
+        observed: desired.len(),
+        inserted,
+        deleted: 0,
+        rebuilt: false,
+      }
+    })
+  } else {
+    conn.execute(
+      "DELETE FROM usage_events WHERE session_id = ?1",
+      params![session_id],
+    )
+    .and_then(|deleted| {
+      insert_prepared_usage_events(conn, &desired).map(|inserted| UsageEventWriteStats {
+        observed: desired.len(),
+        inserted,
+        deleted,
+        rebuilt: true,
+      })
+    })
+  };
+  match result {
+    Ok(stats) => {
+      conn.execute_batch("RELEASE SAVEPOINT codex_pacer_usage_event_write")?;
+      Ok(stats)
+    }
+    Err(error) => {
+      let _ = conn.execute_batch(
+        "ROLLBACK TO SAVEPOINT codex_pacer_usage_event_write; RELEASE SAVEPOINT codex_pacer_usage_event_write",
+      );
+      Err(error)
+    }
+  }
+}
+
+fn prepare_usage_events<'a, Timestamps, EventAt>(
+  timestamps: Timestamps,
+  event_at: &mut EventAt,
+) -> rusqlite::Result<Vec<PreparedUsageEvent>>
+where
+  Timestamps: ExactSizeIterator<Item = &'a str> + Clone,
+  EventAt: FnMut(usize) -> Option<NewUsageEvent<'a>>,
+{
+  let mut parsed_timestamps = Vec::with_capacity(timestamps.len());
   for timestamp in timestamps.clone() {
     let timestamp_ms = parse_epoch_millis(timestamp).map_err(|error| {
       rusqlite::Error::ToSqlConversionFailure(Box::new(IoError::new(
@@ -34,7 +130,38 @@ where
         format!("Invalid usage event timestamp {timestamp:?}: {error}"),
       )))
     })?;
-    timestamp_epochs.push(timestamp_ms);
+    parsed_timestamps.push((timestamp.to_string(), timestamp_ms));
+  }
+
+  let mut prepared = Vec::with_capacity(parsed_timestamps.len());
+  for (index, (timestamp, timestamp_ms)) in parsed_timestamps.into_iter().enumerate() {
+    let Some(event) = event_at(index) else {
+      continue;
+    };
+    prepared.push(PreparedUsageEvent {
+      session_id: event.session_id.to_string(),
+      timestamp,
+      timestamp_ms,
+      model_id: event.model_id,
+      input_tokens: event.input_tokens,
+      cached_input_tokens: event.cached_input_tokens,
+      output_tokens: event.output_tokens,
+      reasoning_output_tokens: event.reasoning_output_tokens,
+      total_tokens: event.total_tokens,
+      value_usd: event.value_usd,
+      fast_mode_auto: event.fast_mode_auto,
+      fast_mode_effective: event.fast_mode_effective,
+    });
+  }
+  Ok(prepared)
+}
+
+fn insert_prepared_usage_events(
+  conn: &Connection,
+  events: &[PreparedUsageEvent],
+) -> rusqlite::Result<usize> {
+  if events.is_empty() {
+    return Ok(0);
   }
 
   let mut statement = conn.prepare(
@@ -49,14 +176,11 @@ where
   )?;
 
   let mut inserted = 0usize;
-  for (index, (timestamp, timestamp_ms)) in timestamps.zip(timestamp_epochs).enumerate() {
-    let Some(event) = event_at(index) else {
-      continue;
-    };
+  for event in events {
     statement.execute(params![
       event.session_id,
-      timestamp,
-      timestamp_ms,
+      event.timestamp,
+      event.timestamp_ms,
       event.model_id,
       event.input_tokens,
       event.cached_input_tokens,
@@ -73,13 +197,46 @@ where
   Ok(inserted)
 }
 
+fn load_session_usage_events(
+  conn: &Connection,
+  session_id: &str,
+) -> rusqlite::Result<Vec<PreparedUsageEvent>> {
+  let mut statement = conn.prepare(
+    "
+    SELECT session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE session_id = ?1
+    ORDER BY id
+    ",
+  )?;
+  let rows = statement.query_map(params![session_id], |row| {
+    Ok(PreparedUsageEvent {
+      session_id: row.get(0)?,
+      timestamp: row.get(1)?,
+      timestamp_ms: row.get::<_, Option<i64>>(2)?.unwrap_or(i64::MIN),
+      model_id: row.get(3)?,
+      input_tokens: row.get(4)?,
+      cached_input_tokens: row.get(5)?,
+      output_tokens: row.get(6)?,
+      reasoning_output_tokens: row.get(7)?,
+      total_tokens: row.get(8)?,
+      value_usd: row.get(9)?,
+      fast_mode_auto: row.get::<_, i64>(10)? != 0,
+      fast_mode_effective: row.get::<_, i64>(11)? != 0,
+    })
+  })?;
+  rows.collect()
+}
+
 #[cfg(test)]
 mod tests {
   use rusqlite::Connection;
 
   use crate::database::{init_db, parse_epoch_millis};
 
-  use super::{insert_usage_events, NewUsageEvent};
+  use super::{insert_usage_events, replace_session_usage_events, NewUsageEvent};
 
   fn event<'a>(
     session_id: &'a str,
@@ -168,5 +325,129 @@ mod tests {
       .query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0))
       .expect("count usage events");
     assert_eq!(count, 0);
+  }
+
+  #[test]
+  fn repeated_session_usage_replace_writes_nothing_and_preserves_ids() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T02:00:00Z", "2026-07-10T02:01:00Z"];
+    replace_session_usage_events(
+      &conn,
+      "session-1",
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("insert initial usage");
+    let ids_before = usage_ids(&conn, "session-1");
+    let changes_before = conn.total_changes();
+
+    let stats = replace_session_usage_events(
+      &conn,
+      "session-1",
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("repeat usage");
+
+    assert_eq!(stats.inserted, 0);
+    assert_eq!(stats.deleted, 0);
+    assert!(!stats.rebuilt);
+    assert_eq!(usage_ids(&conn, "session-1"), ids_before);
+    assert_eq!(conn.total_changes(), changes_before);
+  }
+
+  #[test]
+  fn appended_session_usage_preserves_prefix_ids() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let initial = ["2026-07-10T02:00:00Z", "2026-07-10T02:01:00Z"];
+    replace_session_usage_events(&conn, "session-1", initial.iter().copied(), |index| {
+      Some(event("session-1", "gpt-5.4", index as i64 + 1))
+    })
+    .expect("insert initial usage");
+    let ids_before = usage_ids(&conn, "session-1");
+    let appended = [
+      "2026-07-10T02:00:00Z",
+      "2026-07-10T02:01:00Z",
+      "2026-07-10T02:02:00Z",
+    ];
+
+    let stats = replace_session_usage_events(
+      &conn,
+      "session-1",
+      appended.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("append usage");
+    let ids_after = usage_ids(&conn, "session-1");
+
+    assert_eq!(stats.inserted, 1);
+    assert_eq!(stats.deleted, 0);
+    assert!(!stats.rebuilt);
+    assert_eq!(&ids_after[..ids_before.len()], ids_before.as_slice());
+    assert_eq!(ids_after.len(), 3);
+  }
+
+  #[test]
+  fn changed_session_usage_prefix_rebuilds_safely() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let timestamps = ["2026-07-10T02:00:00Z", "2026-07-10T02:01:00Z"];
+    replace_session_usage_events(
+      &conn,
+      "session-1",
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    )
+    .expect("insert initial usage");
+    let ids_before = usage_ids(&conn, "session-1");
+
+    let stats = replace_session_usage_events(
+      &conn,
+      "session-1",
+      timestamps.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 10)),
+    )
+    .expect("rebuild changed usage");
+    let ids_after = usage_ids(&conn, "session-1");
+
+    assert_eq!(stats.inserted, 2);
+    assert_eq!(stats.deleted, 2);
+    assert!(stats.rebuilt);
+    assert_ne!(ids_after, ids_before);
+  }
+
+  #[test]
+  fn malformed_session_usage_replace_preserves_existing_rows() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let initial = ["2026-07-10T02:00:00Z"];
+    replace_session_usage_events(&conn, "session-1", initial.iter().copied(), |_| {
+      Some(event("session-1", "gpt-5.4", 1))
+    })
+    .expect("insert initial usage");
+    let ids_before = usage_ids(&conn, "session-1");
+    let malformed = ["2026-07-10T02:00:00Z", "invalid-timestamp"];
+
+    let result = replace_session_usage_events(
+      &conn,
+      "session-1",
+      malformed.iter().copied(),
+      |index| Some(event("session-1", "gpt-5.4", index as i64 + 1)),
+    );
+
+    assert!(result.is_err());
+    assert_eq!(usage_ids(&conn, "session-1"), ids_before);
+  }
+
+  fn usage_ids(conn: &Connection, session_id: &str) -> Vec<i64> {
+    conn
+      .prepare("SELECT id FROM usage_events WHERE session_id = ?1 ORDER BY id")
+      .expect("prepare usage ids")
+      .query_map([session_id], |row| row.get(0))
+      .expect("query usage ids")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect usage ids")
   }
 }

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Timelike};
 use rusqlite::{params, Connection, OptionalExtension};
+use serde::Deserialize;
 use serde_json::Value;
 use walkdir::WalkDir;
 
@@ -1047,23 +1048,14 @@ fn read_parent_replay_snapshots(
 
   for line_result in BufReader::new(file).lines() {
     let line = line_result.map_err(|_| ())?;
-    let may_be_session_meta = json_line_has_string_field(&line, "type", "session_meta");
-    let may_be_token_count = json_line_has_string_field(&line, "type", "event_msg")
-      && json_line_has_string_field(&line, "type", "token_count");
-    if !may_be_session_meta && !may_be_token_count {
+    if !line.contains("\"session_meta\"") && !line.contains("\"token_count\"") {
       continue;
     }
 
-    let Ok(value) = serde_json::from_str::<Value>(&line) else {
-      continue;
-    };
-    match value.get("type").and_then(Value::as_str) {
+    let envelope = serde_json::from_str::<ReplayParentLineEnvelope<'_>>(&line).map_err(|_| ())?;
+    match envelope.record_type {
       Some("session_meta") if first_session_meta_id.is_none() => {
-        let Some(session_id) = value
-          .get("payload")
-          .and_then(|payload| payload.get("id"))
-          .and_then(Value::as_str)
-        else {
+        let Some(session_id) = envelope.payload.as_ref().and_then(|payload| payload.id) else {
           continue;
         };
         if filename_session_id.is_none() && session_id != requested_parent_id {
@@ -1071,28 +1063,25 @@ fn read_parent_replay_snapshots(
         }
         first_session_meta_id = Some(session_id.to_string());
       }
-      Some("event_msg") => {
-        let payload = value.get("payload").unwrap_or(&Value::Null);
-        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
-          continue;
-        }
-        let info = payload.get("info").unwrap_or(&Value::Null);
-        let total_usage = info.get("total_token_usage").unwrap_or(&Value::Null);
-        let Some(timestamp) = value.get("timestamp").and_then(Value::as_str) else {
-          continue;
-        };
-        if total_usage.is_null() {
-          continue;
-        }
+      Some("event_msg")
+        if envelope
+          .payload
+          .as_ref()
+          .and_then(|payload| payload.record_type)
+          == Some("token_count") =>
+      {
+        let timestamp = envelope.timestamp.ok_or(())?;
+        let details = serde_json::from_str::<ReplayParentTokenDetails>(&line).map_err(|_| ())?;
 
         snapshots.push(UsageSnapshot {
           timestamp: timestamp.to_string(),
           model_id: String::new(),
-          usage: token_usage_from_json(total_usage),
-          last_token_usage: info
-            .get("last_token_usage")
-            .filter(|last_usage| !last_usage.is_null())
-            .map(token_usage_from_json),
+          usage: details.payload.info.total_token_usage.into_token_usage(),
+          last_token_usage: details
+            .payload
+            .info
+            .last_token_usage
+            .map(ReplayParentTokenUsage::into_token_usage),
           plan_type: None,
           limit_id: None,
           limit_name: None,
@@ -1113,25 +1102,66 @@ fn read_parent_replay_snapshots(
   Ok(snapshots)
 }
 
-fn json_line_has_string_field(line: &str, field: &str, expected_value: &str) -> bool {
-  let field = format!("\"{field}\"");
-  let expected_value = format!("\"{expected_value}\"");
-
-  line.match_indices(&field).any(|(index, _)| {
-    line[index + field.len()..]
-      .trim_start()
-      .strip_prefix(':')
-      .is_some_and(|rest| rest.trim_start().starts_with(&expected_value))
-  })
+#[derive(Deserialize)]
+struct ReplayParentLineEnvelope<'a> {
+  #[serde(default)]
+  timestamp: Option<&'a str>,
+  #[serde(rename = "type", default)]
+  record_type: Option<&'a str>,
+  #[serde(default, borrow)]
+  payload: Option<ReplayParentPayloadEnvelope<'a>>,
 }
 
-fn token_usage_from_json(value: &Value) -> TokenUsage {
-  TokenUsage {
-    input_tokens: read_i64(value, "input_tokens"),
-    cached_input_tokens: read_i64(value, "cached_input_tokens"),
-    output_tokens: read_i64(value, "output_tokens"),
-    reasoning_output_tokens: read_i64(value, "reasoning_output_tokens"),
-    total_tokens: read_total_tokens(value),
+#[derive(Deserialize)]
+struct ReplayParentPayloadEnvelope<'a> {
+  #[serde(default)]
+  id: Option<&'a str>,
+  #[serde(rename = "type", default)]
+  record_type: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct ReplayParentTokenDetails {
+  payload: ReplayParentTokenPayload,
+}
+
+#[derive(Deserialize)]
+struct ReplayParentTokenPayload {
+  info: ReplayParentTokenInfo,
+}
+
+#[derive(Deserialize)]
+struct ReplayParentTokenInfo {
+  total_token_usage: ReplayParentTokenUsage,
+  #[serde(default)]
+  last_token_usage: Option<ReplayParentTokenUsage>,
+}
+
+#[derive(Deserialize)]
+struct ReplayParentTokenUsage {
+  #[serde(default)]
+  input_tokens: i64,
+  #[serde(default)]
+  cached_input_tokens: i64,
+  #[serde(default)]
+  output_tokens: i64,
+  #[serde(default)]
+  reasoning_output_tokens: i64,
+  #[serde(default)]
+  total_tokens: Option<i64>,
+}
+
+impl ReplayParentTokenUsage {
+  fn into_token_usage(self) -> TokenUsage {
+    TokenUsage {
+      input_tokens: self.input_tokens,
+      cached_input_tokens: self.cached_input_tokens,
+      output_tokens: self.output_tokens,
+      reasoning_output_tokens: self.reasoning_output_tokens,
+      total_tokens: self
+        .total_tokens
+        .unwrap_or_else(|| self.input_tokens + self.output_tokens),
+    }
   }
 }
 
@@ -1905,6 +1935,130 @@ mod tests {
 
   fn fork_instant(timestamp: &str) -> chrono::DateTime<chrono::FixedOffset> {
     chrono::DateTime::parse_from_rfc3339(timestamp).expect("valid fork instant")
+  }
+
+  #[test]
+  fn parent_replay_reader_rejects_malformed_token_candidate_between_snapshots() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "10101010-1010-4010-8010-101010101010";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = format!(
+      "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{parent_session_id}\"}}}}\n"
+    );
+    body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    }));
+    body.push_str(
+      "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":\n",
+    );
+    body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:03Z",
+      total: (180, 0, 0, 180),
+      last: (80, 0, 0, 80),
+    }));
+    std::fs::write(&parent_path, body).expect("write malformed replay parent");
+
+    assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
+  }
+
+  #[test]
+  fn parent_replay_reader_rejects_token_count_without_timestamp() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "20202020-2020-4020-8020-202020202020";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    });
+    body.push_str(
+      concat!(
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{",
+        "\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":0,",
+        "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":180}}}}\n"
+      ),
+    );
+    std::fs::write(&parent_path, body).expect("write replay parent without timestamp");
+
+    assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
+  }
+
+  #[test]
+  fn parent_replay_reader_rejects_token_count_without_total_usage() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "30303030-3030-4030-8030-303030303030";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    });
+    body.push_str(
+      concat!(
+        "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",",
+        "\"payload\":{\"type\":\"token_count\",\"info\":{",
+        "\"last_token_usage\":{\"input_tokens\":80,\"cached_input_tokens\":0,",
+        "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":80}}}}\n"
+      ),
+    );
+    std::fs::write(&parent_path, body).expect("write replay parent without total usage");
+
+    assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
+  }
+
+  #[test]
+  fn parent_replay_reader_rejects_non_numeric_token_usage() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "40404040-4040-4040-8040-404040404040";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let body = concat!(
+      "{\"timestamp\":\"2026-03-24T00:00:01Z\",\"type\":\"event_msg\",",
+      "\"payload\":{\"type\":\"token_count\",\"info\":{",
+      "\"total_token_usage\":{\"input_tokens\":\"not-a-number\",\"cached_input_tokens\":0,",
+      "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":100}}}}\n"
+    );
+    std::fs::write(&parent_path, body).expect("write replay parent with invalid usage");
+
+    assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
+  }
+
+  #[test]
+  fn parent_replay_reader_ignores_nested_token_types_in_unrelated_root_record() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "50505050-5050-4050-8050-505050505050";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    });
+    body.push_str(
+      concat!(
+        "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"response_item\",",
+        "\"payload\":{\"message\":{\"type\":\"event_msg\",\"payload\":{",
+        "\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
+        "\"input_tokens\":900,\"cached_input_tokens\":0,\"output_tokens\":0,",
+        "\"reasoning_output_tokens\":0,\"total_tokens\":900}}}}}}\n"
+      ),
+    );
+    std::fs::write(&parent_path, body).expect("write replay parent with nested token types");
+
+    let snapshots = read_parent_replay_snapshots(&parent_path, parent_session_id)
+      .expect("ignore unrelated nested token fields");
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].usage.total_tokens, 100);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -11,7 +11,6 @@ use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
-use tempfile::NamedTempFile;
 use walkdir::WalkDir;
 
 use crate::database::{
@@ -24,7 +23,7 @@ use crate::pricing::{
   calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing, seed_pricing_catalog,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 struct SessionFile {
   path: PathBuf,
   bucket: String,
@@ -158,14 +157,6 @@ impl PreparedScan {
   }
 
   #[cfg(test)]
-  fn spool_path(&self) -> Option<&Path> {
-    match &self.storage {
-      PreparedStorage::Memory(_) => None,
-      PreparedStorage::Spool { file, .. } => Some(file.path()),
-    }
-  }
-
-  #[cfg(test)]
   fn parent_replay_cache_evictions(&self) -> usize {
     self.stats.parent_replay_cache_evictions
   }
@@ -227,7 +218,7 @@ struct ExistingSessionSource {
 }
 
 struct PreparedSession {
-  session_file: SessionFile,
+  session_file: PreparedSessionFile,
   parsed: ParsedSession,
   file_needs_rate_limit_repair: bool,
   file_needs_token_v2_repair: bool,
@@ -235,6 +226,25 @@ struct PreparedSession {
   replay_parent_unavailable: bool,
   related_pending_token_v2_paths: Vec<String>,
   related_pending_fork_replay_v3_paths: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PreparedSessionFile {
+  source_path: String,
+  bucket: String,
+  file_size: i64,
+  file_mtime_ms: i64,
+}
+
+impl From<SessionFile> for PreparedSessionFile {
+  fn from(session_file: SessionFile) -> Self {
+    Self {
+      source_path: session_file.path.to_string_lossy().into_owned(),
+      bucket: session_file.bucket,
+      file_size: session_file.file_size,
+      file_mtime_ms: session_file.file_mtime_ms,
+    }
+  }
 }
 
 struct PreparedParseFailure {
@@ -258,7 +268,7 @@ struct MissingSessionPlan {
 
 enum PreparedStorage {
   Memory(Vec<PreparedSession>),
-  Spool { file: NamedTempFile, records: usize },
+  Spool { file: File, records: usize },
 }
 
 enum PreparedStorageBuilder {
@@ -268,14 +278,13 @@ enum PreparedStorageBuilder {
   },
   Spool {
     writer: BufWriter<File>,
-    file: NamedTempFile,
     records: usize,
   },
 }
 
 #[derive(Serialize, Deserialize)]
 struct SpoolPreparedSession {
-  session_file: SessionFile,
+  session_file: PreparedSessionFile,
   raw_session: RawSession,
   snapshots: SpoolUsageSnapshots,
   rate_limit_samples: Vec<RateLimitSampleRecord>,
@@ -473,45 +482,50 @@ impl PreparedSession {
   fn estimated_bytes(&self) -> usize {
     let raw = &self.parsed.raw_session;
     let mut bytes = std::mem::size_of::<Self>()
-      .saturating_add(self.session_file.path.to_string_lossy().len())
-      .saturating_add(self.session_file.bucket.len())
-      .saturating_add(raw.session_id.len())
-      .saturating_add(option_string_len(&raw.parent_session_id))
-      .saturating_add(raw.root_session_id.len())
-      .saturating_add(option_string_len(&raw.title))
-      .saturating_add(raw.source_state.len())
-      .saturating_add(option_string_len(&raw.source_path))
-      .saturating_add(option_string_len(&raw.started_at))
-      .saturating_add(option_string_len(&raw.updated_at))
-      .saturating_add(option_string_len(&raw.agent_nickname))
-      .saturating_add(option_string_len(&raw.agent_role))
-      .saturating_add(raw.model_ids.iter().map(String::len).sum::<usize>())
+      .saturating_add(self.session_file.source_path.capacity())
+      .saturating_add(self.session_file.bucket.capacity())
+      .saturating_add(raw.session_id.capacity())
+      .saturating_add(option_string_capacity(&raw.parent_session_id))
+      .saturating_add(raw.root_session_id.capacity())
+      .saturating_add(option_string_capacity(&raw.title))
+      .saturating_add(raw.source_state.capacity())
+      .saturating_add(option_string_capacity(&raw.source_path))
+      .saturating_add(option_string_capacity(&raw.started_at))
+      .saturating_add(option_string_capacity(&raw.updated_at))
+      .saturating_add(option_string_capacity(&raw.agent_nickname))
+      .saturating_add(option_string_capacity(&raw.agent_role))
+      .saturating_add(estimated_string_vec_bytes(&raw.model_ids))
       .saturating_add(estimated_usage_snapshots_bytes(&self.parsed.snapshots))
-      .saturating_add(option_string_len(&self.parsed.explicit_forked_from_id))
-      .saturating_add(option_string_len(&self.parsed.latest_plan_type))
-      .saturating_add(option_string_len(&self.parsed.last_model_id));
+      .saturating_add(option_string_capacity(&self.parsed.explicit_forked_from_id))
+      .saturating_add(option_string_capacity(&self.parsed.latest_plan_type))
+      .saturating_add(option_string_capacity(&self.parsed.last_model_id))
+      .saturating_add(
+        self
+          .parsed
+          .rate_limit_samples
+          .capacity()
+          .saturating_mul(std::mem::size_of::<RateLimitSampleRecord>()),
+      );
 
     for sample in &self.parsed.rate_limit_samples {
       bytes = bytes
-        .saturating_add(std::mem::size_of::<RateLimitSampleRecord>())
-        .saturating_add(sample.source_kind.len())
-        .saturating_add(option_string_len(&sample.source_session_id))
-        .saturating_add(sample.bucket.len())
-        .saturating_add(sample.sample_timestamp.len())
-        .saturating_add(option_string_len(&sample.limit_id))
-        .saturating_add(option_string_len(&sample.limit_name))
-        .saturating_add(option_string_len(&sample.plan_type))
-        .saturating_add(sample.window_start.len())
-        .saturating_add(sample.resets_at.len());
-    }
-    for path in self
-      .related_pending_token_v2_paths
-      .iter()
-      .chain(&self.related_pending_fork_replay_v3_paths)
-    {
-      bytes = bytes.saturating_add(path.len());
+        .saturating_add(sample.source_kind.capacity())
+        .saturating_add(option_string_capacity(&sample.source_session_id))
+        .saturating_add(sample.bucket.capacity())
+        .saturating_add(sample.sample_timestamp.capacity())
+        .saturating_add(option_string_capacity(&sample.limit_id))
+        .saturating_add(option_string_capacity(&sample.limit_name))
+        .saturating_add(option_string_capacity(&sample.plan_type))
+        .saturating_add(sample.window_start.capacity())
+        .saturating_add(sample.resets_at.capacity());
     }
     bytes
+      .saturating_add(estimated_string_vec_bytes(
+        &self.related_pending_token_v2_paths,
+      ))
+      .saturating_add(estimated_string_vec_bytes(
+        &self.related_pending_fork_replay_v3_paths,
+      ))
   }
 }
 
@@ -537,49 +551,44 @@ impl PreparedStorageBuilder {
         mut entries,
         estimated_bytes,
       } => {
-        let next_bytes = estimated_bytes.saturating_add(entry.estimated_bytes());
-        if next_bytes <= PREPARED_SPOOL_THRESHOLD_BYTES {
-          entries.push(entry);
+        let previous_spare_bytes = entries
+          .capacity()
+          .saturating_sub(entries.len())
+          .saturating_mul(std::mem::size_of::<PreparedSession>());
+        let entries_bytes = estimated_bytes.saturating_sub(previous_spare_bytes);
+        let entry_bytes = entry.estimated_bytes();
+        entries.push(entry);
+        let next_spare_bytes = entries
+          .capacity()
+          .saturating_sub(entries.len())
+          .saturating_mul(std::mem::size_of::<PreparedSession>());
+        let next_bytes = entries_bytes
+          .saturating_add(entry_bytes)
+          .saturating_add(next_spare_bytes);
+        if entries.len() == 1 || next_bytes <= PREPARED_SPOOL_THRESHOLD_BYTES {
           Self::Memory {
             entries,
             estimated_bytes: next_bytes,
           }
         } else {
-          let file = tempfile::Builder::new()
-            .prefix("codex-pacer-prepared-")
-            .suffix(".jsons")
-            .tempfile()
+          let file = tempfile::tempfile()
             .map_err(|error| format!("Failed to create prepared scan spool: {error}"))?;
-          let writer_file = file
-            .reopen()
-            .map_err(|error| format!("Failed to open prepared scan spool: {error}"))?;
-          let mut writer = BufWriter::new(writer_file);
+          let mut writer = BufWriter::new(file);
           let mut records = 0usize;
           for buffered in entries {
             write_spool_record(&mut writer, buffered)?;
             records += 1;
           }
-          write_spool_record(&mut writer, entry)?;
-          records += 1;
-          Self::Spool {
-            file,
-            writer,
-            records,
-          }
+          Self::Spool { writer, records }
         }
       }
       Self::Spool {
-        file,
         mut writer,
         mut records,
       } => {
         write_spool_record(&mut writer, entry)?;
         records += 1;
-        Self::Spool {
-          file,
-          writer,
-          records,
-        }
+        Self::Spool { writer, records }
       }
     };
     Ok(())
@@ -589,14 +598,15 @@ impl PreparedStorageBuilder {
     match self {
       Self::Memory { entries, .. } => Ok(PreparedStorage::Memory(entries)),
       Self::Spool {
-        file,
         mut writer,
         records,
       } => {
         writer
           .flush()
           .map_err(|error| format!("Failed to flush prepared scan spool: {error}"))?;
-        drop(writer);
+        let file = writer
+          .into_inner()
+          .map_err(|error| format!("Failed to finish prepared scan spool: {}", error.error()))?;
         Ok(PreparedStorage::Spool { file, records })
       }
     }
@@ -628,12 +638,17 @@ impl ParentReplayCache {
   }
 
   fn insert(&mut self, session_id: String, snapshots: Option<Vec<UsageSnapshot>>) {
-    let entry_bytes = session_id.len().saturating_add(
-      snapshots
-        .as_deref()
-        .map(estimated_usage_snapshots_bytes)
-        .unwrap_or(1),
-    );
+    let insertion_order_id = session_id.clone();
+    let entry_bytes = std::mem::size_of::<ParentReplayCacheEntry>()
+      .saturating_add(std::mem::size_of::<String>().saturating_mul(2))
+      .saturating_add(session_id.capacity())
+      .saturating_add(insertion_order_id.capacity())
+      .saturating_add(
+        snapshots
+          .as_ref()
+          .map(estimated_usage_snapshots_bytes)
+          .unwrap_or(1),
+      );
     if entry_bytes > PARENT_REPLAY_CACHE_MAX_BYTES {
       self.oversized_bypasses += 1;
       return;
@@ -652,7 +667,7 @@ impl ParentReplayCache {
     }
 
     self.estimated_bytes = self.estimated_bytes.saturating_add(entry_bytes);
-    self.insertion_order.push_back(session_id.clone());
+    self.insertion_order.push_back(insertion_order_id);
     self.entries.insert(
       session_id,
       ParentReplayCacheEntry {
@@ -671,20 +686,31 @@ impl ParentReplayCache {
   }
 }
 
-fn option_string_len(value: &Option<String>) -> usize {
-  value.as_ref().map(String::len).unwrap_or_default()
+fn option_string_capacity(value: &Option<String>) -> usize {
+  value.as_ref().map(String::capacity).unwrap_or_default()
 }
 
-fn estimated_usage_snapshots_bytes(snapshots: &[UsageSnapshot]) -> usize {
-  snapshots.iter().fold(0usize, |bytes, snapshot| {
-    bytes
-      .saturating_add(std::mem::size_of::<UsageSnapshot>())
-      .saturating_add(snapshot.timestamp.len())
-      .saturating_add(snapshot.model_id.len())
-      .saturating_add(option_string_len(&snapshot.plan_type))
-      .saturating_add(option_string_len(&snapshot.limit_id))
-      .saturating_add(option_string_len(&snapshot.limit_name))
-  })
+fn estimated_string_vec_bytes(values: &Vec<String>) -> usize {
+  values
+    .capacity()
+    .saturating_mul(std::mem::size_of::<String>())
+    .saturating_add(values.iter().fold(0usize, |bytes, value| {
+      bytes.saturating_add(value.capacity())
+    }))
+}
+
+fn estimated_usage_snapshots_bytes(snapshots: &Vec<UsageSnapshot>) -> usize {
+  snapshots
+    .capacity()
+    .saturating_mul(std::mem::size_of::<UsageSnapshot>())
+    .saturating_add(snapshots.iter().fold(0usize, |bytes, snapshot| {
+      bytes
+        .saturating_add(snapshot.timestamp.capacity())
+        .saturating_add(snapshot.model_id.capacity())
+        .saturating_add(option_string_capacity(&snapshot.plan_type))
+        .saturating_add(option_string_capacity(&snapshot.limit_id))
+        .saturating_add(option_string_capacity(&snapshot.limit_name))
+    }))
 }
 
 pub fn perform_scan(
@@ -935,7 +961,7 @@ pub(crate) fn prepare_scan(
     }
 
     storage.push(PreparedSession {
-      session_file,
+      session_file: session_file.into(),
       parsed,
       file_needs_rate_limit_repair,
       file_needs_token_v2_repair,
@@ -946,6 +972,12 @@ pub(crate) fn prepare_scan(
     })?;
     updated_sessions += 1;
   }
+
+  let titles = if effective_kind == ScanKind::Full {
+    titles
+  } else {
+    HashMap::new()
+  };
 
   let parent_replay_cache_evictions = parent_snapshot_cache.evictions();
   let parent_replay_cache_oversized_bypasses = parent_snapshot_cache.oversized_bypasses();
@@ -1104,11 +1136,11 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
         commit_one_prepared_session(&tx, entry, &catalog).map_err(|error| error.to_string())?;
       }
     }
-    PreparedStorage::Spool { file, records } => {
-      let reader_file = file
-        .reopen()
-        .map_err(|error| format!("Failed to open prepared scan spool for commit: {error}"))?;
-      let reader = BufReader::new(reader_file);
+    PreparedStorage::Spool { mut file, records } => {
+      file
+        .seek(SeekFrom::Start(0))
+        .map_err(|error| format!("Failed to rewind prepared scan spool: {error}"))?;
+      let reader = BufReader::new(file);
       let mut stream =
         serde_json::Deserializer::from_reader(reader).into_iter::<SpoolPreparedSession>();
       let mut records_read = 0usize;
@@ -1120,9 +1152,6 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
         records_read += 1;
       }
       drop(stream);
-      file
-        .close()
-        .map_err(|error| format!("Failed to remove prepared scan spool: {error}"))?;
       if records_read != records {
         return Err(format!(
           "Prepared scan spool ended early: expected {records} records, read {records_read}."
@@ -1458,14 +1487,14 @@ fn commit_one_prepared_session(
     related_pending_token_v2_paths,
     related_pending_fork_replay_v3_paths,
   } = entry;
-  let source_path = session_file.path.to_string_lossy().to_string();
+  let source_path = &session_file.source_path;
 
   persist_session(conn, &session_file, &parsed, catalog)?;
   if file_needs_rate_limit_repair {
-    clear_pending_data_repair_file(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)?;
+    clear_pending_data_repair_file(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, source_path)?;
   }
   if file_needs_token_v2_repair {
-    clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)?;
+    clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, source_path)?;
     for related_source_path in related_pending_token_v2_paths {
       clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &related_source_path)?;
     }
@@ -1475,11 +1504,11 @@ fn commit_one_prepared_session(
       mark_data_repair_file_pending(
         conn,
         TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
-        &source_path,
+        source_path,
         "fork replay parent unavailable",
       )?;
     } else {
-      clear_pending_data_repair_file(conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)?;
+      clear_pending_data_repair_file(conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, source_path)?;
       for related_source_path in related_pending_fork_replay_v3_paths {
         clear_pending_data_repair_file(
           conn,
@@ -2538,7 +2567,7 @@ fn replayed_child_snapshot_cutoff(
 
 fn persist_session(
   conn: &Connection,
-  session_file: &SessionFile,
+  session_file: &PreparedSessionFile,
   parsed: &ParsedSession,
   catalog: &HashMap<String, crate::models::PricingCatalogEntry>,
 ) -> rusqlite::Result<()> {
@@ -2672,7 +2701,7 @@ fn persist_session(
       last_imported_at = excluded.last_imported_at
     ",
     params![
-      session_file.path.to_string_lossy().to_string(),
+      session_file.source_path,
       parsed.raw_session.session_id,
       session_file.bucket,
       session_file.file_size,
@@ -2686,10 +2715,7 @@ fn persist_session(
     DELETE FROM import_state
     WHERE session_id = ?1 AND source_path <> ?2
     ",
-    params![
-      parsed.raw_session.session_id,
-      session_file.path.to_string_lossy().to_string(),
-    ],
+    params![parsed.raw_session.session_id, session_file.source_path,],
   )?;
 
   Ok(())
@@ -3346,6 +3372,57 @@ mod tests {
     assert!(!right.last_completed_at.is_empty());
   }
 
+  #[cfg(unix)]
+  fn prepared_session_fixture(
+    source_path: PathBuf,
+    session_id: &str,
+    model_id_bytes: usize,
+  ) -> PreparedSession {
+    let model_id = "x".repeat(model_id_bytes.max(1));
+    let persisted_source_path = source_path.to_string_lossy().to_string();
+    PreparedSession {
+      session_file: PreparedSessionFile::from(SessionFile {
+        path: source_path,
+        bucket: "active".to_string(),
+        file_size: 1,
+        file_mtime_ms: 1,
+      }),
+      parsed: ParsedSession {
+        raw_session: RawSession {
+          session_id: session_id.to_string(),
+          root_session_id: session_id.to_string(),
+          source_state: "active".to_string(),
+          source_path: Some(persisted_source_path),
+          model_ids: vec![model_id.clone()],
+          ..Default::default()
+        },
+        snapshots: vec![UsageSnapshot {
+          timestamp: "2026-07-10T00:00:00Z".to_string(),
+          model_id,
+          usage: replay_usage((10, 0, 0, 0, 10)),
+          last_token_usage: Some(replay_usage((10, 0, 0, 0, 10))),
+          plan_type: None,
+          limit_id: None,
+          limit_name: None,
+          explicit_fast_mode: None,
+        }],
+        rate_limit_samples: Vec::new(),
+        explicit_forked_from_id: None,
+        explicit_fork_timestamp: None,
+        inherited_token_snapshot_cutoff: 0,
+        explicit_fast_mode: None,
+        latest_plan_type: None,
+        last_model_id: None,
+      },
+      file_needs_rate_limit_repair: false,
+      file_needs_token_v2_repair: false,
+      file_needs_fork_replay_v3_repair: false,
+      replay_parent_unavailable: false,
+      related_pending_token_v2_paths: Vec::new(),
+      related_pending_fork_replay_v3_paths: Vec::new(),
+    }
+  }
+
   #[test]
   fn prepare_scan_is_read_only() {
     let directory = tempdir().expect("tempdir");
@@ -3746,35 +3823,117 @@ mod tests {
     .expect("prepare incremental scan");
 
     assert!(!prepared.uses_spool());
-    assert!(prepared.spool_path().is_none());
   }
 
   #[test]
-  fn large_prepare_spills_and_drop_removes_spool() {
+  fn incremental_prepare_drops_full_title_index_after_parsing() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "67676767-6767-6767-6767-676767676767";
+    let session_path = sessions.join("title-update.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+
+    let mut title_index =
+      format!("{{\"id\":\"{session_id}\",\"thread_name\":\"Incremental title\"}}\n");
+    for index in 0..2_000 {
+      title_index.push_str(&format!(
+        "{{\"id\":\"unrelated-{index}\",\"thread_name\":\"Unused title {index}\"}}\n"
+      ));
+    }
+    std::fs::write(codex_home.join("session_index.jsonl"), title_index).expect("write title index");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental title update");
+
+    assert_eq!(prepared.effective_kind, ScanKind::Incremental);
+    assert!(prepared.titles.is_empty());
+    assert_eq!(prepared.titles.capacity(), 0);
+    let parsed_title = match &prepared.storage {
+      PreparedStorage::Memory(entries) => entries[0].parsed.raw_session.title.as_deref(),
+      PreparedStorage::Spool { .. } => panic!("small title update should stay in memory"),
+    };
+    assert_eq!(parsed_title, Some("Incremental title"));
+    commit_prepared_scan(prepared).expect("commit incremental title update");
+    let conn = open_connection(&db_path).expect("open database");
+    let title: String = conn
+      .query_row(
+        "SELECT title FROM sessions WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+      )
+      .expect("load updated title");
+    assert_eq!(title, "Incremental title");
+  }
+
+  #[test]
+  fn single_large_incremental_stays_in_memory() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions = codex_home.join("sessions");
     std::fs::create_dir_all(&sessions).expect("sessions");
     let session_id = "70707070-7070-7070-7070-707070707070";
-    let mut body = format!(
-      concat!(
-        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
-        "\"payload\":{{\"id\":\"{}\"}}}}\n",
-        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
-        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
-      ),
-      session_id
+    let session_path = sessions.join("large.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
     );
-    let mut total_tokens = 0i64;
-    while body.len() <= PREPARED_SPOOL_THRESHOLD_BYTES * 4 {
-      total_tokens += 10;
-      body.push_str(&token_count_line(TokenFixture {
-        timestamp: "2026-07-10T00:00:02Z",
-        total: (total_tokens, 0, 0, total_tokens),
-        last: (10, 0, 0, 10),
-      }));
-    }
-    std::fs::write(sessions.join("large.jsonl"), body).expect("write large session");
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+    write_large_session_file(
+      &session_path,
+      session_id,
+      PREPARED_SPOOL_THRESHOLD_BYTES * 4,
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare large scan");
+
+    assert!(!prepared.uses_spool());
+    assert!(!prepared.stats().used_spool);
+    assert_eq!(prepared.updated_sessions, 1);
+  }
+
+  #[test]
+  fn multiple_changed_sessions_spill() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    write_large_session_file(
+      &sessions.join("a-large.jsonl"),
+      "74747474-7474-7474-7474-747474747474",
+      PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+    );
+    write_session_file(
+      &sessions.join("z-second.jsonl"),
+      "75757575-7575-7575-7575-757575757575",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     let db_path = directory.path().join("usage.sqlite");
     initialize_scan_database(&db_path);
 
@@ -3783,13 +3942,129 @@ mod tests {
       Some(codex_home.to_string_lossy().to_string()),
       ScanKind::Full,
     )
-    .expect("prepare large scan");
+    .expect("prepare multiple changed sessions");
 
     assert!(prepared.uses_spool());
-    let spool_path = prepared.spool_path().expect("spool path").to_path_buf();
-    assert!(spool_path.is_file());
-    drop(prepared);
-    assert!(!spool_path.exists());
+    assert!(prepared.stats().used_spool);
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn spool_file_is_anonymous_and_unlinked() {
+    use std::os::unix::fs::MetadataExt;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    write_large_session_file(
+      &sessions.join("a-large.jsonl"),
+      "76767676-7676-7676-7676-767676767676",
+      PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+    );
+    write_session_file(
+      &sessions.join("z-second.jsonl"),
+      "77777777-7777-7777-7777-777777777777",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare anonymous spool");
+    let link_count = match &prepared.storage {
+      PreparedStorage::Memory(_) => panic!("expected spool storage"),
+      PreparedStorage::Spool { file, .. } => file.metadata().expect("spool metadata").nlink(),
+    };
+
+    assert_eq!(link_count, 0, "spool must have no directory entry");
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn non_utf8_session_path_matches_memory_and_spool_round_trip() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let session_id = "78787878-7878-7878-7878-787878787878";
+    let non_utf8_path = PathBuf::from(std::ffi::OsString::from_vec(
+      b"/synthetic/00-non-utf8-\x80.jsonl".to_vec(),
+    ));
+    let expected_path = non_utf8_path.to_string_lossy().to_string();
+    let mut memory_builder = PreparedStorageBuilder::new();
+    memory_builder
+      .push(prepared_session_fixture(
+        non_utf8_path.clone(),
+        session_id,
+        1,
+      ))
+      .expect("keep non-UTF-8 entry in memory");
+    let memory_storage = memory_builder.finish().expect("finish memory storage");
+    assert!(matches!(&memory_storage, PreparedStorage::Memory(_)));
+
+    let mut spool_builder = PreparedStorageBuilder::new();
+    spool_builder
+      .push(prepared_session_fixture(non_utf8_path, session_id, 1))
+      .expect("buffer non-UTF-8 entry");
+    spool_builder
+      .push(prepared_session_fixture(
+        PathBuf::from("/synthetic/zz-large.jsonl"),
+        "79797979-7979-7979-7979-797979797979",
+        PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+      ))
+      .expect("spill entries without serializing PathBuf directly");
+    let spool_storage = spool_builder.finish().expect("finish spool storage");
+    assert!(matches!(
+      &spool_storage,
+      PreparedStorage::Spool { records: 2, .. }
+    ));
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("Codex home");
+    let persist_and_load = |db_path: &Path, storage: PreparedStorage| {
+      initialize_scan_database(db_path);
+      let mut prepared = prepare_scan(
+        db_path,
+        Some(codex_home.to_string_lossy().to_string()),
+        ScanKind::Full,
+      )
+      .expect("prepare empty scan shell");
+      prepared.storage = storage;
+      prepared.imported_sessions = 1;
+      prepared.updated_sessions = 1;
+      commit_prepared_scan(prepared).expect("commit synthetic prepared scan");
+      let conn = open_connection(db_path).expect("open committed database");
+      conn
+        .query_row(
+          "
+          SELECT sessions.source_path, import_state.source_path,
+                 COALESCE(SUM(usage_events.total_tokens), 0)
+          FROM sessions
+          JOIN import_state USING (session_id)
+          LEFT JOIN usage_events USING (session_id)
+          WHERE sessions.session_id = ?1
+          GROUP BY sessions.source_path, import_state.source_path
+          ",
+          params![session_id],
+          |row| {
+            Ok((
+              row.get::<_, String>(0)?,
+              row.get::<_, String>(1)?,
+              row.get::<_, i64>(2)?,
+            ))
+          },
+        )
+        .expect("load persisted prepared entry")
+    };
+
+    let memory_result = persist_and_load(&directory.path().join("memory.sqlite"), memory_storage);
+    let spool_result = persist_and_load(&directory.path().join("spool.sqlite"), spool_storage);
+    assert_eq!(spool_result, memory_result);
+    assert_eq!(memory_result, (expected_path.clone(), expected_path, 10));
   }
 
   #[test]
@@ -3838,7 +4113,7 @@ mod tests {
   }
 
   #[test]
-  fn spooled_commit_preserves_last_usage_and_removes_spool() {
+  fn spooled_commit_preserves_last_usage_with_anonymous_file() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions = codex_home.join("sessions");
@@ -3867,7 +4142,12 @@ mod tests {
       }));
       snapshots += 1;
     }
-    std::fs::write(sessions.join("spooled-fork.jsonl"), body).expect("write fork session");
+    std::fs::write(sessions.join("a-spooled-fork.jsonl"), body).expect("write fork session");
+    write_session_file(
+      &sessions.join("z-spool-filler.jsonl"),
+      "72727272-7272-7272-7272-727272727273",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     let db_path = directory.path().join("usage.sqlite");
     initialize_scan_database(&db_path);
 
@@ -3878,13 +4158,33 @@ mod tests {
     )
     .expect("prepare spooled fork");
     assert!(prepared.stats().used_spool);
-    let spool_path = prepared.spool_path().expect("spool path").to_path_buf();
 
     commit_prepared_scan(prepared).expect("commit spooled fork");
 
-    assert!(!spool_path.exists());
     let conn = open_connection(&db_path).expect("open database");
     assert_eq!(session_usage_totals(&conn, session_id).3, snapshots * 10);
+  }
+
+  #[test]
+  fn prepared_estimates_include_reserved_vec_and_string_capacity() {
+    let mut model_id = String::with_capacity(4 * 1024);
+    model_id.push('x');
+    let mut snapshots = Vec::with_capacity(64);
+    snapshots.push(UsageSnapshot {
+      timestamp: "2026-07-10T00:00:00Z".to_string(),
+      model_id,
+      usage: replay_usage((10, 0, 0, 0, 10)),
+      last_token_usage: Some(replay_usage((10, 0, 0, 0, 10))),
+      plan_type: None,
+      limit_id: None,
+      limit_name: None,
+      explicit_fast_mode: None,
+    });
+
+    let estimate = estimated_usage_snapshots_bytes(&snapshots);
+
+    assert!(estimate >= snapshots.capacity() * std::mem::size_of::<UsageSnapshot>());
+    assert!(estimate >= snapshots[0].model_id.capacity());
   }
 
   #[test]
@@ -3935,6 +4235,40 @@ mod tests {
     assert_eq!(cache.evictions(), 0);
     assert_eq!(cache.oversized_bypasses(), 1);
     assert!(cache.get("oversized-parent").is_none());
+  }
+
+  #[test]
+  fn parent_replay_cache_counts_reserved_capacity_toward_its_limit() {
+    let mut reserved_key = String::with_capacity(PARENT_REPLAY_CACHE_MAX_BYTES + 1);
+    reserved_key.push('p');
+    let mut key_cache = ParentReplayCache::new();
+
+    key_cache.insert(reserved_key, None);
+
+    assert_eq!(key_cache.evictions(), 0);
+    assert_eq!(key_cache.oversized_bypasses(), 1);
+    assert!(key_cache.get("p").is_none());
+    assert!(key_cache.estimated_bytes <= PARENT_REPLAY_CACHE_MAX_BYTES);
+
+    let snapshot_capacity = PARENT_REPLAY_CACHE_MAX_BYTES
+      .checked_div(std::mem::size_of::<UsageSnapshot>())
+      .unwrap_or_default()
+      + 1;
+    let mut snapshots = Vec::with_capacity(snapshot_capacity);
+    snapshots.push(replay_snapshot(
+      "2026-07-10T00:00:00Z",
+      "gpt-5.6-sol",
+      (10, 0, 0, 10, 10),
+      Some((10, 0, 0, 10, 10)),
+    ));
+    let mut snapshot_cache = ParentReplayCache::new();
+
+    snapshot_cache.insert("reserved-snapshots".to_string(), Some(snapshots));
+
+    assert_eq!(snapshot_cache.evictions(), 0);
+    assert_eq!(snapshot_cache.oversized_bypasses(), 1);
+    assert!(snapshot_cache.get("reserved-snapshots").is_none());
+    assert!(snapshot_cache.estimated_bytes <= PARENT_REPLAY_CACHE_MAX_BYTES);
   }
 
   #[test]
@@ -7770,6 +8104,29 @@ mod tests {
       last_output,
       last_total,
     )
+  }
+
+  fn write_large_session_file(path: &Path, session_id: &str, minimum_bytes: usize) -> i64 {
+    let mut body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
+      ),
+      session_id
+    );
+    let mut total_tokens = 0i64;
+    while body.len() <= minimum_bytes {
+      total_tokens += 10;
+      body.push_str(&token_count_line(TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (total_tokens, 0, 0, total_tokens),
+        last: (10, 0, 0, 10),
+      }));
+    }
+    std::fs::write(path, body).expect("write large session");
+    total_tokens
   }
 
   fn write_session_file(path: &Path, session_id: &str, snapshots: &[(&str, i64, i64, i64, i64)]) {

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3463,6 +3463,320 @@ mod tests {
   }
 
   #[test]
+  fn incremental_fork_scan_loads_unchanged_archived_parent() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archived_sessions_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_sessions_dir).expect("archived sessions dir");
+
+    let parent_session_id = "11111111-1111-4111-8111-111111111111";
+    let child_session_id = "22222222-2222-4222-8222-222222222222";
+    let parent_path = archived_sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    let parent_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:00:01Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:10:01Z",
+        total: (180, 0, 0, 180),
+        last: (80, 0, 0, 80),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:20:01Z",
+        total: (260, 0, 0, 260),
+        last: (80, 0, 0, 80),
+      },
+    ];
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    for fixture in parent_fixtures.iter().copied() {
+      parent_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&parent_path, parent_body).expect("write archived parent session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("full parent scan");
+
+    let child_created_at = "2026-03-24T00:30:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    for (index, fixture) in parent_fixtures.iter().copied().enumerate() {
+      let timestamp = match index {
+        0 => "2026-03-24T00:30:01Z",
+        1 => "2026-03-24T00:30:02Z",
+        _ => "2026-03-24T00:30:03Z",
+      };
+      child_body.push_str(&token_count_line(TokenFixture {
+        timestamp,
+        ..fixture
+      }));
+    }
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (310, 0, 0, 310),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write active fork child");
+
+    let incremental =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("incremental child scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let parent_total = session_usage_totals(&conn, parent_session_id).3;
+    let child_total = session_usage_totals(&conn, child_session_id).3;
+    assert_eq!(incremental.updated_sessions, 1);
+    assert_eq!(parent_total, 260);
+    assert_eq!(child_total, 50);
+    assert_eq!(parent_total + child_total, 310);
+  }
+
+  #[test]
+  fn nested_fork_replay_uses_direct_parent() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let root_session_id = "33333333-3333-4333-8333-333333333333";
+    let child_session_id = "44444444-4444-4444-8444-444444444444";
+    let grandchild_session_id = "55555555-5555-4555-8555-555555555555";
+    let root_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{root_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    let grandchild_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T01-00-00-{grandchild_session_id}.jsonl"
+    ));
+    let root_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:00:01Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:10:01Z",
+        total: (180, 0, 0, 180),
+        last: (80, 0, 0, 80),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:20:01Z",
+        total: (260, 0, 0, 260),
+        last: (80, 0, 0, 80),
+      },
+    ];
+    let child_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:30:01Z",
+        ..root_fixtures[0]
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:30:02Z",
+        ..root_fixtures[1]
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:30:03Z",
+        ..root_fixtures[2]
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:31:00Z",
+        total: (310, 0, 0, 310),
+        last: (50, 0, 0, 50),
+      },
+    ];
+
+    let mut root_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      root_session_id,
+    );
+    for fixture in root_fixtures.iter().copied() {
+      root_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&root_path, root_body).expect("write root session");
+
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_session_id,
+      root_session_id,
+    );
+    for fixture in child_fixtures.iter().copied() {
+      child_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&child_path, child_body).expect("write child session");
+
+    let mut grandchild_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      grandchild_session_id,
+      child_session_id,
+    );
+    for (index, fixture) in child_fixtures.iter().copied().enumerate() {
+      let timestamp = match index {
+        0 => "2026-03-24T01:00:01Z",
+        1 => "2026-03-24T01:00:02Z",
+        2 => "2026-03-24T01:00:03Z",
+        _ => "2026-03-24T01:00:04Z",
+      };
+      grandchild_body.push_str(&token_count_line(TokenFixture {
+        timestamp,
+        ..fixture
+      }));
+    }
+    grandchild_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T01:01:00Z",
+      total: (330, 0, 0, 330),
+      last: (20, 0, 0, 20),
+    }));
+    std::fs::write(&grandchild_path, grandchild_body).expect("write grandchild session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full family scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let root_total = session_usage_totals(&conn, root_session_id).3;
+    let child_total = session_usage_totals(&conn, child_session_id).3;
+    let grandchild_total = session_usage_totals(&conn, grandchild_session_id).3;
+    assert_eq!(root_total, 260);
+    assert_eq!(child_total, 50);
+    assert_eq!(grandchild_total, 20);
+    assert_eq!(root_total + child_total + grandchild_total, 330);
+  }
+
+  #[test]
+  fn parent_path_validation_rejects_child_file_with_replayed_parent_meta() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "66666666-6666-4666-8666-666666666666";
+    let child_session_id = "77777777-7777-4777-8777-777777777777";
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T01-00-00-{child_session_id}.jsonl"
+    ));
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    parent_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (25, 0, 0, 25),
+      last: (25, 0, 0, 25),
+    }));
+    std::fs::write(&parent_path, parent_body).expect("write parent session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("full parent scan");
+
+    let conn = open_connection(&db_path).expect("open db to corrupt parent source path");
+    assert_eq!(
+      conn
+        .execute(
+          "UPDATE sessions SET source_path = ?1 WHERE session_id = ?2",
+          params![child_path.to_string_lossy().to_string(), parent_session_id],
+        )
+        .expect("corrupt parent source path"),
+      1
+    );
+    drop(conn);
+
+    let child_created_at = "2026-03-24T01:00:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    for fixture in [
+      TokenFixture {
+        timestamp: child_created_at,
+        total: (100, 0, 0, 100),
+        last: (40, 0, 0, 40),
+      },
+      TokenFixture {
+        timestamp: child_created_at,
+        total: (150, 0, 0, 150),
+        last: (50, 0, 0, 50),
+      },
+    ] {
+      child_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&child_path, child_body).expect("write child with replayed parent meta");
+
+    let incremental =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("incremental child scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(incremental.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, parent_session_id).3, 25);
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 90);
+  }
+
+  #[test]
   fn fork_first_snapshot_uses_last_usage_as_baseline() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -7358,6 +7358,32 @@ mod tests {
   }
 
   #[test]
+  #[ignore = "resource profiling helper; requires database and Codex home copies"]
+  fn profile_real_incremental_scan() {
+    let db_path = std::env::var_os("CODEX_PACER_PROFILE_DB")
+      .map(PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_DB to a database copy");
+    let codex_home = std::env::var_os("CODEX_PACER_PROFILE_CODEX_HOME")
+      .map(PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_CODEX_HOME");
+    let started = std::time::Instant::now();
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental scan");
+    eprintln!(
+      "profile incremental elapsed_ms={} visited={} read_bytes={} tail={} full={}",
+      started.elapsed().as_millis(),
+      prepared.stats().files_visited,
+      prepared.stats().source_bytes_read,
+      prepared.stats().tail_parsed_files,
+      prepared.stats().fully_parsed_files
+    );
+  }
+
+  #[test]
   fn changed_checkpoint_suffix_falls_back_to_full_session_parse() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1,24 +1,30 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Timelike};
-use rusqlite::{params, Connection, OptionalExtension};
-use serde::Deserialize;
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, TransactionBehavior};
+use serde::de::{SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use tempfile::NamedTempFile;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, get_sync_settings, init_db, now_utc_string, open_connection,
-  replace_session_rate_limit_samples, set_last_scan_started_for_source, set_scan_completed_for_source,
+  bool_to_i64, init_db, now_utc_string, open_connection, preview_scan_freshness_for_source,
+  replace_session_rate_limit_samples, set_last_scan_started_for_source_in_transaction,
+  set_scan_completed_for_source,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
   calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing, seed_pricing_catalog,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct SessionFile {
   path: PathBuf,
   bucket: String,
@@ -64,40 +70,684 @@ enum TopologyMaintenance {
 }
 
 enum SessionParseError {
-  Fatal(String),
+  Fatal { message: String, bytes_read: u64 },
+}
+
+struct CountingReader<R> {
+  inner: R,
+  bytes_read: u64,
+}
+
+impl<R> CountingReader<R> {
+  fn new(inner: R) -> Self {
+    Self {
+      inner,
+      bytes_read: 0,
+    }
+  }
+}
+
+impl<R: Read> Read for CountingReader<R> {
+  fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+    let bytes_read = self.inner.read(buffer)?;
+    self.bytes_read = self.bytes_read.saturating_add(bytes_read as u64);
+    Ok(bytes_read)
+  }
 }
 
 const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
 const TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY: &str = "token_usage_fork_replay_v3";
 const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
+const PREPARED_SPOOL_THRESHOLD_BYTES: usize = 256 * 1024;
+const PARENT_REPLAY_CACHE_MAX_ENTRIES: usize = 4;
+const PARENT_REPLAY_CACHE_MAX_BYTES: usize = 256 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ScanScope {
+pub(crate) enum ScanKind {
   Full,
   Incremental,
 }
 
-pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
-  perform_scan_with_scope(db_path, codex_home_override, ScanScope::Full)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PreparedScanStats {
+  pub files_visited: usize,
+  pub source_bytes_read: u64,
+  pub full_rebuild: bool,
+  pub used_spool: bool,
+  pub parent_replay_cache_evictions: usize,
+  pub parent_replay_cache_oversized_bypasses: usize,
 }
 
-pub fn perform_incremental_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
-  perform_scan_with_scope(db_path, codex_home_override, ScanScope::Incremental)
+pub(crate) struct PreparedScan {
+  db_path: PathBuf,
+  source_identity: PreparedSourceIdentity,
+  scan_started_at: String,
+  track_scan_freshness: bool,
+  effective_kind: ScanKind,
+  freshness_full_scan_required: bool,
+  stats: PreparedScanStats,
+  imported_sessions: usize,
+  updated_sessions: usize,
+  skipped_session_files: bool,
+  storage: PreparedStorage,
+  parse_failures: Vec<PreparedParseFailure>,
+  titles: HashMap<String, String>,
+  missing_plan: MissingSourcePlan,
+  topology_dirty: bool,
+  topology_needs_repair: bool,
+  new_root_session_ids: Vec<String>,
+  needs_rate_limit_backfill: bool,
+  needs_token_usage_v2_repair_sweep: bool,
+  needs_fork_replay_v3_repair_sweep: bool,
 }
 
-fn perform_scan_with_scope(
+impl PreparedScan {
+  #[allow(dead_code)]
+  pub(crate) fn stats(&self) -> PreparedScanStats {
+    self.stats
+  }
+
+  #[allow(dead_code)]
+  pub(crate) fn source_key(&self) -> &PreparedScanSourceKey {
+    &self.source_identity.key
+  }
+
+  #[cfg(test)]
+  fn uses_spool(&self) -> bool {
+    matches!(self.storage, PreparedStorage::Spool { .. })
+  }
+
+  #[cfg(test)]
+  fn spool_path(&self) -> Option<&Path> {
+    match &self.storage {
+      PreparedStorage::Memory(_) => None,
+      PreparedStorage::Spool { file, .. } => Some(file.path()),
+    }
+  }
+
+  #[cfg(test)]
+  fn parent_replay_cache_evictions(&self) -> usize {
+    self.stats.parent_replay_cache_evictions
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedScanSourceKey {
+  selector: Option<String>,
+  resolved_home: PathBuf,
+}
+
+impl PreparedScanSourceKey {
+  #[allow(dead_code)]
+  pub(crate) fn selector(&self) -> Option<&str> {
+    self.selector.as_deref()
+  }
+
+  #[allow(dead_code)]
+  pub(crate) fn resolved_home(&self) -> &Path {
+    &self.resolved_home
+  }
+}
+
+struct PreparedSourceIdentity {
+  key: PreparedScanSourceKey,
+  scan_commit_revision: i64,
+  tracked_configured_home: Option<PathBuf>,
+  last_scan_codex_home: Option<String>,
+  last_scan_started_at: Option<String>,
+  last_scan_completed_at: Option<String>,
+  last_full_scan_completed_at: Option<String>,
+}
+
+struct PreparationDatabaseSnapshot {
+  scan_source_selector: Option<String>,
+  scan_commit_revision: i64,
+  last_scan_codex_home: Option<String>,
+  last_scan_started_at: Option<String>,
+  last_scan_completed_at: Option<String>,
+  last_full_scan_completed_at: Option<String>,
+  import_state: HashMap<String, ImportState>,
+  needs_rate_limit_backfill: bool,
+  pending_rate_limit_repair_paths: HashSet<String>,
+  needs_token_usage_v2_repair_sweep: bool,
+  pending_token_v2_repair_paths: HashSet<String>,
+  needs_fork_replay_v3_repair_sweep: bool,
+  pending_fork_replay_v3_repair_paths: HashSet<String>,
+  session_source_paths: HashMap<String, PathBuf>,
+  existing_relations: HashMap<String, ExistingSessionRelation>,
+  existing_session_sources: Vec<ExistingSessionSource>,
+  topology_needs_repair: bool,
+}
+
+struct ExistingSessionSource {
+  session_id: String,
+  source_path: String,
+  source_state: String,
+  source_bucket: Option<String>,
+}
+
+struct PreparedSession {
+  session_file: SessionFile,
+  parsed: ParsedSession,
+  file_needs_rate_limit_repair: bool,
+  file_needs_token_v2_repair: bool,
+  file_needs_fork_replay_v3_repair: bool,
+  replay_parent_unavailable: bool,
+  related_pending_token_v2_paths: Vec<String>,
+  related_pending_fork_replay_v3_paths: Vec<String>,
+}
+
+struct PreparedParseFailure {
+  source_path: String,
+  error: String,
+  mark_rate_limit_repair: bool,
+  mark_token_v2_repair: bool,
+  mark_fork_replay_v3_repair: bool,
+}
+
+#[derive(Default)]
+struct MissingSourcePlan {
+  sessions_to_mark_missing: Vec<MissingSessionPlan>,
+  import_state_paths_to_delete: Vec<String>,
+}
+
+struct MissingSessionPlan {
+  session_id: String,
+  expected_source_path: String,
+}
+
+enum PreparedStorage {
+  Memory(Vec<PreparedSession>),
+  Spool { file: NamedTempFile, records: usize },
+}
+
+enum PreparedStorageBuilder {
+  Memory {
+    entries: Vec<PreparedSession>,
+    estimated_bytes: usize,
+  },
+  Spool {
+    writer: BufWriter<File>,
+    file: NamedTempFile,
+    records: usize,
+  },
+}
+
+#[derive(Serialize, Deserialize)]
+struct SpoolPreparedSession {
+  session_file: SessionFile,
+  raw_session: RawSession,
+  snapshots: SpoolUsageSnapshots,
+  rate_limit_samples: Vec<RateLimitSampleRecord>,
+  explicit_forked_from_id: Option<String>,
+  explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
+  inherited_token_snapshot_cutoff: usize,
+  explicit_fast_mode: Option<bool>,
+  latest_plan_type: Option<String>,
+  last_model_id: Option<String>,
+  file_needs_rate_limit_repair: bool,
+  file_needs_token_v2_repair: bool,
+  file_needs_fork_replay_v3_repair: bool,
+  replay_parent_unavailable: bool,
+  related_pending_token_v2_paths: Vec<String>,
+  related_pending_fork_replay_v3_paths: Vec<String>,
+}
+
+struct SpoolUsageSnapshots(Vec<UsageSnapshot>);
+
+#[derive(Deserialize)]
+struct SpoolUsageSnapshot {
+  timestamp: String,
+  model_id: String,
+  usage: TokenUsage,
+  last_token_usage: Option<TokenUsage>,
+  plan_type: Option<String>,
+  limit_id: Option<String>,
+  limit_name: Option<String>,
+  explicit_fast_mode: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct SpoolUsageSnapshotRef<'a> {
+  timestamp: &'a str,
+  model_id: &'a str,
+  usage: &'a TokenUsage,
+  last_token_usage: Option<&'a TokenUsage>,
+  plan_type: Option<&'a str>,
+  limit_id: Option<&'a str>,
+  limit_name: Option<&'a str>,
+  explicit_fast_mode: Option<bool>,
+}
+
+struct ParentReplayCacheEntry {
+  snapshots: Option<Vec<UsageSnapshot>>,
+  estimated_bytes: usize,
+}
+
+struct ParentReplayCache {
+  entries: HashMap<String, ParentReplayCacheEntry>,
+  insertion_order: VecDeque<String>,
+  estimated_bytes: usize,
+  evictions: usize,
+  oversized_bypasses: usize,
+}
+
+impl Serialize for SpoolUsageSnapshots {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+    for snapshot in &self.0 {
+      sequence.serialize_element(&SpoolUsageSnapshotRef {
+        timestamp: &snapshot.timestamp,
+        model_id: &snapshot.model_id,
+        usage: &snapshot.usage,
+        last_token_usage: snapshot.last_token_usage.as_ref(),
+        plan_type: snapshot.plan_type.as_deref(),
+        limit_id: snapshot.limit_id.as_deref(),
+        limit_name: snapshot.limit_name.as_deref(),
+        explicit_fast_mode: snapshot.explicit_fast_mode,
+      })?;
+    }
+    sequence.end()
+  }
+}
+
+struct SpoolUsageSnapshotsVisitor;
+
+impl<'de> Visitor<'de> for SpoolUsageSnapshotsVisitor {
+  type Value = SpoolUsageSnapshots;
+
+  fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str("a sequence of prepared usage snapshots")
+  }
+
+  fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+  where
+    A: SeqAccess<'de>,
+  {
+    let mut snapshots = Vec::with_capacity(sequence.size_hint().unwrap_or_default());
+    while let Some(snapshot) = sequence.next_element::<SpoolUsageSnapshot>()? {
+      snapshots.push(snapshot.into());
+    }
+    Ok(SpoolUsageSnapshots(snapshots))
+  }
+}
+
+impl<'de> Deserialize<'de> for SpoolUsageSnapshots {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    deserializer.deserialize_seq(SpoolUsageSnapshotsVisitor)
+  }
+}
+
+impl From<SpoolUsageSnapshot> for UsageSnapshot {
+  fn from(snapshot: SpoolUsageSnapshot) -> Self {
+    Self {
+      timestamp: snapshot.timestamp,
+      model_id: snapshot.model_id,
+      usage: snapshot.usage,
+      last_token_usage: snapshot.last_token_usage,
+      plan_type: snapshot.plan_type,
+      limit_id: snapshot.limit_id,
+      limit_name: snapshot.limit_name,
+      explicit_fast_mode: snapshot.explicit_fast_mode,
+    }
+  }
+}
+
+impl From<PreparedSession> for SpoolPreparedSession {
+  fn from(entry: PreparedSession) -> Self {
+    let PreparedSession {
+      session_file,
+      parsed,
+      file_needs_rate_limit_repair,
+      file_needs_token_v2_repair,
+      file_needs_fork_replay_v3_repair,
+      replay_parent_unavailable,
+      related_pending_token_v2_paths,
+      related_pending_fork_replay_v3_paths,
+    } = entry;
+    let ParsedSession {
+      raw_session,
+      snapshots,
+      rate_limit_samples,
+      explicit_forked_from_id,
+      explicit_fork_timestamp,
+      inherited_token_snapshot_cutoff,
+      explicit_fast_mode,
+      latest_plan_type,
+      last_model_id,
+    } = parsed;
+
+    Self {
+      session_file,
+      raw_session,
+      snapshots: SpoolUsageSnapshots(snapshots),
+      rate_limit_samples,
+      explicit_forked_from_id,
+      explicit_fork_timestamp,
+      inherited_token_snapshot_cutoff,
+      explicit_fast_mode,
+      latest_plan_type,
+      last_model_id,
+      file_needs_rate_limit_repair,
+      file_needs_token_v2_repair,
+      file_needs_fork_replay_v3_repair,
+      replay_parent_unavailable,
+      related_pending_token_v2_paths,
+      related_pending_fork_replay_v3_paths,
+    }
+  }
+}
+
+impl From<SpoolPreparedSession> for PreparedSession {
+  fn from(entry: SpoolPreparedSession) -> Self {
+    Self {
+      session_file: entry.session_file,
+      parsed: ParsedSession {
+        raw_session: entry.raw_session,
+        snapshots: entry.snapshots.0,
+        rate_limit_samples: entry.rate_limit_samples,
+        explicit_forked_from_id: entry.explicit_forked_from_id,
+        explicit_fork_timestamp: entry.explicit_fork_timestamp,
+        inherited_token_snapshot_cutoff: entry.inherited_token_snapshot_cutoff,
+        explicit_fast_mode: entry.explicit_fast_mode,
+        latest_plan_type: entry.latest_plan_type,
+        last_model_id: entry.last_model_id,
+      },
+      file_needs_rate_limit_repair: entry.file_needs_rate_limit_repair,
+      file_needs_token_v2_repair: entry.file_needs_token_v2_repair,
+      file_needs_fork_replay_v3_repair: entry.file_needs_fork_replay_v3_repair,
+      replay_parent_unavailable: entry.replay_parent_unavailable,
+      related_pending_token_v2_paths: entry.related_pending_token_v2_paths,
+      related_pending_fork_replay_v3_paths: entry.related_pending_fork_replay_v3_paths,
+    }
+  }
+}
+
+impl PreparedSession {
+  fn estimated_bytes(&self) -> usize {
+    let raw = &self.parsed.raw_session;
+    let mut bytes = std::mem::size_of::<Self>()
+      .saturating_add(self.session_file.path.to_string_lossy().len())
+      .saturating_add(self.session_file.bucket.len())
+      .saturating_add(raw.session_id.len())
+      .saturating_add(option_string_len(&raw.parent_session_id))
+      .saturating_add(raw.root_session_id.len())
+      .saturating_add(option_string_len(&raw.title))
+      .saturating_add(raw.source_state.len())
+      .saturating_add(option_string_len(&raw.source_path))
+      .saturating_add(option_string_len(&raw.started_at))
+      .saturating_add(option_string_len(&raw.updated_at))
+      .saturating_add(option_string_len(&raw.agent_nickname))
+      .saturating_add(option_string_len(&raw.agent_role))
+      .saturating_add(raw.model_ids.iter().map(String::len).sum::<usize>())
+      .saturating_add(estimated_usage_snapshots_bytes(&self.parsed.snapshots))
+      .saturating_add(option_string_len(&self.parsed.explicit_forked_from_id))
+      .saturating_add(option_string_len(&self.parsed.latest_plan_type))
+      .saturating_add(option_string_len(&self.parsed.last_model_id));
+
+    for sample in &self.parsed.rate_limit_samples {
+      bytes = bytes
+        .saturating_add(std::mem::size_of::<RateLimitSampleRecord>())
+        .saturating_add(sample.source_kind.len())
+        .saturating_add(option_string_len(&sample.source_session_id))
+        .saturating_add(sample.bucket.len())
+        .saturating_add(sample.sample_timestamp.len())
+        .saturating_add(option_string_len(&sample.limit_id))
+        .saturating_add(option_string_len(&sample.limit_name))
+        .saturating_add(option_string_len(&sample.plan_type))
+        .saturating_add(sample.window_start.len())
+        .saturating_add(sample.resets_at.len());
+    }
+    for path in self
+      .related_pending_token_v2_paths
+      .iter()
+      .chain(&self.related_pending_fork_replay_v3_paths)
+    {
+      bytes = bytes.saturating_add(path.len());
+    }
+    bytes
+  }
+}
+
+impl PreparedStorageBuilder {
+  fn new() -> Self {
+    Self::Memory {
+      entries: Vec::new(),
+      estimated_bytes: 0,
+    }
+  }
+
+  fn push(&mut self, entry: PreparedSession) -> Result<(), String> {
+    let state = std::mem::replace(
+      self,
+      Self::Memory {
+        entries: Vec::new(),
+        estimated_bytes: 0,
+      },
+    );
+
+    *self = match state {
+      Self::Memory {
+        mut entries,
+        estimated_bytes,
+      } => {
+        let next_bytes = estimated_bytes.saturating_add(entry.estimated_bytes());
+        if next_bytes <= PREPARED_SPOOL_THRESHOLD_BYTES {
+          entries.push(entry);
+          Self::Memory {
+            entries,
+            estimated_bytes: next_bytes,
+          }
+        } else {
+          let file = tempfile::Builder::new()
+            .prefix("codex-pacer-prepared-")
+            .suffix(".jsons")
+            .tempfile()
+            .map_err(|error| format!("Failed to create prepared scan spool: {error}"))?;
+          let writer_file = file
+            .reopen()
+            .map_err(|error| format!("Failed to open prepared scan spool: {error}"))?;
+          let mut writer = BufWriter::new(writer_file);
+          let mut records = 0usize;
+          for buffered in entries {
+            write_spool_record(&mut writer, buffered)?;
+            records += 1;
+          }
+          write_spool_record(&mut writer, entry)?;
+          records += 1;
+          Self::Spool {
+            file,
+            writer,
+            records,
+          }
+        }
+      }
+      Self::Spool {
+        file,
+        mut writer,
+        mut records,
+      } => {
+        write_spool_record(&mut writer, entry)?;
+        records += 1;
+        Self::Spool {
+          file,
+          writer,
+          records,
+        }
+      }
+    };
+    Ok(())
+  }
+
+  fn finish(self) -> Result<PreparedStorage, String> {
+    match self {
+      Self::Memory { entries, .. } => Ok(PreparedStorage::Memory(entries)),
+      Self::Spool {
+        file,
+        mut writer,
+        records,
+      } => {
+        writer
+          .flush()
+          .map_err(|error| format!("Failed to flush prepared scan spool: {error}"))?;
+        drop(writer);
+        Ok(PreparedStorage::Spool { file, records })
+      }
+    }
+  }
+}
+
+fn write_spool_record(writer: &mut BufWriter<File>, entry: PreparedSession) -> Result<(), String> {
+  let entry = SpoolPreparedSession::from(entry);
+  serde_json::to_writer(&mut *writer, &entry)
+    .map_err(|error| format!("Failed to write prepared scan spool: {error}"))?;
+  writer
+    .write_all(b"\n")
+    .map_err(|error| format!("Failed to delimit prepared scan spool: {error}"))
+}
+
+impl ParentReplayCache {
+  fn new() -> Self {
+    Self {
+      entries: HashMap::new(),
+      insertion_order: VecDeque::new(),
+      estimated_bytes: 0,
+      evictions: 0,
+      oversized_bypasses: 0,
+    }
+  }
+
+  fn get(&self, session_id: &str) -> Option<&Option<Vec<UsageSnapshot>>> {
+    self.entries.get(session_id).map(|entry| &entry.snapshots)
+  }
+
+  fn insert(&mut self, session_id: String, snapshots: Option<Vec<UsageSnapshot>>) {
+    let entry_bytes = session_id.len().saturating_add(
+      snapshots
+        .as_deref()
+        .map(estimated_usage_snapshots_bytes)
+        .unwrap_or(1),
+    );
+    if entry_bytes > PARENT_REPLAY_CACHE_MAX_BYTES {
+      self.oversized_bypasses += 1;
+      return;
+    }
+
+    while self.entries.len() >= PARENT_REPLAY_CACHE_MAX_ENTRIES
+      || self.estimated_bytes.saturating_add(entry_bytes) > PARENT_REPLAY_CACHE_MAX_BYTES
+    {
+      let Some(oldest_session_id) = self.insertion_order.pop_front() else {
+        break;
+      };
+      if let Some(oldest) = self.entries.remove(&oldest_session_id) {
+        self.estimated_bytes = self.estimated_bytes.saturating_sub(oldest.estimated_bytes);
+        self.evictions += 1;
+      }
+    }
+
+    self.estimated_bytes = self.estimated_bytes.saturating_add(entry_bytes);
+    self.insertion_order.push_back(session_id.clone());
+    self.entries.insert(
+      session_id,
+      ParentReplayCacheEntry {
+        snapshots,
+        estimated_bytes: entry_bytes,
+      },
+    );
+  }
+
+  fn evictions(&self) -> usize {
+    self.evictions
+  }
+
+  fn oversized_bypasses(&self) -> usize {
+    self.oversized_bypasses
+  }
+}
+
+fn option_string_len(value: &Option<String>) -> usize {
+  value.as_ref().map(String::len).unwrap_or_default()
+}
+
+fn estimated_usage_snapshots_bytes(snapshots: &[UsageSnapshot]) -> usize {
+  snapshots.iter().fold(0usize, |bytes, snapshot| {
+    bytes
+      .saturating_add(std::mem::size_of::<UsageSnapshot>())
+      .saturating_add(snapshot.timestamp.len())
+      .saturating_add(snapshot.model_id.len())
+      .saturating_add(option_string_len(&snapshot.plan_type))
+      .saturating_add(option_string_len(&snapshot.limit_id))
+      .saturating_add(option_string_len(&snapshot.limit_name))
+  })
+}
+
+pub fn perform_scan(
   db_path: &Path,
   codex_home_override: Option<String>,
-  requested_scope: ScanScope,
 ) -> Result<ScanResult, String> {
-  let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  perform_scan_with_kind(db_path, codex_home_override, ScanKind::Full)
+}
+
+pub fn perform_incremental_scan(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+) -> Result<ScanResult, String> {
+  perform_scan_with_kind(db_path, codex_home_override, ScanKind::Incremental)
+}
+
+fn perform_scan_with_kind(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_kind: ScanKind,
+) -> Result<ScanResult, String> {
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
-  let scan_source_selector = get_sync_settings(&conn)
-    .map_err(|error| error.to_string())?
-    .codex_home;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
+  drop(conn);
+
+  let prepared = prepare_scan(db_path, codex_home_override, requested_kind)?;
+  commit_prepared_scan(prepared)
+}
+
+pub(crate) fn prepare_scan(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_kind: ScanKind,
+) -> Result<PreparedScan, String> {
+  let scan_started_at = now_utc_string();
+  let database_snapshot =
+    load_preparation_database_snapshot(db_path).map_err(|error| error.to_string())?;
+  let PreparationDatabaseSnapshot {
+    scan_source_selector,
+    scan_commit_revision,
+    last_scan_codex_home,
+    last_scan_started_at,
+    last_scan_completed_at,
+    last_full_scan_completed_at,
+    import_state,
+    needs_rate_limit_backfill,
+    pending_rate_limit_repair_paths,
+    needs_token_usage_v2_repair_sweep,
+    pending_token_v2_repair_paths,
+    needs_fork_replay_v3_repair_sweep,
+    pending_fork_replay_v3_repair_paths,
+    mut session_source_paths,
+    existing_relations,
+    existing_session_sources,
+    topology_needs_repair,
+  } = database_snapshot;
 
   let home_dir = dirs::home_dir();
+  let configured_home =
+    resolve_codex_home(scan_source_selector.as_deref(), None, home_dir.as_deref())
+      .and_then(|path| expand_home_prefix(path, home_dir.as_deref()))
+      .ok();
   let codex_home = validate_codex_home(
     resolve_codex_home(
       scan_source_selector.as_deref(),
@@ -112,31 +762,9 @@ fn perform_scan_with_scope(
     home_dir.as_deref(),
   );
   let resolved_codex_home = codex_home.to_string_lossy().to_string();
-  let scan_started_at = now_utc_string();
-  let scan_freshness_start = if track_scan_freshness {
-    set_last_scan_started_for_source(
-      &conn,
-      &scan_started_at,
-      scan_source_selector.as_deref(),
-      &resolved_codex_home,
-    )
-    .map_err(|error| error.to_string())?
-  } else {
-    Default::default()
-  };
-
-  let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
-  let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
-  let pending_rate_limit_repair_paths =
-    load_pending_data_repair_paths(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY).map_err(|error| error.to_string())?;
-  let needs_token_usage_v2_repair_sweep =
-    data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let pending_token_v2_repair_paths =
-    load_pending_data_repair_paths(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let needs_fork_replay_v3_repair_sweep =
-    data_repair_is_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let pending_fork_replay_v3_repair_paths =
-    load_pending_data_repair_paths(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let freshness_full_scan_required = track_scan_freshness
+    && (last_scan_codex_home.as_deref() != Some(resolved_codex_home.as_str())
+      || last_full_scan_completed_at.is_none());
   let pending_token_v2_repair_session_ids =
     pending_repair_session_ids(&import_state, &pending_token_v2_repair_paths);
   let pending_fork_replay_v3_repair_session_ids =
@@ -147,31 +775,41 @@ fn perform_scan_with_scope(
   pending_repair_session_ids.extend(pending_fork_replay_v3_repair_session_ids.iter().cloned());
   let needs_token_usage_repair_sweep =
     needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
-  let effective_scope = effective_scan_scope(
-    requested_scope,
+  let effective_kind = effective_scan_scope(
+    requested_kind,
     import_state.is_empty(),
     needs_rate_limit_backfill,
     needs_token_usage_repair_sweep,
-    scan_freshness_start.full_scan_required,
+    freshness_full_scan_required,
   );
 
-  let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
-    ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
-    ScanScope::Incremental => {
+  let (session_files, active_paths_kept_for_archive_retry) = match effective_kind {
+    ScanKind::Full => (collect_session_files(&codex_home), HashSet::new()),
+    ScanKind::Incremental => {
       collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
     }
   };
-  let session_source_paths =
-    load_session_source_paths(&conn, &import_state, &session_files).map_err(|error| error.to_string())?;
+  let stats = PreparedScanStats {
+    files_visited: session_files.len(),
+    source_bytes_read: 0,
+    full_rebuild: effective_kind == ScanKind::Full,
+    used_spool: false,
+    parent_replay_cache_evictions: 0,
+    parent_replay_cache_oversized_bypasses: 0,
+  };
+  for session_file in &session_files {
+    let Some(session_id) = fallback_session_id_from_filename(&session_file.path) else {
+      continue;
+    };
+    session_source_paths.insert(session_id, session_file.path.clone());
+  }
   let mut present_paths: HashSet<String> = session_files
     .iter()
     .map(|item| item.path.to_string_lossy().to_string())
     .collect();
   present_paths.extend(active_paths_kept_for_archive_retry);
 
-  let mut changed_sessions = 0usize;
   let mut imported_session_ids = HashSet::new();
-
   let mut changed_files = Vec::new();
   for session_file in &session_files {
     let source_path = session_file.path.to_string_lossy().to_string();
@@ -193,7 +831,7 @@ fn perform_scan_with_scope(
       || session_has_pending_token_v2_repair
       || session_has_pending_fork_replay_v3_repair
     {
-      changed_files.push(session_file);
+      changed_files.push(session_file.clone());
       continue;
     }
     if let Some(state) = import_state.get(&source_path) {
@@ -209,10 +847,10 @@ fn perform_scan_with_scope(
       }
     }
 
-    changed_files.push(session_file);
+    changed_files.push(session_file.clone());
   }
 
-  let titles = if effective_scope == ScanScope::Full || !changed_files.is_empty() {
+  let titles = if effective_kind == ScanKind::Full || !changed_files.is_empty() {
     load_session_index(&codex_home)
   } else {
     HashMap::new()
@@ -221,143 +859,293 @@ fn perform_scan_with_scope(
   let mut topology_dirty = false;
   let mut new_root_session_ids = Vec::new();
   let mut skipped_session_files = false;
-  let mut parent_snapshot_cache: HashMap<String, Option<Vec<UsageSnapshot>>> = HashMap::new();
-  if !changed_files.is_empty() {
-    let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
-    let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
+  let mut parse_failures = Vec::new();
+  let mut parent_snapshot_cache = ParentReplayCache::new();
+  let mut storage = PreparedStorageBuilder::new();
+  let mut updated_sessions = 0usize;
+  let mut source_bytes_read = 0u64;
 
-    for session_file in changed_files {
-      let source_path = session_file.path.to_string_lossy().to_string();
-      let file_needs_rate_limit_repair =
-        needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
-      let mut file_needs_token_v2_repair =
-        needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
-      let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
-        || pending_fork_replay_v3_repair_paths.contains(&source_path);
-      let mut parsed = match parse_session_file(session_file, &titles) {
-        Ok(parsed) => parsed,
-        Err(error) => {
-          skipped_session_files = true;
-          log::warn!(
-            "Skipping unreadable session file {}: {}",
-            session_file.path.display(),
-            error
-          );
-          if file_needs_token_v2_repair {
-            mark_data_repair_file_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path, &error)
-              .map_err(|error| error.to_string())?;
-          }
-          if file_needs_fork_replay_v3_repair {
-            mark_data_repair_file_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path, &error)
-              .map_err(|error| error.to_string())?;
-          }
-          if file_needs_rate_limit_repair {
-            mark_data_repair_file_pending(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path, &error)
-              .map_err(|error| error.to_string())?;
-          }
-          continue;
-        }
-      };
-      let replay_parent_unavailable = assign_inherited_token_snapshot_cutoff(
+  for session_file in changed_files {
+    let source_path = session_file.path.to_string_lossy().to_string();
+    let file_needs_rate_limit_repair =
+      needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
+    let mut file_needs_token_v2_repair =
+      needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
+    let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
+      || pending_fork_replay_v3_repair_paths.contains(&source_path);
+    let (mut parsed, bytes_read) = match parse_session_file_counted(&session_file, &titles) {
+      Ok(parsed) => parsed,
+      Err((error, bytes_read)) => {
+        source_bytes_read = source_bytes_read.saturating_add(bytes_read);
+        skipped_session_files = true;
+        log::warn!(
+          "Skipping unreadable session file {}: {}",
+          session_file.path.display(),
+          error
+        );
+        parse_failures.push(PreparedParseFailure {
+          source_path,
+          error,
+          mark_rate_limit_repair: file_needs_rate_limit_repair,
+          mark_token_v2_repair: file_needs_token_v2_repair,
+          mark_fork_replay_v3_repair: file_needs_fork_replay_v3_repair,
+        });
+        continue;
+      }
+    };
+    source_bytes_read = source_bytes_read.saturating_add(bytes_read);
+
+    let (replay_parent_unavailable, parent_replay_bytes_read) =
+      assign_inherited_token_snapshot_cutoff(
         &mut parsed,
         &session_source_paths,
         &mut parent_snapshot_cache,
       );
-      let related_pending_token_v2_paths = pending_repair_paths_for_session(
-        &import_state,
-        &pending_token_v2_repair_paths,
-        &parsed.raw_session.session_id,
-      );
-      let related_pending_fork_replay_v3_paths = pending_repair_paths_for_session(
-        &import_state,
-        &pending_fork_replay_v3_repair_paths,
-        &parsed.raw_session.session_id,
-      );
-      file_needs_token_v2_repair |= !related_pending_token_v2_paths.is_empty();
-      file_needs_fork_replay_v3_repair |=
-        replay_parent_unavailable || !related_pending_fork_replay_v3_paths.is_empty();
-      imported_session_ids.insert(parsed.raw_session.session_id.clone());
+    source_bytes_read = source_bytes_read.saturating_add(parent_replay_bytes_read);
+    let related_pending_token_v2_paths = pending_repair_paths_for_session(
+      &import_state,
+      &pending_token_v2_repair_paths,
+      &parsed.raw_session.session_id,
+    );
+    let related_pending_fork_replay_v3_paths = pending_repair_paths_for_session(
+      &import_state,
+      &pending_fork_replay_v3_repair_paths,
+      &parsed.raw_session.session_id,
+    );
+    file_needs_token_v2_repair |= !related_pending_token_v2_paths.is_empty();
+    file_needs_fork_replay_v3_repair |=
+      replay_parent_unavailable || !related_pending_fork_replay_v3_paths.is_empty();
+    imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
-      match classify_topology_maintenance(
-        existing_relations.get(&parsed.raw_session.session_id),
-        existing_relations.get(&parsed.raw_session.session_id).map(|item| item.child_count).unwrap_or_default(),
-        parsed.raw_session.parent_session_id.as_deref(),
-      ) {
-        TopologyMaintenance::None => {}
-        TopologyMaintenance::InsertRootLink => {
-          new_root_session_ids.push(parsed.raw_session.session_id.clone());
-        }
-        TopologyMaintenance::RecomputeAll => {
-          topology_dirty = true;
-        }
+    match classify_topology_maintenance(
+      existing_relations.get(&parsed.raw_session.session_id),
+      existing_relations
+        .get(&parsed.raw_session.session_id)
+        .map(|item| item.child_count)
+        .unwrap_or_default(),
+      parsed.raw_session.parent_session_id.as_deref(),
+    ) {
+      TopologyMaintenance::None => {}
+      TopologyMaintenance::InsertRootLink => {
+        new_root_session_ids.push(parsed.raw_session.session_id.clone());
       }
+      TopologyMaintenance::RecomputeAll => {
+        topology_dirty = true;
+      }
+    }
 
-      persist_session(&mut conn, session_file, &parsed, &catalog).map_err(|error| error.to_string())?;
-      if file_needs_rate_limit_repair {
-        clear_pending_data_repair_file(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)
-          .map_err(|error| error.to_string())?;
-      }
-      if file_needs_token_v2_repair {
-        clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)
-          .map_err(|error| error.to_string())?;
-        for related_source_path in related_pending_token_v2_paths {
-          clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &related_source_path)
-            .map_err(|error| error.to_string())?;
-        }
-      }
-      if file_needs_fork_replay_v3_repair {
-        if replay_parent_unavailable {
-          mark_data_repair_file_pending(
-            &conn,
-            TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
-            &source_path,
-            "fork replay parent unavailable",
-          )
-            .map_err(|error| error.to_string())?;
-        } else {
-          clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
-            .map_err(|error| error.to_string())?;
-          for related_source_path in related_pending_fork_replay_v3_paths {
-            clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &related_source_path)
-              .map_err(|error| error.to_string())?;
-          }
-        }
-      }
-      changed_sessions += 1;
+    storage.push(PreparedSession {
+      session_file,
+      parsed,
+      file_needs_rate_limit_repair,
+      file_needs_token_v2_repair,
+      file_needs_fork_replay_v3_repair,
+      replay_parent_unavailable,
+      related_pending_token_v2_paths,
+      related_pending_fork_replay_v3_paths,
+    })?;
+    updated_sessions += 1;
+  }
+
+  let parent_replay_cache_evictions = parent_snapshot_cache.evictions();
+  let parent_replay_cache_oversized_bypasses = parent_snapshot_cache.oversized_bypasses();
+  drop(parent_snapshot_cache);
+  drop(session_source_paths);
+  drop(existing_relations);
+
+  let missing_plan = prepare_missing_source_plan(
+    &existing_session_sources,
+    &import_state,
+    &present_paths,
+    effective_kind,
+    freshness_full_scan_required,
+  );
+  let storage = storage.finish()?;
+  let stats = PreparedScanStats {
+    source_bytes_read,
+    used_spool: matches!(&storage, PreparedStorage::Spool { .. }),
+    parent_replay_cache_evictions,
+    parent_replay_cache_oversized_bypasses,
+    ..stats
+  };
+
+  Ok(PreparedScan {
+    db_path: db_path.to_path_buf(),
+    source_identity: PreparedSourceIdentity {
+      key: PreparedScanSourceKey {
+        selector: scan_source_selector,
+        resolved_home: codex_home,
+      },
+      scan_commit_revision,
+      tracked_configured_home: track_scan_freshness.then_some(configured_home).flatten(),
+      last_scan_codex_home,
+      last_scan_started_at,
+      last_scan_completed_at,
+      last_full_scan_completed_at,
+    },
+    scan_started_at,
+    track_scan_freshness,
+    effective_kind,
+    freshness_full_scan_required,
+    stats,
+    imported_sessions: imported_session_ids.len(),
+    updated_sessions,
+    skipped_session_files,
+    storage,
+    parse_failures,
+    titles,
+    missing_plan,
+    topology_dirty,
+    topology_needs_repair,
+    new_root_session_ids,
+    needs_rate_limit_backfill,
+    needs_token_usage_v2_repair_sweep,
+    needs_fork_replay_v3_repair_sweep,
+  })
+}
+
+pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult, String> {
+  let PreparedScan {
+    db_path,
+    source_identity,
+    scan_started_at,
+    track_scan_freshness,
+    effective_kind,
+    freshness_full_scan_required,
+    stats,
+    imported_sessions,
+    updated_sessions,
+    skipped_session_files,
+    storage,
+    parse_failures,
+    titles,
+    missing_plan,
+    topology_dirty,
+    topology_needs_repair,
+    new_root_session_ids,
+    needs_rate_limit_backfill,
+    needs_token_usage_v2_repair_sweep,
+    needs_fork_replay_v3_repair_sweep,
+  } = prepared;
+
+  let mut conn = open_connection(&db_path).map_err(|error| error.to_string())?;
+  let tx = conn
+    .transaction_with_behavior(TransactionBehavior::Immediate)
+    .map_err(|error| error.to_string())?;
+  validate_prepared_source_identity(&tx, &source_identity)?;
+  let catalog = load_catalog_map(&tx).map_err(|error| error.to_string())?;
+  let resolved_codex_home = source_identity
+    .key
+    .resolved_home
+    .to_string_lossy()
+    .to_string();
+
+  let scan_freshness_preview = if track_scan_freshness {
+    preview_scan_freshness_for_source(
+      &tx,
+      source_identity.key.selector.as_deref(),
+      &resolved_codex_home,
+    )
+    .map_err(|error| error.to_string())?
+  } else {
+    Default::default()
+  };
+  if scan_freshness_preview.recorded
+    && scan_freshness_preview.full_scan_required != freshness_full_scan_required
+  {
+    return Err("Prepared scan freshness changed before commit.".to_string());
+  }
+
+  let scan_freshness_start = if track_scan_freshness {
+    set_last_scan_started_for_source_in_transaction(
+      &tx,
+      &scan_started_at,
+      source_identity.key.selector.as_deref(),
+      &resolved_codex_home,
+    )
+    .map_err(|error| error.to_string())?
+  } else {
+    Default::default()
+  };
+
+  for failure in parse_failures {
+    if failure.mark_token_v2_repair {
+      mark_data_repair_file_pending(
+        &tx,
+        TOKEN_USAGE_MONOTONIC_REPAIR_KEY,
+        &failure.source_path,
+        &failure.error,
+      )
+      .map_err(|error| error.to_string())?;
+    }
+    if failure.mark_fork_replay_v3_repair {
+      mark_data_repair_file_pending(
+        &tx,
+        TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+        &failure.source_path,
+        &failure.error,
+      )
+      .map_err(|error| error.to_string())?;
+    }
+    if failure.mark_rate_limit_repair {
+      mark_data_repair_file_pending(
+        &tx,
+        RATE_LIMIT_SAMPLE_BACKFILL_KEY,
+        &failure.source_path,
+        &failure.error,
+      )
+      .map_err(|error| error.to_string())?;
     }
   }
 
-  if effective_scope == ScanScope::Full {
-    refresh_session_titles(&conn, &titles).map_err(|error| error.to_string())?;
+  match storage {
+    PreparedStorage::Memory(entries) => {
+      for entry in entries {
+        commit_one_prepared_session(&tx, entry, &catalog).map_err(|error| error.to_string())?;
+      }
+    }
+    PreparedStorage::Spool { file, records } => {
+      let reader_file = file
+        .reopen()
+        .map_err(|error| format!("Failed to open prepared scan spool for commit: {error}"))?;
+      let reader = BufReader::new(reader_file);
+      let mut stream =
+        serde_json::Deserializer::from_reader(reader).into_iter::<SpoolPreparedSession>();
+      let mut records_read = 0usize;
+      while let Some(entry) = stream.next() {
+        let entry =
+          entry.map_err(|error| format!("Failed to read prepared scan spool: {error}"))?;
+        commit_one_prepared_session(&tx, PreparedSession::from(entry), &catalog)
+          .map_err(|error| error.to_string())?;
+        records_read += 1;
+      }
+      drop(stream);
+      file
+        .close()
+        .map_err(|error| format!("Failed to remove prepared scan spool: {error}"))?;
+      if records_read != records {
+        return Err(format!(
+          "Prepared scan spool ended early: expected {records} records, read {records_read}."
+        ));
+      }
+    }
   }
 
-  if effective_scope == ScanScope::Full {
-    // A full scan that is required for freshness is authoritative even on retry:
-    // paths outside the resolved source must not remain active just because they still exist.
-    let reconcile_existing_absent_sources = scan_freshness_start.full_scan_required;
-    mark_missing_sources(
-      &conn,
-      &present_paths,
-      reconcile_existing_absent_sources,
-    )
-    .map_err(|error| error.to_string())?;
-    prune_import_state(
-      &conn,
-      &present_paths,
-      reconcile_existing_absent_sources,
-    )
-    .map_err(|error| error.to_string())?;
-  } else {
-    mark_missing_active_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
+  if effective_kind == ScanKind::Full {
+    refresh_session_titles(&tx, &titles).map_err(|error| error.to_string())?;
   }
-  let topology_needs_repair = conversation_links_need_repair(&conn).map_err(|error| error.to_string())?;
+  apply_missing_source_plan(&tx, missing_plan).map_err(|error| error.to_string())?;
+
+  let topology_needs_repair = topology_needs_repair
+    || conversation_links_need_repair(&tx).map_err(|error| error.to_string())?;
   if topology_dirty || topology_needs_repair {
-    recompute_conversation_links(&conn).map_err(|error| error.to_string())?;
+    recompute_conversation_links(&tx).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
-    upsert_root_conversation_links(&conn, &new_root_session_ids).map_err(|error| error.to_string())?;
+    upsert_root_conversation_links(&tx, &new_root_session_ids)
+      .map_err(|error| error.to_string())?;
   }
 
-  let missing_sessions = conn
+  let missing_sessions = tx
     .query_row(
       "SELECT COUNT(*) FROM sessions WHERE source_state = 'missing'",
       [],
@@ -367,55 +1155,360 @@ fn perform_scan_with_scope(
 
   let completed_at = now_utc_string();
   if needs_rate_limit_backfill {
-    mark_data_repair_complete(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &completed_at)
+    mark_data_repair_complete(&tx, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
   if needs_token_usage_v2_repair_sweep {
-    mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
+    mark_data_repair_complete(&tx, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
   if needs_fork_replay_v3_repair_sweep {
-    mark_data_repair_complete(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &completed_at)
+    mark_data_repair_complete(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
   if scan_freshness_start.recorded {
     set_scan_completed_for_source(
-      &conn,
+      &tx,
       &completed_at,
-      scan_source_selector.as_deref(),
+      source_identity.key.selector.as_deref(),
       &resolved_codex_home,
-      effective_scope == ScanScope::Full && !skipped_session_files,
-      effective_scope == ScanScope::Full && skipped_session_files,
+      effective_kind == ScanKind::Full && !skipped_session_files,
+      effective_kind == ScanKind::Full && skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
 
+  let revision_updated = tx
+    .execute(
+      "
+      UPDATE sync_settings
+      SET scan_commit_revision = scan_commit_revision + 1
+      WHERE singleton_id = 1 AND scan_commit_revision = ?1
+      ",
+      params![source_identity.scan_commit_revision],
+    )
+    .map_err(|error| error.to_string())?;
+  if revision_updated != 1 {
+    return Err("Prepared scan is stale before commit.".to_string());
+  }
+
+  tx.commit().map_err(|error| error.to_string())?;
+
   Ok(ScanResult {
-    codex_home: codex_home.to_string_lossy().to_string(),
-    scanned_files: session_files.len(),
-    imported_sessions: imported_session_ids.len(),
-    updated_sessions: changed_sessions,
+    codex_home: resolved_codex_home,
+    scanned_files: stats.files_visited,
+    imported_sessions,
+    updated_sessions,
     missing_sessions,
     last_completed_at: completed_at,
   })
 }
 
+fn open_scan_snapshot(db_path: &Path) -> rusqlite::Result<Connection> {
+  let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+  conn.busy_timeout(Duration::from_secs(10))?;
+  conn.pragma_update(None, "query_only", "ON")?;
+  Ok(conn)
+}
+
+fn load_preparation_database_snapshot(
+  db_path: &Path,
+) -> rusqlite::Result<PreparationDatabaseSnapshot> {
+  let mut conn = open_scan_snapshot(db_path)?;
+  let tx = conn.transaction()?;
+  let (
+    scan_source_selector,
+    scan_commit_revision,
+    last_scan_codex_home,
+    last_scan_started_at,
+    last_scan_completed_at,
+    last_full_scan_completed_at,
+  ): (
+    Option<String>,
+    i64,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+  ) = tx.query_row(
+    "
+    SELECT codex_home, scan_commit_revision, last_scan_codex_home,
+           last_scan_started_at, last_scan_completed_at, last_full_scan_completed_at
+    FROM sync_settings
+    WHERE singleton_id = 1
+    ",
+    [],
+    |row| {
+      Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+      ))
+    },
+  )?;
+  let import_state = load_import_state(&tx)?;
+  let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&tx)?;
+  let pending_rate_limit_repair_paths =
+    load_pending_data_repair_paths(&tx, RATE_LIMIT_SAMPLE_BACKFILL_KEY)?;
+  let needs_token_usage_v2_repair_sweep =
+    data_repair_is_pending(&tx, TOKEN_USAGE_MONOTONIC_REPAIR_KEY)?;
+  let pending_token_v2_repair_paths =
+    load_pending_data_repair_paths(&tx, TOKEN_USAGE_MONOTONIC_REPAIR_KEY)?;
+  let needs_fork_replay_v3_repair_sweep =
+    data_repair_is_pending(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY)?;
+  let pending_fork_replay_v3_repair_paths =
+    load_pending_data_repair_paths(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY)?;
+  let session_source_paths = load_session_source_paths(&tx, &import_state, &[])?;
+  let existing_relations = load_existing_session_relations(&tx)?;
+  let existing_session_sources = {
+    let mut stmt = tx.prepare(
+      "
+      SELECT session_id, source_path, source_state, source_bucket
+      FROM sessions
+      WHERE source_path IS NOT NULL
+      ",
+    )?;
+    let rows = stmt
+      .query_map([], |row| {
+        Ok(ExistingSessionSource {
+          session_id: row.get(0)?,
+          source_path: row.get(1)?,
+          source_state: row.get(2)?,
+          source_bucket: row.get(3)?,
+        })
+      })?
+      .collect::<rusqlite::Result<Vec<_>>>()?;
+    rows
+  };
+  let topology_needs_repair = conversation_links_need_repair(&tx)?;
+  tx.commit()?;
+
+  Ok(PreparationDatabaseSnapshot {
+    scan_source_selector,
+    scan_commit_revision,
+    last_scan_codex_home,
+    last_scan_started_at,
+    last_scan_completed_at,
+    last_full_scan_completed_at,
+    import_state,
+    needs_rate_limit_backfill,
+    pending_rate_limit_repair_paths,
+    needs_token_usage_v2_repair_sweep,
+    pending_token_v2_repair_paths,
+    needs_fork_replay_v3_repair_sweep,
+    pending_fork_replay_v3_repair_paths,
+    session_source_paths,
+    existing_relations,
+    existing_session_sources,
+    topology_needs_repair,
+  })
+}
+
+fn validate_prepared_source_identity(
+  conn: &Connection,
+  prepared: &PreparedSourceIdentity,
+) -> Result<(), String> {
+  let (
+    selector,
+    scan_commit_revision,
+    last_scan_codex_home,
+    last_scan_started_at,
+    last_scan_completed_at,
+    last_full_scan_completed_at,
+  ): (
+    Option<String>,
+    i64,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+  ) = conn
+    .query_row(
+      "
+      SELECT codex_home, scan_commit_revision, last_scan_codex_home,
+             last_scan_started_at, last_scan_completed_at, last_full_scan_completed_at
+      FROM sync_settings
+      WHERE singleton_id = 1
+      ",
+      [],
+      |row| {
+        Ok((
+          row.get(0)?,
+          row.get(1)?,
+          row.get(2)?,
+          row.get(3)?,
+          row.get(4)?,
+          row.get(5)?,
+        ))
+      },
+    )
+    .map_err(|error| error.to_string())?;
+  let home_dir = dirs::home_dir();
+  let configured_home = resolve_codex_home(selector.as_deref(), None, home_dir.as_deref())
+    .and_then(|path| expand_home_prefix(path, home_dir.as_deref()))
+    .ok();
+
+  if selector != prepared.key.selector
+    || scan_commit_revision != prepared.scan_commit_revision
+    || prepared
+      .tracked_configured_home
+      .as_ref()
+      .is_some_and(|prepared_home| Some(prepared_home) != configured_home.as_ref())
+    || last_scan_codex_home != prepared.last_scan_codex_home
+    || last_scan_started_at != prepared.last_scan_started_at
+    || last_scan_completed_at != prepared.last_scan_completed_at
+    || last_full_scan_completed_at != prepared.last_full_scan_completed_at
+  {
+    return Err("Prepared scan source changed before commit.".to_string());
+  }
+  Ok(())
+}
+
+fn prepare_missing_source_plan(
+  existing_sources: &[ExistingSessionSource],
+  import_state: &HashMap<String, ImportState>,
+  present_paths: &HashSet<String>,
+  scan_kind: ScanKind,
+  reconcile_existing_absent_sources: bool,
+) -> MissingSourcePlan {
+  let mut plan = MissingSourcePlan::default();
+
+  match scan_kind {
+    ScanKind::Full => {
+      for source in existing_sources {
+        if !present_paths.contains(&source.source_path)
+          && (reconcile_existing_absent_sources || !Path::new(&source.source_path).exists())
+        {
+          plan.sessions_to_mark_missing.push(MissingSessionPlan {
+            session_id: source.session_id.clone(),
+            expected_source_path: source.source_path.clone(),
+          });
+        }
+      }
+      for source_path in import_state.keys() {
+        if !present_paths.contains(source_path)
+          && (reconcile_existing_absent_sources || !Path::new(source_path).exists())
+        {
+          plan.import_state_paths_to_delete.push(source_path.clone());
+        }
+      }
+    }
+    ScanKind::Incremental => {
+      for source in existing_sources {
+        if source.source_state == "active"
+          && source.source_bucket.as_deref() == Some("active")
+          && !present_paths.contains(&source.source_path)
+          && !Path::new(&source.source_path).exists()
+        {
+          plan.sessions_to_mark_missing.push(MissingSessionPlan {
+            session_id: source.session_id.clone(),
+            expected_source_path: source.source_path.clone(),
+          });
+          plan
+            .import_state_paths_to_delete
+            .push(source.source_path.clone());
+        }
+      }
+    }
+  }
+
+  plan
+}
+
+fn apply_missing_source_plan(conn: &Connection, plan: MissingSourcePlan) -> rusqlite::Result<()> {
+  let imported_at = now_utc_string();
+  for missing in plan.sessions_to_mark_missing {
+    conn.execute(
+      "
+      UPDATE sessions
+      SET source_state = 'missing', imported_at = ?1
+      WHERE session_id = ?2 AND source_path = ?3
+      ",
+      params![
+        imported_at,
+        missing.session_id,
+        missing.expected_source_path
+      ],
+    )?;
+  }
+  for source_path in plan.import_state_paths_to_delete {
+    conn.execute(
+      "DELETE FROM import_state WHERE source_path = ?1",
+      params![source_path],
+    )?;
+  }
+  Ok(())
+}
+
+fn commit_one_prepared_session(
+  conn: &Connection,
+  entry: PreparedSession,
+  catalog: &HashMap<String, crate::models::PricingCatalogEntry>,
+) -> rusqlite::Result<()> {
+  let PreparedSession {
+    session_file,
+    parsed,
+    file_needs_rate_limit_repair,
+    file_needs_token_v2_repair,
+    file_needs_fork_replay_v3_repair,
+    replay_parent_unavailable,
+    related_pending_token_v2_paths,
+    related_pending_fork_replay_v3_paths,
+  } = entry;
+  let source_path = session_file.path.to_string_lossy().to_string();
+
+  persist_session(conn, &session_file, &parsed, catalog)?;
+  if file_needs_rate_limit_repair {
+    clear_pending_data_repair_file(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)?;
+  }
+  if file_needs_token_v2_repair {
+    clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)?;
+    for related_source_path in related_pending_token_v2_paths {
+      clear_pending_data_repair_file(conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &related_source_path)?;
+    }
+  }
+  if file_needs_fork_replay_v3_repair {
+    if replay_parent_unavailable {
+      mark_data_repair_file_pending(
+        conn,
+        TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+        &source_path,
+        "fork replay parent unavailable",
+      )?;
+    } else {
+      clear_pending_data_repair_file(conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)?;
+      for related_source_path in related_pending_fork_replay_v3_paths {
+        clear_pending_data_repair_file(
+          conn,
+          TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+          &related_source_path,
+        )?;
+      }
+    }
+  }
+
+  Ok(())
+}
+
 fn effective_scan_scope(
-  requested_scope: ScanScope,
+  requested_scope: ScanKind,
   import_state_is_empty: bool,
   needs_rate_limit_backfill: bool,
   needs_token_usage_repair_sweep: bool,
   resolved_source_requires_full_scan: bool,
-) -> ScanScope {
-  if requested_scope == ScanScope::Full
+) -> ScanKind {
+  if requested_scope == ScanKind::Full
     || import_state_is_empty
     || needs_rate_limit_backfill
     || needs_token_usage_repair_sweep
     || resolved_source_requires_full_scan
   {
-    ScanScope::Full
+    ScanKind::Full
   } else {
-    ScanScope::Incremental
+    ScanKind::Incremental
   }
 }
 
@@ -477,7 +1570,10 @@ fn classify_topology_maintenance(
   existing_child_count: usize,
   parent_session_id: Option<&str>,
 ) -> TopologyMaintenance {
-  match (existing_relation.filter(|item| item.exists), parent_session_id) {
+  match (
+    existing_relation.filter(|item| item.exists),
+    parent_session_id,
+  ) {
     (Some(existing_relation), next_parent_session_id) => {
       if existing_relation.parent_session_id.as_deref() == next_parent_session_id {
         TopologyMaintenance::None
@@ -600,7 +1696,10 @@ fn load_session_index(codex_home: &Path) -> HashMap<String, String> {
   titles
 }
 
-fn refresh_session_titles(conn: &Connection, titles: &HashMap<String, String>) -> rusqlite::Result<()> {
+fn refresh_session_titles(
+  conn: &Connection,
+  titles: &HashMap<String, String>,
+) -> rusqlite::Result<()> {
   for (session_id, title) in titles {
     conn.execute(
       "UPDATE sessions SET title = ?1 WHERE session_id = ?2",
@@ -634,7 +1733,10 @@ fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
   }
 
   let mut files = Vec::new();
-  for entry in WalkDir::new(sessions_root).into_iter().filter_map(Result::ok) {
+  for entry in WalkDir::new(sessions_root)
+    .into_iter()
+    .filter_map(Result::ok)
+  {
     if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), "active") {
       files.push(session_file);
     }
@@ -657,10 +1759,9 @@ fn collect_incremental_session_files(
 
   for state in import_state.values() {
     if state.source_bucket == "archived" {
-      let Some(session_file) = session_file_from_path(
-        PathBuf::from(&state.source_path),
-        "archived",
-      ) else {
+      let Some(session_file) =
+        session_file_from_path(PathBuf::from(&state.source_path), "archived")
+      else {
         continue;
       };
       let session_has_pending_repair = state
@@ -724,21 +1825,37 @@ fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
   })
 }
 
+fn parse_session_file_counted(
+  session_file: &SessionFile,
+  titles: &HashMap<String, String>,
+) -> Result<(ParsedSession, u64), (String, u64)> {
+  parse_session_file_once(session_file, titles).map_err(|error| match error {
+    SessionParseError::Fatal {
+      message,
+      bytes_read,
+    } => (message, bytes_read),
+  })
+}
+
+#[cfg(test)]
 fn parse_session_file(
   session_file: &SessionFile,
   titles: &HashMap<String, String>,
 ) -> Result<ParsedSession, String> {
-  parse_session_file_once(session_file, titles).map_err(|error| match error {
-    SessionParseError::Fatal(message) => message,
-  })
+  parse_session_file_counted(session_file, titles)
+    .map(|(parsed, _)| parsed)
+    .map_err(|(error, _)| error)
 }
 
 fn parse_session_file_once(
   session_file: &SessionFile,
   titles: &HashMap<String, String>,
-) -> Result<ParsedSession, SessionParseError> {
-  let file = File::open(&session_file.path)
-    .map_err(|error| SessionParseError::Fatal(format!("Failed to open {}: {error}", session_file.path.display())))?;
+) -> Result<(ParsedSession, u64), SessionParseError> {
+  let file = File::open(&session_file.path).map_err(|error| SessionParseError::Fatal {
+    message: format!("Failed to open {}: {error}", session_file.path.display()),
+    bytes_read: 0,
+  })?;
+  let mut reader = BufReader::new(CountingReader::new(file));
   let expected_session_id = fallback_session_id_from_filename(&session_file.path);
 
   let mut session_id = String::new();
@@ -758,10 +1875,18 @@ fn parse_session_file_once(
   let mut first_session_meta: Option<SessionMetaCandidate> = None;
   let mut matching_session_meta: Option<SessionMetaCandidate> = None;
 
-  for line_result in BufReader::new(file).lines() {
-    let line = line_result.map_err(|error| {
-      SessionParseError::Fatal(format!("Failed to read {}: {error}", session_file.path.display()))
-    })?;
+  let mut line = String::new();
+  loop {
+    line.clear();
+    let line_bytes = reader
+      .read_line(&mut line)
+      .map_err(|error| SessionParseError::Fatal {
+        message: format!("Failed to read {}: {error}", session_file.path.display()),
+        bytes_read: reader.get_ref().bytes_read,
+      })?;
+    if line_bytes == 0 {
+      break;
+    }
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
     }
@@ -791,24 +1916,26 @@ fn parse_session_file_once(
       updated_at = timestamp.clone();
     }
 
-    match value.get("type").and_then(Value::as_str).unwrap_or_default() {
+    match value
+      .get("type")
+      .and_then(Value::as_str)
+      .unwrap_or_default()
+    {
       "session_meta" => {
         let payload = value.get("payload").unwrap_or(&Value::Null);
         let candidate_explicit_forked_from_id = payload
           .get("forked_from_id")
           .and_then(Value::as_str)
           .map(ToString::to_string);
-        let parent = candidate_explicit_forked_from_id
-          .clone()
-          .or_else(|| {
-            payload
-              .get("source")
-              .and_then(|source| source.get("subagent"))
-              .and_then(|subagent| subagent.get("thread_spawn"))
-              .and_then(|thread_spawn| thread_spawn.get("parent_thread_id"))
-              .and_then(Value::as_str)
-              .map(ToString::to_string)
-          });
+        let parent = candidate_explicit_forked_from_id.clone().or_else(|| {
+          payload
+            .get("source")
+            .and_then(|source| source.get("subagent"))
+            .and_then(|subagent| subagent.get("thread_spawn"))
+            .and_then(|thread_spawn| thread_spawn.get("parent_thread_id"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+        });
         let candidate_explicit_fork_timestamp = candidate_explicit_forked_from_id
           .as_ref()
           .and_then(|_| timestamp.as_deref())
@@ -918,7 +2045,9 @@ fn parse_session_file_once(
         let sample_timestamp = timestamp.unwrap_or_else(now_utc_string);
         rate_limit_samples.extend(extract_rate_limit_samples(&sample_timestamp, payload));
 
-        let model_id = current_model.clone().unwrap_or_else(|| "unknown".to_string());
+        let model_id = current_model
+          .clone()
+          .unwrap_or_else(|| "unknown".to_string());
         seen_models.insert(model_id.clone());
 
         snapshots.push(UsageSnapshot {
@@ -936,6 +2065,7 @@ fn parse_session_file_once(
     }
   }
 
+  let bytes_read = reader.get_ref().bytes_read;
   if let Some(candidate) = matching_session_meta.or(first_session_meta) {
     session_id = candidate.session_id;
     parent_session_id = candidate.parent_session_id.or(parent_session_id);
@@ -952,10 +2082,13 @@ fn parse_session_file_once(
   }
 
   if session_id.is_empty() {
-    return Err(SessionParseError::Fatal(format!(
-      "Could not determine session id for {}",
-      session_file.path.display()
-    )));
+    return Err(SessionParseError::Fatal {
+      message: format!(
+        "Could not determine session id for {}",
+        session_file.path.display()
+      ),
+      bytes_read,
+    });
   }
 
   let title = titles.get(&session_id).cloned();
@@ -965,30 +2098,33 @@ fn parse_session_file_once(
     sample.source_session_id = Some(session_id.clone());
   }
 
-  Ok(ParsedSession {
-    raw_session: RawSession {
-      session_id: session_id.clone(),
-      parent_session_id,
-      root_session_id: session_id,
-      title,
-      source_state: session_file.bucket.clone(),
-      source_path: Some(session_file.path.to_string_lossy().to_string()),
-      started_at,
-      updated_at,
-      model_ids: seen_models.into_iter().collect(),
-      contains_subagents: false,
-      agent_nickname,
-      agent_role,
+  Ok((
+    ParsedSession {
+      raw_session: RawSession {
+        session_id: session_id.clone(),
+        parent_session_id,
+        root_session_id: session_id,
+        title,
+        source_state: session_file.bucket.clone(),
+        source_path: Some(session_file.path.to_string_lossy().to_string()),
+        started_at,
+        updated_at,
+        model_ids: seen_models.into_iter().collect(),
+        contains_subagents: false,
+        agent_nickname,
+        agent_role,
+      },
+      snapshots,
+      rate_limit_samples,
+      explicit_forked_from_id,
+      explicit_fork_timestamp,
+      inherited_token_snapshot_cutoff: 0,
+      explicit_fast_mode,
+      latest_plan_type,
+      last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
     },
-    snapshots,
-    rate_limit_samples,
-    explicit_forked_from_id,
-    explicit_fork_timestamp,
-    inherited_token_snapshot_cutoff: 0,
-    explicit_fast_mode,
-    latest_plan_type,
-    last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
-  })
+    bytes_read,
+  ))
 }
 
 fn fallback_session_id_from_filename(path: &Path) -> Option<String> {
@@ -1017,7 +2153,10 @@ fn looks_like_session_id(value: &str) -> bool {
     .iter()
     .zip(expected_lengths.iter())
     .all(|(segment, expected_len)| {
-      segment.len() == *expected_len && segment.chars().all(|character| character.is_ascii_hexdigit())
+      segment.len() == *expected_len
+        && segment
+          .chars()
+          .all(|character| character.is_ascii_hexdigit())
     })
 }
 
@@ -1027,9 +2166,8 @@ fn load_session_source_paths(
   session_files: &[SessionFile],
 ) -> rusqlite::Result<HashMap<String, PathBuf>> {
   let mut source_paths = HashMap::new();
-  let mut stmt = conn.prepare(
-    "SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL",
-  )?;
+  let mut stmt =
+    conn.prepare("SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL")?;
   let rows = stmt.query_map([], |row| {
     Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
   })?;
@@ -1060,90 +2198,110 @@ fn load_session_source_paths(
 fn assign_inherited_token_snapshot_cutoff(
   parsed: &mut ParsedSession,
   session_source_paths: &HashMap<String, PathBuf>,
-  parent_snapshot_cache: &mut HashMap<String, Option<Vec<UsageSnapshot>>>,
-) -> bool {
+  parent_snapshot_cache: &mut ParentReplayCache,
+) -> (bool, u64) {
   let Some(parent_session_id) = parsed
     .explicit_forked_from_id
     .as_deref()
     .filter(|session_id| !session_id.trim().is_empty())
+    .map(ToString::to_string)
   else {
-    return false;
+    return (false, 0);
   };
   let Some(fork_timestamp) = parsed.explicit_fork_timestamp else {
-    return false;
+    return (false, 0);
   };
 
-  if !parent_snapshot_cache.contains_key(parent_session_id) {
-    let parent_snapshots = match session_source_paths.get(parent_session_id) {
-      Some(source_path) => match read_parent_replay_snapshots(source_path, parent_session_id) {
-        Ok(snapshots) => Some(snapshots),
-        Err(()) => {
+  if let Some(cached) = parent_snapshot_cache.get(&parent_session_id) {
+    let Some(parent_snapshots) = cached.as_deref() else {
+      return (true, 0);
+    };
+    parsed.inherited_token_snapshot_cutoff =
+      replayed_child_snapshot_cutoff(parent_snapshots, &parsed.snapshots, Some(fork_timestamp));
+    return (false, 0);
+  }
+
+  let (parent_snapshots, bytes_read) = match session_source_paths.get(&parent_session_id) {
+    Some(source_path) => {
+      match read_parent_replay_snapshots_counted(source_path, &parent_session_id) {
+        Ok((snapshots, bytes_read)) => (Some(snapshots), bytes_read),
+        Err(bytes_read) => {
           log::warn!(
             "Replay parent unavailable: child_id={}, parent_id={}, source_path={}",
             parsed.raw_session.session_id,
             parent_session_id,
             source_path.display()
           );
-          None
+          (None, bytes_read)
         }
-      },
-      None => {
-        log::warn!(
-          "Replay parent unavailable: child_id={}, parent_id={}",
-          parsed.raw_session.session_id,
-          parent_session_id
-        );
-        None
       }
-    };
-    parent_snapshot_cache.insert(parent_session_id.to_string(), parent_snapshots);
-  }
-
-  let Some(parent_snapshots) = parent_snapshot_cache
-    .get(parent_session_id)
-    .and_then(Option::as_deref)
-  else {
-    return true;
+    }
+    None => {
+      log::warn!(
+        "Replay parent unavailable: child_id={}, parent_id={}",
+        parsed.raw_session.session_id,
+        parent_session_id
+      );
+      (None, 0)
+    }
   };
-
-  parsed.inherited_token_snapshot_cutoff = replayed_child_snapshot_cutoff(
-    parent_snapshots,
-    &parsed.snapshots,
-    Some(fork_timestamp),
-  );
-  false
+  let replay_parent_unavailable = parent_snapshots.is_none();
+  if let Some(parent_snapshots) = parent_snapshots.as_deref() {
+    parsed.inherited_token_snapshot_cutoff =
+      replayed_child_snapshot_cutoff(parent_snapshots, &parsed.snapshots, Some(fork_timestamp));
+  }
+  parent_snapshot_cache.insert(parent_session_id, parent_snapshots);
+  (replay_parent_unavailable, bytes_read)
 }
 
+#[cfg(test)]
 fn read_parent_replay_snapshots(
   source_path: &Path,
   requested_parent_id: &str,
 ) -> Result<Vec<UsageSnapshot>, ()> {
+  read_parent_replay_snapshots_counted(source_path, requested_parent_id)
+    .map(|(snapshots, _)| snapshots)
+    .map_err(|_| ())
+}
+
+fn read_parent_replay_snapshots_counted(
+  source_path: &Path,
+  requested_parent_id: &str,
+) -> Result<(Vec<UsageSnapshot>, u64), u64> {
   let filename_session_id = fallback_session_id_from_filename(source_path);
   if filename_session_id
     .as_deref()
     .is_some_and(|session_id| session_id != requested_parent_id)
   {
-    return Err(());
+    return Err(0);
   }
 
-  let file = File::open(source_path).map_err(|_| ())?;
+  let file = File::open(source_path).map_err(|_| 0u64)?;
+  let mut reader = BufReader::new(CountingReader::new(file));
   let mut first_session_meta_id: Option<String> = None;
   let mut snapshots = Vec::new();
+  let mut line = String::new();
 
-  for line_result in BufReader::new(file).lines() {
-    let line = line_result.map_err(|_| ())?;
+  loop {
+    line.clear();
+    match reader.read_line(&mut line) {
+      Ok(0) => break,
+      Ok(_) => {}
+      Err(_) => return Err(reader.get_ref().bytes_read),
+    }
     if !line.contains("\"session_meta\"") && !line.contains("\"token_count\"") {
       continue;
     }
 
-    let envelope = serde_json::from_str::<ReplayParentLineEnvelope<'_>>(&line).map_err(|_| ())?;
+    let envelope = serde_json::from_str::<ReplayParentLineEnvelope<'_>>(&line)
+      .map_err(|_| reader.get_ref().bytes_read)?;
     match envelope.record_type {
       Some("session_meta") if first_session_meta_id.is_none() => {
         let Some(session_id) = envelope.payload.as_ref().and_then(|payload| payload.id) else {
           continue;
         };
         if filename_session_id.is_none() && session_id != requested_parent_id {
-          return Err(());
+          return Err(reader.get_ref().bytes_read);
         }
         first_session_meta_id = Some(session_id.to_string());
       }
@@ -1154,8 +2312,9 @@ fn read_parent_replay_snapshots(
           .and_then(|payload| payload.record_type)
           == Some("token_count") =>
       {
-        let timestamp = envelope.timestamp.ok_or(())?;
-        let details = serde_json::from_str::<ReplayParentTokenDetails>(&line).map_err(|_| ())?;
+        let timestamp = envelope.timestamp.ok_or(reader.get_ref().bytes_read)?;
+        let details = serde_json::from_str::<ReplayParentTokenDetails>(&line)
+          .map_err(|_| reader.get_ref().bytes_read)?;
 
         snapshots.push(UsageSnapshot {
           timestamp: timestamp.to_string(),
@@ -1176,14 +2335,15 @@ fn read_parent_replay_snapshots(
     }
   }
 
+  let bytes_read = reader.get_ref().bytes_read;
   if filename_session_id.is_none() && first_session_meta_id.is_none() {
-    return Err(());
+    return Err(bytes_read);
   }
   if snapshots.is_empty() {
-    return Err(());
+    return Err(bytes_read);
   }
 
-  Ok(snapshots)
+  Ok((snapshots, bytes_read))
 }
 
 #[derive(Deserialize)]
@@ -1280,7 +2440,10 @@ fn canonical_replay_snapshots(snapshots: &[UsageSnapshot]) -> Vec<CanonicalRepla
     }
 
     high_water = Some(snapshot.usage.total_tokens);
-    canonical.push(CanonicalReplaySnapshot { raw_index, snapshot });
+    canonical.push(CanonicalReplaySnapshot {
+      raw_index,
+      snapshot,
+    });
   }
 
   canonical
@@ -1328,7 +2491,11 @@ fn replayed_child_snapshot_cutoff(
         .is_ok_and(|timestamp| timestamp <= explicit_fork_timestamp)
     })
     .count();
-  let minimum_match_length = if eligible_parent_snapshot_count == 1 { 1 } else { 2 };
+  let minimum_match_length = if eligible_parent_snapshot_count == 1 {
+    1
+  } else {
+    2
+  };
   if child_pattern.len() < minimum_match_length {
     return 0;
   }
@@ -1370,17 +2537,16 @@ fn replayed_child_snapshot_cutoff(
 }
 
 fn persist_session(
-  conn: &mut Connection,
+  conn: &Connection,
   session_file: &SessionFile,
   parsed: &ParsedSession,
   catalog: &HashMap<String, crate::models::PricingCatalogEntry>,
 ) -> rusqlite::Result<()> {
-  let tx = conn.transaction()?;
   let created_at = now_utc_string();
   let imported_at = created_at.clone();
   let fast_mode_default = false;
 
-  tx.execute(
+  conn.execute(
     "
     INSERT INTO sessions (
       session_id, root_session_id, parent_session_id, title, source_state, source_path,
@@ -1426,11 +2592,15 @@ fn persist_session(
     ],
   )?;
 
-  tx.execute(
+  conn.execute(
     "DELETE FROM usage_events WHERE session_id = ?1",
     params![parsed.raw_session.session_id],
   )?;
-  replace_session_rate_limit_samples(&tx, &parsed.raw_session.session_id, &parsed.rate_limit_samples)?;
+  replace_session_rate_limit_samples(
+    conn,
+    &parsed.raw_session.session_id,
+    &parsed.rate_limit_samples,
+  )?;
 
   let snapshot_cutoff = parsed.inherited_token_snapshot_cutoff;
   let mut previous_usage = snapshot_cutoff
@@ -1466,7 +2636,7 @@ fn persist_session(
     let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
     let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
 
-    tx.execute(
+    conn.execute(
       "
       INSERT INTO usage_events (
         session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
@@ -1490,7 +2660,7 @@ fn persist_session(
     )?;
   }
 
-  tx.execute(
+  conn.execute(
     "
     INSERT INTO import_state (source_path, session_id, source_bucket, file_size, file_mtime_ms, last_imported_at)
     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
@@ -1511,7 +2681,7 @@ fn persist_session(
     ],
   )?;
 
-  tx.execute(
+  conn.execute(
     "
     DELETE FROM import_state
     WHERE session_id = ?1 AND source_path <> ?2
@@ -1522,7 +2692,7 @@ fn persist_session(
     ],
   )?;
 
-  tx.commit()
+  Ok(())
 }
 
 fn diff_usage(previous: &TokenUsage, current: &TokenUsage) -> TokenUsage {
@@ -1532,9 +2702,15 @@ fn diff_usage(previous: &TokenUsage, current: &TokenUsage) -> TokenUsage {
 
   TokenUsage {
     input_tokens: non_negative_delta(current.input_tokens, previous.input_tokens),
-    cached_input_tokens: non_negative_delta(current.cached_input_tokens, previous.cached_input_tokens),
+    cached_input_tokens: non_negative_delta(
+      current.cached_input_tokens,
+      previous.cached_input_tokens,
+    ),
     output_tokens: non_negative_delta(current.output_tokens, previous.output_tokens),
-    reasoning_output_tokens: non_negative_delta(current.reasoning_output_tokens, previous.reasoning_output_tokens),
+    reasoning_output_tokens: non_negative_delta(
+      current.reasoning_output_tokens,
+      previous.reasoning_output_tokens,
+    ),
     total_tokens: current.total_tokens - previous.total_tokens,
   }
 }
@@ -1587,7 +2763,9 @@ fn extract_rate_limit_samples(timestamp: &str, payload: &Value) -> Vec<RateLimit
     let Some(resets_at) = unix_seconds_to_rfc3339_local(resets_at_seconds) else {
       continue;
     };
-    let Some(window_start) = unix_seconds_to_rfc3339_local(resets_at_seconds - window_duration_mins * 60) else {
+    let Some(window_start) =
+      unix_seconds_to_rfc3339_local(resets_at_seconds - window_duration_mins * 60)
+    else {
       continue;
     };
 
@@ -1669,7 +2847,11 @@ fn data_repair_is_pending(conn: &Connection, repair_key: &str) -> rusqlite::Resu
   Ok(completed.is_none())
 }
 
-fn mark_data_repair_complete(conn: &Connection, repair_key: &str, completed_at: &str) -> rusqlite::Result<()> {
+fn mark_data_repair_complete(
+  conn: &Connection,
+  repair_key: &str,
+  completed_at: &str,
+) -> rusqlite::Result<()> {
   conn.execute(
     "
     INSERT INTO data_repairs (repair_key, completed_at)
@@ -1681,7 +2863,10 @@ fn mark_data_repair_complete(conn: &Connection, repair_key: &str, completed_at: 
   Ok(())
 }
 
-fn load_pending_data_repair_paths(conn: &Connection, repair_key: &str) -> rusqlite::Result<HashSet<String>> {
+fn load_pending_data_repair_paths(
+  conn: &Connection,
+  repair_key: &str,
+) -> rusqlite::Result<HashSet<String>> {
   let mut stmt = conn.prepare(
     "
     SELECT source_path
@@ -1711,7 +2896,8 @@ fn pending_repair_paths_for_session(
         .and_then(|state| state.session_id.as_deref());
       import_state_session_id == Some(session_id)
         || (import_state_session_id.is_none()
-          && fallback_session_id_from_filename(Path::new(source_path)).as_deref() == Some(session_id))
+          && fallback_session_id_from_filename(Path::new(source_path)).as_deref()
+            == Some(session_id))
     })
     .cloned()
     .collect()
@@ -1751,7 +2937,11 @@ fn mark_data_repair_file_pending(
   Ok(())
 }
 
-fn clear_pending_data_repair_file(conn: &Connection, repair_key: &str, source_path: &str) -> rusqlite::Result<()> {
+fn clear_pending_data_repair_file(
+  conn: &Connection,
+  repair_key: &str,
+  source_path: &str,
+) -> rusqlite::Result<()> {
   conn.execute(
     "
     DELETE FROM data_repair_pending_files
@@ -1762,7 +2952,9 @@ fn clear_pending_data_repair_file(conn: &Connection, repair_key: &str, source_pa
   Ok(())
 }
 
-fn load_existing_session_relations(conn: &Connection) -> rusqlite::Result<HashMap<String, ExistingSessionRelation>> {
+fn load_existing_session_relations(
+  conn: &Connection,
+) -> rusqlite::Result<HashMap<String, ExistingSessionRelation>> {
   let mut stmt = conn.prepare("SELECT session_id, parent_session_id FROM sessions")?;
   let rows = stmt.query_map([], |row| {
     Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
@@ -1782,7 +2974,10 @@ fn load_existing_session_relations(conn: &Connection) -> rusqlite::Result<HashMa
   Ok(relations)
 }
 
-fn upsert_root_conversation_links(conn: &Connection, session_ids: &[String]) -> rusqlite::Result<()> {
+fn upsert_root_conversation_links(
+  conn: &Connection,
+  session_ids: &[String],
+) -> rusqlite::Result<()> {
   for session_id in session_ids {
     conn.execute(
       "
@@ -1816,84 +3011,6 @@ fn conversation_links_need_repair(conn: &Connection) -> rusqlite::Result<bool> {
   )
 }
 
-fn mark_missing_sources(
-  conn: &Connection,
-  present_paths: &HashSet<String>,
-  reconcile_existing_absent_sources: bool,
-) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare("SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL")?;
-  let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
-
-  for row in rows {
-    let (session_id, source_path) = row?;
-    if !present_paths.contains(&source_path)
-      && (reconcile_existing_absent_sources || !Path::new(&source_path).exists())
-    {
-      conn.execute(
-        "
-        UPDATE sessions
-        SET source_state = 'missing', imported_at = ?1
-        WHERE session_id = ?2
-        ",
-        params![now_utc_string(), session_id],
-      )?;
-    }
-  }
-  Ok(())
-}
-
-fn mark_missing_active_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare(
-    "
-    SELECT session_id, source_path
-    FROM sessions
-    WHERE source_state = 'active' AND source_bucket = 'active' AND source_path IS NOT NULL
-    ",
-  )?;
-  let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
-
-  for row in rows {
-    let (session_id, source_path) = row?;
-    if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
-      let now = now_utc_string();
-      conn.execute(
-        "
-        UPDATE sessions
-        SET source_state = 'missing', imported_at = ?1
-        WHERE session_id = ?2
-        ",
-        params![now, session_id],
-      )?;
-      conn.execute(
-        "DELETE FROM import_state WHERE source_path = ?1",
-        params![source_path],
-      )?;
-    }
-  }
-  Ok(())
-}
-
-fn prune_import_state(
-  conn: &Connection,
-  present_paths: &HashSet<String>,
-  reconcile_existing_absent_sources: bool,
-) -> rusqlite::Result<()> {
-  let mut stmt = conn.prepare("SELECT source_path FROM import_state")?;
-  let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-  for row in rows {
-    let source_path = row?;
-    if !present_paths.contains(&source_path)
-      && (reconcile_existing_absent_sources || !Path::new(&source_path).exists())
-    {
-      conn.execute(
-        "DELETE FROM import_state WHERE source_path = ?1",
-        params![source_path],
-      )?;
-    }
-  }
-  Ok(())
-}
-
 fn recompute_conversation_links(conn: &Connection) -> rusqlite::Result<()> {
   let mut stmt = conn.prepare("SELECT session_id, parent_session_id FROM sessions")?;
   let rows = stmt.query_map([], |row| {
@@ -1922,7 +3039,12 @@ fn recompute_conversation_links(conn: &Connection) -> rusqlite::Result<()> {
         parent_session_id = excluded.parent_session_id,
         depth = excluded.depth
       ",
-      params![session_id, root_session_id, parents.get(session_id).cloned().flatten(), depth as i64],
+      params![
+        session_id,
+        root_session_id,
+        parents.get(session_id).cloned().flatten(),
+        depth as i64
+      ],
     )?;
 
     conn.execute(
@@ -1977,15 +3099,18 @@ fn read_i64(value: &Value, key: &str) -> i64 {
 }
 
 fn read_total_tokens(value: &Value) -> i64 {
-  value.get("total_tokens").and_then(Value::as_i64).unwrap_or_else(|| {
-    read_i64(value, "input_tokens") + read_i64(value, "output_tokens")
-  })
+  value
+    .get("total_tokens")
+    .and_then(Value::as_i64)
+    .unwrap_or_else(|| read_i64(value, "input_tokens") + read_i64(value, "output_tokens"))
 }
 
 fn read_percent(value: &Value, key: &str) -> Option<i64> {
-  value
-    .get(key)
-    .and_then(|field| field.as_i64().or_else(|| field.as_f64().map(|number| number.round() as i64)))
+  value.get(key).and_then(|field| {
+    field
+      .as_i64()
+      .or_else(|| field.as_f64().map(|number| number.round() as i64))
+  })
 }
 
 #[derive(Debug, Clone)]
@@ -2001,7 +3126,8 @@ struct ImportState {
 mod tests {
   use super::*;
   use crate::database::{
-    get_last_full_scan_completed, init_db, now_utc_string, open_connection, save_sync_settings,
+    get_last_full_scan_completed, get_sync_settings, init_db, now_utc_string, open_connection,
+    save_sync_settings,
   };
   use rusqlite::OptionalExtension;
   use std::ffi::OsString;
@@ -2064,6 +3190,850 @@ mod tests {
     chrono::DateTime::parse_from_rfc3339(timestamp).expect("valid fork instant")
   }
 
+  #[derive(Debug, PartialEq, Eq)]
+  struct DatabaseMutationFingerprint {
+    sessions: i64,
+    conversation_links: i64,
+    usage_events: i64,
+    import_state: i64,
+    data_repairs: i64,
+    pending_repairs: i64,
+    rate_limit_samples: i64,
+    freshness: (
+      Option<String>,
+      Option<String>,
+      Option<String>,
+      Option<String>,
+      Option<String>,
+      String,
+      i64,
+    ),
+  }
+
+  fn database_mutation_fingerprint(conn: &Connection) -> DatabaseMutationFingerprint {
+    let count = |table: &str| {
+      conn
+        .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+          row.get(0)
+        })
+        .expect("count table")
+    };
+    let freshness = conn
+      .query_row(
+        "
+        SELECT codex_home, last_scan_codex_home, last_scan_started_at,
+               last_scan_completed_at, last_full_scan_completed_at, updated_at,
+               scan_commit_revision
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| {
+          Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+            row.get(5)?,
+            row.get(6)?,
+          ))
+        },
+      )
+      .expect("load freshness fingerprint");
+
+    DatabaseMutationFingerprint {
+      sessions: count("sessions"),
+      conversation_links: count("conversation_links"),
+      usage_events: count("usage_events"),
+      import_state: count("import_state"),
+      data_repairs: count("data_repairs"),
+      pending_repairs: count("data_repair_pending_files"),
+      rate_limit_samples: count("rate_limit_samples"),
+      freshness,
+    }
+  }
+
+  fn initialize_scan_database(db_path: &Path) {
+    let conn = open_connection(db_path).expect("open database");
+    init_db(&conn).expect("init database");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+  }
+
+  fn configure_codex_home(db_path: &Path, codex_home: &Path) {
+    let conn = open_connection(db_path).expect("open database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.codex_home = Some(codex_home.to_string_lossy().to_string());
+    save_sync_settings(&conn, &settings).expect("save source");
+  }
+
+  fn write_session_with_rate_limit_sample(path: &Path, session_id: &str, total_tokens: i64) {
+    let body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:02Z\",\"type\":\"event_msg\",\"payload\":{{",
+        "\"type\":\"token_count\",\"info\":{{\"total_token_usage\":{{",
+        "\"input_tokens\":{},\"cached_input_tokens\":0,\"output_tokens\":0,",
+        "\"reasoning_output_tokens\":0,\"total_tokens\":{}}}}},",
+        "\"rate_limits\":{{\"plan_type\":\"pro\",\"primary\":{{",
+        "\"used_percent\":25,\"window_duration_mins\":300,\"resets_at\":1783648800",
+        "}}}}}}}}\n"
+      ),
+      session_id, total_tokens, total_tokens,
+    );
+    std::fs::write(path, body).expect("write session with rate limit sample");
+  }
+
+  fn write_replay_cache_pair(
+    sessions: &Path,
+    prefix: usize,
+    parent_session_id: &str,
+    child_session_id: &str,
+  ) {
+    let timestamp = "2026-07-10T00:00:00Z";
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      timestamp, parent_session_id, timestamp,
+    );
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      timestamp, child_session_id, parent_session_id, timestamp,
+    );
+    for total in [10, 20, 30] {
+      let line = token_count_line(TokenFixture {
+        timestamp,
+        total: (total, 0, 0, total),
+        last: (10, 0, 0, 10),
+      });
+      parent_body.push_str(&line);
+      child_body.push_str(&line);
+    }
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp,
+      total: (40, 0, 0, 40),
+      last: (10, 0, 0, 10),
+    }));
+
+    std::fs::write(
+      sessions.join(format!("{prefix:02}-parent-{parent_session_id}.jsonl")),
+      parent_body,
+    )
+    .expect("write replay parent");
+    std::fs::write(
+      sessions.join(format!("{prefix:02}-child-{child_session_id}.jsonl")),
+      child_body,
+    )
+    .expect("write replay child");
+  }
+
+  fn assert_scan_results_equivalent(left: &ScanResult, right: &ScanResult) {
+    assert_eq!(left.codex_home, right.codex_home);
+    assert_eq!(left.scanned_files, right.scanned_files);
+    assert_eq!(left.imported_sessions, right.imported_sessions);
+    assert_eq!(left.updated_sessions, right.updated_sessions);
+    assert_eq!(left.missing_sessions, right.missing_sessions);
+    assert!(!left.last_completed_at.is_empty());
+    assert!(!right.last_completed_at.is_empty());
+  }
+
+  #[test]
+  fn prepare_scan_is_read_only() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    write_session_file(
+      &sessions.join("read-only.jsonl"),
+      "10101010-1010-1010-1010-101010101010",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+
+    let conn = open_connection(&db_path).expect("open database");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare scan");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+    drop(prepared);
+
+    let read_only = open_scan_snapshot(&db_path).expect("open read-only snapshot");
+    let error = read_only
+      .execute(
+        "UPDATE sync_settings SET updated_at = 'forbidden' WHERE singleton_id = 1",
+        [],
+      )
+      .expect_err("read-only snapshot must reject writes");
+    assert!(matches!(
+      error,
+      rusqlite::Error::SqliteFailure(ref sqlite_error, _)
+        if sqlite_error.code == rusqlite::ErrorCode::ReadOnly
+    ));
+  }
+
+  #[test]
+  fn prepared_scan_exposes_read_only_runtime_metadata_and_is_send() {
+    fn assert_send_static<T: Send + 'static>() {}
+    assert_send_static::<PreparedScan>();
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    write_session_file(
+      &sessions.join("metadata.jsonl"),
+      "11111111-1111-1111-1111-111111111111",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+
+    let prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare scan");
+    let stats = prepared.stats();
+    assert_eq!(stats.files_visited, 1);
+    assert!(stats.source_bytes_read > 0);
+    assert!(stats.full_rebuild);
+    assert!(!stats.used_spool);
+    assert_eq!(
+      prepared.source_key().selector(),
+      Some(codex_home.to_string_lossy().as_ref())
+    );
+    assert_eq!(prepared.source_key().resolved_home(), codex_home.as_path());
+  }
+
+  #[test]
+  fn prepared_scan_stays_uncommitted_until_commit() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "20202020-2020-2020-2020-202020202020";
+    let session_path = sessions.join("prepared.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare scan");
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(database_mutation_fingerprint(&conn).sessions, 0);
+    drop(conn);
+
+    std::fs::remove_file(&session_path).expect("remove parsed source");
+    let result =
+      commit_prepared_scan(prepared).expect("commit prepared scan without source reread");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, session_id).3, 110);
+  }
+
+  #[test]
+  fn commit_prepared_scan_is_atomic() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let first_session_id = "30303030-3030-3030-3030-303030303030";
+    let failed_session_id = "40404040-4040-4040-4040-404040404040";
+    write_session_with_rate_limit_sample(&sessions.join("a-first.jsonl"), first_session_id, 110);
+    write_session_file(
+      &sessions.join("b-fails.jsonl"),
+      failed_session_id,
+      &[("2026-07-10T00:01:00Z", 200, 40, 20, 220)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+    let prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    conn
+      .execute_batch(&format!(
+        "
+        CREATE TRIGGER fail_second_prepared_session
+        BEFORE INSERT ON sessions
+        WHEN NEW.session_id = '{failed_session_id}'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced mid-commit failure');
+        END;
+        "
+      ))
+      .expect("install failure trigger");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let error = commit_prepared_scan(prepared).expect_err("commit must fail");
+    assert!(error.contains("forced mid-commit failure"));
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+  }
+
+  #[test]
+  fn commit_checks_full_scan_guard_before_freshness_write() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("Codex home");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+    let mut prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare scan");
+    prepared.freshness_full_scan_required = !prepared.freshness_full_scan_required;
+
+    let conn = open_connection(&db_path).expect("open database");
+    conn
+      .execute_batch(
+        "
+        CREATE TRIGGER reject_freshness_write
+        BEFORE UPDATE ON sync_settings
+        BEGIN
+          SELECT RAISE(ABORT, 'freshness write happened before guard');
+        END;
+        ",
+      )
+      .expect("install freshness trigger");
+    drop(conn);
+
+    let error = commit_prepared_scan(prepared).expect_err("reject mismatched freshness plan");
+    assert!(
+      error.contains("freshness changed"),
+      "unexpected error: {error}"
+    );
+    assert!(!error.contains("freshness write happened"));
+  }
+
+  #[test]
+  fn commit_rejects_changed_source_without_prepared_writes() {
+    let directory = tempdir().expect("tempdir");
+    let first_codex_home = directory.path().join("codex-home-a");
+    let second_codex_home = directory.path().join("codex-home-b");
+    let sessions = first_codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&second_codex_home).expect("second source");
+    write_session_file(
+      &sessions.join("stale.jsonl"),
+      "50505050-5050-5050-5050-505050505050",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &first_codex_home);
+    let prepared = prepare_scan(&db_path, None, ScanKind::Full).expect("prepare first source");
+
+    configure_codex_home(&db_path, &second_codex_home);
+    let conn = open_connection(&db_path).expect("open database");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let error = commit_prepared_scan(prepared).expect_err("reject stale prepared source");
+    assert!(error.contains("source changed"));
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+  }
+
+  #[test]
+  fn override_commit_ignores_unrelated_default_source_change() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let first_default_home = directory.path().join("default-a");
+    let second_default_home = directory.path().join("default-b");
+    let scanned_home = directory.path().join("explicit-override");
+    let sessions = scanned_home.join("sessions");
+    std::fs::create_dir_all(&first_default_home).expect("first default source");
+    std::fs::create_dir_all(&second_default_home).expect("second default source");
+    std::fs::create_dir_all(&sessions).expect("override sessions");
+    let session_id = "53535353-5353-5353-5353-535353535353";
+    write_session_file(
+      &sessions.join("override.jsonl"),
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    let _environment = CodexHomeEnvGuard::set(&first_default_home);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(scanned_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare override scan");
+    std::env::set_var("CODEX_HOME", &second_default_home);
+
+    commit_prepared_scan(prepared).expect("commit override scan");
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(session_usage_totals(&conn, session_id).3, 110);
+  }
+
+  #[test]
+  fn same_source_scan_commit_after_prepare_is_rejected_without_writes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "51515151-5151-5151-5151-515151515151";
+    let session_path = sessions.join("same-source.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+    commit_prepared_scan(prepare_scan(&db_path, None, ScanKind::Full).expect("prepare full"))
+      .expect("commit full");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+
+    let stale = prepare_scan(&db_path, None, ScanKind::Incremental).expect("prepare stale scan");
+    let winner = prepare_scan(&db_path, None, ScanKind::Incremental).expect("prepare winning scan");
+    commit_prepared_scan(winner).expect("commit winning scan");
+    let conn = open_connection(&db_path).expect("open database");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let error = commit_prepared_scan(stale).expect_err("reject stale same-source scan");
+    assert!(error.contains("source changed") || error.contains("stale"));
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+  }
+
+  #[test]
+  fn untracked_override_rejects_same_source_commit_after_prepare() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let default_home = directory.path().join("default-home");
+    let scanned_home = directory.path().join("explicit-override");
+    let sessions = scanned_home.join("sessions");
+    std::fs::create_dir_all(&default_home).expect("default source");
+    std::fs::create_dir_all(&sessions).expect("override sessions");
+    let _environment = CodexHomeEnvGuard::set(&default_home);
+    let session_id = "54545454-5454-5454-5454-545454545454";
+    let session_path = sessions.join("untracked-override.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    let source_override = Some(scanned_home.to_string_lossy().to_string());
+    commit_prepared_scan(
+      prepare_scan(&db_path, source_override.clone(), ScanKind::Full)
+        .expect("prepare initial scan"),
+    )
+    .expect("commit initial scan");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+
+    let stale = prepare_scan(&db_path, source_override.clone(), ScanKind::Incremental)
+      .expect("prepare stale override scan");
+    let winner = prepare_scan(&db_path, source_override, ScanKind::Incremental)
+      .expect("prepare winning override scan");
+    commit_prepared_scan(winner).expect("commit winning override scan");
+    let conn = open_connection(&db_path).expect("open database");
+    let before = database_mutation_fingerprint(&conn);
+    drop(conn);
+
+    let error = commit_prepared_scan(stale).expect_err("reject stale override scan");
+    assert!(error.contains("source changed") || error.contains("stale"));
+    let conn = open_connection(&db_path).expect("reopen database");
+    assert_eq!(database_mutation_fingerprint(&conn), before);
+  }
+
+  #[test]
+  fn prepare_stats_count_only_bytes_consumed_before_parse_failure() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_path = sessions.join("partial-read.jsonl");
+    let mut file = File::create(&session_path).expect("session file");
+    writeln!(
+      file,
+      "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"52525252-5252-5252-5252-525252525252\"}}}}"
+    )
+    .expect("write metadata");
+    file.write_all(&[0xff, b'\n']).expect("write invalid utf8");
+    file
+      .write_all(&vec![b' '; 32 * 1024])
+      .expect("write unread tail");
+    drop(file);
+    let file_size = std::fs::metadata(&session_path).expect("metadata").len();
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare scan with unreadable file");
+
+    assert!(prepared.stats().source_bytes_read > 0);
+    assert!(prepared.stats().source_bytes_read < file_size);
+  }
+
+  #[test]
+  fn small_incremental_prepare_stays_in_memory() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "60606060-6060-6060-6060-606060606060";
+    let session_path = sessions.join("small.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental scan");
+
+    assert!(!prepared.uses_spool());
+    assert!(prepared.spool_path().is_none());
+  }
+
+  #[test]
+  fn large_prepare_spills_and_drop_removes_spool() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "70707070-7070-7070-7070-707070707070";
+    let mut body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
+      ),
+      session_id
+    );
+    let mut total_tokens = 0i64;
+    while body.len() <= PREPARED_SPOOL_THRESHOLD_BYTES * 4 {
+      total_tokens += 10;
+      body.push_str(&token_count_line(TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (total_tokens, 0, 0, total_tokens),
+        last: (10, 0, 0, 10),
+      }));
+    }
+    std::fs::write(sessions.join("large.jsonl"), body).expect("write large session");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare large scan");
+
+    assert!(prepared.uses_spool());
+    let spool_path = prepared.spool_path().expect("spool path").to_path_buf();
+    assert!(spool_path.is_file());
+    drop(prepared);
+    assert!(!spool_path.exists());
+  }
+
+  #[test]
+  fn prepared_scan_started_at_includes_parse_time() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "73737373-7373-7373-7373-737373737373";
+    let mut body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
+      ),
+      session_id
+    );
+    let mut total_tokens = 0i64;
+    while body.len() <= PREPARED_SPOOL_THRESHOLD_BYTES * 32 {
+      total_tokens += 10;
+      body.push_str(&token_count_line(TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (total_tokens, 0, 0, total_tokens),
+        last: (10, 0, 0, 10),
+      }));
+    }
+    std::fs::write(sessions.join("timed.jsonl"), body).expect("write timed session");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare timed scan");
+    let scan_started_at =
+      chrono::DateTime::parse_from_rfc3339(&prepared.scan_started_at).expect("parse scan start");
+    let elapsed = chrono::Utc::now().signed_duration_since(scan_started_at);
+
+    assert!(
+      elapsed >= chrono::Duration::milliseconds(10),
+      "scan start should precede parsing, elapsed={elapsed:?}"
+    );
+  }
+
+  #[test]
+  fn spooled_commit_preserves_last_usage_and_removes_spool() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "71717171-7171-7171-7171-717171717171";
+    let missing_parent_id = "72727272-7272-7272-7272-727272727272";
+    let mut body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}\n"
+      ),
+      session_id, missing_parent_id,
+    );
+    let mut snapshots = 0i64;
+    let mut total_tokens = 1_000i64;
+    while body.len() <= PREPARED_SPOOL_THRESHOLD_BYTES * 3 {
+      if snapshots > 0 {
+        total_tokens += 10;
+      }
+      body.push_str(&token_count_line(TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (total_tokens, 0, 0, total_tokens),
+        last: (10, 0, 0, 10),
+      }));
+      snapshots += 1;
+    }
+    std::fs::write(sessions.join("spooled-fork.jsonl"), body).expect("write fork session");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare spooled fork");
+    assert!(prepared.stats().used_spool);
+    let spool_path = prepared.spool_path().expect("spool path").to_path_buf();
+
+    commit_prepared_scan(prepared).expect("commit spooled fork");
+
+    assert!(!spool_path.exists());
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(session_usage_totals(&conn, session_id).3, snapshots * 10);
+  }
+
+  #[test]
+  fn bounded_parent_replay_cache_evicts_without_changing_fork_results() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let pair_count = PARENT_REPLAY_CACHE_MAX_ENTRIES + 1;
+    let mut child_session_ids = Vec::new();
+    for index in 0..pair_count {
+      let parent_session_id = format!("90000000-0000-0000-0000-{index:012x}");
+      let child_session_id = format!("a0000000-0000-0000-0000-{index:012x}");
+      write_replay_cache_pair(&sessions, index, &parent_session_id, &child_session_id);
+      child_session_ids.push(child_session_id);
+    }
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare replay pairs");
+
+    assert!(prepared.parent_replay_cache_evictions() > 0);
+    commit_prepared_scan(prepared).expect("commit replay pairs");
+    let conn = open_connection(&db_path).expect("open database");
+    for child_session_id in child_session_ids {
+      assert_eq!(session_usage_totals(&conn, &child_session_id).3, 10);
+    }
+  }
+
+  #[test]
+  fn oversized_parent_replay_cache_entry_is_bypassed_not_evicted() {
+    let oversized_model_id = "x".repeat(PARENT_REPLAY_CACHE_MAX_BYTES);
+    let snapshots = vec![replay_snapshot(
+      "2026-07-10T00:00:00Z",
+      &oversized_model_id,
+      (10, 0, 0, 10, 10),
+      Some((10, 0, 0, 10, 10)),
+    )];
+    let mut cache = ParentReplayCache::new();
+
+    cache.insert("oversized-parent".to_string(), Some(snapshots));
+
+    assert_eq!(cache.evictions(), 0);
+    assert_eq!(cache.oversized_bypasses(), 1);
+    assert!(cache.get("oversized-parent").is_none());
+  }
+
+  #[test]
+  fn prepared_stats_include_parent_replay_bytes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let parent_session_id = "91919191-9191-9191-9191-919191919191";
+    let child_session_id = "92929292-9292-9292-9292-929292929292";
+    write_replay_cache_pair(&sessions, 0, parent_session_id, child_session_id);
+    let main_scan_bytes = std::fs::read_dir(&sessions)
+      .expect("read sessions")
+      .map(|entry| {
+        entry
+          .expect("session entry")
+          .metadata()
+          .expect("metadata")
+          .len()
+      })
+      .sum::<u64>();
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Full,
+    )
+    .expect("prepare replay pair");
+
+    assert!(prepared.stats().source_bytes_read > main_scan_bytes);
+  }
+
+  #[test]
+  fn full_and_incremental_wrappers_match_prepared_scan_results() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "80808080-8080-8080-8080-808080808080";
+    let session_path = sessions.join("compatibility.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let direct_db_path = directory.path().join("direct.sqlite");
+    let wrapper_db_path = directory.path().join("wrapper.sqlite");
+    initialize_scan_database(&direct_db_path);
+
+    let direct_full = commit_prepared_scan(
+      prepare_scan(
+        &direct_db_path,
+        Some(codex_home.to_string_lossy().to_string()),
+        ScanKind::Full,
+      )
+      .expect("prepare direct full scan"),
+    )
+    .expect("commit direct full scan");
+    let wrapper_full = perform_scan(
+      &wrapper_db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+    )
+    .expect("wrapper full scan");
+    assert_scan_results_equivalent(&direct_full, &wrapper_full);
+
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+    let direct_incremental = commit_prepared_scan(
+      prepare_scan(
+        &direct_db_path,
+        Some(codex_home.to_string_lossy().to_string()),
+        ScanKind::Incremental,
+      )
+      .expect("prepare direct incremental scan"),
+    )
+    .expect("commit direct incremental scan");
+    let wrapper_incremental = perform_incremental_scan(
+      &wrapper_db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+    )
+    .expect("wrapper incremental scan");
+    assert_scan_results_equivalent(&direct_incremental, &wrapper_incremental);
+
+    let direct_conn = open_connection(&direct_db_path).expect("open direct database");
+    let wrapper_conn = open_connection(&wrapper_db_path).expect("open wrapper database");
+    assert_eq!(
+      session_usage_totals(&direct_conn, session_id),
+      session_usage_totals(&wrapper_conn, session_id)
+    );
+  }
+
   #[test]
   fn parent_replay_reader_rejects_malformed_token_candidate_between_snapshots() {
     let directory = tempdir().expect("tempdir");
@@ -2104,13 +4074,11 @@ mod tests {
       total: (100, 0, 0, 100),
       last: (100, 0, 0, 100),
     });
-    body.push_str(
-      concat!(
-        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{",
-        "\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":0,",
-        "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":180}}}}\n"
-      ),
-    );
+    body.push_str(concat!(
+      "{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{",
+      "\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":0,",
+      "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":180}}}}\n"
+    ));
     std::fs::write(&parent_path, body).expect("write replay parent without timestamp");
 
     assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
@@ -2128,14 +4096,12 @@ mod tests {
       total: (100, 0, 0, 100),
       last: (100, 0, 0, 100),
     });
-    body.push_str(
-      concat!(
-        "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",",
-        "\"payload\":{\"type\":\"token_count\",\"info\":{",
-        "\"last_token_usage\":{\"input_tokens\":80,\"cached_input_tokens\":0,",
-        "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":80}}}}\n"
-      ),
-    );
+    body.push_str(concat!(
+      "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",",
+      "\"payload\":{\"type\":\"token_count\",\"info\":{",
+      "\"last_token_usage\":{\"input_tokens\":80,\"cached_input_tokens\":0,",
+      "\"output_tokens\":0,\"reasoning_output_tokens\":0,\"total_tokens\":80}}}}\n"
+    ));
     std::fs::write(&parent_path, body).expect("write replay parent without total usage");
 
     assert!(read_parent_replay_snapshots(&parent_path, parent_session_id).is_err());
@@ -2171,15 +4137,13 @@ mod tests {
       total: (100, 0, 0, 100),
       last: (100, 0, 0, 100),
     });
-    body.push_str(
-      concat!(
-        "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"response_item\",",
-        "\"payload\":{\"message\":{\"type\":\"event_msg\",\"payload\":{",
-        "\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
-        "\"input_tokens\":900,\"cached_input_tokens\":0,\"output_tokens\":0,",
-        "\"reasoning_output_tokens\":0,\"total_tokens\":900}}}}}}\n"
-      ),
-    );
+    body.push_str(concat!(
+      "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"response_item\",",
+      "\"payload\":{\"message\":{\"type\":\"event_msg\",\"payload\":{",
+      "\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
+      "\"input_tokens\":900,\"cached_input_tokens\":0,\"output_tokens\":0,",
+      "\"reasoning_output_tokens\":0,\"total_tokens\":900}}}}}}\n"
+    ));
     std::fs::write(&parent_path, body).expect("write replay parent with nested token types");
 
     let snapshots = read_parent_replay_snapshots(&parent_path, parent_session_id)
@@ -2232,11 +4196,7 @@ mod tests {
     ];
 
     assert_eq!(
-      replayed_child_snapshot_cutoff(
-        &parent,
-        &child,
-        Some(fork_instant("2026-03-24T00:05:00Z")),
-      ),
+      replayed_child_snapshot_cutoff(&parent, &child, Some(fork_instant("2026-03-24T00:05:00Z")),),
       3
     );
   }
@@ -2271,11 +4231,7 @@ mod tests {
     let child = vec![first, second, third];
 
     assert_eq!(
-      replayed_child_snapshot_cutoff(
-        &parent,
-        &child,
-        Some(fork_instant("2026-03-24T00:04:00Z")),
-      ),
+      replayed_child_snapshot_cutoff(&parent, &child, Some(fork_instant("2026-03-24T00:04:00Z")),),
       3
     );
   }
@@ -2319,12 +4275,8 @@ mod tests {
       (180, 20, 35, 2, 217),
       Some((80, 10, 15, 1, 96)),
     );
-    let child_second = replay_snapshot(
-      "2026-03-24T00:01:00Z",
-      "model",
-      (180, 20, 35, 2, 217),
-      None,
-    );
+    let child_second =
+      replay_snapshot("2026-03-24T00:01:00Z", "model", (180, 20, 35, 2, 217), None);
 
     assert_eq!(
       replayed_child_snapshot_cutoff(
@@ -2445,11 +4397,7 @@ mod tests {
     );
 
     assert_eq!(
-      replayed_child_snapshot_cutoff(
-        &[first.clone(), second.clone()],
-        &[first, second],
-        None,
-      ),
+      replayed_child_snapshot_cutoff(&[first.clone(), second.clone()], &[first, second], None,),
       0
     );
   }
@@ -2504,7 +4452,10 @@ mod tests {
       Some(fork_instant("2026-03-24T08:30:00+08:00"))
     );
     let serialized = serde_json::to_value(&parsed.snapshots[0]).expect("serialize snapshot");
-    assert!(!serialized.as_object().expect("snapshot object").contains_key("lastTokenUsage"));
+    assert!(!serialized
+      .as_object()
+      .expect("snapshot object")
+      .contains_key("lastTokenUsage"));
   }
 
   #[test]
@@ -2539,7 +4490,10 @@ mod tests {
     )
     .expect("parse thread-spawn session");
 
-    assert_eq!(parsed.raw_session.parent_session_id.as_deref(), Some(parent_id));
+    assert_eq!(
+      parsed.raw_session.parent_session_id.as_deref(),
+      Some(parent_id)
+    );
     assert!(parsed.explicit_forked_from_id.is_none());
     assert!(parsed.explicit_fork_timestamp.is_none());
   }
@@ -2679,9 +4633,8 @@ mod tests {
       )
       .expect("query usage");
 
-    let standard = (75.0 / 1_000_000.0) * 5.0
-      + (25.0 / 1_000_000.0) * 0.5
-      + (40.0 / 1_000_000.0) * 30.0;
+    let standard =
+      (75.0 / 1_000_000.0) * 5.0 + (25.0 / 1_000_000.0) * 0.5 + (40.0 / 1_000_000.0) * 30.0;
     assert!((value_usd - standard).abs() < 1e-9);
     assert_eq!(fast_mode_auto, 0);
     assert_eq!(fast_mode_effective, 0);
@@ -2710,8 +4663,13 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    let (input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd):
-      (i64, i64, i64, i64, f64) = conn
+    let (input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd): (
+      i64,
+      i64,
+      i64,
+      i64,
+      f64,
+    ) = conn
       .query_row(
         "
         SELECT input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd
@@ -2735,9 +4693,8 @@ mod tests {
     assert_eq!(cached_input_tokens, 25);
     assert_eq!(output_tokens, 40);
     assert_eq!(total_tokens, 140);
-    let standard = (75.0 / 1_000_000.0) * 5.0
-      + (25.0 / 1_000_000.0) * 0.5
-      + (40.0 / 1_000_000.0) * 30.0;
+    let standard =
+      (75.0 / 1_000_000.0) * 5.0 + (25.0 / 1_000_000.0) * 0.5 + (40.0 / 1_000_000.0) * 30.0;
     assert!((value_usd - standard).abs() < 1e-9);
   }
 
@@ -2750,7 +4707,9 @@ mod tests {
 
     let child_session_id = "019d4f72-a2ee-77a0-bd4a-76f43b7b299b";
     let wrong_session_id = "019d4d7c-457e-7020-8b5f-7940eb5e3716";
-    let session_path = sessions_dir.join(format!("rollout-2026-04-03T02-26-46-{child_session_id}.jsonl"));
+    let session_path = sessions_dir.join(format!(
+      "rollout-2026-04-03T02-26-46-{child_session_id}.jsonl"
+    ));
     write_session_file_with_parent(
       &session_path,
       child_session_id,
@@ -2799,7 +4758,10 @@ mod tests {
       .optional()
       .expect("query repaired import state");
     assert_eq!(repaired_session_id.as_deref(), Some(child_session_id));
-    assert_eq!(session_usage_totals(&conn, child_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(
+      session_usage_totals(&conn, child_session_id),
+      (100, 20, 25, 125, 1)
+    );
   }
 
   #[test]
@@ -2828,7 +4790,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.parent_session_id.as_deref(), Some("root-parent"));
+    assert_eq!(
+      parsed.raw_session.parent_session_id.as_deref(),
+      Some("root-parent")
+    );
     assert_eq!(parsed.raw_session.agent_nickname.as_deref(), Some("Hume"));
     assert_eq!(parsed.snapshots.len(), 2);
     assert_eq!(parsed.latest_plan_type.as_deref(), Some("pro"));
@@ -2837,10 +4802,9 @@ mod tests {
   #[test]
   fn parser_prefers_file_matching_session_meta_when_fork_file_replays_parent_meta() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
-        .path()
-        .join("rollout-2026-03-24T00-00-00-55555555-5555-5555-5555-555555555555.jsonl");
+    let session_path = directory
+      .path()
+      .join("rollout-2026-03-24T00-00-00-55555555-5555-5555-5555-555555555555.jsonl");
     std::fs::write(
       &session_path,
       concat!(
@@ -2863,7 +4827,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "55555555-5555-5555-5555-555555555555");
+    assert_eq!(
+      parsed.raw_session.session_id,
+      "55555555-5555-5555-5555-555555555555"
+    );
     assert_eq!(
       parsed.raw_session.parent_session_id.as_deref(),
       Some("44444444-4444-4444-4444-444444444444")
@@ -2930,10 +4897,9 @@ mod tests {
   #[test]
   fn parser_supports_legacy_top_level_id_format() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
-        .path()
-        .join("rollout-2025-09-09T16-29-03-0df0be29-d74d-468f-8dda-0630fc6e989e.jsonl");
+    let session_path = directory
+      .path()
+      .join("rollout-2025-09-09T16-29-03-0df0be29-d74d-468f-8dda-0630fc6e989e.jsonl");
     std::fs::write(
       &session_path,
       concat!(
@@ -2955,17 +4921,22 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "0df0be29-d74d-468f-8dda-0630fc6e989e");
-    assert_eq!(parsed.raw_session.started_at.as_deref(), Some("2025-09-09T08:29:03.118Z"));
+    assert_eq!(
+      parsed.raw_session.session_id,
+      "0df0be29-d74d-468f-8dda-0630fc6e989e"
+    );
+    assert_eq!(
+      parsed.raw_session.started_at.as_deref(),
+      Some("2025-09-09T08:29:03.118Z")
+    );
   }
 
   #[test]
   fn parser_falls_back_to_session_id_from_filename() {
     let directory = tempdir().expect("tempdir");
-    let session_path =
-      directory
-        .path()
-        .join("rollout-2026-03-17T18-00-21-019cfb3d-415c-7623-aab0-22e73abcec2e.jsonl");
+    let session_path = directory
+      .path()
+      .join("rollout-2026-03-17T18-00-21-019cfb3d-415c-7623-aab0-22e73abcec2e.jsonl");
     std::fs::write(
       &session_path,
       concat!(
@@ -2986,7 +4957,10 @@ mod tests {
     )
     .expect("parse");
 
-    assert_eq!(parsed.raw_session.session_id, "019cfb3d-415c-7623-aab0-22e73abcec2e");
+    assert_eq!(
+      parsed.raw_session.session_id,
+      "019cfb3d-415c-7623-aab0-22e73abcec2e"
+    );
   }
 
   #[test]
@@ -2997,11 +4971,19 @@ mod tests {
       child_count: 0,
     };
     assert_eq!(
-      classify_topology_maintenance(Some(&existing_child), existing_child.child_count, Some("root-parent")),
+      classify_topology_maintenance(
+        Some(&existing_child),
+        existing_child.child_count,
+        Some("root-parent")
+      ),
       TopologyMaintenance::None
     );
     assert_eq!(
-      classify_topology_maintenance(Some(&existing_child), existing_child.child_count, Some("other-parent")),
+      classify_topology_maintenance(
+        Some(&existing_child),
+        existing_child.child_count,
+        Some("other-parent")
+      ),
       TopologyMaintenance::RecomputeAll
     );
 
@@ -3011,7 +4993,11 @@ mod tests {
       child_count: 2,
     };
     assert_eq!(
-      classify_topology_maintenance(Some(&missing_parent_placeholder), missing_parent_placeholder.child_count, None),
+      classify_topology_maintenance(
+        Some(&missing_parent_placeholder),
+        missing_parent_placeholder.child_count,
+        None
+      ),
       TopologyMaintenance::RecomputeAll
     );
     assert_eq!(
@@ -3033,7 +5019,11 @@ mod tests {
 
     let parent_session_id = "44444444-4444-4444-4444-444444444444";
     let child_session_id = "55555555-5555-5555-5555-555555555555";
-    write_session_file(&sessions_dir.join("parent.jsonl"), parent_session_id, &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)]);
+    write_session_file(
+      &sessions_dir.join("parent.jsonl"),
+      parent_session_id,
+      &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)],
+    );
     write_session_file_with_parent(
       &sessions_dir.join("child.jsonl"),
       child_session_id,
@@ -3066,7 +5056,11 @@ mod tests {
     );
     assert_eq!(
       conversation_link(&conn, child_session_id),
-      Some((parent_session_id.to_string(), Some(parent_session_id.to_string()), 1))
+      Some((
+        parent_session_id.to_string(),
+        Some(parent_session_id.to_string()),
+        1
+      ))
     );
   }
 
@@ -3107,7 +5101,11 @@ mod tests {
     );
     assert_eq!(
       conversation_link(&conn, child_session_id),
-      Some((parent_session_id.to_string(), Some(parent_session_id.to_string()), 1))
+      Some((
+        parent_session_id.to_string(),
+        Some(parent_session_id.to_string()),
+        1
+      ))
     );
   }
 
@@ -3125,24 +5123,34 @@ mod tests {
     write_session_file(
       &active_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("active".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("active".to_string())
+    );
 
     let archived_path = archived_dir.join("sample.jsonl");
     std::fs::rename(&active_path, &archived_path).expect("move to archived");
 
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("archived".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("archived".to_string())
+    );
   }
 
   #[test]
@@ -3173,13 +5181,19 @@ mod tests {
       ],
     );
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 0);
-    assert_eq!(session_usage_totals(&conn, active_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, archived_session_id), (0, 0, 0, 0, 0));
+    assert_eq!(
+      session_usage_totals(&conn, active_session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, archived_session_id),
+      (0, 0, 0, 0, 0)
+    );
   }
 
   #[test]
@@ -3212,13 +5226,19 @@ mod tests {
       &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
     );
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+    assert_eq!(
+      session_usage_totals(&conn, existing_session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, new_session_id),
+      (180, 40, 45, 225, 1)
+    );
   }
 
   #[test]
@@ -3247,13 +5267,19 @@ mod tests {
       &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
     );
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+    assert_eq!(
+      session_usage_totals(&conn, existing_session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, new_session_id),
+      (180, 40, 45, 225, 1)
+    );
   }
 
   #[test]
@@ -3275,13 +5301,19 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
     std::fs::remove_file(&session_path).expect("remove active session");
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 0);
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("missing".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("missing".to_string())
+    );
   }
 
   #[test]
@@ -3310,13 +5342,19 @@ mod tests {
       &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
     );
 
-    let result =
-      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, recovered_session_id), (180, 40, 45, 225, 1));
+    assert_eq!(
+      session_usage_totals(&conn, existing_session_id),
+      (100, 20, 25, 125, 1)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, recovered_session_id),
+      (180, 40, 45, 225, 1)
+    );
     let pending_count: i64 = conn
       .query_row(
         "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
@@ -3339,9 +5377,7 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 150, 30, 40, 190),
-      ],
+      &[("2026-03-24T00:00:01Z", 150, 30, 40, 190)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
@@ -3350,8 +5386,14 @@ mod tests {
 
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (150, 30, 40, 190, 1));
-    assert_eq!(session_source_state(&conn, session_id), Some("missing".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (150, 30, 40, 190, 1)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("missing".to_string())
+    );
   }
 
   #[test]
@@ -3366,9 +5408,7 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
@@ -3387,8 +5427,14 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("third scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
-    assert_eq!(session_source_state(&conn, session_id), Some("active".to_string()));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id),
+      Some("active".to_string())
+    );
   }
 
   #[test]
@@ -3415,7 +5461,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (960, 120, 120, 1200, 3));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (960, 120, 120, 1200, 3)
+    );
   }
 
   #[test]
@@ -3492,18 +5541,31 @@ mod tests {
           )
           VALUES (?1, '2026-05-18T14:42:50Z', 'gpt-5.4', ?2, ?3, ?4, 0, ?5, 0.0, 0, 0)
           ",
-          params![session_id, input_tokens, cached_input_tokens, output_tokens, total_tokens],
+          params![
+            session_id,
+            input_tokens,
+            cached_input_tokens,
+            output_tokens,
+            total_tokens
+          ],
         )
         .expect("insert stale usage event");
     }
-    assert_eq!(session_usage_totals(&conn, session_id), (1840, 230, 230, 2300, 4));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (1840, 230, 230, 2300, 4)
+    );
     drop(conn);
 
-    let result = perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+    let result =
+      perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, session_id), (960, 120, 120, 1200, 3));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (960, 120, 120, 1200, 3)
+    );
     let repair_completed: Option<String> = conn
       .query_row(
         "SELECT completed_at FROM data_repairs WHERE repair_key = ?1",
@@ -3572,10 +5634,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, child_created_at,
     );
     for (index, fixture) in parent_fixtures.iter().copied().enumerate() {
       let timestamp = match index {
@@ -3725,8 +5784,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_session_id,
-      parent_session_id,
+      child_session_id, parent_session_id,
     );
     child_body.push_str(&token_count_line(inherited));
     child_body.push_str(&token_count_line(TokenFixture {
@@ -3887,7 +5945,8 @@ mod tests {
         ("2026-05-18T14:42:50Z", 960, 120, 120, 1200),
       ],
     );
-    std::fs::write(sessions_dir.join("unparseable.jsonl"), "not json\n").expect("write bad session");
+    std::fs::write(sessions_dir.join("unparseable.jsonl"), "not json\n")
+      .expect("write bad session");
 
     let db_path = directory.path().join("usage.sqlite");
     let conn = open_connection(&db_path).expect("open db");
@@ -3932,7 +5991,13 @@ mod tests {
           )
           VALUES (?1, '2026-05-18T14:42:50Z', 'gpt-5.4', ?2, ?3, ?4, 0, ?5, 0.0, 0, 0)
           ",
-          params![session_id, input_tokens, cached_input_tokens, output_tokens, total_tokens],
+          params![
+            session_id,
+            input_tokens,
+            cached_input_tokens,
+            output_tokens,
+            total_tokens
+          ],
         )
         .expect("insert stale usage event");
     }
@@ -3941,7 +6006,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, session_id), (960, 120, 120, 1200, 3));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (960, 120, 120, 1200, 3)
+    );
     let repair_completed: Option<String> = conn
       .query_row(
         "SELECT completed_at FROM data_repairs WHERE repair_key = ?1",
@@ -3961,7 +6029,12 @@ mod tests {
       .expect("query pending repair file");
     assert_eq!(
       pending_path.as_deref(),
-      Some(sessions_dir.join("unparseable.jsonl").to_string_lossy().as_ref())
+      Some(
+        sessions_dir
+          .join("unparseable.jsonl")
+          .to_string_lossy()
+          .as_ref()
+      )
     );
     let session_rate_sample_count: i64 = conn
       .query_row(
@@ -3973,7 +6046,8 @@ mod tests {
     assert!(session_rate_sample_count > 0);
     drop(conn);
 
-    let result = perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("rescan");
+    let result =
+      perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("rescan");
     assert_eq!(result.updated_sessions, 0);
   }
 
@@ -4060,16 +6134,17 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
     let conn = open_connection(&db_path).expect("open db after first scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
     drop(conn);
 
     write_session_file(
@@ -4083,7 +6158,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after second scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
   }
 
   #[test]
@@ -4098,16 +6176,17 @@ mod tests {
     write_session_file(
       &session_path,
       session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-      ],
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
 
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
     let conn = open_connection(&db_path).expect("open db after first scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
     drop(conn);
 
     std::fs::write(
@@ -4124,7 +6203,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after incomplete rescan");
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 25, 125, 1)
+    );
     drop(conn);
 
     write_session_file(
@@ -4138,7 +6220,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("third scan");
 
     let conn = open_connection(&db_path).expect("open db after third scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
   }
 
   #[test]
@@ -4174,7 +6259,10 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db after second scan");
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 45, 225, 2));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
   }
 
   #[test]
@@ -4186,10 +6274,12 @@ mod tests {
 
     let parent_session_id = "77777777-7777-7777-7777-777777777777";
     let child_session_id = "88888888-8888-8888-8888-888888888888";
-    let parent_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"));
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-05-00-{child_session_id}.jsonl"));
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-05-00-{child_session_id}.jsonl"
+    ));
 
     write_session_file(
       &parent_path,
@@ -4214,8 +6304,14 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
 
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(session_usage_totals(&conn, parent_session_id), (260, 60, 65, 325, 3));
-    assert_eq!(session_usage_totals(&conn, child_session_id), (140, 20, 25, 165, 2));
+    assert_eq!(
+      session_usage_totals(&conn, parent_session_id),
+      (260, 60, 65, 325, 3)
+    );
+    assert_eq!(
+      session_usage_totals(&conn, child_session_id),
+      (140, 20, 25, 165, 2)
+    );
     assert_eq!(
       session_root_and_subagents(&conn, parent_session_id),
       Some((parent_session_id.to_string(), true))
@@ -4243,10 +6339,12 @@ mod tests {
 
     let parent_session_id = "99999999-9999-9999-9999-999999999999";
     let child_session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-    let parent_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"));
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"));
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
     let parent_fixtures = [
       TokenFixture {
         timestamp: "2026-03-24T00:00:01Z",
@@ -4287,10 +6385,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, child_created_at,
     );
     for fixture in parent_fixtures.iter().copied() {
       child_body.push_str(&token_count_line(TokenFixture {
@@ -4357,10 +6452,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, child_created_at,
     );
     child_body.push_str(&token_count_line(TokenFixture {
       timestamp: "2026-03-24T00:30:01Z",
@@ -4445,10 +6537,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, child_created_at,
     );
     for (index, fixture) in parent_fixtures.iter().copied().enumerate() {
       let timestamp = match index {
@@ -4558,8 +6647,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_session_id,
-      root_session_id,
+      child_session_id, root_session_id,
     );
     for fixture in child_fixtures.iter().copied() {
       child_body.push_str(&token_count_line(fixture));
@@ -4573,8 +6661,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      grandchild_session_id,
-      child_session_id,
+      grandchild_session_id, child_session_id,
     );
     for (index, fixture) in child_fixtures.iter().copied().enumerate() {
       let timestamp = match index {
@@ -4596,7 +6683,8 @@ mod tests {
     std::fs::write(&grandchild_path, grandchild_body).expect("write grandchild session");
 
     let db_path = directory.path().join("usage.sqlite");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full family scan");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("full family scan");
 
     let conn = open_connection(&db_path).expect("open db");
     let root_total = session_usage_totals(&conn, root_session_id).3;
@@ -4676,11 +6764,7 @@ mod tests {
         "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_created_at,
-      child_session_id,
-      parent_session_id,
-      parent_session_id,
-      child_created_at,
+      child_created_at, child_session_id, parent_session_id, parent_session_id, child_created_at,
     );
     for fixture in [
       TokenFixture {
@@ -4717,8 +6801,9 @@ mod tests {
 
     let parent_session_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
     let child_session_id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T01-00-00-{child_session_id}.jsonl"));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T01-00-00-{child_session_id}.jsonl"
+    ));
     let mut child_body = format!(
       concat!(
         "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"session_meta\",",
@@ -4726,8 +6811,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_session_id,
-      parent_session_id,
+      child_session_id, parent_session_id,
     );
     child_body.push_str(&token_count_line(TokenFixture {
       timestamp: "2026-03-24T01:00:00Z",
@@ -4752,8 +6836,9 @@ mod tests {
 
     let parent_session_id = "dddddddd-dddd-dddd-dddd-dddddddddddd";
     let child_session_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
-    let child_path =
-      sessions_dir.join(format!("rollout-2026-03-24T02-00-00-{child_session_id}.jsonl"));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T02-00-00-{child_session_id}.jsonl"
+    ));
     let mut child_body = format!(
       concat!(
         "{{\"timestamp\":\"2026-03-24T02:00:00Z\",\"type\":\"session_meta\",\"payload\":{{",
@@ -4762,8 +6847,7 @@ mod tests {
         "{{\"timestamp\":\"2026-03-24T02:00:00Z\",\"type\":\"turn_context\",",
         "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
       ),
-      child_session_id,
-      parent_session_id,
+      child_session_id, parent_session_id,
     );
     child_body.push_str(&token_count_line(TokenFixture {
       timestamp: "2026-03-24T02:00:00Z",
@@ -4846,11 +6930,8 @@ mod tests {
       .expect("create source switch trigger");
     drop(conn);
 
-    perform_scan(
-      &db_path,
-      Some(old_codex_home.to_string_lossy().to_string()),
-    )
-    .expect("scan old source");
+    perform_scan(&db_path, Some(old_codex_home.to_string_lossy().to_string()))
+      .expect("scan old source");
 
     let conn = open_connection(&db_path).expect("reopen database");
     let (codex_home, started, completed, full_completed): (
@@ -4898,18 +6979,19 @@ mod tests {
       .expect("scan matching source");
 
     let conn = open_connection(&db_path).expect("reopen database");
-    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) = conn
-      .query_row(
-        "
+    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) =
+      conn
+        .query_row(
+          "
         SELECT last_scan_started_at, last_scan_completed_at,
                last_full_scan_completed_at
         FROM sync_settings
         WHERE singleton_id = 1
         ",
-        [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-      )
-      .expect("load scan freshness");
+          [],
+          |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("load scan freshness");
 
     assert!(started.is_some());
     assert!(completed.is_some());
@@ -4932,25 +7014,23 @@ mod tests {
     save_sync_settings(&conn, &settings).expect("save new source");
     drop(conn);
 
-    perform_scan(
-      &db_path,
-      Some(old_codex_home.to_string_lossy().to_string()),
-    )
-    .expect("scan previous source");
+    perform_scan(&db_path, Some(old_codex_home.to_string_lossy().to_string()))
+      .expect("scan previous source");
 
     let conn = open_connection(&db_path).expect("reopen database");
-    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) = conn
-      .query_row(
-        "
+    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) =
+      conn
+        .query_row(
+          "
         SELECT last_scan_started_at, last_scan_completed_at,
                last_full_scan_completed_at
         FROM sync_settings
         WHERE singleton_id = 1
         ",
-        [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-      )
-      .expect("load scan freshness");
+          [],
+          |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("load scan freshness");
 
     assert_eq!(started, None);
     assert_eq!(completed, None);
@@ -4960,8 +7040,8 @@ mod tests {
   #[test]
   fn changed_resolved_default_source_forces_full_scan() {
     assert_eq!(
-      effective_scan_scope(ScanScope::Incremental, false, false, false, true),
-      ScanScope::Full
+      effective_scan_scope(ScanKind::Incremental, false, false, false, true),
+      ScanKind::Full
     );
   }
 
@@ -5010,17 +7090,26 @@ mod tests {
       .expect("load scan source identity");
 
     assert_eq!(selector, None);
-    assert_eq!(resolved_source.as_deref(), Some(second_codex_home.to_string_lossy().as_ref()));
+    assert_eq!(
+      resolved_source.as_deref(),
+      Some(second_codex_home.to_string_lossy().as_ref())
+    );
     assert_eq!(result.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
     assert_eq!(session_usage_totals(&conn, first_session_id).3, 110);
-    assert_eq!(session_source_state(&conn, first_session_id), Some("missing".to_string()));
-    assert_eq!(import_state_session_id(&conn, &first_sessions.join("first.jsonl")), None);
+    assert_eq!(
+      session_source_state(&conn, first_session_id),
+      Some("missing".to_string())
+    );
+    assert_eq!(
+      import_state_session_id(&conn, &first_sessions.join("first.jsonl")),
+      None
+    );
     assert!(first_sessions.join("first.jsonl").is_file());
   }
 
   #[test]
-  fn full_scan_retry_reconciles_previous_source_after_the_first_attempt_fails() {
+  fn failed_full_scan_rolls_back_freshness_and_retry_reconciles_previous_source() {
     let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
     let directory = tempdir().expect("tempdir");
     let first_codex_home = directory.path().join("codex-home-a");
@@ -5049,6 +7138,9 @@ mod tests {
     perform_scan(&db_path, None).expect("scan first default source");
 
     let conn = open_connection(&db_path).expect("open database");
+    let previous_full_scan_completed_at =
+      get_last_full_scan_completed(&conn).expect("load previous full freshness");
+    assert!(previous_full_scan_completed_at.is_some());
     conn
       .execute_batch(&format!(
         "
@@ -5064,11 +7156,15 @@ mod tests {
     drop(conn);
 
     std::env::set_var("CODEX_HOME", &second_codex_home);
-    let error = perform_incremental_scan(&db_path, None).expect_err("first moved-source scan should fail");
+    let error =
+      perform_incremental_scan(&db_path, None).expect_err("first moved-source scan should fail");
     assert!(error.contains("forced source reconciliation failure"));
 
     let conn = open_connection(&db_path).expect("reopen failed database");
-    assert_eq!(get_last_full_scan_completed(&conn).expect("load full freshness"), None);
+    assert_eq!(
+      get_last_full_scan_completed(&conn).expect("load rolled-back freshness"),
+      previous_full_scan_completed_at
+    );
     conn
       .execute_batch("DROP TRIGGER fail_previous_source_reconciliation;")
       .expect("drop reconciliation trigger");
@@ -5079,7 +7175,10 @@ mod tests {
     let conn = open_connection(&db_path).expect("open retried database");
     assert_eq!(retry.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
-    assert_eq!(session_source_state(&conn, first_session_id), Some("missing".to_string()));
+    assert_eq!(
+      session_source_state(&conn, first_session_id),
+      Some("missing".to_string())
+    );
     assert_eq!(import_state_session_id(&conn, &first_session_path), None);
     assert!(first_session_path.is_file());
   }
@@ -5105,7 +7204,9 @@ mod tests {
     perform_scan(&db_path, None).expect("initial full scan");
 
     let conn = open_connection(&db_path).expect("open initial database");
-    assert!(get_last_full_scan_completed(&conn).expect("load initial freshness").is_some());
+    assert!(get_last_full_scan_completed(&conn)
+      .expect("load initial freshness")
+      .is_some());
     conn
       .execute(
         "DELETE FROM data_repairs WHERE repair_key = ?1",
@@ -5135,7 +7236,10 @@ mod tests {
       )
       .optional()
       .expect("load pending rate-limit repair");
-    assert_eq!(pending_rate_limit_path.as_deref(), Some(session_path.to_string_lossy().as_ref()));
+    assert_eq!(
+      pending_rate_limit_path.as_deref(),
+      Some(session_path.to_string_lossy().as_ref())
+    );
     drop(conn);
 
     write_session_file(
@@ -5151,7 +7255,9 @@ mod tests {
     let conn = open_connection(&db_path).expect("open repaired database");
     assert_eq!(retry.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, session_id).3, 220);
-    assert!(get_last_full_scan_completed(&conn).expect("load repaired freshness").is_some());
+    assert!(get_last_full_scan_completed(&conn)
+      .expect("load repaired freshness")
+      .is_some());
     let pending_rate_limit_count: i64 = conn
       .query_row(
         "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
@@ -5170,9 +7276,8 @@ mod tests {
     std::fs::create_dir_all(&archived_sessions).expect("archived sessions");
 
     let session_id = "69696969-6969-4969-8969-696969696969";
-    let session_path = archived_sessions.join(format!(
-      "rollout-2026-07-10T00-00-00-{session_id}.jsonl"
-    ));
+    let session_path =
+      archived_sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
     write_session_file(
       &session_path,
       session_id,
@@ -5245,11 +7350,15 @@ mod tests {
     perform_scan(&db_path, None).expect("scan first default source");
 
     std::env::set_var("CODEX_HOME", &second_codex_home);
-    let partial = perform_incremental_scan(&db_path, None).expect("scan moved source with skipped archive");
+    let partial =
+      perform_incremental_scan(&db_path, None).expect("scan moved source with skipped archive");
     assert_eq!(partial.scanned_files, 2);
 
     let conn = open_connection(&db_path).expect("open partial database");
-    assert_eq!(get_last_full_scan_completed(&conn).expect("load full freshness"), None);
+    assert_eq!(
+      get_last_full_scan_completed(&conn).expect("load full freshness"),
+      None
+    );
     drop(conn);
 
     write_session_file(
@@ -5275,7 +7384,8 @@ mod tests {
       directory.path()
     );
     assert_eq!(
-      validate_codex_home(PathBuf::from("~/codex-home"), Some(directory.path())).expect("tilde prefix"),
+      validate_codex_home(PathBuf::from("~/codex-home"), Some(directory.path()))
+        .expect("tilde prefix"),
       nested
     );
   }
@@ -5291,7 +7401,11 @@ mod tests {
     let session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
     let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
     let archived_path = archived.join(active_path.file_name().expect("filename"));
-    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    write_session_file(
+      &active_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
@@ -5309,7 +7423,10 @@ mod tests {
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(session_usage_totals(&conn, session_id).3, 200);
-    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+    assert_eq!(
+      session_source_state(&conn, session_id).as_deref(),
+      Some("archived")
+    );
   }
 
   #[test]
@@ -5325,7 +7442,11 @@ mod tests {
     let session_id = "a0a0a0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0";
     let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
     let archived_path = archived.join(active_path.file_name().expect("filename"));
-    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    write_session_file(
+      &active_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
 
@@ -5346,11 +7467,15 @@ mod tests {
     drop(file);
     std::fs::rename(&active_path, &archived_path).expect("archive session");
 
-    let first_result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
-      .expect("import complete prefix from archive");
+    let first_result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+        .expect("import complete prefix from archive");
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(first_result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 10, 110, 1));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (100, 20, 10, 110, 1)
+    );
     let archived_state: i64 = conn
       .query_row(
         "SELECT COUNT(*) FROM import_state WHERE source_path = ?1 AND source_bucket = 'archived'",
@@ -5380,8 +7505,14 @@ mod tests {
       .expect("reimport finished archive");
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
-    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 20, 200, 2));
-    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 20, 200, 2)
+    );
+    assert_eq!(
+      session_source_state(&conn, session_id).as_deref(),
+      Some("archived")
+    );
   }
 
   #[test]
@@ -5397,7 +7528,11 @@ mod tests {
     let session_id = "a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1";
     let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
     let archived_path = archived.join(active_path.file_name().expect("filename"));
-    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    write_session_file(
+      &active_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
     write_session_file(
       &sessions.join("other.jsonl"),
       "a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2",
@@ -5442,7 +7577,10 @@ mod tests {
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(session_usage_totals(&conn, session_id).3, 200);
-    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+    assert_eq!(
+      session_source_state(&conn, session_id).as_deref(),
+      Some("archived")
+    );
   }
 
   #[test]
@@ -5458,12 +7596,18 @@ mod tests {
       &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
     );
     let index_path = codex_home.join("session_index.jsonl");
-    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"A\"}}\n"))
-      .expect("title A");
+    std::fs::write(
+      &index_path,
+      format!("{{\"id\":\"{session_id}\",\"thread_name\":\"A\"}}\n"),
+    )
+    .expect("title A");
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
-    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"B\"}}\n"))
-      .expect("title B");
+    std::fs::write(
+      &index_path,
+      format!("{{\"id\":\"{session_id}\",\"thread_name\":\"B\"}}\n"),
+    )
+    .expect("title B");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db");
@@ -5502,7 +7646,8 @@ mod tests {
     drop(file);
 
     let db_path = directory.path().join("usage.sqlite");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan skips bad file");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("scan skips bad file");
     let conn = open_connection(&db_path).expect("open db");
     let sessions_count: i64 = conn
       .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
@@ -5537,14 +7682,20 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
     let conn = open_connection(&db_path).expect("open db");
     conn
-      .execute("DELETE FROM conversation_links WHERE session_id = ?1", params![child])
+      .execute(
+        "DELETE FROM conversation_links WHERE session_id = ?1",
+        params![child],
+      )
       .expect("remove link");
     drop(conn);
 
     perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
       .expect("repair scan");
     let conn = open_connection(&db_path).expect("open db");
-    assert_eq!(conversation_link(&conn, child).expect("child link").0, parent);
+    assert_eq!(
+      conversation_link(&conn, child).expect("child link").0,
+      parent
+    );
   }
 
   #[test]
@@ -5581,7 +7732,10 @@ mod tests {
       .expect("repair scan");
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(
-      conversation_link(&conn, child).expect("child link").1.as_deref(),
+      conversation_link(&conn, child)
+        .expect("child link")
+        .1
+        .as_deref(),
       Some(parent)
     );
   }
@@ -5659,11 +7813,7 @@ mod tests {
           "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
           "}}}}\n"
         ),
-        timestamp,
-        input_tokens,
-        cached_input_tokens,
-        output_tokens,
-        total_tokens
+        timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens
       ));
     }
 
@@ -5676,7 +7826,10 @@ mod tests {
     parent_session_id: &str,
     snapshots: &[(&str, i64, i64, i64, i64)],
   ) {
-    let first_timestamp = snapshots.first().map(|item| item.0).unwrap_or("2026-03-24T00:00:00Z");
+    let first_timestamp = snapshots
+      .first()
+      .map(|item| item.0)
+      .unwrap_or("2026-03-24T00:00:00Z");
     let mut body = format!(
       concat!(
         "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
@@ -5708,11 +7861,7 @@ mod tests {
           "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
           "}}}}\n"
         ),
-        timestamp,
-        input_tokens,
-        cached_input_tokens,
-        output_tokens,
-        total_tokens
+        timestamp, input_tokens, cached_input_tokens, output_tokens, total_tokens
       ));
     }
 
@@ -5730,7 +7879,10 @@ mod tests {
       .expect("query root and subagents")
   }
 
-  fn conversation_link(conn: &Connection, session_id: &str) -> Option<(String, Option<String>, i64)> {
+  fn conversation_link(
+    conn: &Connection,
+    session_id: &str,
+  ) -> Option<(String, Option<String>, i64)> {
     conn
       .query_row(
         "
@@ -5759,7 +7911,15 @@ mod tests {
         WHERE session_id = ?1
         ",
         params![session_id],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        |row| {
+          Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+          ))
+        },
       )
       .expect("query usage totals")
   }

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -120,6 +120,8 @@ fn perform_scan_with_scope(
 
   let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
+  let pending_rate_limit_repair_paths =
+    load_pending_data_repair_paths(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY).map_err(|error| error.to_string())?;
   let needs_token_usage_repair_sweep =
     data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
   let pending_token_repair_paths =
@@ -148,7 +150,10 @@ fn perform_scan_with_scope(
   let mut changed_files = Vec::new();
   for session_file in &session_files {
     let source_path = session_file.path.to_string_lossy().to_string();
-    if needs_rate_limit_backfill || needs_token_usage_repair_sweep || pending_token_repair_paths.contains(&source_path)
+    if needs_rate_limit_backfill
+      || pending_rate_limit_repair_paths.contains(&source_path)
+      || needs_token_usage_repair_sweep
+      || pending_token_repair_paths.contains(&source_path)
     {
       changed_files.push(session_file);
       continue;
@@ -184,6 +189,8 @@ fn perform_scan_with_scope(
 
     for session_file in changed_files {
       let source_path = session_file.path.to_string_lossy().to_string();
+      let file_needs_rate_limit_repair =
+        needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
       let file_needs_token_repair =
         needs_token_usage_repair_sweep || pending_token_repair_paths.contains(&source_path);
       let parsed = match parse_session_file(session_file, &titles) {
@@ -197,6 +204,10 @@ fn perform_scan_with_scope(
           );
           if file_needs_token_repair {
             mark_data_repair_file_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path, &error)
+              .map_err(|error| error.to_string())?;
+          }
+          if file_needs_rate_limit_repair {
+            mark_data_repair_file_pending(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path, &error)
               .map_err(|error| error.to_string())?;
           }
           continue;
@@ -219,6 +230,10 @@ fn perform_scan_with_scope(
       }
 
       persist_session(&mut conn, session_file, &parsed, &catalog).map_err(|error| error.to_string())?;
+      if file_needs_rate_limit_repair {
+        clear_pending_data_repair_file(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)
+          .map_err(|error| error.to_string())?;
+      }
       if file_needs_token_repair {
         clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)
           .map_err(|error| error.to_string())?;
@@ -232,8 +247,21 @@ fn perform_scan_with_scope(
   }
 
   if effective_scope == ScanScope::Full {
-    mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
-    prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
+    // A full scan that is required for freshness is authoritative even on retry:
+    // paths outside the resolved source must not remain active just because they still exist.
+    let reconcile_existing_absent_sources = scan_freshness_start.full_scan_required;
+    mark_missing_sources(
+      &conn,
+      &present_paths,
+      reconcile_existing_absent_sources,
+    )
+    .map_err(|error| error.to_string())?;
+    prune_import_state(
+      &conn,
+      &present_paths,
+      reconcile_existing_absent_sources,
+    )
+    .map_err(|error| error.to_string())?;
   } else {
     mark_missing_active_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
   }
@@ -268,6 +296,7 @@ fn perform_scan_with_scope(
       scan_source_selector.as_deref(),
       &resolved_codex_home,
       effective_scope == ScanScope::Full && !skipped_session_files,
+      effective_scope == ScanScope::Full && skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
@@ -1273,13 +1302,19 @@ fn conversation_links_need_repair(conn: &Connection) -> rusqlite::Result<bool> {
   )
 }
 
-fn mark_missing_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
+fn mark_missing_sources(
+  conn: &Connection,
+  present_paths: &HashSet<String>,
+  reconcile_existing_absent_sources: bool,
+) -> rusqlite::Result<()> {
   let mut stmt = conn.prepare("SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL")?;
   let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
 
   for row in rows {
     let (session_id, source_path) = row?;
-    if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
+    if !present_paths.contains(&source_path)
+      && (reconcile_existing_absent_sources || !Path::new(&source_path).exists())
+    {
       conn.execute(
         "
         UPDATE sessions
@@ -1324,12 +1359,18 @@ fn mark_missing_active_sources(conn: &Connection, present_paths: &HashSet<String
   Ok(())
 }
 
-fn prune_import_state(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
+fn prune_import_state(
+  conn: &Connection,
+  present_paths: &HashSet<String>,
+  reconcile_existing_absent_sources: bool,
+) -> rusqlite::Result<()> {
   let mut stmt = conn.prepare("SELECT source_path FROM import_state")?;
   let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
   for row in rows {
     let source_path = row?;
-    if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
+    if !present_paths.contains(&source_path)
+      && (reconcile_existing_absent_sources || !Path::new(&source_path).exists())
+    {
       conn.execute(
         "DELETE FROM import_state WHERE source_path = ?1",
         params![source_path],
@@ -2966,7 +3007,7 @@ mod tests {
   }
 
   #[test]
-  fn incremental_scan_finds_untracked_archives_after_default_source_moves() {
+  fn moved_default_source_reconciles_sessions_from_the_previous_existing_home() {
     let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
     let directory = tempdir().expect("tempdir");
     let first_codex_home = directory.path().join("codex-home-a");
@@ -3014,6 +3055,152 @@ mod tests {
     assert_eq!(result.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
     assert_eq!(session_usage_totals(&conn, first_session_id).3, 110);
+    assert_eq!(session_source_state(&conn, first_session_id), Some("missing".to_string()));
+    assert_eq!(import_state_session_id(&conn, &first_sessions.join("first.jsonl")), None);
+    assert!(first_sessions.join("first.jsonl").is_file());
+  }
+
+  #[test]
+  fn full_scan_retry_reconciles_previous_source_after_the_first_attempt_fails() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let first_codex_home = directory.path().join("codex-home-a");
+    let second_codex_home = directory.path().join("codex-home-b");
+    let first_sessions = first_codex_home.join("sessions");
+    let second_sessions = second_codex_home.join("sessions");
+    std::fs::create_dir_all(&first_sessions).expect("first sessions");
+    std::fs::create_dir_all(&second_sessions).expect("second sessions");
+
+    let first_session_id = "19191919-1919-1919-1919-191919191919";
+    let first_session_path = first_sessions.join("first.jsonl");
+    write_session_file(
+      &first_session_path,
+      first_session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let second_session_id = "29292929-2929-2929-2929-292929292929";
+    write_session_file(
+      &second_sessions.join("second.jsonl"),
+      second_session_id,
+      &[("2026-07-10T01:00:00Z", 200, 40, 20, 220)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    let _environment = CodexHomeEnvGuard::set(&first_codex_home);
+    perform_scan(&db_path, None).expect("scan first default source");
+
+    let conn = open_connection(&db_path).expect("open database");
+    conn
+      .execute_batch(&format!(
+        "
+        CREATE TRIGGER fail_previous_source_reconciliation
+        BEFORE UPDATE OF source_state ON sessions
+        WHEN OLD.session_id = '{first_session_id}'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced source reconciliation failure');
+        END;
+        "
+      ))
+      .expect("create reconciliation trigger");
+    drop(conn);
+
+    std::env::set_var("CODEX_HOME", &second_codex_home);
+    let error = perform_incremental_scan(&db_path, None).expect_err("first moved-source scan should fail");
+    assert!(error.contains("forced source reconciliation failure"));
+
+    let conn = open_connection(&db_path).expect("reopen failed database");
+    assert_eq!(get_last_full_scan_completed(&conn).expect("load full freshness"), None);
+    conn
+      .execute_batch("DROP TRIGGER fail_previous_source_reconciliation;")
+      .expect("drop reconciliation trigger");
+    drop(conn);
+
+    let retry = perform_incremental_scan(&db_path, None).expect("retry moved default source");
+
+    let conn = open_connection(&db_path).expect("open retried database");
+    assert_eq!(retry.scanned_files, 1);
+    assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
+    assert_eq!(session_source_state(&conn, first_session_id), Some("missing".to_string()));
+    assert_eq!(import_state_session_id(&conn, &first_session_path), None);
+    assert!(first_session_path.is_file());
+  }
+
+  #[test]
+  fn partial_full_scan_invalidates_freshness_and_tracks_skipped_rate_limit_backfill() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let archived_sessions = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&archived_sessions).expect("archived sessions");
+
+    let session_id = "39393939-3939-3939-3939-393939393939";
+    let session_path = archived_sessions.join("archive.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    let _environment = CodexHomeEnvGuard::set(&codex_home);
+    perform_scan(&db_path, None).expect("initial full scan");
+
+    let conn = open_connection(&db_path).expect("open initial database");
+    assert!(get_last_full_scan_completed(&conn).expect("load initial freshness").is_some());
+    conn
+      .execute(
+        "DELETE FROM data_repairs WHERE repair_key = ?1",
+        params![RATE_LIMIT_SAMPLE_BACKFILL_KEY],
+      )
+      .expect("make rate-limit backfill pending");
+    drop(conn);
+
+    std::fs::write(&session_path, [0xff, 0xfe, 0xfd]).expect("corrupt archived session");
+    perform_scan(&db_path, None).expect("partial full scan");
+
+    let conn = open_connection(&db_path).expect("open partial database");
+    let (completed, full_completed): (Option<String>, Option<String>) = conn
+      .query_row(
+        "SELECT last_scan_completed_at, last_full_scan_completed_at FROM sync_settings WHERE singleton_id = 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+      )
+      .expect("load partial scan freshness");
+    assert!(completed.is_some());
+    assert_eq!(full_completed, None);
+    let pending_rate_limit_path: Option<String> = conn
+      .query_row(
+        "SELECT source_path FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![RATE_LIMIT_SAMPLE_BACKFILL_KEY],
+        |row| row.get(0),
+      )
+      .optional()
+      .expect("load pending rate-limit repair");
+    assert_eq!(pending_rate_limit_path.as_deref(), Some(session_path.to_string_lossy().as_ref()));
+    drop(conn);
+
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 200, 40, 20, 220),
+      ],
+    );
+    let retry = perform_incremental_scan(&db_path, None).expect("retry repaired archive");
+
+    let conn = open_connection(&db_path).expect("open repaired database");
+    assert_eq!(retry.scanned_files, 1);
+    assert_eq!(session_usage_totals(&conn, session_id).3, 220);
+    assert!(get_last_full_scan_completed(&conn).expect("load repaired freshness").is_some());
+    let pending_rate_limit_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![RATE_LIMIT_SAMPLE_BACKFILL_KEY],
+        |row| row.get(0),
+      )
+      .expect("count pending rate-limit repairs");
+    assert_eq!(pending_rate_limit_count, 0);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -258,7 +258,7 @@ fn perform_scan_with_scope(
           continue;
         }
       };
-      assign_inherited_token_snapshot_cutoff(
+      let replay_parent_unavailable = assign_inherited_token_snapshot_cutoff(
         &mut parsed,
         &session_source_paths,
         &mut parent_snapshot_cache,
@@ -274,7 +274,8 @@ fn perform_scan_with_scope(
         &parsed.raw_session.session_id,
       );
       file_needs_token_v2_repair |= !related_pending_token_v2_paths.is_empty();
-      file_needs_fork_replay_v3_repair |= !related_pending_fork_replay_v3_paths.is_empty();
+      file_needs_fork_replay_v3_repair |=
+        replay_parent_unavailable || !related_pending_fork_replay_v3_paths.is_empty();
       imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
       match classify_topology_maintenance(
@@ -305,11 +306,21 @@ fn perform_scan_with_scope(
         }
       }
       if file_needs_fork_replay_v3_repair {
-        clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
-          .map_err(|error| error.to_string())?;
-        for related_source_path in related_pending_fork_replay_v3_paths {
-          clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &related_source_path)
+        if replay_parent_unavailable {
+          mark_data_repair_file_pending(
+            &conn,
+            TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+            &source_path,
+            "fork replay parent unavailable",
+          )
             .map_err(|error| error.to_string())?;
+        } else {
+          clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
+            .map_err(|error| error.to_string())?;
+          for related_source_path in related_pending_fork_replay_v3_paths {
+            clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &related_source_path)
+              .map_err(|error| error.to_string())?;
+          }
         }
       }
       changed_sessions += 1;
@@ -1050,16 +1061,16 @@ fn assign_inherited_token_snapshot_cutoff(
   parsed: &mut ParsedSession,
   session_source_paths: &HashMap<String, PathBuf>,
   parent_snapshot_cache: &mut HashMap<String, Option<Vec<UsageSnapshot>>>,
-) {
+) -> bool {
   let Some(parent_session_id) = parsed
     .explicit_forked_from_id
     .as_deref()
     .filter(|session_id| !session_id.trim().is_empty())
   else {
-    return;
+    return false;
   };
   let Some(fork_timestamp) = parsed.explicit_fork_timestamp else {
-    return;
+    return false;
   };
 
   if !parent_snapshot_cache.contains_key(parent_session_id) {
@@ -1092,7 +1103,7 @@ fn assign_inherited_token_snapshot_cutoff(
     .get(parent_session_id)
     .and_then(Option::as_deref)
   else {
-    return;
+    return true;
   };
 
   parsed.inherited_token_snapshot_cutoff = replayed_child_snapshot_cutoff(
@@ -1100,6 +1111,7 @@ fn assign_inherited_token_snapshot_cutoff(
     &parsed.snapshots,
     Some(fork_timestamp),
   );
+  false
 }
 
 fn read_parent_replay_snapshots(
@@ -3682,6 +3694,98 @@ mod tests {
         |row| row.get(0),
       )
       .expect("count pending v3 repair files");
+    assert_eq!(pending_v3_count, 0);
+  }
+
+  #[test]
+  fn fork_repair_retries_child_after_parent_source_recovers() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "63636363-6363-4363-8363-636363636363";
+    let child_session_id = "64646464-6464-4464-8464-646464646464";
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    std::fs::write(&parent_path, "not json\n").expect("write unavailable parent");
+    let inherited = TokenFixture {
+      timestamp: "2026-03-24T00:30:00Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    };
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:30:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_session_id,
+      parent_session_id,
+    );
+    child_body.push_str(&token_count_line(inherited));
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (150, 0, 0, 150),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write fork child");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+
+    let conn = open_connection(&db_path).expect("open initial db");
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 150);
+    let pending_child_count: i64 = conn
+      .query_row(
+        "
+        SELECT COUNT(*)
+        FROM data_repair_pending_files
+        WHERE repair_key = ?1 AND source_path = ?2
+        ",
+        params![
+          TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+          child_path.to_string_lossy().to_string()
+        ],
+        |row| row.get(0),
+      )
+      .expect("count pending child repair");
+    assert_eq!(pending_child_count, 1);
+    drop(conn);
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    parent_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:00Z",
+      ..inherited
+    }));
+    std::fs::write(&parent_path, parent_body).expect("restore parent source");
+    let retry = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("retry recovered parent and child");
+
+    let conn = open_connection(&db_path).expect("open repaired db");
+    assert_eq!(retry.updated_sessions, 2);
+    assert_eq!(session_usage_totals(&conn, parent_session_id).3, 100);
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 50);
+    let pending_v3_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY],
+        |row| row.get(0),
+      )
+      .expect("count pending v3 repairs");
     assert_eq!(pending_v3_count, 0);
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -126,6 +126,31 @@ const PARSER_PREFIX_SIGNATURE_BYTES: u64 = 128;
 const PARENT_REPLAY_CACHE_MAX_ENTRIES: usize = 4;
 const PARENT_REPLAY_CACHE_MAX_BYTES: usize = 256 * 1024;
 
+struct RefreshMemoryRelief;
+
+impl Drop for RefreshMemoryRelief {
+  fn drop(&mut self) {
+    release_unused_process_memory();
+  }
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+  fn malloc_zone_pressure_relief(zone: *mut std::ffi::c_void, goal: usize) -> usize;
+}
+
+#[cfg(target_os = "macos")]
+fn release_unused_process_memory() {
+  // SAFETY: A null zone asks the macOS allocator to visit every registered zone.
+  // The call only releases pages currently unused by those zones.
+  unsafe {
+    malloc_zone_pressure_relief(std::ptr::null_mut(), 0);
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn release_unused_process_memory() {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScanKind {
   Full,
@@ -1105,6 +1130,7 @@ pub(crate) fn prepare_scan(
 }
 
 pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult, String> {
+  let _memory_relief = RefreshMemoryRelief;
   let PreparedScan {
     db_path,
     source_identity,

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1380,6 +1380,60 @@ mod tests {
   }
 
   #[test]
+  fn scan_prices_gpt_56_sol_at_standard_api_equivalent_value() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "56565656-5656-5656-5656-565656565656";
+    let session_path = sessions_dir.join("gpt56-sol.jsonl");
+    std::fs::write(
+      &session_path,
+      concat!(
+        "{\"timestamp\":\"2026-07-09T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"56565656-5656-5656-5656-565656565656\"}}\n",
+        "{\"timestamp\":\"2026-07-09T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.6-sol\"}}\n",
+        "{\"timestamp\":\"2026-07-09T00:00:02Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":25,\"output_tokens\":40,\"reasoning_output_tokens\":0,\"total_tokens\":140}},\"rate_limits\":{\"plan_type\":\"pro\"}}}\n"
+      ),
+    )
+    .expect("write GPT-5.6 Sol session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let (input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd):
+      (i64, i64, i64, i64, f64) = conn
+      .query_row(
+        "
+        SELECT input_tokens, cached_input_tokens, output_tokens, total_tokens, value_usd
+        FROM usage_events
+        WHERE session_id = ?1
+        ",
+        params![session_id],
+        |row| {
+          Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+          ))
+        },
+      )
+      .expect("query usage");
+
+    assert_eq!(input_tokens, 100);
+    assert_eq!(cached_input_tokens, 25);
+    assert_eq!(output_tokens, 40);
+    assert_eq!(total_tokens, 140);
+    let standard = (75.0 / 1_000_000.0) * 5.0
+      + (25.0 / 1_000_000.0) * 0.5
+      + (40.0 / 1_000_000.0) * 30.0;
+    assert!((value_usd - standard).abs() < 1e-9);
+  }
+
+  #[test]
   fn import_state_mismatch_reimports_even_when_file_metadata_is_unchanged() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -141,10 +141,10 @@ fn perform_scan_with_scope(
     pending_repair_session_ids(&import_state, &pending_token_v2_repair_paths);
   let pending_fork_replay_v3_repair_session_ids =
     pending_repair_session_ids(&import_state, &pending_fork_replay_v3_repair_paths);
-  let pending_token_repair_session_ids = pending_token_v2_repair_session_ids
-    .union(&pending_fork_replay_v3_repair_session_ids)
-    .cloned()
-    .collect::<HashSet<_>>();
+  let mut pending_repair_session_ids =
+    pending_repair_session_ids(&import_state, &pending_rate_limit_repair_paths);
+  pending_repair_session_ids.extend(pending_token_v2_repair_session_ids.iter().cloned());
+  pending_repair_session_ids.extend(pending_fork_replay_v3_repair_session_ids.iter().cloned());
   let needs_token_usage_repair_sweep =
     needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
   let effective_scope = effective_scan_scope(
@@ -158,7 +158,7 @@ fn perform_scan_with_scope(
   let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
     ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
     ScanScope::Incremental => {
-      collect_incremental_session_files(&codex_home, &import_state, &pending_token_repair_session_ids)
+      collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
     }
   };
   let session_source_paths =
@@ -4965,6 +4965,57 @@ mod tests {
     assert_eq!(retry.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, session_id).3, 220);
     assert!(get_last_full_scan_completed(&conn).expect("load repaired freshness").is_some());
+    let pending_rate_limit_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![RATE_LIMIT_SAMPLE_BACKFILL_KEY],
+        |row| row.get(0),
+      )
+      .expect("count pending rate-limit repairs");
+    assert_eq!(pending_rate_limit_count, 0);
+  }
+
+  #[test]
+  fn incremental_scan_retries_unchanged_pending_rate_limit_archive() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let archived_sessions = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&archived_sessions).expect("archived sessions");
+
+    let session_id = "69696969-6969-4969-8969-696969696969";
+    let session_path = archived_sessions.join(format!(
+      "rollout-2026-07-10T00-00-00-{session_id}.jsonl"
+    ));
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-07-10T00:00:01Z", 80, 0, 20, 100)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    conn
+      .execute(
+        "
+        INSERT INTO data_repair_pending_files (repair_key, source_path, last_error, updated_at)
+        VALUES (?1, ?2, 'temporary read failure', ?3)
+        ",
+        params![
+          RATE_LIMIT_SAMPLE_BACKFILL_KEY,
+          session_path.to_string_lossy().to_string(),
+          now_utc_string(),
+        ],
+      )
+      .expect("insert pending rate-limit archive");
+    drop(conn);
+
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("retry unchanged rate-limit archive");
+
+    let conn = open_connection(&db_path).expect("open retried db");
+    assert_eq!(result.updated_sessions, 1);
     let pending_rate_limit_count: i64 = conn
       .query_row(
         "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -14,9 +14,9 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, now_utc_string, open_connection, preview_scan_freshness_for_source,
-  replace_session_rate_limit_samples, set_last_scan_started_for_source_in_transaction,
-  set_scan_completed_for_source,
+  bool_to_i64, insert_usage_events, now_utc_string, open_connection,
+  preview_scan_freshness_for_source, replace_session_rate_limit_samples,
+  set_last_scan_started_for_source_in_transaction, set_scan_completed_for_source, NewUsageEvent,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
@@ -2642,57 +2642,54 @@ fn persist_session(
     .and_then(|index| parsed.snapshots.get(index))
     .map(|snapshot| snapshot.usage.clone());
 
-  for snapshot in parsed.snapshots.iter().skip(snapshot_cutoff) {
-    if previous_usage.as_ref() == Some(&snapshot.usage) {
-      continue;
-    }
-
-    let delta = if let Some(previous) = previous_usage.as_ref() {
-      if snapshot.usage.total_tokens <= previous.total_tokens {
-        continue;
+  insert_usage_events(
+    conn,
+    parsed
+      .snapshots
+      .iter()
+      .skip(snapshot_cutoff)
+      .map(|snapshot| snapshot.timestamp.as_str()),
+    |index| {
+      let snapshot = &parsed.snapshots[snapshot_cutoff + index];
+      if previous_usage.as_ref() == Some(&snapshot.usage) {
+        return None;
       }
-      diff_usage(previous, &snapshot.usage)
-    } else if parsed.explicit_forked_from_id.is_some() {
-      snapshot
-        .last_token_usage
-        .clone()
-        .unwrap_or_else(|| snapshot.usage.clone())
-    } else {
-      snapshot.usage.clone()
-    };
 
-    previous_usage = Some(snapshot.usage.clone());
+      let delta = if let Some(previous) = previous_usage.as_ref() {
+        if snapshot.usage.total_tokens <= previous.total_tokens {
+          return None;
+        }
+        diff_usage(previous, &snapshot.usage)
+      } else if parsed.explicit_forked_from_id.is_some() {
+        snapshot
+          .last_token_usage
+          .clone()
+          .unwrap_or_else(|| snapshot.usage.clone())
+      } else {
+        snapshot.usage.clone()
+      };
 
-    if is_zero_delta(&delta) {
-      continue;
-    }
+      previous_usage = Some(snapshot.usage.clone());
+      if is_zero_delta(&delta) {
+        return None;
+      }
 
-    let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
-    let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
-
-    conn.execute(
-      "
-      INSERT INTO usage_events (
-        session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
-        reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective
-      )
-      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
-      ",
-      params![
-        parsed.raw_session.session_id,
-        snapshot.timestamp,
-        normalize_model_id(&snapshot.model_id),
-        delta.input_tokens,
-        delta.cached_input_tokens,
-        delta.output_tokens,
-        delta.reasoning_output_tokens,
-        delta.total_tokens,
+      let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
+      let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
+      Some(NewUsageEvent {
+        session_id: &parsed.raw_session.session_id,
+        model_id: normalize_model_id(&snapshot.model_id),
+        input_tokens: delta.input_tokens,
+        cached_input_tokens: delta.cached_input_tokens,
+        output_tokens: delta.output_tokens,
+        reasoning_output_tokens: delta.reasoning_output_tokens,
+        total_tokens: delta.total_tokens,
         value_usd,
-        0,
-        0,
-      ],
-    )?;
-  }
+        fast_mode_auto: false,
+        fast_mode_effective: false,
+      })
+    },
+  )?;
 
   conn.execute(
     "
@@ -5231,6 +5228,58 @@ mod tests {
     assert_eq!(samples.2, "seven_day".to_string());
     assert_eq!(samples.3, 79);
     assert_eq!(samples.4, 88);
+  }
+
+  #[test]
+  fn scan_persists_usage_event_epoch_timestamp() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_path = sessions_dir.join("usage-epoch.jsonl");
+    std::fs::write(
+      &session_path,
+      concat!(
+        "{\"timestamp\":\"2026-07-10T10:00:00+08:00\",\"type\":\"session_meta\",\"payload\":{\"id\":\"98989898-9898-4898-8898-989898989898\"}}\n",
+        "{\"timestamp\":\"2026-07-10T10:00:01+08:00\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n",
+        "{\"timestamp\":\"2026-07-10T10:00:02+08:00\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":25,\"reasoning_output_tokens\":0,\"total_tokens\":125}}}}\n"
+      ),
+    )
+    .expect("write session");
+    let db_path = directory.path().join("usage.sqlite");
+
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    let persisted = conn
+      .query_row(
+        "SELECT timestamp, timestamp_ms FROM usage_events",
+        [],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+      )
+      .expect("load usage epoch");
+    assert_eq!(persisted.0, "2026-07-10T10:00:02+08:00");
+    assert_eq!(
+      persisted.1,
+      Some(
+        crate::database::parse_epoch_millis(&persisted.0).expect("parse expected usage epoch")
+      )
+    );
+  }
+
+  #[test]
+  fn persist_session_delegates_usage_inserts_to_database_writer() {
+    let source = include_str!("importer.rs");
+    let persist_session_source = source
+      .split("fn persist_session(")
+      .nth(1)
+      .expect("persist_session source")
+      .split("fn diff_usage(")
+      .next()
+      .expect("persist_session body");
+
+    assert!(persist_session_source.contains("insert_usage_events("));
+    assert!(!persist_session_source.contains("INSERT INTO usage_events"));
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2033,9 +2033,18 @@ fn try_parse_session_tail_counted(
         reader.get_ref().bytes_read,
       )
     })?;
-    if line_bytes == 0 || !line.ends_with('\n') {
+    if line_bytes == 0 {
       break;
     }
+    let has_trailing_newline = line.ends_with('\n');
+    let value = match serde_json::from_str::<Value>(&line) {
+      Ok(value) => value,
+      Err(_) if !has_trailing_newline => break,
+      Err(_) => {
+        completed_offset = completed_offset.saturating_add(line_bytes as u64);
+        continue;
+      }
+    };
     completed_offset = completed_offset.saturating_add(line_bytes as u64);
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
@@ -2043,9 +2052,6 @@ fn try_parse_session_tail_counted(
     if line.contains("\"fast_mode\":false") || line.contains("\"quick_mode\":false") {
       explicit_fast_mode = Some(false);
     }
-    let Ok(value) = serde_json::from_str::<Value>(&line) else {
-      continue;
-    };
     let timestamp = value
       .get("timestamp")
       .and_then(Value::as_str)
@@ -2236,9 +2242,15 @@ fn parse_session_file_once(
     if line_bytes == 0 {
       break;
     }
-    if !line.ends_with('\n') {
-      break;
-    }
+    let has_trailing_newline = line.ends_with('\n');
+    let value = match serde_json::from_str::<Value>(&line) {
+      Ok(value) => value,
+      Err(_) if !has_trailing_newline => break,
+      Err(_) => {
+        completed_offset = completed_offset.saturating_add(line_bytes as u64);
+        continue;
+      }
+    };
     completed_offset = completed_offset.saturating_add(line_bytes as u64);
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
@@ -2246,10 +2258,6 @@ fn parse_session_file_once(
     if line.contains("\"fast_mode\":false") || line.contains("\"quick_mode\":false") {
       explicit_fast_mode = Some(false);
     }
-
-    let Ok(value) = serde_json::from_str::<Value>(&line) else {
-      continue;
-    };
 
     if session_id.is_empty() {
       if let Some(id) = value.get("id").and_then(Value::as_str) {
@@ -7282,7 +7290,7 @@ mod tests {
   }
 
   #[test]
-  fn incomplete_trailing_token_line_is_ignored_until_next_rescan() {
+  fn complete_trailing_token_line_without_newline_is_imported_once() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions_dir = codex_home.join("sessions");
@@ -7312,31 +7320,24 @@ mod tests {
         "{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"55555555-5555-5555-5555-555555555555\"}}\n",
         "{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n",
         "{\"timestamp\":\"2026-03-24T00:00:01Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":25,\"reasoning_output_tokens\":0,\"total_tokens\":125}},\"rate_limits\":{\"plan_type\":\"pro\"}}}\n",
-        "{\"timestamp\":\"2026-03-24T00:00:10Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":40,\"output_tokens\":45,\"reasoning_output_tokens\":0,\"total_tokens\":225}},\"rate_limits\":{\"plan_type\":\"pro\"}}"
+        "{\"timestamp\":\"2026-03-24T00:00:10Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":180,\"cached_input_tokens\":40,\"output_tokens\":45,\"reasoning_output_tokens\":0,\"total_tokens\":225}},\"rate_limits\":{\"plan_type\":\"pro\"}}}"
       ),
     )
-    .expect("write incomplete session");
+    .expect("write complete session without trailing newline");
 
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
 
-    let conn = open_connection(&db_path).expect("open db after incomplete rescan");
+    let conn = open_connection(&db_path).expect("open db after no-newline rescan");
     assert_eq!(
       session_usage_totals(&conn, session_id),
-      (100, 20, 25, 125, 1)
+      (180, 40, 45, 225, 2)
     );
     drop(conn);
 
-    write_session_file(
-      &session_path,
-      session_id,
-      &[
-        ("2026-03-24T00:00:01Z", 100, 20, 25, 125),
-        ("2026-03-24T00:00:10Z", 180, 40, 45, 225),
-      ],
-    );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("third scan");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("unchanged third scan");
 
-    let conn = open_connection(&db_path).expect("open db after third scan");
+    let conn = open_connection(&db_path).expect("open db after unchanged scan");
     assert_eq!(
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -14,9 +14,10 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, insert_usage_events, now_utc_string, open_connection,
+  bool_to_i64, now_utc_string, open_connection,
   preview_scan_freshness_for_source, replace_session_rate_limit_samples,
-  set_last_scan_started_for_source_in_transaction, set_scan_completed_for_source, NewUsageEvent,
+  replace_session_usage_events, set_last_scan_started_for_source_in_transaction,
+  set_scan_completed_for_source, NewUsageEvent,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
@@ -2626,10 +2627,6 @@ fn persist_session(
     ],
   )?;
 
-  conn.execute(
-    "DELETE FROM usage_events WHERE session_id = ?1",
-    params![parsed.raw_session.session_id],
-  )?;
   replace_session_rate_limit_samples(
     conn,
     &parsed.raw_session.session_id,
@@ -2669,8 +2666,9 @@ fn persist_session(
     usage_event_plan.push((snapshot_index, delta));
   }
 
-  insert_usage_events(
+  replace_session_usage_events(
     conn,
+    &parsed.raw_session.session_id,
     usage_event_plan
       .iter()
       .map(|(snapshot_index, _)| parsed.snapshots[*snapshot_index].timestamp.as_str()),
@@ -5431,7 +5429,7 @@ mod tests {
       .next()
       .expect("persist_session body");
 
-    assert!(persist_session_source.contains("insert_usage_events("));
+    assert!(persist_session_source.contains("replace_session_usage_events("));
     assert!(!persist_session_source.contains("INSERT INTO usage_events"));
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-use chrono::{Local, LocalResult, TimeZone, Timelike};
+use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Timelike};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde_json::Value;
 use walkdir::WalkDir;
@@ -30,6 +30,10 @@ struct ParsedSession {
   raw_session: RawSession,
   snapshots: Vec<UsageSnapshot>,
   rate_limit_samples: Vec<RateLimitSampleRecord>,
+  #[allow(dead_code)]
+  explicit_forked_from_id: Option<String>,
+  #[allow(dead_code)]
+  explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
   explicit_fast_mode: Option<bool>,
   latest_plan_type: Option<String>,
   last_model_id: Option<String>,
@@ -39,6 +43,8 @@ struct ParsedSession {
 struct SessionMetaCandidate {
   session_id: String,
   parent_session_id: Option<String>,
+  explicit_forked_from_id: Option<String>,
+  explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
   agent_nickname: Option<String>,
   agent_role: Option<String>,
 }
@@ -651,6 +657,8 @@ fn parse_session_file_once(
   let mut current_model: Option<String> = None;
   let mut agent_nickname: Option<String> = None;
   let mut agent_role: Option<String> = None;
+  let mut explicit_forked_from_id: Option<String> = None;
+  let mut explicit_fork_timestamp: Option<DateTime<FixedOffset>> = None;
   let mut explicit_fast_mode: Option<bool> = None;
   let mut latest_plan_type: Option<String> = None;
   let mut snapshots = Vec::new();
@@ -695,10 +703,12 @@ fn parse_session_file_once(
     match value.get("type").and_then(Value::as_str).unwrap_or_default() {
       "session_meta" => {
         let payload = value.get("payload").unwrap_or(&Value::Null);
-        let parent = payload
+        let candidate_explicit_forked_from_id = payload
           .get("forked_from_id")
           .and_then(Value::as_str)
-          .map(ToString::to_string)
+          .map(ToString::to_string);
+        let parent = candidate_explicit_forked_from_id
+          .clone()
           .or_else(|| {
             payload
               .get("source")
@@ -708,6 +718,10 @@ fn parse_session_file_once(
               .and_then(Value::as_str)
               .map(ToString::to_string)
           });
+        let candidate_explicit_fork_timestamp = candidate_explicit_forked_from_id
+          .as_ref()
+          .and_then(|_| timestamp.as_deref())
+          .and_then(|timestamp| DateTime::parse_from_rfc3339(timestamp).ok());
 
         let nickname = payload
           .get("agent_nickname")
@@ -741,6 +755,8 @@ fn parse_session_file_once(
           let candidate = SessionMetaCandidate {
             session_id: id.to_string(),
             parent_session_id: parent,
+            explicit_forked_from_id: candidate_explicit_forked_from_id,
+            explicit_fork_timestamp: candidate_explicit_fork_timestamp,
             agent_nickname: nickname,
             agent_role: role,
           };
@@ -784,6 +800,16 @@ fn parse_session_file_once(
           reasoning_output_tokens: read_i64(total_usage, "reasoning_output_tokens"),
           total_tokens: read_total_tokens(total_usage),
         };
+        let last_token_usage = info
+          .get("last_token_usage")
+          .filter(|last_usage| !last_usage.is_null())
+          .map(|last_usage| TokenUsage {
+            input_tokens: read_i64(last_usage, "input_tokens"),
+            cached_input_tokens: read_i64(last_usage, "cached_input_tokens"),
+            output_tokens: read_i64(last_usage, "output_tokens"),
+            reasoning_output_tokens: read_i64(last_usage, "reasoning_output_tokens"),
+            total_tokens: read_total_tokens(last_usage),
+          });
 
         let plan_type = payload
           .get("rate_limits")
@@ -808,6 +834,7 @@ fn parse_session_file_once(
           timestamp: sample_timestamp,
           model_id,
           usage,
+          last_token_usage,
           plan_type,
           limit_id,
           limit_name,
@@ -821,6 +848,8 @@ fn parse_session_file_once(
   if let Some(candidate) = matching_session_meta.or(first_session_meta) {
     session_id = candidate.session_id;
     parent_session_id = candidate.parent_session_id.or(parent_session_id);
+    explicit_forked_from_id = candidate.explicit_forked_from_id;
+    explicit_fork_timestamp = candidate.explicit_fork_timestamp;
     agent_nickname = candidate.agent_nickname.or(agent_nickname);
     agent_role = candidate.agent_role.or(agent_role);
   }
@@ -862,6 +891,8 @@ fn parse_session_file_once(
     },
     snapshots,
     rate_limit_samples,
+    explicit_forked_from_id,
+    explicit_fork_timestamp,
     explicit_fast_mode,
     latest_plan_type,
     last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
@@ -896,6 +927,118 @@ fn looks_like_session_id(value: &str) -> bool {
     .all(|(segment, expected_len)| {
       segment.len() == *expected_len && segment.chars().all(|character| character.is_ascii_hexdigit())
     })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReplayKey {
+  total_token_usage: TokenUsage,
+  last_token_usage: TokenUsage,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CanonicalReplaySnapshot<'a> {
+  raw_index: usize,
+  snapshot: &'a UsageSnapshot,
+}
+
+impl CanonicalReplaySnapshot<'_> {
+  fn replay_key(&self) -> Option<ReplayKey> {
+    Some(ReplayKey {
+      total_token_usage: self.snapshot.usage.clone(),
+      last_token_usage: self.snapshot.last_token_usage.clone()?,
+    })
+  }
+}
+
+fn canonical_replay_snapshots(snapshots: &[UsageSnapshot]) -> Vec<CanonicalReplaySnapshot<'_>> {
+  let mut high_water: Option<i64> = None;
+  let mut canonical = Vec::new();
+
+  for (raw_index, snapshot) in snapshots.iter().enumerate() {
+    if high_water.is_some_and(|total| snapshot.usage.total_tokens <= total) {
+      continue;
+    }
+
+    high_water = Some(snapshot.usage.total_tokens);
+    canonical.push(CanonicalReplaySnapshot { raw_index, snapshot });
+  }
+
+  canonical
+}
+
+fn kmp_prefix_table(pattern: &[ReplayKey]) -> Vec<usize> {
+  let mut table = vec![0; pattern.len()];
+
+  for index in 1..pattern.len() {
+    let mut prefix_len = table[index - 1];
+    while prefix_len > 0 && pattern[index] != pattern[prefix_len] {
+      prefix_len = table[prefix_len - 1];
+    }
+    if pattern[index] == pattern[prefix_len] {
+      prefix_len += 1;
+    }
+    table[index] = prefix_len;
+  }
+
+  table
+}
+
+#[allow(dead_code)]
+fn replayed_child_snapshot_cutoff(
+  parent_snapshots: &[UsageSnapshot],
+  child_snapshots: &[UsageSnapshot],
+  explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
+) -> usize {
+  let Some(explicit_fork_timestamp) = explicit_fork_timestamp else {
+    return 0;
+  };
+
+  let child_canonical = canonical_replay_snapshots(child_snapshots);
+  let mut child_pattern = Vec::new();
+  for snapshot in &child_canonical {
+    let Some(key) = snapshot.replay_key() else {
+      break;
+    };
+    child_pattern.push(key);
+  }
+  if child_pattern.len() < 2 {
+    return 0;
+  }
+
+  let prefix_table = kmp_prefix_table(&child_pattern);
+  let mut matched = 0;
+  let mut longest_match = 0;
+
+  for parent in canonical_replay_snapshots(parent_snapshots) {
+    let Ok(parent_timestamp) = DateTime::parse_from_rfc3339(&parent.snapshot.timestamp) else {
+      continue;
+    };
+    if parent_timestamp > explicit_fork_timestamp {
+      continue;
+    }
+
+    let Some(parent_key) = parent.replay_key() else {
+      matched = 0;
+      continue;
+    };
+
+    while matched > 0 && child_pattern[matched] != parent_key {
+      matched = prefix_table[matched - 1];
+    }
+    if child_pattern[matched] == parent_key {
+      matched += 1;
+      longest_match = longest_match.max(matched);
+      if matched == child_pattern.len() {
+        break;
+      }
+    }
+  }
+
+  if longest_match < 2 {
+    0
+  } else {
+    child_canonical[longest_match - 1].raw_index + 1
+  }
 }
 
 fn persist_session(
@@ -1516,6 +1659,423 @@ mod tests {
         std::env::remove_var("CODEX_HOME");
       }
     }
+  }
+
+  fn replay_usage(values: (i64, i64, i64, i64, i64)) -> TokenUsage {
+    TokenUsage {
+      input_tokens: values.0,
+      cached_input_tokens: values.1,
+      output_tokens: values.2,
+      reasoning_output_tokens: values.3,
+      total_tokens: values.4,
+    }
+  }
+
+  fn replay_snapshot(
+    timestamp: &str,
+    model_id: &str,
+    total: (i64, i64, i64, i64, i64),
+    last: Option<(i64, i64, i64, i64, i64)>,
+  ) -> UsageSnapshot {
+    UsageSnapshot {
+      timestamp: timestamp.to_string(),
+      model_id: model_id.to_string(),
+      usage: replay_usage(total),
+      last_token_usage: last.map(replay_usage),
+      plan_type: None,
+      limit_id: None,
+      limit_name: None,
+      explicit_fast_mode: None,
+    }
+  }
+
+  fn fork_instant(timestamp: &str) -> chrono::DateTime<chrono::FixedOffset> {
+    chrono::DateTime::parse_from_rfc3339(timestamp).expect("valid fork instant")
+  }
+
+  #[test]
+  fn replay_matching_accepts_a_complete_three_record_match() {
+    let parent = vec![
+      replay_snapshot(
+        "2026-03-24T00:00:01Z",
+        "parent-a",
+        (100, 10, 20, 1, 121),
+        Some((100, 10, 20, 1, 121)),
+      ),
+      replay_snapshot(
+        "2026-03-24T00:01:01Z",
+        "parent-b",
+        (180, 20, 35, 2, 217),
+        Some((80, 10, 15, 1, 96)),
+      ),
+      replay_snapshot(
+        "2026-03-24T00:02:01Z",
+        "parent-c",
+        (260, 30, 50, 3, 313),
+        Some((80, 10, 15, 1, 96)),
+      ),
+    ];
+    let child = vec![
+      replay_snapshot(
+        "2026-03-24T00:10:00Z",
+        "child-x",
+        (100, 10, 20, 1, 121),
+        Some((100, 10, 20, 1, 121)),
+      ),
+      replay_snapshot(
+        "2026-03-24T00:10:00Z",
+        "child-y",
+        (180, 20, 35, 2, 217),
+        Some((80, 10, 15, 1, 96)),
+      ),
+      replay_snapshot(
+        "2026-03-24T00:10:00Z",
+        "child-z",
+        (260, 30, 50, 3, 313),
+        Some((80, 10, 15, 1, 96)),
+      ),
+    ];
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &parent,
+        &child,
+        Some(fork_instant("2026-03-24T00:05:00Z")),
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn replay_matching_finds_a_child_prefix_in_the_middle_of_the_parent() {
+    let unrelated = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "parent",
+      (20, 0, 5, 0, 25),
+      Some((20, 0, 5, 0, 25)),
+    );
+    let first = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "parent",
+      (100, 10, 20, 1, 121),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let second = replay_snapshot(
+      "2026-03-24T00:02:00Z",
+      "parent",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let third = replay_snapshot(
+      "2026-03-24T00:03:00Z",
+      "parent",
+      (260, 30, 50, 3, 313),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let parent = vec![unrelated, first.clone(), second.clone(), third.clone()];
+    let child = vec![first, second, third];
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &parent,
+        &child,
+        Some(fork_instant("2026-03-24T00:04:00Z")),
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn replay_matching_rejects_one_exact_record() {
+    let record = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        std::slice::from_ref(&record),
+        std::slice::from_ref(&record),
+        Some(fork_instant("2026-03-24T00:01:00Z")),
+      ),
+      0
+    );
+  }
+
+  #[test]
+  fn replay_matching_missing_last_usage_breaks_the_match() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let parent_second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let child_second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      None,
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), parent_second],
+        &[first, child_second],
+        Some(fork_instant("2026-03-24T00:02:00Z")),
+      ),
+      0
+    );
+  }
+
+  #[test]
+  fn replay_matching_omits_same_total_changed_last_from_the_canonical_sequence() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let changed_last = replay_snapshot(
+      "2026-03-24T00:00:30Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((1, 2, 3, 4, 10)),
+    );
+    let second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), second.clone()],
+        &[first, changed_last, second],
+        Some(fork_instant("2026-03-24T00:02:00Z")),
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn replay_matching_uses_cumulative_high_water_after_a_rollback() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let rollback = replay_snapshot(
+      "2026-03-24T00:00:30Z",
+      "model",
+      (70, 5, 10, 0, 80),
+      Some((5, 0, 2, 0, 7)),
+    );
+    let recovery = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (140, 15, 30, 2, 172),
+      Some((40, 5, 10, 1, 51)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), recovery.clone()],
+        &[first, rollback, recovery],
+        Some(fork_instant("2026-03-24T00:02:00Z")),
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn replay_matching_excludes_parent_records_after_the_fork_instant() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+    let post_fork = replay_snapshot(
+      "2026-03-24T00:06:00Z",
+      "model",
+      (260, 30, 50, 3, 313),
+      Some((80, 10, 15, 1, 96)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), second.clone(), post_fork.clone()],
+        &[first, second, post_fork],
+        Some(fork_instant("2026-03-24T00:05:00Z")),
+      ),
+      2
+    );
+  }
+
+  #[test]
+  fn replay_matching_without_a_valid_fork_instant_returns_zero() {
+    let first = replay_snapshot(
+      "2026-03-24T00:00:00Z",
+      "model",
+      (100, 10, 20, 1, 121),
+      Some((100, 10, 20, 1, 121)),
+    );
+    let second = replay_snapshot(
+      "2026-03-24T00:01:00Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
+
+    assert_eq!(
+      replayed_child_snapshot_cutoff(
+        &[first.clone(), second.clone()],
+        &[first, second],
+        None,
+      ),
+      0
+    );
+  }
+
+  #[test]
+  fn parser_retains_last_usage_and_matching_explicit_fork_metadata() {
+    let directory = tempdir().expect("tempdir");
+    let child_id = "55555555-5555-5555-5555-555555555555";
+    let parent_id = "44444444-4444-4444-4444-444444444444";
+    let session_path = directory
+      .path()
+      .join(format!("rollout-2026-03-24T00-30-00-{child_id}.jsonl"));
+    std::fs::write(
+      &session_path,
+      format!(
+        concat!(
+          "{{\"timestamp\":\"2026-03-24T08:30:00+08:00\",\"type\":\"session_meta\",",
+          "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+          "{{\"timestamp\":\"2026-03-24T00:30:01Z\",\"type\":\"event_msg\",",
+          "\"payload\":{{\"type\":\"token_count\",\"info\":{{",
+          "\"total_token_usage\":{{\"input_tokens\":180,\"cached_input_tokens\":20,",
+          "\"output_tokens\":35,\"reasoning_output_tokens\":2,\"total_tokens\":217}},",
+          "\"last_token_usage\":{{\"input_tokens\":80,\"cached_input_tokens\":10,",
+          "\"output_tokens\":15,\"reasoning_output_tokens\":1,\"total_tokens\":96}}",
+          "}}}}}}\n",
+          "{{\"timestamp\":\"2026-03-24T00:30:02Z\",\"type\":\"session_meta\",",
+          "\"payload\":{{\"id\":\"{}\"}}}}\n"
+        ),
+        child_id, parent_id, parent_id,
+      ),
+    )
+    .expect("write fork session");
+
+    let parsed = parse_session_file(
+      &SessionFile {
+        path: session_path,
+        bucket: "active".to_string(),
+        file_size: 0,
+        file_mtime_ms: 0,
+      },
+      &HashMap::new(),
+    )
+    .expect("parse fork session");
+
+    assert_eq!(
+      parsed.snapshots[0].last_token_usage,
+      Some(replay_usage((80, 10, 15, 1, 96)))
+    );
+    assert_eq!(parsed.explicit_forked_from_id.as_deref(), Some(parent_id));
+    assert_eq!(
+      parsed.explicit_fork_timestamp,
+      Some(fork_instant("2026-03-24T08:30:00+08:00"))
+    );
+    let serialized = serde_json::to_value(&parsed.snapshots[0]).expect("serialize snapshot");
+    assert!(!serialized.as_object().expect("snapshot object").contains_key("lastTokenUsage"));
+  }
+
+  #[test]
+  fn parser_leaves_explicit_fork_fields_empty_for_thread_spawn_only_metadata() {
+    let directory = tempdir().expect("tempdir");
+    let child_id = "77777777-7777-7777-7777-777777777777";
+    let parent_id = "66666666-6666-6666-6666-666666666666";
+    let session_path = directory
+      .path()
+      .join(format!("rollout-2026-03-24T01-00-00-{child_id}.jsonl"));
+    std::fs::write(
+      &session_path,
+      format!(
+        concat!(
+          "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"session_meta\",",
+          "\"payload\":{{\"id\":\"{}\",\"source\":{{\"subagent\":{{\"thread_spawn\":{{",
+          "\"parent_thread_id\":\"{}\"}}}}}}}}}}\n"
+        ),
+        child_id, parent_id,
+      ),
+    )
+    .expect("write thread-spawn session");
+
+    let parsed = parse_session_file(
+      &SessionFile {
+        path: session_path,
+        bucket: "active".to_string(),
+        file_size: 0,
+        file_mtime_ms: 0,
+      },
+      &HashMap::new(),
+    )
+    .expect("parse thread-spawn session");
+
+    assert_eq!(parsed.raw_session.parent_session_id.as_deref(), Some(parent_id));
+    assert!(parsed.explicit_forked_from_id.is_none());
+    assert!(parsed.explicit_fork_timestamp.is_none());
+  }
+
+  #[test]
+  fn parser_invalid_explicit_fork_timestamp_disables_replay_metadata() {
+    let directory = tempdir().expect("tempdir");
+    let child_id = "99999999-9999-9999-9999-999999999999";
+    let parent_id = "88888888-8888-8888-8888-888888888888";
+    let session_path = directory
+      .path()
+      .join(format!("rollout-2026-03-24T01-30-00-{child_id}.jsonl"));
+    std::fs::write(
+      &session_path,
+      format!(
+        concat!(
+          "{{\"timestamp\":\"not-an-instant\",\"type\":\"session_meta\",",
+          "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n"
+        ),
+        child_id, parent_id,
+      ),
+    )
+    .expect("write invalid fork session");
+
+    let parsed = parse_session_file(
+      &SessionFile {
+        path: session_path,
+        bucket: "active".to_string(),
+        file_size: 0,
+        file_mtime_ms: 0,
+      },
+      &HashMap::new(),
+    )
+    .expect("parse invalid fork session");
+
+    assert_eq!(parsed.explicit_forked_from_id.as_deref(), Some(parent_id));
+    assert!(parsed.explicit_fork_timestamp.is_none());
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -68,6 +68,7 @@ enum SessionParseError {
 }
 
 const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
+const TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY: &str = "token_usage_fork_replay_v3";
 const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -128,10 +129,16 @@ fn perform_scan_with_scope(
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
   let pending_rate_limit_repair_paths =
     load_pending_data_repair_paths(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY).map_err(|error| error.to_string())?;
-  let needs_token_usage_repair_sweep =
+  let needs_token_usage_v2_repair_sweep =
     data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let pending_token_repair_paths =
+  let pending_token_v2_repair_paths =
     load_pending_data_repair_paths(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let needs_fork_replay_v3_repair_sweep =
+    data_repair_is_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let pending_fork_replay_v3_repair_paths =
+    load_pending_data_repair_paths(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let needs_token_usage_repair_sweep =
+    needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
   let effective_scope = effective_scan_scope(
     requested_scope,
     import_state.is_empty(),
@@ -161,7 +168,8 @@ fn perform_scan_with_scope(
     if needs_rate_limit_backfill
       || pending_rate_limit_repair_paths.contains(&source_path)
       || needs_token_usage_repair_sweep
-      || pending_token_repair_paths.contains(&source_path)
+      || pending_token_v2_repair_paths.contains(&source_path)
+      || pending_fork_replay_v3_repair_paths.contains(&source_path)
     {
       changed_files.push(session_file);
       continue;
@@ -200,8 +208,10 @@ fn perform_scan_with_scope(
       let source_path = session_file.path.to_string_lossy().to_string();
       let file_needs_rate_limit_repair =
         needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
-      let file_needs_token_repair =
-        needs_token_usage_repair_sweep || pending_token_repair_paths.contains(&source_path);
+      let file_needs_token_v2_repair =
+        needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
+      let file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
+        || pending_fork_replay_v3_repair_paths.contains(&source_path);
       let mut parsed = match parse_session_file(session_file, &titles) {
         Ok(parsed) => parsed,
         Err(error) => {
@@ -211,8 +221,12 @@ fn perform_scan_with_scope(
             session_file.path.display(),
             error
           );
-          if file_needs_token_repair {
+          if file_needs_token_v2_repair {
             mark_data_repair_file_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path, &error)
+              .map_err(|error| error.to_string())?;
+          }
+          if file_needs_fork_replay_v3_repair {
+            mark_data_repair_file_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path, &error)
               .map_err(|error| error.to_string())?;
           }
           if file_needs_rate_limit_repair {
@@ -248,8 +262,12 @@ fn perform_scan_with_scope(
         clear_pending_data_repair_file(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &source_path)
           .map_err(|error| error.to_string())?;
       }
-      if file_needs_token_repair {
+      if file_needs_token_v2_repair {
         clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)
+          .map_err(|error| error.to_string())?;
+      }
+      if file_needs_fork_replay_v3_repair {
+        clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
           .map_err(|error| error.to_string())?;
       }
       changed_sessions += 1;
@@ -299,8 +317,12 @@ fn perform_scan_with_scope(
     mark_data_repair_complete(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
-  if needs_token_usage_repair_sweep {
+  if needs_token_usage_v2_repair_sweep {
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
+      .map_err(|error| error.to_string())?;
+  }
+  if needs_fork_replay_v3_repair_sweep {
+    mark_data_repair_complete(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
   if scan_freshness_start.recorded {
@@ -3380,6 +3402,188 @@ mod tests {
       .optional()
       .expect("query data repair marker");
     assert!(repair_completed.is_some());
+  }
+
+  #[test]
+  fn v3_repair_rebuilds_unchanged_fork_usage() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "56565656-5656-4656-8656-565656565656";
+    let child_session_id = "57575757-5757-4757-8757-575757575757";
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    let repaired_session_id = "58585858-5858-4858-8858-585858585858";
+    let repaired_path = sessions_dir.join("unparseable-v3.jsonl");
+    let parent_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:00:01Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:10:01Z",
+        total: (180, 0, 0, 180),
+        last: (80, 0, 0, 80),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:20:01Z",
+        total: (260, 0, 0, 260),
+        last: (80, 0, 0, 80),
+      },
+    ];
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    for fixture in parent_fixtures.iter().copied() {
+      parent_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&parent_path, parent_body).expect("write parent session");
+
+    let child_created_at = "2026-03-24T00:30:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    for (index, fixture) in parent_fixtures.iter().copied().enumerate() {
+      let timestamp = match index {
+        0 => "2026-03-24T00:30:01Z",
+        1 => "2026-03-24T00:30:02Z",
+        _ => "2026-03-24T00:30:03Z",
+      };
+      child_body.push_str(&token_count_line(TokenFixture {
+        timestamp,
+        ..fixture
+      }));
+    }
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (310, 0, 0, 310),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write fork session");
+    std::fs::write(&repaired_path, "not json\n").expect("write unreadable repair fixture");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, parent_session_id).3, 260);
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 50);
+    conn
+      .execute(
+        "DELETE FROM usage_events WHERE session_id = ?1",
+        params![child_session_id],
+      )
+      .expect("delete corrected child usage");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
+          reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective
+        )
+        VALUES (?1, '2026-03-24T00:31:00Z', 'gpt-5.4', 310, 0, 0, 0, 310, 0.0, 0, 0)
+        ",
+        params![child_session_id],
+      )
+      .expect("insert legacy overcounted child usage");
+    conn
+      .execute(
+        "DELETE FROM data_repairs WHERE repair_key = 'token_usage_fork_replay_v3'",
+        [],
+      )
+      .expect("simulate database upgraded from v2");
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 310);
+    drop(conn);
+
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("v3 repair scan");
+
+    let conn = open_connection(&db_path).expect("open repaired db");
+    assert_eq!(result.updated_sessions, 2);
+    assert_eq!(session_usage_totals(&conn, parent_session_id).3, 260);
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 50);
+    let v2_completed: Option<String> = conn
+      .query_row(
+        "SELECT completed_at FROM data_repairs WHERE repair_key = 'token_usage_monotonic_v2'",
+        [],
+        |row| row.get(0),
+      )
+      .optional()
+      .expect("query v2 repair marker");
+    let v3_completed: Option<String> = conn
+      .query_row(
+        "SELECT completed_at FROM data_repairs WHERE repair_key = 'token_usage_fork_replay_v3'",
+        [],
+        |row| row.get(0),
+      )
+      .optional()
+      .expect("query v3 repair marker");
+    let pending_v3_path: Option<String> = conn
+      .query_row(
+        "
+        SELECT source_path
+        FROM data_repair_pending_files
+        WHERE repair_key = 'token_usage_fork_replay_v3'
+        ",
+        [],
+        |row| row.get(0),
+      )
+      .optional()
+      .expect("query pending v3 repair file");
+    assert!(v2_completed.is_some());
+    assert!(v3_completed.is_some());
+    assert_eq!(
+      pending_v3_path.as_deref(),
+      Some(repaired_path.to_string_lossy().as_ref())
+    );
+    drop(conn);
+
+    write_session_file(
+      &repaired_path,
+      repaired_session_id,
+      &[("2026-03-24T01:00:01Z", 40, 0, 10, 50)],
+    );
+    let retry = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("retry v3 repair file");
+
+    let conn = open_connection(&db_path).expect("open retried db");
+    assert_eq!(retry.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, repaired_session_id).3, 50);
+    let pending_v3_count: i64 = conn
+      .query_row(
+        "
+        SELECT COUNT(*)
+        FROM data_repair_pending_files
+        WHERE repair_key = 'token_usage_fork_replay_v3'
+        ",
+        [],
+        |row| row.get(0),
+      )
+      .expect("count pending v3 repair files");
+    assert_eq!(pending_v3_count, 0);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -87,7 +87,7 @@ fn perform_scan_with_scope(
   init_db(&conn).map_err(|error| error.to_string())?;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
 
-  let codex_home = resolve_codex_home(&conn, codex_home_override)?;
+  let codex_home = validate_codex_home(resolve_codex_home(&conn, codex_home_override)?, dirs::home_dir().as_deref())?;
   let scan_started_at = now_utc_string();
   set_last_scan_started(&conn, &scan_started_at).map_err(|error| error.to_string())?;
 
@@ -107,14 +107,15 @@ fn perform_scan_with_scope(
     ScanScope::Incremental
   };
 
-  let session_files = match effective_scope {
-    ScanScope::Full => collect_session_files(&codex_home),
-    ScanScope::Incremental => collect_active_session_files(&codex_home),
+  let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
+    ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
+    ScanScope::Incremental => collect_incremental_session_files(&codex_home, &import_state),
   };
-  let present_paths: HashSet<String> = session_files
+  let mut present_paths: HashSet<String> = session_files
     .iter()
     .map(|item| item.path.to_string_lossy().to_string())
     .collect();
+  present_paths.extend(active_paths_kept_for_archive_retry);
 
   let mut changed_sessions = 0usize;
   let mut imported_session_ids = HashSet::new();
@@ -143,10 +144,15 @@ fn perform_scan_with_scope(
     changed_files.push(session_file);
   }
 
+  let titles = if effective_scope == ScanScope::Full || !changed_files.is_empty() {
+    load_session_index(&codex_home)
+  } else {
+    HashMap::new()
+  };
+
   let mut topology_dirty = false;
   let mut new_root_session_ids = Vec::new();
   if !changed_files.is_empty() {
-    let titles = load_session_index(&codex_home);
     let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
     let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
 
@@ -195,12 +201,17 @@ fn perform_scan_with_scope(
   }
 
   if effective_scope == ScanScope::Full {
+    refresh_session_titles(&conn, &titles).map_err(|error| error.to_string())?;
+  }
+
+  if effective_scope == ScanScope::Full {
     mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
     prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
   } else {
     mark_missing_active_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
   }
-  if topology_dirty {
+  let topology_needs_repair = conversation_links_need_repair(&conn).map_err(|error| error.to_string())?;
+  if topology_dirty || topology_needs_repair {
     recompute_conversation_links(&conn).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
     upsert_root_conversation_links(&conn, &new_root_session_ids).map_err(|error| error.to_string())?;
@@ -354,6 +365,30 @@ fn resolve_codex_home(conn: &Connection, override_value: Option<String>) -> Resu
   Ok(home_dir.join(".codex"))
 }
 
+fn validate_codex_home(path: PathBuf, home_dir: Option<&Path>) -> Result<PathBuf, String> {
+  let expanded = expand_home_prefix(path, home_dir)?;
+  if !expanded.is_dir() {
+    return Err(format!(
+      "Codex home is not an existing directory: {}",
+      expanded.display()
+    ));
+  }
+  Ok(expanded)
+}
+
+fn expand_home_prefix(path: PathBuf, home_dir: Option<&Path>) -> Result<PathBuf, String> {
+  let Ok(suffix) = path.strip_prefix(Path::new("~")) else {
+    return Ok(path);
+  };
+  let Some(home_dir) = home_dir else {
+    return Err(format!(
+      "Unable to resolve home directory for Codex home path: {}",
+      path.display()
+    ));
+  };
+  Ok(home_dir.join(suffix))
+}
+
 fn load_session_index(codex_home: &Path) -> HashMap<String, String> {
   let mut titles = HashMap::new();
   let path = codex_home.join("session_index.jsonl");
@@ -380,6 +415,16 @@ fn load_session_index(codex_home: &Path) -> HashMap<String, String> {
   }
 
   titles
+}
+
+fn refresh_session_titles(conn: &Connection, titles: &HashMap<String, String>) -> rusqlite::Result<()> {
+  for (session_id, title) in titles {
+    conn.execute(
+      "UPDATE sessions SET title = ?1 WHERE session_id = ?2",
+      params![title, session_id],
+    )?;
+  }
+  Ok(())
 }
 
 fn collect_session_files(codex_home: &Path) -> Vec<SessionFile> {
@@ -413,6 +458,38 @@ fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
   }
   files.sort_by(|left, right| left.path.cmp(&right.path));
   files
+}
+
+fn collect_incremental_session_files(
+  codex_home: &Path,
+  import_state: &HashMap<String, ImportState>,
+) -> (Vec<SessionFile>, HashSet<String>) {
+  let mut files = collect_active_session_files(codex_home);
+  let mut collected_paths = files
+    .iter()
+    .map(|session_file| session_file.path.to_string_lossy().to_string())
+    .collect::<HashSet<_>>();
+  let mut active_paths_kept_for_archive_retry = HashSet::new();
+
+  for state in import_state.values() {
+    if state.source_bucket != "active" || collected_paths.contains(&state.source_path) {
+      continue;
+    }
+    let Some(filename) = Path::new(&state.source_path).file_name() else {
+      continue;
+    };
+    let archived_path = codex_home.join("archived_sessions").join(filename);
+    let Some(session_file) = session_file_from_path(archived_path, "archived") else {
+      continue;
+    };
+    active_paths_kept_for_archive_retry.insert(state.source_path.clone());
+    if collected_paths.insert(session_file.path.to_string_lossy().to_string()) {
+      files.push(session_file);
+    }
+  }
+
+  files.sort_by(|left, right| left.path.cmp(&right.path));
+  (files, active_paths_kept_for_archive_retry)
 }
 
 fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
@@ -473,7 +550,10 @@ fn parse_session_file_once(
   let mut first_session_meta: Option<SessionMetaCandidate> = None;
   let mut matching_session_meta: Option<SessionMetaCandidate> = None;
 
-  for line in BufReader::new(file).lines().map_while(Result::ok) {
+  for line_result in BufReader::new(file).lines() {
+    let line = line_result.map_err(|error| {
+      SessionParseError::Fatal(format!("Failed to read {}: {error}", session_file.path.display()))
+    })?;
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
     }
@@ -962,7 +1042,7 @@ fn normalize_local_timestamp(timestamp: chrono::DateTime<Local>) -> chrono::Date
 fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, ImportState>> {
   let mut stmt = conn.prepare(
     "
-    SELECT source_path, session_id, file_size, file_mtime_ms
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms
     FROM import_state
     ",
   )?;
@@ -971,8 +1051,9 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
     Ok(ImportState {
       source_path: row.get(0)?,
       session_id: row.get(1)?,
-      file_size: row.get(2)?,
-      file_mtime_ms: row.get(3)?,
+      source_bucket: row.get(2)?,
+      file_size: row.get(3)?,
+      file_mtime_ms: row.get(4)?,
     })
   })?;
 
@@ -1094,6 +1175,22 @@ fn upsert_root_conversation_links(conn: &Connection, session_ids: &[String]) -> 
   }
 
   Ok(())
+}
+
+fn conversation_links_need_repair(conn: &Connection) -> rusqlite::Result<bool> {
+  conn.query_row(
+    "
+    SELECT EXISTS (
+      SELECT 1
+      FROM sessions AS session
+      LEFT JOIN conversation_links AS link ON link.session_id = session.session_id
+      WHERE link.session_id IS NULL
+         OR link.parent_session_id IS NOT session.parent_session_id
+    )
+    ",
+    [],
+    |row| Ok(row.get::<_, i64>(0)? != 0),
+  )
 }
 
 fn mark_missing_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
@@ -1260,6 +1357,7 @@ fn read_percent(value: &Value, key: &str) -> Option<i64> {
 struct ImportState {
   source_path: String,
   session_id: Option<String>,
+  source_bucket: String,
   file_size: i64,
   file_mtime_ms: i64,
 }
@@ -2576,6 +2674,277 @@ mod tests {
     assert_eq!(
       import_state_session_id(&conn, &child_path),
       Some(child_session_id.to_string())
+    );
+  }
+
+  #[test]
+  fn invalid_custom_home_does_not_advance_completed_scan_time() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let missing = directory.path().join("missing-codex-home");
+
+    let error = perform_scan(&db_path, Some(missing.to_string_lossy().to_string()))
+      .expect_err("missing home must fail");
+    assert!(error.contains("existing directory"));
+
+    let conn = open_connection(&db_path).expect("open db");
+    let completed: Option<String> = conn
+      .query_row(
+        "SELECT last_scan_completed_at FROM sync_settings WHERE singleton_id = 1",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load completion");
+    assert!(completed.is_none());
+  }
+
+  #[test]
+  fn custom_home_path_expands_supported_tilde_forms() {
+    let directory = tempdir().expect("tempdir");
+    let nested = directory.path().join("codex-home");
+    std::fs::create_dir_all(&nested).expect("codex home");
+
+    assert_eq!(
+      validate_codex_home(PathBuf::from("~"), Some(directory.path())).expect("bare tilde"),
+      directory.path()
+    );
+    assert_eq!(
+      validate_codex_home(PathBuf::from("~/codex-home"), Some(directory.path())).expect("tilde prefix"),
+      nested
+    );
+  }
+
+  #[test]
+  fn incremental_scan_imports_final_snapshot_after_active_file_is_archived() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    let archived = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&archived).expect("archive");
+    let session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let archived_path = archived.join(active_path.file_name().expect("filename"));
+    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+
+    write_session_file(
+      &active_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+    std::fs::rename(&active_path, &archived_path).expect("archive session");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, session_id).3, 200);
+    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+  }
+
+  #[test]
+  fn incremental_scan_retries_moved_archive_after_read_error() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    let archived = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&archived).expect("archive");
+    let session_id = "a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1";
+    let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let archived_path = archived.join(active_path.file_name().expect("filename"));
+    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    write_session_file(
+      &sessions.join("other.jsonl"),
+      "a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2",
+      &[("2026-07-10T00:00:00Z", 50, 10, 5, 55)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+
+    let mut file = File::create(&active_path).expect("session file");
+    writeln!(
+      file,
+      "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session_id}\"}}}}"
+    )
+    .expect("meta");
+    file.write_all(&[0xff, b'\n']).expect("invalid utf8");
+    drop(file);
+    std::fs::rename(&active_path, &archived_path).expect("archive session");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("scan skips unreadable archive");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let retained_state: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM import_state WHERE source_path = ?1",
+        params![active_path.to_string_lossy().to_string()],
+        |row| row.get(0),
+      )
+      .expect("retained active state");
+    assert_eq!(retained_state, 1);
+    drop(conn);
+
+    write_session_file(
+      &archived_path,
+      session_id,
+      &[
+        ("2026-07-10T00:00:00Z", 100, 20, 10, 110),
+        ("2026-07-10T00:01:00Z", 180, 40, 20, 200),
+      ],
+    );
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("retry moved archive");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, session_id).3, 200);
+    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+  }
+
+  #[test]
+  fn full_scan_refreshes_title_when_only_session_index_changes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    write_session_file(
+      &sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl")),
+      session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let index_path = codex_home.join("session_index.jsonl");
+    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"A\"}}\n"))
+      .expect("title A");
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    std::fs::write(&index_path, format!("{{\"id\":\"{session_id}\",\"thread_name\":\"B\"}}\n"))
+      .expect("title B");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let title: String = conn
+      .query_row(
+        "SELECT title FROM sessions WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+      )
+      .expect("title");
+    assert_eq!(title, "B");
+  }
+
+  #[test]
+  fn invalid_utf8_does_not_commit_partial_session_or_import_state() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let session_id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    let path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let mut file = File::create(&path).expect("session file");
+    writeln!(
+      file,
+      "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session_id}\"}}}}"
+    )
+    .expect("meta");
+    file.write_all(&[0xff, b'\n']).expect("invalid utf8");
+    writeln!(
+      file,
+      "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.6-sol\"}}}}"
+    )
+    .expect("tail");
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan skips bad file");
+    let conn = open_connection(&db_path).expect("open db");
+    let sessions_count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+      .expect("sessions");
+    let states_count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM import_state", [], |row| row.get(0))
+      .expect("states");
+    assert_eq!((sessions_count, states_count), (0, 0));
+  }
+
+  #[test]
+  fn incremental_scan_repairs_missing_conversation_link_without_source_change() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let parent = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let child = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    write_session_file_with_parent(
+      &sessions.join(format!("rollout-2026-07-10T00-00-00-{parent}.jsonl")),
+      parent,
+      None,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    write_session_file_with_parent(
+      &sessions.join(format!("rollout-2026-07-10T00-01-00-{child}.jsonl")),
+      child,
+      Some(parent),
+      &[("2026-07-10T00:01:00Z", 50, 10, 5, 55)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open db");
+    conn
+      .execute("DELETE FROM conversation_links WHERE session_id = ?1", params![child])
+      .expect("remove link");
+    drop(conn);
+
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("repair scan");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(conversation_link(&conn, child).expect("child link").0, parent);
+  }
+
+  #[test]
+  fn incremental_scan_repairs_conversation_link_parent_mismatch_without_source_change() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    let parent = "f1f1f1f1-f1f1-f1f1-f1f1-f1f1f1f1f1f1";
+    let child = "f2f2f2f2-f2f2-f2f2-f2f2-f2f2f2f2f2f2";
+    write_session_file(
+      &sessions.join(format!("rollout-2026-07-10T00-00-00-{parent}.jsonl")),
+      parent,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    write_session_file_with_parent(
+      &sessions.join(format!("rollout-2026-07-10T00-01-00-{child}.jsonl")),
+      child,
+      Some(parent),
+      &[("2026-07-10T00:01:00Z", 50, 10, 5, 55)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open db");
+    conn
+      .execute(
+        "UPDATE conversation_links SET parent_session_id = NULL WHERE session_id = ?1",
+        params![child],
+      )
+      .expect("corrupt direct parent");
+    drop(conn);
+
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("repair scan");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(
+      conversation_link(&conn, child).expect("child link").1.as_deref(),
+      Some(parent)
     );
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3722,7 +3722,7 @@ mod tests {
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
       .expect("full parent scan");
 
-    let conn = open_connection(&db_path).expect("open db to corrupt parent source path");
+    let conn = open_connection(&db_path).expect("open db to corrupt parent source paths");
     assert_eq!(
       conn
         .execute(
@@ -3732,7 +3732,17 @@ mod tests {
         .expect("corrupt parent source path"),
       1
     );
+    assert_eq!(
+      conn
+        .execute(
+          "UPDATE import_state SET source_path = ?1 WHERE session_id = ?2",
+          params![child_path.to_string_lossy().to_string(), parent_session_id],
+        )
+        .expect("corrupt parent import state path"),
+      1
+    );
     drop(conn);
+    std::fs::remove_file(&parent_path).expect("remove original parent source");
 
     let child_created_at = "2026-03-24T01:00:00Z";
     let mut child_body = format!(

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -807,14 +807,65 @@ fn perform_scan_with_kind(
   commit_prepared_scan(prepared)
 }
 
+#[cfg(test)]
 pub(crate) fn prepare_scan(
   db_path: &Path,
   codex_home_override: Option<String>,
   requested_kind: ScanKind,
 ) -> Result<PreparedScan, String> {
+  let database_snapshot = load_preparation_database_snapshot(
+    db_path,
+    codex_home_override.as_deref(),
+    requested_kind,
+  )
+  .map_err(|error| error.to_string())?;
+  prepare_scan_from_snapshot(
+    db_path,
+    codex_home_override,
+    requested_kind,
+    database_snapshot,
+  )
+}
+
+pub(crate) fn prepare_scan_with_cached_snapshot_connection(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_kind: ScanKind,
+  cached_connection: &mut Option<Connection>,
+) -> Result<PreparedScan, String> {
+  if cached_connection.is_none() {
+    let connection = open_scan_snapshot(db_path).map_err(|error| error.to_string())?;
+    connection
+      .pragma_update(None, "cache_size", -16_384)
+      .map_err(|error| error.to_string())?;
+    *cached_connection = Some(connection);
+  }
+  let database_snapshot = match load_preparation_database_snapshot_from_connection(
+    cached_connection.as_mut().expect("cached connection initialized"),
+    codex_home_override.as_deref(),
+    requested_kind,
+  ) {
+    Ok(snapshot) => snapshot,
+    Err(error) => {
+      *cached_connection = None;
+      return Err(error.to_string());
+    }
+  };
+  prepare_scan_from_snapshot(
+    db_path,
+    codex_home_override,
+    requested_kind,
+    database_snapshot,
+  )
+}
+
+fn prepare_scan_from_snapshot(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_kind: ScanKind,
+  database_snapshot: PreparationDatabaseSnapshot,
+) -> Result<PreparedScan, String> {
   let scan_started_at = now_utc_string();
-  let database_snapshot =
-    load_preparation_database_snapshot(db_path).map_err(|error| error.to_string())?;
   let PreparationDatabaseSnapshot {
     scan_source_selector,
     scan_commit_revision,
@@ -830,7 +881,7 @@ pub(crate) fn prepare_scan(
     needs_fork_replay_v3_repair_sweep,
     pending_fork_replay_v3_repair_paths,
     mut session_source_paths,
-    existing_relations,
+    mut existing_relations,
     existing_session_sources,
     topology_needs_repair,
   } = database_snapshot;
@@ -865,6 +916,9 @@ pub(crate) fn prepare_scan(
     pending_repair_session_ids(&import_state, &pending_rate_limit_repair_paths);
   pending_repair_session_ids.extend(pending_token_v2_repair_session_ids.iter().cloned());
   pending_repair_session_ids.extend(pending_fork_replay_v3_repair_session_ids.iter().cloned());
+  let mut pending_repair_paths = pending_rate_limit_repair_paths.clone();
+  pending_repair_paths.extend(pending_token_v2_repair_paths.iter().cloned());
+  pending_repair_paths.extend(pending_fork_replay_v3_repair_paths.iter().cloned());
   let needs_token_usage_repair_sweep =
     needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
   let effective_kind = effective_scan_scope(
@@ -879,7 +933,12 @@ pub(crate) fn prepare_scan(
     ScanKind::Full => (collect_session_files(&codex_home), HashSet::new()),
     ScanKind::Reconcile => (collect_session_files(&codex_home), HashSet::new()),
     ScanKind::Incremental => {
-      collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
+      collect_incremental_session_files(
+        &codex_home,
+        &import_state,
+        &pending_repair_session_ids,
+        &pending_repair_paths,
+      )
     }
   };
   let stats = PreparedScanStats {
@@ -932,8 +991,9 @@ pub(crate) fn prepare_scan(
     if let Some(state) = import_state.get(&source_path) {
       let session_id_mismatch = import_state_session_id_mismatch(state, session_file);
       if state.file_size == session_file.file_size
-        && state.file_mtime_ms == session_file.file_mtime_ms
         && !session_id_mismatch
+        && (state.file_mtime_ms == session_file.file_mtime_ms
+          || parser_checkpoint_prefix_matches(state, session_file))
       {
         if let Some(session_id) = &state.session_id {
           imported_session_ids.insert(session_id.clone());
@@ -1024,6 +1084,7 @@ pub(crate) fn prepare_scan(
     };
     source_bytes_read = source_bytes_read.saturating_add(bytes_read);
 
+    ensure_replay_parent_source_path(db_path, &parsed, &mut session_source_paths)?;
     let (replay_parent_unavailable, parent_replay_bytes_read) =
       if matches!(parsed.mode, ParsedSessionMode::Full) {
         assign_inherited_token_snapshot_cutoff(
@@ -1050,6 +1111,11 @@ pub(crate) fn prepare_scan(
       replay_parent_unavailable || !related_pending_fork_replay_v3_paths.is_empty();
     imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
+    ensure_existing_relation_context(
+      db_path,
+      &parsed.raw_session.session_id,
+      &mut existing_relations,
+    )?;
     match classify_topology_maintenance(
       existing_relations.get(&parsed.raw_session.session_id),
       existing_relations
@@ -1276,7 +1342,8 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
   apply_missing_source_plan(&tx, missing_plan).map_err(|error| error.to_string())?;
 
   let topology_needs_repair = topology_needs_repair
-    || conversation_links_need_repair(&tx).map_err(|error| error.to_string())?;
+    || (effective_kind != ScanKind::Incremental
+      && conversation_links_need_repair(&tx).map_err(|error| error.to_string())?);
   if topology_dirty || topology_needs_repair {
     recompute_conversation_links(&tx).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
@@ -1359,10 +1426,25 @@ fn open_scan_snapshot(db_path: &Path) -> rusqlite::Result<Connection> {
   Ok(conn)
 }
 
+#[cfg(test)]
 fn load_preparation_database_snapshot(
   db_path: &Path,
+  codex_home_override: Option<&str>,
+  requested_kind: ScanKind,
 ) -> rusqlite::Result<PreparationDatabaseSnapshot> {
   let mut conn = open_scan_snapshot(db_path)?;
+  load_preparation_database_snapshot_from_connection(
+    &mut conn,
+    codex_home_override,
+    requested_kind,
+  )
+}
+
+fn load_preparation_database_snapshot_from_connection(
+  conn: &mut Connection,
+  codex_home_override: Option<&str>,
+  requested_kind: ScanKind,
+) -> rusqlite::Result<PreparationDatabaseSnapshot> {
   let tx = conn.transaction()?;
   let (
     scan_source_selector,
@@ -1397,7 +1479,6 @@ fn load_preparation_database_snapshot(
       ))
     },
   )?;
-  let import_state = load_import_state(&tx)?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&tx)?;
   let pending_rate_limit_repair_paths =
     load_pending_data_repair_paths(&tx, RATE_LIMIT_SAMPLE_BACKFILL_KEY)?;
@@ -1409,29 +1490,72 @@ fn load_preparation_database_snapshot(
     data_repair_is_pending(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY)?;
   let pending_fork_replay_v3_repair_paths =
     load_pending_data_repair_paths(&tx, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY)?;
-  let session_source_paths = load_session_source_paths(&tx, &import_state, &[])?;
-  let existing_relations = load_existing_session_relations(&tx)?;
-  let existing_session_sources = {
-    let mut stmt = tx.prepare(
+  let mut pending_repair_paths = pending_rate_limit_repair_paths.clone();
+  pending_repair_paths.extend(pending_token_v2_repair_paths.iter().cloned());
+  pending_repair_paths.extend(pending_fork_replay_v3_repair_paths.iter().cloned());
+  let import_state_is_empty = tx.query_row(
+    "SELECT NOT EXISTS (SELECT 1 FROM import_state LIMIT 1)",
+    [],
+    |row| Ok(row.get::<_, i64>(0)? != 0),
+  )?;
+  let home_dir = dirs::home_dir();
+  let resolved_requested_home = resolve_codex_home(
+    scan_source_selector.as_deref(),
+    codex_home_override.map(ToString::to_string),
+    home_dir.as_deref(),
+  )
+  .and_then(|path| expand_home_prefix(path, home_dir.as_deref()));
+  let use_incremental_snapshot = requested_kind == ScanKind::Incremental
+    && !import_state_is_empty
+    && !needs_rate_limit_backfill
+    && !needs_token_usage_v2_repair_sweep
+    && !needs_fork_replay_v3_repair_sweep
+    && last_full_scan_completed_at.is_some()
+    && resolved_requested_home.as_ref().is_ok_and(|path| {
+      last_scan_codex_home.as_deref() == Some(path.to_string_lossy().as_ref())
+    });
+  let import_state = if use_incremental_snapshot {
+    load_incremental_import_state(&tx, &pending_repair_paths)?
+  } else {
+    load_import_state(&tx)?
+  };
+  let session_source_paths = if use_incremental_snapshot {
+    import_state
+      .values()
+      .filter_map(|state| {
+        state
+          .session_id
+          .as_ref()
+          .map(|session_id| (session_id.clone(), PathBuf::from(&state.source_path)))
+      })
+      .collect()
+  } else {
+    load_session_source_paths(&tx, &import_state, &[])?
+  };
+  let existing_relations = if use_incremental_snapshot {
+    load_incremental_session_relations(&tx, &import_state)?
+  } else {
+    load_existing_session_relations(&tx)?
+  };
+  let existing_session_sources = if use_incremental_snapshot {
+    load_incremental_session_sources(&tx, &import_state)?
+  } else {
+    {
+      let mut stmt = tx.prepare(
       "
       SELECT session_id, source_path, source_state, source_bucket
       FROM sessions
       WHERE source_path IS NOT NULL
       ",
-    )?;
-    let rows = stmt
-      .query_map([], |row| {
-        Ok(ExistingSessionSource {
-          session_id: row.get(0)?,
-          source_path: row.get(1)?,
-          source_state: row.get(2)?,
-          source_bucket: row.get(3)?,
-        })
-      })?
-      .collect::<rusqlite::Result<Vec<_>>>()?;
-    rows
+      )?;
+      let sources = stmt
+        .query_map([], existing_session_source_from_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+      sources
+    }
   };
-  let topology_needs_repair = conversation_links_need_repair(&tx)?;
+  let topology_needs_repair =
+    !use_incremental_snapshot && conversation_links_need_repair(&tx)?;
   tx.commit()?;
 
   Ok(PreparationDatabaseSnapshot {
@@ -1874,20 +1998,31 @@ fn collect_session_files(codex_home: &Path) -> Vec<SessionFile> {
   files
 }
 
-fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
+fn collect_recent_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
   let sessions_root = codex_home.join("sessions");
-  if !sessions_root.exists() {
-    return Vec::new();
-  }
-
   let mut files = Vec::new();
-  for entry in WalkDir::new(sessions_root)
-    .into_iter()
-    .filter_map(Result::ok)
-  {
-    if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), "active") {
-      files.push(session_file);
+  let mut collect_directory = |directory: &Path| {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+      return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+      if let Some(session_file) = session_file_from_path(entry.path(), "active") {
+        files.push(session_file);
+      }
     }
+  };
+
+  // Legacy clients may place session files directly under `sessions`.
+  collect_directory(&sessions_root);
+  let today = Local::now().date_naive();
+  for days_ago in 0..=2 {
+    let date = today - chrono::Duration::days(days_ago);
+    collect_directory(
+      &sessions_root
+        .join(date.format("%Y").to_string())
+        .join(date.format("%m").to_string())
+        .join(date.format("%d").to_string()),
+    );
   }
   files.sort_by(|left, right| left.path.cmp(&right.path));
   files
@@ -1897,25 +2032,47 @@ fn collect_incremental_session_files(
   codex_home: &Path,
   import_state: &HashMap<String, ImportState>,
   pending_repair_session_ids: &HashSet<String>,
+  pending_repair_paths: &HashSet<String>,
 ) -> (Vec<SessionFile>, HashSet<String>) {
-  let mut files = collect_active_session_files(codex_home);
+  let mut files = collect_recent_active_session_files(codex_home);
   let mut collected_paths = files
     .iter()
     .map(|session_file| session_file.path.to_string_lossy().to_string())
     .collect::<HashSet<_>>();
   let mut active_paths_kept_for_archive_retry = HashSet::new();
 
+  for state in import_state.values().filter(|state| state.source_bucket == "active") {
+    if collected_paths.contains(&state.source_path) {
+      continue;
+    }
+    let Some(session_file) = session_file_from_path(PathBuf::from(&state.source_path), "active") else {
+      continue;
+    };
+    collected_paths.insert(state.source_path.clone());
+    files.push(session_file);
+  }
+
   for state in import_state.values() {
     if state.source_bucket == "archived" {
+      let session_has_pending_repair = state
+        .session_id
+        .as_ref()
+        .is_some_and(|session_id| pending_repair_session_ids.contains(session_id));
+      let needs_tail_retry = state
+        .parser_checkpoint
+        .as_ref()
+        .is_some_and(|checkpoint| checkpoint.completed_offset < state.file_size.max(0) as u64);
+      if !session_has_pending_repair
+        && !pending_repair_paths.contains(&state.source_path)
+        && !needs_tail_retry
+      {
+        continue;
+      }
       let Some(session_file) =
         session_file_from_path(PathBuf::from(&state.source_path), "archived")
       else {
         continue;
       };
-      let session_has_pending_repair = state
-        .session_id
-        .as_ref()
-        .is_some_and(|session_id| pending_repair_session_ids.contains(session_id));
       if state.file_size == session_file.file_size
         && state.file_mtime_ms == session_file.file_mtime_ms
         && !session_has_pending_repair
@@ -1971,6 +2128,15 @@ fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
     file_size,
     file_mtime_ms,
   })
+}
+
+fn parser_checkpoint_prefix_matches(state: &ImportState, session_file: &SessionFile) -> bool {
+  let Some(checkpoint) = state.parser_checkpoint.as_ref() else {
+    return false;
+  };
+  checkpoint.completed_offset == session_file.file_size.max(0) as u64
+    && read_prefix_signature(&session_file.path, checkpoint.completed_offset)
+      .is_ok_and(|signature| signature == checkpoint.prefix_signature)
 }
 
 fn parse_session_file_counted(
@@ -2838,6 +3004,76 @@ impl ReplayParentTokenUsage {
   }
 }
 
+fn ensure_replay_parent_source_path(
+  db_path: &Path,
+  parsed: &ParsedSession,
+  session_source_paths: &mut HashMap<String, PathBuf>,
+) -> Result<(), String> {
+  if !matches!(parsed.mode, ParsedSessionMode::Full) {
+    return Ok(());
+  }
+  let Some(parent_session_id) = parsed
+    .explicit_forked_from_id
+    .as_deref()
+    .filter(|session_id| !session_id.trim().is_empty())
+  else {
+    return Ok(());
+  };
+  if session_source_paths.contains_key(parent_session_id) {
+    return Ok(());
+  }
+
+  let conn = open_scan_snapshot(db_path).map_err(|error| error.to_string())?;
+  let source_path = conn
+    .query_row(
+      "SELECT source_path FROM sessions WHERE session_id = ?1 AND source_path IS NOT NULL",
+      params![parent_session_id],
+      |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(|error| error.to_string())?;
+  if let Some(source_path) = source_path {
+    session_source_paths.insert(parent_session_id.to_string(), PathBuf::from(source_path));
+  }
+  Ok(())
+}
+
+fn ensure_existing_relation_context(
+  db_path: &Path,
+  session_id: &str,
+  existing_relations: &mut HashMap<String, ExistingSessionRelation>,
+) -> Result<(), String> {
+  if existing_relations.contains_key(session_id) {
+    return Ok(());
+  }
+  let conn = open_scan_snapshot(db_path).map_err(|error| error.to_string())?;
+  let existing_parent = conn
+    .query_row(
+      "SELECT parent_session_id FROM sessions WHERE session_id = ?1",
+      params![session_id],
+      |row| row.get::<_, Option<String>>(0),
+    )
+    .optional()
+    .map_err(|error| error.to_string())?;
+  let child_count = conn
+    .query_row(
+      "SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?1",
+      params![session_id],
+      |row| row.get::<_, i64>(0),
+    )
+    .map_err(|error| error.to_string())?
+    .max(0) as usize;
+  existing_relations.insert(
+    session_id.to_string(),
+    ExistingSessionRelation {
+      exists: existing_parent.is_some(),
+      parent_session_id: existing_parent.flatten(),
+      child_count,
+    },
+  );
+  Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ReplayKey {
   total_token_usage: TokenUsage,
@@ -3116,15 +3352,16 @@ fn persist_session(
     "
     INSERT INTO import_state (
       source_path, session_id, source_bucket, file_size, file_mtime_ms,
-      parser_checkpoint, last_imported_at
+      parser_checkpoint, parser_completed_offset, last_imported_at
     )
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
     ON CONFLICT(source_path) DO UPDATE SET
       session_id = excluded.session_id,
       source_bucket = excluded.source_bucket,
       file_size = excluded.file_size,
       file_mtime_ms = excluded.file_mtime_ms,
       parser_checkpoint = excluded.parser_checkpoint,
+      parser_completed_offset = excluded.parser_completed_offset,
       last_imported_at = excluded.last_imported_at
     ",
     params![
@@ -3134,6 +3371,7 @@ fn persist_session(
       session_file.file_size,
       session_file.file_mtime_ms,
       parser_checkpoint,
+      parsed.checkpoint.completed_offset as i64,
       now_utc_string(),
     ],
   )?;
@@ -3294,6 +3532,62 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
   Ok(result)
 }
 
+fn load_incremental_import_state(
+  conn: &Connection,
+  pending_repair_paths: &HashSet<String>,
+) -> rusqlite::Result<HashMap<String, ImportState>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms, parser_checkpoint
+    FROM import_state
+    WHERE source_bucket = 'active'
+    UNION ALL
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms, parser_checkpoint
+    FROM import_state INDEXED BY idx_import_state_incomplete_archived_tail
+    WHERE source_bucket = 'archived'
+      AND parser_completed_offset < file_size
+    ",
+  )?;
+  let rows = stmt.query_map([], import_state_from_row)?;
+
+  let mut result = HashMap::new();
+  for row in rows {
+    let state = row?;
+    result.insert(state.source_path.clone(), state);
+  }
+  drop(stmt);
+  for source_path in pending_repair_paths {
+    let state = conn
+      .query_row(
+        "
+        SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms, parser_checkpoint
+        FROM import_state
+        WHERE source_path = ?1
+        ",
+        params![source_path],
+        import_state_from_row,
+      )
+      .optional()?;
+    if let Some(state) = state {
+      result.insert(state.source_path.clone(), state);
+    }
+  }
+  Ok(result)
+}
+
+fn import_state_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ImportState> {
+  Ok(ImportState {
+    source_path: row.get(0)?,
+    session_id: row.get(1)?,
+    source_bucket: row.get(2)?,
+    file_size: row.get(3)?,
+    file_mtime_ms: row.get(4)?,
+    parser_checkpoint: row
+      .get::<_, Option<String>>(5)?
+      .and_then(|checkpoint| serde_json::from_str(&checkpoint).ok()),
+  })
+}
+
 fn needs_rate_limit_sample_backfill(conn: &Connection) -> rusqlite::Result<bool> {
   data_repair_is_pending(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY)
 }
@@ -3434,6 +3728,112 @@ fn load_existing_session_relations(
   }
 
   Ok(relations)
+}
+
+fn load_incremental_session_relations(
+  conn: &Connection,
+  import_state: &HashMap<String, ImportState>,
+) -> rusqlite::Result<HashMap<String, ExistingSessionRelation>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, parent_session_id
+    FROM sessions
+    WHERE source_state = 'active'
+    ",
+  )?;
+  let rows = stmt.query_map([], |row| {
+    Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+  })?;
+
+  let mut relations = HashMap::new();
+  for row in rows {
+    let (session_id, parent_session_id) = row?;
+    relations.insert(
+      session_id,
+      ExistingSessionRelation {
+        exists: true,
+        parent_session_id,
+        child_count: 0,
+      },
+    );
+  }
+  drop(stmt);
+  for state in import_state
+    .values()
+    .filter(|state| state.source_bucket != "active")
+  {
+    let Some(session_id) = state.session_id.as_deref() else {
+      continue;
+    };
+    let parent_session_id = conn
+      .query_row(
+        "SELECT parent_session_id FROM sessions WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get::<_, Option<String>>(0),
+      )
+      .optional()?;
+    if let Some(parent_session_id) = parent_session_id {
+      relations.insert(
+        session_id.to_string(),
+        ExistingSessionRelation {
+          exists: true,
+          parent_session_id,
+          child_count: 0,
+        },
+      );
+    }
+  }
+  Ok(relations)
+}
+
+fn existing_session_source_from_row(
+  row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<ExistingSessionSource> {
+  Ok(ExistingSessionSource {
+    session_id: row.get(0)?,
+    source_path: row.get(1)?,
+    source_state: row.get(2)?,
+    source_bucket: row.get(3)?,
+  })
+}
+
+fn load_incremental_session_sources(
+  conn: &Connection,
+  import_state: &HashMap<String, ImportState>,
+) -> rusqlite::Result<Vec<ExistingSessionSource>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, source_path, source_state, source_bucket
+    FROM sessions
+    WHERE source_path IS NOT NULL AND source_state = 'active'
+    ",
+  )?;
+  let rows = stmt.query_map([], existing_session_source_from_row)?;
+  let mut sources = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+  drop(stmt);
+  for state in import_state
+    .values()
+    .filter(|state| state.source_bucket != "active")
+  {
+    let Some(session_id) = state.session_id.as_deref() else {
+      continue;
+    };
+    let source = conn
+      .query_row(
+        "
+        SELECT session_id, source_path, source_state, source_bucket
+        FROM sessions
+        WHERE session_id = ?1 AND source_path IS NOT NULL
+        ",
+        params![session_id],
+        existing_session_source_from_row,
+      )
+      .optional()?;
+    if let Some(source) = source {
+      sources.push(source);
+    }
+  }
+  Ok(sources)
 }
 
 fn upsert_root_conversation_links(
@@ -6061,7 +6461,16 @@ mod tests {
     );
 
     let db_path = directory.path().join("usage.sqlite");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "UPDATE sync_settings SET codex_home = ?1 WHERE singleton_id = 1",
+        params![codex_home.to_string_lossy().to_string()],
+      )
+      .expect("configure source home");
+    drop(conn);
+    perform_scan(&db_path, None).expect("first scan");
 
     write_session_file_with_parent(
       &sessions_dir.join("child.jsonl"),
@@ -6072,7 +6481,7 @@ mod tests {
         ("2026-03-24T00:10:02Z", 160, 20, 25, 185),
       ],
     );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+    perform_incremental_scan(&db_path, None).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(
@@ -6110,14 +6519,23 @@ mod tests {
     );
 
     let db_path = directory.path().join("usage.sqlite");
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "UPDATE sync_settings SET codex_home = ?1 WHERE singleton_id = 1",
+        params![codex_home.to_string_lossy().to_string()],
+      )
+      .expect("configure source home");
+    drop(conn);
+    perform_scan(&db_path, None).expect("first scan");
 
     write_session_file(
       &sessions_dir.join("parent.jsonl"),
       parent_session_id,
       &[("2026-03-24T00:00:01Z", 120, 20, 30, 150)],
     );
-    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("second scan");
+    perform_incremental_scan(&db_path, None).expect("second scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(
@@ -6226,6 +6644,52 @@ mod tests {
   }
 
   #[test]
+  fn incremental_snapshot_does_not_load_archived_database_rows() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archived_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_dir).expect("archived dir");
+
+    write_session_file(
+      &sessions_dir.join("active.jsonl"),
+      "12121212-0000-0000-0000-000000000001",
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    for index in 2..=32 {
+      write_session_file(
+        &archived_dir.join(format!("archived-{index}.jsonl")),
+        &format!("12121212-0000-0000-0000-{index:012}"),
+        &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+      );
+    }
+
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "UPDATE sync_settings SET codex_home = ?1 WHERE singleton_id = 1",
+        params![codex_home.to_string_lossy().to_string()],
+      )
+      .expect("configure source home");
+    drop(conn);
+    perform_scan(&db_path, None).expect("full scan");
+
+    let snapshot = load_preparation_database_snapshot(
+      &db_path,
+      None,
+      ScanKind::Incremental,
+    )
+    .expect("incremental snapshot");
+    assert_eq!(snapshot.import_state.len(), 1);
+    assert_eq!(snapshot.session_source_paths.len(), 1);
+    assert_eq!(snapshot.existing_relations.len(), 1);
+    assert_eq!(snapshot.existing_session_sources.len(), 1);
+  }
+
+  #[test]
   fn incremental_scan_discovers_new_recent_active_session() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
@@ -6271,7 +6735,7 @@ mod tests {
   }
 
   #[test]
-  fn incremental_scan_discovers_new_old_dated_active_session() {
+  fn reconcile_scan_discovers_new_old_dated_active_session() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions_dir = codex_home.join("sessions");
@@ -6296,8 +6760,18 @@ mod tests {
       &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
     );
 
-    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
-      .expect("incremental scan");
+    let incremental = perform_incremental_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+    )
+    .expect("incremental scan");
+    assert_eq!(incremental.updated_sessions, 0);
+    let result = perform_scan_with_kind(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Reconcile,
+    )
+    .expect("reconcile scan");
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 1);
@@ -7251,6 +7725,38 @@ mod tests {
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)
     );
+  }
+
+  #[test]
+  fn unchanged_size_with_new_mtime_uses_checkpoint_instead_of_full_parse() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_id = "45454545-aaaa-bbbb-cccc-454545454545";
+    let session_path = sessions_dir.join("touched.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial scan");
+
+    let unchanged = std::fs::read(&session_path).expect("read source");
+    std::thread::sleep(Duration::from_millis(5));
+    std::fs::write(&session_path, unchanged).expect("rewrite identical source");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare touched source");
+    assert_eq!(prepared.stats().source_bytes_read, 0);
+    assert_eq!(prepared.stats().fully_parsed_files, 0);
+    assert_eq!(prepared.updated_sessions, 0);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2821,6 +2821,159 @@ mod tests {
   }
 
   #[test]
+  fn fork_replay_counts_only_child_usage() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "99999999-9999-9999-9999-999999999999";
+    let child_session_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    let parent_path =
+      sessions_dir.join(format!("rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"));
+    let child_path =
+      sessions_dir.join(format!("rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"));
+    let parent_fixtures = [
+      TokenFixture {
+        timestamp: "2026-03-24T00:00:01Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:10:01Z",
+        total: (180, 0, 0, 180),
+        last: (80, 0, 0, 80),
+      },
+      TokenFixture {
+        timestamp: "2026-03-24T00:20:01Z",
+        total: (260, 0, 0, 260),
+        last: (80, 0, 0, 80),
+      },
+    ];
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    for fixture in parent_fixtures.iter().copied() {
+      parent_body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&parent_path, parent_body).expect("write parent session");
+
+    let child_created_at = "2026-03-24T00:30:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    for fixture in parent_fixtures.iter().copied() {
+      child_body.push_str(&token_count_line(TokenFixture {
+        timestamp: child_created_at,
+        ..fixture
+      }));
+    }
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (310, 0, 0, 310),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write fork session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let parent_total = session_usage_totals(&conn, parent_session_id).3;
+    let child_total = session_usage_totals(&conn, child_session_id).3;
+    assert_eq!(parent_total, 260);
+    assert_eq!(child_total, 50);
+    assert_eq!(parent_total + child_total, 310);
+  }
+
+  #[test]
+  fn fork_first_snapshot_uses_last_usage_as_baseline() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    let child_session_id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    let child_path =
+      sessions_dir.join(format!("rollout-2026-03-24T01-00-00-{child_session_id}.jsonl"));
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T01:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_session_id,
+      parent_session_id,
+    );
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T01:00:00Z",
+      total: (1000, 0, 0, 1000),
+      last: (40, 0, 0, 40),
+    }));
+    std::fs::write(child_path, child_body).expect("write fork session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 40);
+  }
+
+  #[test]
+  fn thread_spawn_without_fork_keeps_full_usage() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    let child_session_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    let child_path =
+      sessions_dir.join(format!("rollout-2026-03-24T02-00-00-{child_session_id}.jsonl"));
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T02:00:00Z\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"source\":{{\"subagent\":{{\"thread_spawn\":{{",
+        "\"parent_thread_id\":\"{}\"}}}}}}}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T02:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_session_id,
+      parent_session_id,
+    );
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T02:00:00Z",
+      total: (1000, 0, 0, 1000),
+      last: (40, 0, 0, 40),
+    }));
+    std::fs::write(child_path, child_body).expect("write thread-spawn session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(session_usage_totals(&conn, child_session_id).3, 1000);
+  }
+
+  #[test]
   fn invalid_custom_home_does_not_advance_completed_scan_time() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
@@ -3574,6 +3727,38 @@ mod tests {
       conversation_link(&conn, child).expect("child link").1.as_deref(),
       Some(parent)
     );
+  }
+
+  #[derive(Clone, Copy)]
+  struct TokenFixture {
+    timestamp: &'static str,
+    total: (i64, i64, i64, i64),
+    last: (i64, i64, i64, i64),
+  }
+
+  fn token_count_line(fixture: TokenFixture) -> String {
+    let (input, cached, output, total) = fixture.total;
+    let (last_input, last_cached, last_output, last_total) = fixture.last;
+    format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"event_msg\",\"payload\":{{",
+        "\"type\":\"token_count\",\"info\":{{",
+        "\"total_token_usage\":{{\"input_tokens\":{},\"cached_input_tokens\":{},",
+        "\"output_tokens\":{},\"reasoning_output_tokens\":0,\"total_tokens\":{}}},",
+        "\"last_token_usage\":{{\"input_tokens\":{},\"cached_input_tokens\":{},",
+        "\"output_tokens\":{},\"reasoning_output_tokens\":0,\"total_tokens\":{}}}",
+        "}}}}}}\n"
+      ),
+      fixture.timestamp,
+      input,
+      cached,
+      output,
+      total,
+      last_input,
+      last_cached,
+      last_output,
+      last_total,
+    )
   }
 
   fn write_session_file(path: &Path, session_id: &str, snapshots: &[(&str, i64, i64, i64, i64)]) {

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2642,38 +2642,41 @@ fn persist_session(
     .and_then(|index| parsed.snapshots.get(index))
     .map(|snapshot| snapshot.usage.clone());
 
+  let mut usage_event_plan = Vec::new();
+  for (snapshot_index, snapshot) in parsed.snapshots.iter().enumerate().skip(snapshot_cutoff) {
+    if previous_usage.as_ref() == Some(&snapshot.usage) {
+      continue;
+    }
+
+    let delta = if let Some(previous) = previous_usage.as_ref() {
+      if snapshot.usage.total_tokens <= previous.total_tokens {
+        continue;
+      }
+      diff_usage(previous, &snapshot.usage)
+    } else if parsed.explicit_forked_from_id.is_some() {
+      snapshot
+        .last_token_usage
+        .clone()
+        .unwrap_or_else(|| snapshot.usage.clone())
+    } else {
+      snapshot.usage.clone()
+    };
+
+    previous_usage = Some(snapshot.usage.clone());
+    if is_zero_delta(&delta) {
+      continue;
+    }
+    usage_event_plan.push((snapshot_index, delta));
+  }
+
   insert_usage_events(
     conn,
-    parsed
-      .snapshots
+    usage_event_plan
       .iter()
-      .skip(snapshot_cutoff)
-      .map(|snapshot| snapshot.timestamp.as_str()),
+      .map(|(snapshot_index, _)| parsed.snapshots[*snapshot_index].timestamp.as_str()),
     |index| {
-      let snapshot = &parsed.snapshots[snapshot_cutoff + index];
-      if previous_usage.as_ref() == Some(&snapshot.usage) {
-        return None;
-      }
-
-      let delta = if let Some(previous) = previous_usage.as_ref() {
-        if snapshot.usage.total_tokens <= previous.total_tokens {
-          return None;
-        }
-        diff_usage(previous, &snapshot.usage)
-      } else if parsed.explicit_forked_from_id.is_some() {
-        snapshot
-          .last_token_usage
-          .clone()
-          .unwrap_or_else(|| snapshot.usage.clone())
-      } else {
-        snapshot.usage.clone()
-      };
-
-      previous_usage = Some(snapshot.usage.clone());
-      if is_zero_delta(&delta) {
-        return None;
-      }
-
+      let (snapshot_index, delta) = &usage_event_plan[index];
+      let snapshot = &parsed.snapshots[*snapshot_index];
       let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
       let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
       Some(NewUsageEvent {
@@ -5265,6 +5268,156 @@ mod tests {
         crate::database::parse_epoch_millis(&persisted.0).expect("parse expected usage epoch")
       )
     );
+  }
+
+  #[test]
+  fn scan_ignores_malformed_timestamps_on_skipped_usage_snapshots() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_path = sessions_dir.join("skipped-usage-timestamps.jsonl");
+    let mut body = concat!(
+      "{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"97979797-9797-4797-8797-979797979797\"}}\n",
+      "{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n"
+    )
+    .to_string();
+    for fixture in [
+      TokenFixture {
+        timestamp: "invalid-zero-delta",
+        total: (0, 0, 0, 0),
+        last: (0, 0, 0, 0),
+      },
+      TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "invalid-duplicate",
+        total: (100, 0, 0, 100),
+        last: (0, 0, 0, 0),
+      },
+      TokenFixture {
+        timestamp: "invalid-non-monotonic",
+        total: (90, 0, 0, 90),
+        last: (0, 0, 0, 0),
+      },
+    ] {
+      body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&session_path, body).expect("write session");
+    let db_path = directory.path().join("usage.sqlite");
+
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    let persisted = conn
+      .query_row(
+        "
+        SELECT COUNT(*), MIN(timestamp), MIN(timestamp_ms), SUM(total_tokens)
+        FROM usage_events
+        ",
+        [],
+        |row| {
+          Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, i64>(3)?,
+          ))
+        },
+      )
+      .expect("load persisted usage");
+    assert_eq!(persisted.0, 1);
+    assert_eq!(persisted.1, "2026-07-10T00:00:02Z");
+    assert_eq!(
+      persisted.2,
+      crate::database::parse_epoch_millis(&persisted.1).expect("parse persisted timestamp")
+    );
+    assert_eq!(persisted.3, 100);
+  }
+
+  #[test]
+  fn malformed_timestamp_on_written_usage_event_rolls_back_batch_and_freshness() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_path = sessions_dir.join("written-usage-timestamps.jsonl");
+    let mut body = concat!(
+      "{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"96969696-9696-4696-8696-969696969696\"}}\n",
+      "{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n"
+    )
+    .to_string();
+    for fixture in [
+      TokenFixture {
+        timestamp: "2026-07-10T00:00:02Z",
+        total: (100, 0, 0, 100),
+        last: (100, 0, 0, 100),
+      },
+      TokenFixture {
+        timestamp: "invalid-written-event",
+        total: (200, 0, 0, 200),
+        last: (100, 0, 0, 100),
+      },
+    ] {
+      body.push_str(&token_count_line(fixture));
+    }
+    std::fs::write(&session_path, body).expect("write session");
+    let db_path = directory.path().join("usage.sqlite");
+    initialize_scan_database(&db_path);
+    configure_codex_home(&db_path, &codex_home);
+    let conn = open_connection(&db_path).expect("open database");
+    let freshness_before = conn
+      .query_row(
+        "
+        SELECT last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at, scan_commit_revision
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| {
+          Ok((
+            row.get::<_, Option<String>>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, i64>(3)?,
+          ))
+        },
+      )
+      .expect("load initial freshness");
+    drop(conn);
+
+    let error = perform_scan(&db_path, None).expect_err("reject malformed written event");
+
+    assert!(error.contains("Invalid usage event timestamp"));
+    let conn = open_connection(&db_path).expect("reopen database");
+    let usage_count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0))
+      .expect("count usage events");
+    let freshness_after = conn
+      .query_row(
+        "
+        SELECT last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at, scan_commit_revision
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| {
+          Ok((
+            row.get::<_, Option<String>>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, i64>(3)?,
+          ))
+        },
+      )
+      .expect("load rolled back freshness");
+    assert_eq!(usage_count, 0);
+    assert_eq!(freshness_after, freshness_before);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2052,6 +2052,27 @@ fn collect_incremental_session_files(
     files.push(session_file);
   }
 
+  let active_root = codex_home.join("sessions");
+  let archived_root = codex_home.join("archived_sessions");
+  for source_path in pending_repair_paths {
+    if collected_paths.contains(source_path) {
+      continue;
+    }
+    let path = PathBuf::from(source_path);
+    let bucket = if path.starts_with(&archived_root) {
+      "archived"
+    } else if path.starts_with(&active_root) {
+      "active"
+    } else {
+      continue;
+    };
+    let Some(session_file) = session_file_from_path(path, bucket) else {
+      continue;
+    };
+    collected_paths.insert(source_path.clone());
+    files.push(session_file);
+  }
+
   for state in import_state.values() {
     if state.source_bucket == "archived" {
       let session_has_pending_repair = state
@@ -6824,7 +6845,9 @@ mod tests {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions_dir = codex_home.join("sessions");
+    let archived_dir = codex_home.join("archived_sessions");
     std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_dir).expect("archived sessions dir");
 
     let existing_session_id = "77777777-8888-9999-aaaa-bbbbbbbbbbbb";
     write_session_file(
@@ -6832,7 +6855,7 @@ mod tests {
       existing_session_id,
       &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
-    let pending_path = sessions_dir.join("unparseable.jsonl");
+    let pending_path = archived_dir.join("unparseable.jsonl");
     std::fs::write(&pending_path, "not json\n").expect("write bad session");
 
     let db_path = directory.path().join("usage.sqlite");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 
 use crate::database::{
   bool_to_i64, get_sync_settings, init_db, now_utc_string, open_connection,
-  replace_session_rate_limit_samples, set_last_full_scan_completed, set_last_scan_completed, set_last_scan_started,
+  replace_session_rate_limit_samples, set_last_scan_started_for_source, set_scan_completed_for_source,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
@@ -85,11 +85,30 @@ fn perform_scan_with_scope(
 ) -> Result<ScanResult, String> {
   let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
+  let scan_source_selector = get_sync_settings(&conn)
+    .map_err(|error| error.to_string())?
+    .codex_home;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
 
-  let codex_home = validate_codex_home(resolve_codex_home(&conn, codex_home_override)?, dirs::home_dir().as_deref())?;
+  let home_dir = dirs::home_dir();
+  let codex_home = validate_codex_home(
+    resolve_codex_home(
+      scan_source_selector.as_deref(),
+      codex_home_override,
+      home_dir.as_deref(),
+    )?,
+    home_dir.as_deref(),
+  )?;
+  let track_scan_freshness = freshness_source_matches(
+    scan_source_selector.as_deref(),
+    &codex_home,
+    home_dir.as_deref(),
+  );
   let scan_started_at = now_utc_string();
-  set_last_scan_started(&conn, &scan_started_at).map_err(|error| error.to_string())?;
+  if track_scan_freshness {
+    set_last_scan_started_for_source(&conn, &scan_started_at, scan_source_selector.as_deref())
+      .map_err(|error| error.to_string())?;
+  }
 
   let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
@@ -234,10 +253,15 @@ fn perform_scan_with_scope(
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
-  if effective_scope == ScanScope::Full {
-    set_last_full_scan_completed(&conn, &completed_at).map_err(|error| error.to_string())?;
+  if track_scan_freshness {
+    set_scan_completed_for_source(
+      &conn,
+      &completed_at,
+      scan_source_selector.as_deref(),
+      effective_scope == ScanScope::Full,
+    )
+    .map_err(|error| error.to_string())?;
   }
-  set_last_scan_completed(&conn, &completed_at).map_err(|error| error.to_string())?;
 
   Ok(ScanResult {
     codex_home: codex_home.to_string_lossy().to_string(),
@@ -339,16 +363,18 @@ pub fn recalculate_all_session_values(conn: &Connection) -> rusqlite::Result<()>
   Ok(())
 }
 
-fn resolve_codex_home(conn: &Connection, override_value: Option<String>) -> Result<PathBuf, String> {
+fn resolve_codex_home(
+  persisted_codex_home: Option<&str>,
+  override_value: Option<String>,
+  home_dir: Option<&Path>,
+) -> Result<PathBuf, String> {
   if let Some(path) = override_value {
     return Ok(PathBuf::from(path));
   }
 
-  if let Ok(settings) = get_sync_settings(conn) {
-    if let Some(path) = settings.codex_home {
-      if !path.trim().is_empty() {
-        return Ok(PathBuf::from(path));
-      }
+  if let Some(path) = persisted_codex_home {
+    if !path.trim().is_empty() {
+      return Ok(PathBuf::from(path));
     }
   }
 
@@ -358,11 +384,22 @@ fn resolve_codex_home(conn: &Connection, override_value: Option<String>) -> Resu
     }
   }
 
-  let Some(home_dir) = dirs::home_dir() else {
+  let Some(home_dir) = home_dir else {
     return Err("Unable to resolve home directory for CODEX_HOME fallback.".to_string());
   };
 
   Ok(home_dir.join(".codex"))
+}
+
+fn freshness_source_matches(
+  persisted_codex_home: Option<&str>,
+  scanned_codex_home: &Path,
+  home_dir: Option<&Path>,
+) -> bool {
+  resolve_codex_home(persisted_codex_home, None, home_dir)
+    .and_then(|path| expand_home_prefix(path, home_dir))
+    .map(|path| path == scanned_codex_home)
+    .unwrap_or(false)
 }
 
 fn validate_codex_home(path: PathBuf, home_dir: Option<&Path>) -> Result<PathBuf, String> {
@@ -1380,7 +1417,7 @@ struct ImportState {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::database::{init_db, now_utc_string, open_connection};
+  use crate::database::{init_db, now_utc_string, open_connection, save_sync_settings};
   use rusqlite::OptionalExtension;
   use tempfile::tempdir;
 
@@ -2705,6 +2742,163 @@ mod tests {
       )
       .expect("load completion");
     assert!(completed.is_none());
+  }
+
+  #[test]
+  fn scan_does_not_restore_freshness_after_source_changes_mid_import() {
+    let directory = tempdir().expect("tempdir");
+    let old_codex_home = directory.path().join("old-codex-home");
+    let new_codex_home = directory.path().join("new-codex-home");
+    let sessions_dir = old_codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("old sessions dir");
+    std::fs::create_dir_all(&new_codex_home).expect("new Codex home");
+
+    let session_path = sessions_dir.join("source-race.jsonl");
+    std::fs::write(
+      &session_path,
+      concat!(
+        "{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"abababab-abab-abab-abab-abababababab\"}}\n",
+        "{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.6-sol\"}}\n",
+        "{\"timestamp\":\"2026-07-10T00:00:02Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":10,\"reasoning_output_tokens\":0,\"total_tokens\":110}}}}\n"
+      ),
+    )
+    .expect("write session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.codex_home = Some(old_codex_home.to_string_lossy().to_string());
+    save_sync_settings(&conn, &settings).expect("save old source");
+
+    let new_home_sql = new_codex_home.to_string_lossy().replace('\'', "''");
+    conn
+      .execute_batch(&format!(
+        "
+        CREATE TRIGGER switch_codex_home_during_import
+        AFTER INSERT ON usage_events
+        BEGIN
+          UPDATE sync_settings
+          SET codex_home = '{new_home_sql}',
+              last_scan_started_at = NULL,
+              last_scan_completed_at = NULL,
+              last_full_scan_completed_at = NULL
+          WHERE singleton_id = 1;
+        END;
+        "
+      ))
+      .expect("create source switch trigger");
+    drop(conn);
+
+    perform_scan(
+      &db_path,
+      Some(old_codex_home.to_string_lossy().to_string()),
+    )
+    .expect("scan old source");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let (codex_home, started, completed, full_completed): (
+      Option<String>,
+      Option<String>,
+      Option<String>,
+      Option<String>,
+    ) = conn
+      .query_row(
+        "
+        SELECT codex_home, last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+      )
+      .expect("load scan freshness");
+
+    assert_eq!(
+      codex_home.as_deref(),
+      Some(new_codex_home.to_string_lossy().as_ref())
+    );
+    assert_eq!(started, None);
+    assert_eq!(completed, None);
+    assert_eq!(full_completed, None);
+  }
+
+  #[test]
+  fn scan_writes_freshness_when_source_selector_is_unchanged() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("Codex home");
+    let db_path = directory.path().join("usage.sqlite");
+
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.codex_home = Some(codex_home.to_string_lossy().to_string());
+    save_sync_settings(&conn, &settings).expect("save source");
+    drop(conn);
+
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("scan matching source");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) = conn
+      .query_row(
+        "
+        SELECT last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+      )
+      .expect("load scan freshness");
+
+    assert!(started.is_some());
+    assert!(completed.is_some());
+    assert!(full_completed.is_some());
+  }
+
+  #[test]
+  fn scan_does_not_write_freshness_for_an_override_from_the_previous_source() {
+    let directory = tempdir().expect("tempdir");
+    let old_codex_home = directory.path().join("old-codex-home");
+    let new_codex_home = directory.path().join("new-codex-home");
+    std::fs::create_dir_all(&old_codex_home).expect("old Codex home");
+    std::fs::create_dir_all(&new_codex_home).expect("new Codex home");
+    let db_path = directory.path().join("usage.sqlite");
+
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.codex_home = Some(new_codex_home.to_string_lossy().to_string());
+    save_sync_settings(&conn, &settings).expect("save new source");
+    drop(conn);
+
+    perform_scan(
+      &db_path,
+      Some(old_codex_home.to_string_lossy().to_string()),
+    )
+    .expect("scan previous source");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let (started, completed, full_completed): (Option<String>, Option<String>, Option<String>) = conn
+      .query_row(
+        "
+        SELECT last_scan_started_at, last_scan_completed_at,
+               last_full_scan_completed_at
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+      )
+      .expect("load scan freshness");
+
+    assert_eq!(started, None);
+    assert_eq!(completed, None);
+    assert_eq!(full_completed, None);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Timelike};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, TransactionBehavior};
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
@@ -280,7 +281,7 @@ enum PreparedStorageBuilder {
     estimated_bytes: usize,
   },
   Spool {
-    writer: BufWriter<File>,
+    writer: GzEncoder<BufWriter<File>>,
     records: usize,
   },
 }
@@ -576,7 +577,7 @@ impl PreparedStorageBuilder {
         } else {
           let file = tempfile::tempfile()
             .map_err(|error| format!("Failed to create prepared scan spool: {error}"))?;
-          let mut writer = BufWriter::new(file);
+          let mut writer = GzEncoder::new(BufWriter::new(file), Compression::fast());
           let mut records = 0usize;
           for buffered in entries {
             write_spool_record(&mut writer, buffered)?;
@@ -601,13 +602,12 @@ impl PreparedStorageBuilder {
     match self {
       Self::Memory { entries, .. } => Ok(PreparedStorage::Memory(entries)),
       Self::Spool {
-        mut writer,
+        writer,
         records,
       } => {
-        writer
-          .flush()
-          .map_err(|error| format!("Failed to flush prepared scan spool: {error}"))?;
         let file = writer
+          .finish()
+          .map_err(|error| format!("Failed to compress prepared scan spool: {error}"))?
           .into_inner()
           .map_err(|error| format!("Failed to finish prepared scan spool: {}", error.error()))?;
         Ok(PreparedStorage::Spool { file, records })
@@ -616,7 +616,10 @@ impl PreparedStorageBuilder {
   }
 }
 
-fn write_spool_record(writer: &mut BufWriter<File>, entry: PreparedSession) -> Result<(), String> {
+fn write_spool_record(
+  writer: &mut GzEncoder<BufWriter<File>>,
+  entry: PreparedSession,
+) -> Result<(), String> {
   let entry = SpoolPreparedSession::from(entry);
   serde_json::to_writer(&mut *writer, &entry)
     .map_err(|error| format!("Failed to write prepared scan spool: {error}"))?;
@@ -1146,7 +1149,7 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
       file
         .seek(SeekFrom::Start(0))
         .map_err(|error| format!("Failed to rewind prepared scan spool: {error}"))?;
-      let reader = BufReader::new(file);
+      let reader = GzDecoder::new(BufReader::new(file));
       let mut stream =
         serde_json::Deserializer::from_reader(reader).into_iter::<SpoolPreparedSession>();
       let mut records_read = 0usize;
@@ -3985,6 +3988,40 @@ mod tests {
     };
 
     assert_eq!(link_count, 0, "spool must have no directory entry");
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn spool_compresses_repetitive_prepared_records() {
+    let mut builder = PreparedStorageBuilder::new();
+    builder
+      .push(prepared_session_fixture(
+        PathBuf::from("/synthetic/a-large.jsonl"),
+        "80808080-8080-8080-8080-808080808080",
+        PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+      ))
+      .expect("buffer first large record");
+    builder
+      .push(prepared_session_fixture(
+        PathBuf::from("/synthetic/b-large.jsonl"),
+        "81818181-8181-8181-8181-818181818181",
+        PREPARED_SPOOL_THRESHOLD_BYTES * 2,
+      ))
+      .expect("spill second large record");
+
+    let storage = builder.finish().expect("finish compressed spool");
+    let bytes = match storage {
+      PreparedStorage::Memory(_) => panic!("expected spool storage"),
+      PreparedStorage::Spool { file, records } => {
+        assert_eq!(records, 2);
+        file.metadata().expect("spool metadata").len()
+      }
+    };
+
+    assert!(
+      bytes < 64 * 1024,
+      "repetitive prepared records should compress below 64 KiB, got {bytes}"
+    );
   }
 
   #[cfg(unix)]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -15,8 +15,8 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, now_utc_string, open_connection,
-  preview_scan_freshness_for_source, replace_session_rate_limit_samples,
+  append_session_rate_limit_samples, append_session_usage_events, bool_to_i64, now_utc_string,
+  open_connection, preview_scan_freshness_for_source, replace_session_rate_limit_samples,
   replace_session_usage_events, set_last_scan_started_for_source_in_transaction,
   set_scan_completed_for_source, NewUsageEvent,
 };
@@ -46,6 +46,26 @@ struct ParsedSession {
   explicit_fast_mode: Option<bool>,
   latest_plan_type: Option<String>,
   last_model_id: Option<String>,
+  mode: ParsedSessionMode,
+  checkpoint: ParserCheckpoint,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum ParsedSessionMode {
+  Full,
+  Tail {
+    previous_usage: Option<TokenUsage>,
+  },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ParserCheckpoint {
+  completed_offset: u64,
+  prefix_signature: Vec<u8>,
+  last_usage: Option<TokenUsage>,
+  current_model: Option<String>,
+  explicit_fast_mode: Option<bool>,
+  latest_plan_type: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +122,7 @@ const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
 const TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY: &str = "token_usage_fork_replay_v3";
 const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
 const PREPARED_SPOOL_THRESHOLD_BYTES: usize = 256 * 1024;
+const PARSER_PREFIX_SIGNATURE_BYTES: u64 = 128;
 const PARENT_REPLAY_CACHE_MAX_ENTRIES: usize = 4;
 const PARENT_REPLAY_CACHE_MAX_BYTES: usize = 256 * 1024;
 
@@ -298,6 +319,8 @@ struct SpoolPreparedSession {
   explicit_fast_mode: Option<bool>,
   latest_plan_type: Option<String>,
   last_model_id: Option<String>,
+  mode: ParsedSessionMode,
+  checkpoint: ParserCheckpoint,
   file_needs_rate_limit_repair: bool,
   file_needs_token_v2_repair: bool,
   file_needs_fork_replay_v3_repair: bool,
@@ -434,6 +457,8 @@ impl From<PreparedSession> for SpoolPreparedSession {
       explicit_fast_mode,
       latest_plan_type,
       last_model_id,
+      mode,
+      checkpoint,
     } = parsed;
 
     Self {
@@ -447,6 +472,8 @@ impl From<PreparedSession> for SpoolPreparedSession {
       explicit_fast_mode,
       latest_plan_type,
       last_model_id,
+      mode,
+      checkpoint,
       file_needs_rate_limit_repair,
       file_needs_token_v2_repair,
       file_needs_fork_replay_v3_repair,
@@ -471,6 +498,8 @@ impl From<SpoolPreparedSession> for PreparedSession {
         explicit_fast_mode: entry.explicit_fast_mode,
         latest_plan_type: entry.latest_plan_type,
         last_model_id: entry.last_model_id,
+        mode: entry.mode,
+        checkpoint: entry.checkpoint,
       },
       file_needs_rate_limit_repair: entry.file_needs_rate_limit_repair,
       file_needs_token_v2_repair: entry.file_needs_token_v2_repair,
@@ -908,7 +937,33 @@ pub(crate) fn prepare_scan(
       needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
     let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
       || pending_fork_replay_v3_repair_paths.contains(&source_path);
-    let (mut parsed, bytes_read) = match parse_session_file_counted(&session_file, &titles) {
+    let tail_candidate = if effective_kind == ScanKind::Incremental
+      && !file_needs_rate_limit_repair
+      && !file_needs_token_v2_repair
+      && !file_needs_fork_replay_v3_repair
+    {
+      if let Some(state) = import_state.get(&source_path) {
+        try_parse_session_tail_counted(
+          &session_file,
+          state,
+          &titles,
+          state
+            .session_id
+            .as_ref()
+            .and_then(|session_id| existing_relations.get(session_id)),
+        )
+      } else {
+        Ok(None)
+      }
+    } else {
+      Ok(None)
+    };
+    let parsed_result = match tail_candidate {
+      Ok(Some(result)) => Ok(result),
+      Ok(None) => parse_session_file_counted(&session_file, &titles),
+      Err(error) => Err(error),
+    };
+    let (mut parsed, bytes_read) = match parsed_result {
       Ok(parsed) => parsed,
       Err((error, bytes_read)) => {
         source_bytes_read = source_bytes_read.saturating_add(bytes_read);
@@ -931,11 +986,15 @@ pub(crate) fn prepare_scan(
     source_bytes_read = source_bytes_read.saturating_add(bytes_read);
 
     let (replay_parent_unavailable, parent_replay_bytes_read) =
-      assign_inherited_token_snapshot_cutoff(
-        &mut parsed,
-        &session_source_paths,
-        &mut parent_snapshot_cache,
-      );
+      if matches!(parsed.mode, ParsedSessionMode::Full) {
+        assign_inherited_token_snapshot_cutoff(
+          &mut parsed,
+          &session_source_paths,
+          &mut parent_snapshot_cache,
+        )
+      } else {
+        (false, 0)
+      };
     source_bytes_read = source_bytes_read.saturating_add(parent_replay_bytes_read);
     let related_pending_token_v2_paths = pending_repair_paths_for_session(
       &import_state,
@@ -1875,6 +1934,231 @@ fn parse_session_file_counted(
   })
 }
 
+fn try_parse_session_tail_counted(
+  session_file: &SessionFile,
+  state: &ImportState,
+  titles: &HashMap<String, String>,
+  existing_relation: Option<&ExistingSessionRelation>,
+) -> Result<Option<(ParsedSession, u64)>, (String, u64)> {
+  let Some(session_id) = state.session_id.as_ref() else {
+    return Ok(None);
+  };
+  let Some(checkpoint) = state.parser_checkpoint.as_ref() else {
+    return Ok(None);
+  };
+  if state.source_bucket != "active"
+    || session_file.bucket != "active"
+    || session_file.file_size <= state.file_size
+    || checkpoint.completed_offset > session_file.file_size.max(0) as u64
+    || import_state_session_id_mismatch(state, session_file)
+  {
+    return Ok(None);
+  }
+  let current_signature = read_prefix_signature(&session_file.path, checkpoint.completed_offset)
+    .map_err(|error| {
+      (
+        format!(
+          "Failed to validate parser checkpoint for {}: {error}",
+          session_file.path.display()
+        ),
+        0,
+      )
+    })?;
+  if current_signature != checkpoint.prefix_signature {
+    return Ok(None);
+  }
+
+  let mut file = File::open(&session_file.path).map_err(|error| {
+    (
+      format!("Failed to open {}: {error}", session_file.path.display()),
+      0,
+    )
+  })?;
+  file
+    .seek(SeekFrom::Start(checkpoint.completed_offset))
+    .map_err(|error| {
+      (
+        format!(
+          "Failed to seek {} to parser checkpoint: {error}",
+          session_file.path.display()
+        ),
+        0,
+      )
+    })?;
+  let mut reader = BufReader::new(CountingReader::new(file));
+  let mut completed_offset = checkpoint.completed_offset;
+  let mut current_model = checkpoint.current_model.clone();
+  let mut explicit_fast_mode = checkpoint.explicit_fast_mode;
+  let mut latest_plan_type = checkpoint.latest_plan_type.clone();
+  let mut updated_at = None;
+  let mut snapshots = Vec::new();
+  let mut rate_limit_samples = Vec::new();
+  let mut seen_models = HashSet::new();
+  if let Some(model) = current_model.as_ref() {
+    seen_models.insert(model.clone());
+  }
+
+  let mut line = String::new();
+  loop {
+    line.clear();
+    let line_bytes = reader.read_line(&mut line).map_err(|error| {
+      (
+        format!("Failed to read {}: {error}", session_file.path.display()),
+        reader.get_ref().bytes_read,
+      )
+    })?;
+    if line_bytes == 0 || !line.ends_with('\n') {
+      break;
+    }
+    completed_offset = completed_offset.saturating_add(line_bytes as u64);
+    if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
+      explicit_fast_mode = Some(true);
+    }
+    if line.contains("\"fast_mode\":false") || line.contains("\"quick_mode\":false") {
+      explicit_fast_mode = Some(false);
+    }
+    let Ok(value) = serde_json::from_str::<Value>(&line) else {
+      continue;
+    };
+    let timestamp = value
+      .get("timestamp")
+      .and_then(Value::as_str)
+      .map(ToString::to_string);
+    if timestamp.is_some() {
+      updated_at = timestamp.clone();
+    }
+    match value
+      .get("type")
+      .and_then(Value::as_str)
+      .unwrap_or_default()
+    {
+      "session_meta" => return Ok(None),
+      "turn_context" => {
+        if let Some(model) = value
+          .get("payload")
+          .and_then(|payload| payload.get("model"))
+          .and_then(Value::as_str)
+        {
+          let model = normalize_model_id(model);
+          seen_models.insert(model.clone());
+          current_model = Some(model);
+        }
+      }
+      "event_msg" => {
+        let payload = value.get("payload").unwrap_or(&Value::Null);
+        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
+          continue;
+        }
+        let info = payload.get("info").unwrap_or(&Value::Null);
+        let total_usage = info.get("total_token_usage").unwrap_or(&Value::Null);
+        if total_usage.is_null() {
+          continue;
+        }
+        let usage = TokenUsage {
+          input_tokens: read_i64(total_usage, "input_tokens"),
+          cached_input_tokens: read_i64(total_usage, "cached_input_tokens"),
+          output_tokens: read_i64(total_usage, "output_tokens"),
+          reasoning_output_tokens: read_i64(total_usage, "reasoning_output_tokens"),
+          total_tokens: read_total_tokens(total_usage),
+        };
+        let last_token_usage = info
+          .get("last_token_usage")
+          .filter(|last_usage| !last_usage.is_null())
+          .map(|last_usage| TokenUsage {
+            input_tokens: read_i64(last_usage, "input_tokens"),
+            cached_input_tokens: read_i64(last_usage, "cached_input_tokens"),
+            output_tokens: read_i64(last_usage, "output_tokens"),
+            reasoning_output_tokens: read_i64(last_usage, "reasoning_output_tokens"),
+            total_tokens: read_total_tokens(last_usage),
+          });
+        let plan_type = payload
+          .get("rate_limits")
+          .and_then(|rate_limits| rate_limits.get("plan_type"))
+          .and_then(Value::as_str)
+          .map(ToString::to_string);
+        if plan_type.is_some() {
+          latest_plan_type = plan_type.clone();
+        }
+        let limit_id = nested_str(payload, &["rate_limits", "limit_id"])
+          .or_else(|| nested_str(payload, &["rate_limits", "primary", "limit_id"]));
+        let limit_name = nested_str(payload, &["rate_limits", "limit_name"])
+          .or_else(|| nested_str(payload, &["rate_limits", "primary", "limit_name"]));
+        let sample_timestamp = timestamp.unwrap_or_else(now_utc_string);
+        rate_limit_samples.extend(extract_rate_limit_samples(&sample_timestamp, payload));
+        let model_id = current_model
+          .clone()
+          .unwrap_or_else(|| "unknown".to_string());
+        seen_models.insert(model_id.clone());
+        snapshots.push(UsageSnapshot {
+          timestamp: sample_timestamp,
+          model_id,
+          usage,
+          last_token_usage,
+          plan_type,
+          limit_id,
+          limit_name,
+          explicit_fast_mode,
+        });
+      }
+      _ => {}
+    }
+  }
+  let bytes_read = reader.get_ref().bytes_read;
+  for sample in &mut rate_limit_samples {
+    sample.source_session_id = Some(session_id.clone());
+  }
+  let new_checkpoint = ParserCheckpoint {
+    completed_offset,
+    prefix_signature: read_prefix_signature(&session_file.path, completed_offset).map_err(
+      |error| {
+        (
+          format!(
+            "Failed to checkpoint {}: {error}",
+            session_file.path.display()
+          ),
+          bytes_read,
+        )
+      },
+    )?,
+    last_usage: monotonic_usage_high_water(checkpoint.last_usage.clone(), &snapshots),
+    current_model: current_model.clone(),
+    explicit_fast_mode,
+    latest_plan_type: latest_plan_type.clone(),
+  };
+  let parent_session_id = existing_relation.and_then(|relation| relation.parent_session_id.clone());
+  Ok(Some((
+    ParsedSession {
+      raw_session: RawSession {
+        session_id: session_id.clone(),
+        parent_session_id,
+        root_session_id: session_id.clone(),
+        title: titles.get(session_id).cloned(),
+        source_state: session_file.bucket.clone(),
+        source_path: Some(session_file.path.to_string_lossy().to_string()),
+        started_at: None,
+        updated_at,
+        model_ids: seen_models.into_iter().collect(),
+        contains_subagents: false,
+        agent_nickname: None,
+        agent_role: None,
+      },
+      snapshots,
+      rate_limit_samples,
+      explicit_forked_from_id: None,
+      explicit_fork_timestamp: None,
+      inherited_token_snapshot_cutoff: 0,
+      explicit_fast_mode,
+      latest_plan_type,
+      last_model_id: current_model.or_else(|| Some("unknown".to_string())),
+      mode: ParsedSessionMode::Tail {
+        previous_usage: checkpoint.last_usage.clone(),
+      },
+      checkpoint: new_checkpoint,
+    },
+    bytes_read,
+  )))
+}
+
 #[cfg(test)]
 fn parse_session_file(
   session_file: &SessionFile,
@@ -1912,6 +2196,7 @@ fn parse_session_file_once(
   let mut seen_models = HashSet::new();
   let mut first_session_meta: Option<SessionMetaCandidate> = None;
   let mut matching_session_meta: Option<SessionMetaCandidate> = None;
+  let mut completed_offset = 0u64;
 
   let mut line = String::new();
   loop {
@@ -1925,6 +2210,10 @@ fn parse_session_file_once(
     if line_bytes == 0 {
       break;
     }
+    if !line.ends_with('\n') {
+      break;
+    }
+    completed_offset = completed_offset.saturating_add(line_bytes as u64);
     if line.contains("\"fast_mode\":true") || line.contains("\"quick_mode\":true") {
       explicit_fast_mode = Some(true);
     }
@@ -2131,6 +2420,22 @@ fn parse_session_file_once(
 
   let title = titles.get(&session_id).cloned();
   let last_model_id = current_model.clone();
+  let checkpoint = ParserCheckpoint {
+    completed_offset,
+    prefix_signature: read_prefix_signature(&session_file.path, completed_offset).map_err(|error| {
+      SessionParseError::Fatal {
+        message: format!(
+          "Failed to checkpoint {}: {error}",
+          session_file.path.display()
+        ),
+        bytes_read,
+      }
+    })?,
+    last_usage: monotonic_usage_high_water(None, &snapshots),
+    current_model: current_model.clone(),
+    explicit_fast_mode,
+    latest_plan_type: latest_plan_type.clone(),
+  };
   let mut rate_limit_samples = rate_limit_samples;
   for sample in &mut rate_limit_samples {
     sample.source_session_id = Some(session_id.clone());
@@ -2160,9 +2465,36 @@ fn parse_session_file_once(
       explicit_fast_mode,
       latest_plan_type,
       last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
+      mode: ParsedSessionMode::Full,
+      checkpoint,
     },
     bytes_read,
   ))
+}
+
+fn read_prefix_signature(path: &Path, completed_offset: u64) -> std::io::Result<Vec<u8>> {
+  let signature_start = completed_offset.saturating_sub(PARSER_PREFIX_SIGNATURE_BYTES);
+  let signature_len = completed_offset.saturating_sub(signature_start) as usize;
+  let mut file = File::open(path)?;
+  file.seek(SeekFrom::Start(signature_start))?;
+  let mut signature = vec![0u8; signature_len];
+  file.read_exact(&mut signature)?;
+  Ok(signature)
+}
+
+fn monotonic_usage_high_water(
+  mut high_water: Option<TokenUsage>,
+  snapshots: &[UsageSnapshot],
+) -> Option<TokenUsage> {
+  for snapshot in snapshots {
+    if high_water
+      .as_ref()
+      .is_none_or(|previous| snapshot.usage.total_tokens > previous.total_tokens)
+    {
+      high_water = Some(snapshot.usage.clone());
+    }
+  }
+  high_water
 }
 
 fn fallback_session_id_from_filename(path: &Path) -> Option<String> {
@@ -2600,7 +2932,7 @@ fn persist_session(
       source_path = excluded.source_path,
       source_bucket = excluded.source_bucket,
       started_at = COALESCE(sessions.started_at, excluded.started_at),
-      updated_at = excluded.updated_at,
+      updated_at = COALESCE(excluded.updated_at, sessions.updated_at),
       agent_nickname = COALESCE(excluded.agent_nickname, sessions.agent_nickname),
       agent_role = COALESCE(excluded.agent_role, sessions.agent_role),
       explicit_fast_mode = excluded.explicit_fast_mode,
@@ -2630,17 +2962,30 @@ fn persist_session(
     ],
   )?;
 
-  replace_session_rate_limit_samples(
-    conn,
-    &parsed.raw_session.session_id,
-    &parsed.rate_limit_samples,
-  )?;
+  match &parsed.mode {
+    ParsedSessionMode::Full => replace_session_rate_limit_samples(
+      conn,
+      &parsed.raw_session.session_id,
+      &parsed.rate_limit_samples,
+    )?,
+    ParsedSessionMode::Tail { .. } => append_session_rate_limit_samples(
+      conn,
+      &parsed.raw_session.session_id,
+      &parsed.rate_limit_samples,
+    )?,
+  };
 
-  let snapshot_cutoff = parsed.inherited_token_snapshot_cutoff;
-  let mut previous_usage = snapshot_cutoff
-    .checked_sub(1)
-    .and_then(|index| parsed.snapshots.get(index))
-    .map(|snapshot| snapshot.usage.clone());
+  let (snapshot_cutoff, mut previous_usage) = match &parsed.mode {
+    ParsedSessionMode::Full => {
+      let snapshot_cutoff = parsed.inherited_token_snapshot_cutoff;
+      let previous_usage = snapshot_cutoff
+        .checked_sub(1)
+        .and_then(|index| parsed.snapshots.get(index))
+        .map(|snapshot| snapshot.usage.clone());
+      (snapshot_cutoff, previous_usage)
+    }
+    ParsedSessionMode::Tail { previous_usage } => (0, previous_usage.clone()),
+  };
 
   let mut usage_event_plan = Vec::new();
   for (snapshot_index, snapshot) in parsed.snapshots.iter().enumerate().skip(snapshot_cutoff) {
@@ -2669,17 +3014,14 @@ fn persist_session(
     usage_event_plan.push((snapshot_index, delta));
   }
 
-  replace_session_usage_events(
-    conn,
-    &parsed.raw_session.session_id,
-    usage_event_plan
-      .iter()
-      .map(|(snapshot_index, _)| parsed.snapshots[*snapshot_index].timestamp.as_str()),
-    |index| {
+  let timestamps = usage_event_plan
+    .iter()
+    .map(|(snapshot_index, _)| parsed.snapshots[*snapshot_index].timestamp.as_str());
+  let event_at = |index: usize| {
       let (snapshot_index, delta) = &usage_event_plan[index];
       let snapshot = &parsed.snapshots[*snapshot_index];
       let resolved_pricing = resolve_pricing(catalog, &snapshot.model_id);
-      let value_usd = calculate_value_usd(&delta, resolved_pricing.as_ref());
+      let value_usd = calculate_value_usd(delta, resolved_pricing.as_ref());
       Some(NewUsageEvent {
         session_id: &parsed.raw_session.session_id,
         model_id: normalize_model_id(&snapshot.model_id),
@@ -2692,18 +3034,38 @@ fn persist_session(
         fast_mode_auto: false,
         fast_mode_effective: false,
       })
-    },
-  )?;
+    };
+  match &parsed.mode {
+    ParsedSessionMode::Full => replace_session_usage_events(
+      conn,
+      &parsed.raw_session.session_id,
+      timestamps,
+      event_at,
+    )?,
+    ParsedSessionMode::Tail { .. } => append_session_usage_events(
+      conn,
+      &parsed.raw_session.session_id,
+      timestamps,
+      event_at,
+    )?,
+  };
+
+  let parser_checkpoint = serde_json::to_string(&parsed.checkpoint)
+    .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?;
 
   conn.execute(
     "
-    INSERT INTO import_state (source_path, session_id, source_bucket, file_size, file_mtime_ms, last_imported_at)
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+    INSERT INTO import_state (
+      source_path, session_id, source_bucket, file_size, file_mtime_ms,
+      parser_checkpoint, last_imported_at
+    )
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
     ON CONFLICT(source_path) DO UPDATE SET
       session_id = excluded.session_id,
       source_bucket = excluded.source_bucket,
       file_size = excluded.file_size,
       file_mtime_ms = excluded.file_mtime_ms,
+      parser_checkpoint = excluded.parser_checkpoint,
       last_imported_at = excluded.last_imported_at
     ",
     params![
@@ -2712,6 +3074,7 @@ fn persist_session(
       session_file.bucket,
       session_file.file_size,
       session_file.file_mtime_ms,
+      parser_checkpoint,
       now_utc_string(),
     ],
   )?;
@@ -2841,7 +3204,7 @@ fn normalize_local_timestamp(timestamp: chrono::DateTime<Local>) -> chrono::Date
 fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, ImportState>> {
   let mut stmt = conn.prepare(
     "
-    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms
+    SELECT source_path, session_id, source_bucket, file_size, file_mtime_ms, parser_checkpoint
     FROM import_state
     ",
   )?;
@@ -2853,6 +3216,9 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
       source_bucket: row.get(2)?,
       file_size: row.get(3)?,
       file_mtime_ms: row.get(4)?,
+      parser_checkpoint: row
+        .get::<_, Option<String>>(5)?
+        .and_then(|checkpoint| serde_json::from_str(&checkpoint).ok()),
     })
   })?;
 
@@ -3152,6 +3518,7 @@ struct ImportState {
   source_bucket: String,
   file_size: i64,
   file_mtime_ms: i64,
+  parser_checkpoint: Option<ParserCheckpoint>,
 }
 
 #[cfg(test)]
@@ -3419,6 +3786,8 @@ mod tests {
         explicit_fast_mode: None,
         latest_plan_type: None,
         last_model_id: None,
+        mode: ParsedSessionMode::Full,
+        checkpoint: ParserCheckpoint::default(),
       },
       file_needs_rate_limit_repair: false,
       file_needs_token_v2_repair: false,
@@ -6737,6 +7106,152 @@ mod tests {
     assert_eq!(
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn growing_active_session_reads_only_completed_tail_after_checkpoint() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "45454545-4545-4545-4545-454545454545";
+    let session_path = sessions_dir.join("growing.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let filler = "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"ignored\",\"payload\":{}}\n";
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open initial session for append");
+    for _ in 0..4_096 {
+      file.write_all(filler.as_bytes()).expect("append filler");
+    }
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial full scan");
+
+    let appended = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (180, 40, 45, 225),
+      last: (80, 20, 20, 100),
+    });
+    std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open growing session")
+      .write_all(appended.as_bytes())
+      .expect("append completed token line");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare incremental tail");
+    assert!(
+      prepared.stats().source_bytes_read < appended.len() as u64 * 4,
+      "incremental parse should avoid rereading the historical prefix; read {} bytes",
+      prepared.stats().source_bytes_read
+    );
+    commit_prepared_scan(prepared).expect("commit incremental tail");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn changed_checkpoint_suffix_falls_back_to_full_session_parse() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_id = "46464646-4646-4646-4646-464646464646";
+    let session_path = sessions_dir.join("rewritten.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial scan");
+
+    let mut body = std::fs::read_to_string(&session_path).expect("read initial session");
+    let suffix_index = body.rfind('\n').expect("session ends with newline");
+    body.insert(suffix_index, ' ');
+    body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (180, 40, 45, 225),
+      last: (80, 20, 20, 100),
+    }));
+    std::fs::write(&session_path, body).expect("rewrite checkpoint suffix and append");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Incremental,
+    )
+    .expect("prepare safe fallback");
+    assert!(
+      prepared.stats().source_bytes_read > 500,
+      "signature mismatch must re-read the complete session"
+    );
+    commit_prepared_scan(prepared).expect("commit fallback scan");
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn tail_checkpoint_keeps_monotonic_usage_high_water() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_id = "47474747-4747-4747-4747-474747474747";
+    let session_path = sessions_dir.join("rollback.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[
+        ("2026-03-24T00:00:01Z", 100, 0, 0, 100),
+        ("2026-03-24T00:00:02Z", 80, 0, 0, 80),
+      ],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial scan with rollback");
+
+    let appended = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (150, 0, 0, 150),
+      last: (50, 0, 0, 50),
+    });
+    std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open session")
+      .write_all(appended.as_bytes())
+      .expect("append recovery after rollback");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("incremental tail scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (150, 0, 0, 150, 2)
     );
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -30,10 +30,9 @@ struct ParsedSession {
   raw_session: RawSession,
   snapshots: Vec<UsageSnapshot>,
   rate_limit_samples: Vec<RateLimitSampleRecord>,
-  #[allow(dead_code)]
   explicit_forked_from_id: Option<String>,
-  #[allow(dead_code)]
   explicit_fork_timestamp: Option<DateTime<FixedOffset>>,
+  inherited_token_snapshot_cutoff: usize,
   explicit_fast_mode: Option<bool>,
   latest_plan_type: Option<String>,
   last_model_id: Option<String>,
@@ -144,6 +143,8 @@ fn perform_scan_with_scope(
     ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
     ScanScope::Incremental => collect_incremental_session_files(&codex_home, &import_state),
   };
+  let session_source_paths =
+    load_session_source_paths(&conn, &import_state, &session_files).map_err(|error| error.to_string())?;
   let mut present_paths: HashSet<String> = session_files
     .iter()
     .map(|item| item.path.to_string_lossy().to_string())
@@ -189,6 +190,7 @@ fn perform_scan_with_scope(
   let mut topology_dirty = false;
   let mut new_root_session_ids = Vec::new();
   let mut skipped_session_files = false;
+  let mut parent_snapshot_cache: HashMap<String, Option<Vec<UsageSnapshot>>> = HashMap::new();
   if !changed_files.is_empty() {
     let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
     let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
@@ -199,7 +201,7 @@ fn perform_scan_with_scope(
         needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
       let file_needs_token_repair =
         needs_token_usage_repair_sweep || pending_token_repair_paths.contains(&source_path);
-      let parsed = match parse_session_file(session_file, &titles) {
+      let mut parsed = match parse_session_file(session_file, &titles) {
         Ok(parsed) => parsed,
         Err(error) => {
           skipped_session_files = true;
@@ -219,6 +221,11 @@ fn perform_scan_with_scope(
           continue;
         }
       };
+      assign_inherited_token_snapshot_cutoff(
+        &mut parsed,
+        &session_source_paths,
+        &mut parent_snapshot_cache,
+      );
       imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
       match classify_topology_maintenance(
@@ -893,6 +900,7 @@ fn parse_session_file_once(
     rate_limit_samples,
     explicit_forked_from_id,
     explicit_fork_timestamp,
+    inherited_token_snapshot_cutoff: 0,
     explicit_fast_mode,
     latest_plan_type,
     last_model_id: last_model_id.or_else(|| Some("unknown".to_string())),
@@ -927,6 +935,204 @@ fn looks_like_session_id(value: &str) -> bool {
     .all(|(segment, expected_len)| {
       segment.len() == *expected_len && segment.chars().all(|character| character.is_ascii_hexdigit())
     })
+}
+
+fn load_session_source_paths(
+  conn: &Connection,
+  import_state: &HashMap<String, ImportState>,
+  session_files: &[SessionFile],
+) -> rusqlite::Result<HashMap<String, PathBuf>> {
+  let mut source_paths = HashMap::new();
+  let mut stmt = conn.prepare(
+    "SELECT session_id, source_path FROM sessions WHERE source_path IS NOT NULL",
+  )?;
+  let rows = stmt.query_map([], |row| {
+    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+  })?;
+
+  for row in rows {
+    let (session_id, source_path) = row?;
+    source_paths.insert(session_id, PathBuf::from(source_path));
+  }
+  drop(stmt);
+
+  for state in import_state.values() {
+    let Some(session_id) = state.session_id.as_ref() else {
+      continue;
+    };
+    source_paths.insert(session_id.clone(), PathBuf::from(&state.source_path));
+  }
+
+  for session_file in session_files {
+    let Some(session_id) = fallback_session_id_from_filename(&session_file.path) else {
+      continue;
+    };
+    source_paths.insert(session_id, session_file.path.clone());
+  }
+
+  Ok(source_paths)
+}
+
+fn assign_inherited_token_snapshot_cutoff(
+  parsed: &mut ParsedSession,
+  session_source_paths: &HashMap<String, PathBuf>,
+  parent_snapshot_cache: &mut HashMap<String, Option<Vec<UsageSnapshot>>>,
+) {
+  let Some(parent_session_id) = parsed
+    .explicit_forked_from_id
+    .as_deref()
+    .filter(|session_id| !session_id.trim().is_empty())
+  else {
+    return;
+  };
+  let Some(fork_timestamp) = parsed.explicit_fork_timestamp else {
+    return;
+  };
+
+  if !parent_snapshot_cache.contains_key(parent_session_id) {
+    let parent_snapshots = match session_source_paths.get(parent_session_id) {
+      Some(source_path) => match read_parent_replay_snapshots(source_path, parent_session_id) {
+        Ok(snapshots) => Some(snapshots),
+        Err(()) => {
+          log::warn!(
+            "Replay parent unavailable: child_id={}, parent_id={}, source_path={}",
+            parsed.raw_session.session_id,
+            parent_session_id,
+            source_path.display()
+          );
+          None
+        }
+      },
+      None => {
+        log::warn!(
+          "Replay parent unavailable: child_id={}, parent_id={}",
+          parsed.raw_session.session_id,
+          parent_session_id
+        );
+        None
+      }
+    };
+    parent_snapshot_cache.insert(parent_session_id.to_string(), parent_snapshots);
+  }
+
+  let Some(parent_snapshots) = parent_snapshot_cache
+    .get(parent_session_id)
+    .and_then(Option::as_deref)
+  else {
+    return;
+  };
+
+  parsed.inherited_token_snapshot_cutoff = replayed_child_snapshot_cutoff(
+    parent_snapshots,
+    &parsed.snapshots,
+    Some(fork_timestamp),
+  );
+}
+
+fn read_parent_replay_snapshots(
+  source_path: &Path,
+  requested_parent_id: &str,
+) -> Result<Vec<UsageSnapshot>, ()> {
+  let filename_session_id = fallback_session_id_from_filename(source_path);
+  if filename_session_id
+    .as_deref()
+    .is_some_and(|session_id| session_id != requested_parent_id)
+  {
+    return Err(());
+  }
+
+  let file = File::open(source_path).map_err(|_| ())?;
+  let mut first_session_meta_id: Option<String> = None;
+  let mut snapshots = Vec::new();
+
+  for line_result in BufReader::new(file).lines() {
+    let line = line_result.map_err(|_| ())?;
+    let may_be_session_meta = json_line_has_string_field(&line, "type", "session_meta");
+    let may_be_token_count = json_line_has_string_field(&line, "type", "event_msg")
+      && json_line_has_string_field(&line, "type", "token_count");
+    if !may_be_session_meta && !may_be_token_count {
+      continue;
+    }
+
+    let Ok(value) = serde_json::from_str::<Value>(&line) else {
+      continue;
+    };
+    match value.get("type").and_then(Value::as_str) {
+      Some("session_meta") if first_session_meta_id.is_none() => {
+        let Some(session_id) = value
+          .get("payload")
+          .and_then(|payload| payload.get("id"))
+          .and_then(Value::as_str)
+        else {
+          continue;
+        };
+        if filename_session_id.is_none() && session_id != requested_parent_id {
+          return Err(());
+        }
+        first_session_meta_id = Some(session_id.to_string());
+      }
+      Some("event_msg") => {
+        let payload = value.get("payload").unwrap_or(&Value::Null);
+        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
+          continue;
+        }
+        let info = payload.get("info").unwrap_or(&Value::Null);
+        let total_usage = info.get("total_token_usage").unwrap_or(&Value::Null);
+        let Some(timestamp) = value.get("timestamp").and_then(Value::as_str) else {
+          continue;
+        };
+        if total_usage.is_null() {
+          continue;
+        }
+
+        snapshots.push(UsageSnapshot {
+          timestamp: timestamp.to_string(),
+          model_id: String::new(),
+          usage: token_usage_from_json(total_usage),
+          last_token_usage: info
+            .get("last_token_usage")
+            .filter(|last_usage| !last_usage.is_null())
+            .map(token_usage_from_json),
+          plan_type: None,
+          limit_id: None,
+          limit_name: None,
+          explicit_fast_mode: None,
+        });
+      }
+      _ => {}
+    }
+  }
+
+  if filename_session_id.is_none() && first_session_meta_id.is_none() {
+    return Err(());
+  }
+  if snapshots.is_empty() {
+    return Err(());
+  }
+
+  Ok(snapshots)
+}
+
+fn json_line_has_string_field(line: &str, field: &str, expected_value: &str) -> bool {
+  let field = format!("\"{field}\"");
+  let expected_value = format!("\"{expected_value}\"");
+
+  line.match_indices(&field).any(|(index, _)| {
+    line[index + field.len()..]
+      .trim_start()
+      .strip_prefix(':')
+      .is_some_and(|rest| rest.trim_start().starts_with(&expected_value))
+  })
+}
+
+fn token_usage_from_json(value: &Value) -> TokenUsage {
+  TokenUsage {
+    input_tokens: read_i64(value, "input_tokens"),
+    cached_input_tokens: read_i64(value, "cached_input_tokens"),
+    output_tokens: read_i64(value, "output_tokens"),
+    reasoning_output_tokens: read_i64(value, "reasoning_output_tokens"),
+    total_tokens: read_total_tokens(value),
+  }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -983,7 +1189,6 @@ fn kmp_prefix_table(pattern: &[ReplayKey]) -> Vec<usize> {
   table
 }
 
-#[allow(dead_code)]
 fn replayed_child_snapshot_cutoff(
   parent_snapshots: &[UsageSnapshot],
   child_snapshots: &[UsageSnapshot],
@@ -1104,9 +1309,13 @@ fn persist_session(
   )?;
   replace_session_rate_limit_samples(&tx, &parsed.raw_session.session_id, &parsed.rate_limit_samples)?;
 
-  let mut previous_usage: Option<TokenUsage> = None;
+  let snapshot_cutoff = parsed.inherited_token_snapshot_cutoff;
+  let mut previous_usage = snapshot_cutoff
+    .checked_sub(1)
+    .and_then(|index| parsed.snapshots.get(index))
+    .map(|snapshot| snapshot.usage.clone());
 
-  for snapshot in &parsed.snapshots {
+  for snapshot in parsed.snapshots.iter().skip(snapshot_cutoff) {
     if previous_usage.as_ref() == Some(&snapshot.usage) {
       continue;
     }
@@ -1116,6 +1325,11 @@ fn persist_session(
         continue;
       }
       diff_usage(previous, &snapshot.usage)
+    } else if parsed.explicit_forked_from_id.is_some() {
+      snapshot
+        .last_token_usage
+        .clone()
+        .unwrap_or_else(|| snapshot.usage.clone())
     } else {
       snapshot.usage.clone()
     };

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -104,11 +104,19 @@ fn perform_scan_with_scope(
     &codex_home,
     home_dir.as_deref(),
   );
+  let resolved_codex_home = codex_home.to_string_lossy().to_string();
   let scan_started_at = now_utc_string();
-  if track_scan_freshness {
-    set_last_scan_started_for_source(&conn, &scan_started_at, scan_source_selector.as_deref())
-      .map_err(|error| error.to_string())?;
-  }
+  let scan_freshness_start = if track_scan_freshness {
+    set_last_scan_started_for_source(
+      &conn,
+      &scan_started_at,
+      scan_source_selector.as_deref(),
+      &resolved_codex_home,
+    )
+    .map_err(|error| error.to_string())?
+  } else {
+    Default::default()
+  };
 
   let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
@@ -116,15 +124,13 @@ fn perform_scan_with_scope(
     data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
   let pending_token_repair_paths =
     load_pending_data_repair_paths(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
-  let effective_scope = if requested_scope == ScanScope::Full
-    || import_state.is_empty()
-    || needs_rate_limit_backfill
-    || needs_token_usage_repair_sweep
-  {
-    ScanScope::Full
-  } else {
-    ScanScope::Incremental
-  };
+  let effective_scope = effective_scan_scope(
+    requested_scope,
+    import_state.is_empty(),
+    needs_rate_limit_backfill,
+    needs_token_usage_repair_sweep,
+    scan_freshness_start.full_scan_required,
+  );
 
   let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
     ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
@@ -253,11 +259,12 @@ fn perform_scan_with_scope(
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
   }
-  if track_scan_freshness {
+  if scan_freshness_start.recorded {
     set_scan_completed_for_source(
       &conn,
       &completed_at,
       scan_source_selector.as_deref(),
+      &resolved_codex_home,
       effective_scope == ScanScope::Full,
     )
     .map_err(|error| error.to_string())?;
@@ -271,6 +278,25 @@ fn perform_scan_with_scope(
     missing_sessions,
     last_completed_at: completed_at,
   })
+}
+
+fn effective_scan_scope(
+  requested_scope: ScanScope,
+  import_state_is_empty: bool,
+  needs_rate_limit_backfill: bool,
+  needs_token_usage_repair_sweep: bool,
+  resolved_source_requires_full_scan: bool,
+) -> ScanScope {
+  if requested_scope == ScanScope::Full
+    || import_state_is_empty
+    || needs_rate_limit_backfill
+    || needs_token_usage_repair_sweep
+    || resolved_source_requires_full_scan
+  {
+    ScanScope::Full
+  } else {
+    ScanScope::Incremental
+  }
 }
 
 fn import_state_session_id_mismatch(state: &ImportState, session_file: &SessionFile) -> bool {
@@ -1419,7 +1445,33 @@ mod tests {
   use super::*;
   use crate::database::{init_db, now_utc_string, open_connection, save_sync_settings};
   use rusqlite::OptionalExtension;
+  use std::ffi::OsString;
+  use std::sync::Mutex;
   use tempfile::tempdir;
+
+  static CODEX_HOME_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+  struct CodexHomeEnvGuard {
+    previous: Option<OsString>,
+  }
+
+  impl CodexHomeEnvGuard {
+    fn set(path: &Path) -> Self {
+      let previous = std::env::var_os("CODEX_HOME");
+      std::env::set_var("CODEX_HOME", path);
+      Self { previous }
+    }
+  }
+
+  impl Drop for CodexHomeEnvGuard {
+    fn drop(&mut self) {
+      if let Some(previous) = self.previous.take() {
+        std::env::set_var("CODEX_HOME", previous);
+      } else {
+        std::env::remove_var("CODEX_HOME");
+      }
+    }
+  }
 
   #[test]
   fn diff_usage_handles_growth_and_component_rollbacks() {
@@ -2899,6 +2951,65 @@ mod tests {
     assert_eq!(started, None);
     assert_eq!(completed, None);
     assert_eq!(full_completed, None);
+  }
+
+  #[test]
+  fn changed_resolved_default_source_forces_full_scan() {
+    assert_eq!(
+      effective_scan_scope(ScanScope::Incremental, false, false, false, true),
+      ScanScope::Full
+    );
+  }
+
+  #[test]
+  fn incremental_scan_finds_untracked_archives_after_default_source_moves() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let first_codex_home = directory.path().join("codex-home-a");
+    let second_codex_home = directory.path().join("codex-home-b");
+    let first_sessions = first_codex_home.join("sessions");
+    let second_archives = second_codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&first_sessions).expect("first sessions");
+    std::fs::create_dir_all(&second_archives).expect("second archives");
+
+    let first_session_id = "18181818-1818-1818-1818-181818181818";
+    write_session_file(
+      &first_sessions.join("first.jsonl"),
+      first_session_id,
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    let second_session_id = "28282828-2828-2828-2828-282828282828";
+    write_session_file(
+      &second_archives.join("second.jsonl"),
+      second_session_id,
+      &[("2026-07-10T01:00:00Z", 200, 40, 20, 220)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    let _environment = CodexHomeEnvGuard::set(&first_codex_home);
+    perform_scan(&db_path, None).expect("scan first default source");
+
+    std::env::set_var("CODEX_HOME", &second_codex_home);
+    let result = perform_incremental_scan(&db_path, None).expect("scan moved default source");
+
+    let conn = open_connection(&db_path).expect("open database");
+    let (selector, resolved_source): (Option<String>, Option<String>) = conn
+      .query_row(
+        "
+        SELECT codex_home, last_scan_codex_home
+        FROM sync_settings
+        WHERE singleton_id = 1
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+      )
+      .expect("load scan source identity");
+
+    assert_eq!(selector, None);
+    assert_eq!(resolved_source.as_deref(), Some(second_codex_home.to_string_lossy().as_ref()));
+    assert_eq!(result.scanned_files, 1);
+    assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
+    assert_eq!(session_usage_totals(&conn, first_session_id).3, 110);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1308,7 +1308,16 @@ fn replayed_child_snapshot_cutoff(
     };
     child_pattern.push(key);
   }
-  if child_pattern.len() < 2 {
+  let parent_canonical = canonical_replay_snapshots(parent_snapshots);
+  let eligible_parent_snapshot_count = parent_canonical
+    .iter()
+    .filter(|parent| {
+      DateTime::parse_from_rfc3339(&parent.snapshot.timestamp)
+        .is_ok_and(|timestamp| timestamp <= explicit_fork_timestamp)
+    })
+    .count();
+  let minimum_match_length = if eligible_parent_snapshot_count == 1 { 1 } else { 2 };
+  if child_pattern.len() < minimum_match_length {
     return 0;
   }
 
@@ -1316,7 +1325,7 @@ fn replayed_child_snapshot_cutoff(
   let mut matched = 0;
   let mut longest_match = 0;
 
-  for parent in canonical_replay_snapshots(parent_snapshots) {
+  for parent in parent_canonical {
     let Ok(parent_timestamp) = DateTime::parse_from_rfc3339(&parent.snapshot.timestamp) else {
       continue;
     };
@@ -1341,7 +1350,7 @@ fn replayed_child_snapshot_cutoff(
     }
   }
 
-  if longest_match < 2 {
+  if longest_match < minimum_match_length {
     0
   } else {
     child_canonical[longest_match - 1].raw_index + 1
@@ -2260,17 +2269,23 @@ mod tests {
   }
 
   #[test]
-  fn replay_matching_rejects_one_exact_record() {
+  fn replay_matching_rejects_one_exact_record_from_longer_parent() {
     let record = replay_snapshot(
       "2026-03-24T00:00:00Z",
       "model",
       (100, 10, 20, 1, 121),
       Some((100, 10, 20, 1, 121)),
     );
+    let parent_second = replay_snapshot(
+      "2026-03-24T00:00:30Z",
+      "model",
+      (180, 20, 35, 2, 217),
+      Some((80, 10, 15, 1, 96)),
+    );
 
     assert_eq!(
       replayed_child_snapshot_cutoff(
-        std::slice::from_ref(&record),
+        &[record.clone(), parent_second],
         std::slice::from_ref(&record),
         Some(fork_instant("2026-03-24T00:01:00Z")),
       ),
@@ -4195,6 +4210,74 @@ mod tests {
     assert_eq!(parent_total, 260);
     assert_eq!(child_total, 50);
     assert_eq!(parent_total + child_total, 310);
+  }
+
+  #[test]
+  fn single_snapshot_parent_replay_counts_only_child_usage() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let parent_session_id = "61616161-6161-4161-8161-616161616161";
+    let child_session_id = "62626262-6262-4262-8262-626262626262";
+    let parent_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let child_path = sessions_dir.join(format!(
+      "rollout-2026-03-24T00-30-00-{child_session_id}.jsonl"
+    ));
+    let inherited = TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    };
+
+    let mut parent_body = format!(
+      concat!(
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"session_meta\",",
+        "\"payload\":{{\"id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      parent_session_id,
+    );
+    parent_body.push_str(&token_count_line(inherited));
+    std::fs::write(&parent_path, parent_body).expect("write single-snapshot parent");
+
+    let child_created_at = "2026-03-24T00:30:00Z";
+    let mut child_body = format!(
+      concat!(
+        "{{\"timestamp\":\"{}\",\"type\":\"session_meta\",\"payload\":{{",
+        "\"id\":\"{}\",\"forked_from_id\":\"{}\"}}}}\n",
+        "{{\"timestamp\":\"{}\",\"type\":\"turn_context\",",
+        "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+      ),
+      child_created_at,
+      child_session_id,
+      parent_session_id,
+      child_created_at,
+    );
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:30:01Z",
+      ..inherited
+    }));
+    child_body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:31:00Z",
+      total: (150, 0, 0, 150),
+      last: (50, 0, 0, 50),
+    }));
+    std::fs::write(&child_path, child_body).expect("write fork child");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    let parent_total = session_usage_totals(&conn, parent_session_id).3;
+    let child_total = session_usage_totals(&conn, child_session_id).3;
+    assert_eq!(parent_total, 100);
+    assert_eq!(child_total, 50);
+    assert_eq!(parent_total + child_total, 150);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3172,7 +3172,7 @@ fn extract_rate_limit_samples(timestamp: &str, payload: &Value) -> Vec<RateLimit
     .map(ToString::to_string);
 
   let mut samples = Vec::new();
-  for (bucket, window_key) in [("five_hour", "primary"), ("seven_day", "secondary")] {
+  for (default_bucket, window_key) in [("five_hour", "primary"), ("seven_day", "secondary")] {
     let Some(rate_window) = rate_limits.get(window_key) else {
       continue;
     };
@@ -3185,6 +3185,11 @@ fn extract_rate_limit_samples(timestamp: &str, payload: &Value) -> Vec<RateLimit
       .or_else(|| rate_window.get("window_minutes").and_then(Value::as_i64))
     else {
       continue;
+    };
+    let bucket = if window_duration_mins == 7 * 24 * 60 {
+      "seven_day"
+    } else {
+      default_bucket
     };
     let Some(resets_at_seconds) = rate_window.get("resets_at").and_then(Value::as_i64) else {
       continue;
@@ -5669,6 +5674,26 @@ mod tests {
     assert_eq!(samples.2, "seven_day".to_string());
     assert_eq!(samples.3, 79);
     assert_eq!(samples.4, 88);
+  }
+
+  #[test]
+  fn primary_only_seven_day_rate_limit_is_imported_into_the_seven_day_bucket() {
+    let payload = serde_json::json!({
+      "rate_limits": {
+        "plan_type": "pro",
+        "primary": {
+          "used_percent": 21,
+          "window_duration_mins": 10_080,
+          "resets_at": 1_774_589_128
+        }
+      }
+    });
+
+    let samples = extract_rate_limit_samples("2026-03-26T11:45:00+08:00", &payload);
+
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].bucket, "seven_day");
+    assert_eq!(samples[0].remaining_percent, 79);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -140,7 +140,7 @@ unsafe extern "C" {
 }
 
 #[cfg(target_os = "macos")]
-fn release_unused_process_memory() {
+pub(crate) fn release_unused_process_memory() {
   // SAFETY: A null zone asks the macOS allocator to visit every registered zone.
   // The call only releases pages currently unused by those zones.
   unsafe {
@@ -149,7 +149,7 @@ fn release_unused_process_memory() {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn release_unused_process_memory() {}
+pub(crate) fn release_unused_process_memory() {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScanKind {

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -162,6 +162,8 @@ pub(crate) enum ScanKind {
 pub(crate) struct PreparedScanStats {
   pub files_visited: usize,
   pub source_bytes_read: u64,
+  pub tail_parsed_files: usize,
+  pub fully_parsed_files: usize,
   pub full_rebuild: bool,
   pub used_spool: bool,
   pub parent_replay_cache_evictions: usize,
@@ -883,6 +885,8 @@ pub(crate) fn prepare_scan(
   let stats = PreparedScanStats {
     files_visited: session_files.len(),
     source_bytes_read: 0,
+    tail_parsed_files: 0,
+    fully_parsed_files: 0,
     full_rebuild: effective_kind == ScanKind::Full,
     used_spool: false,
     parent_replay_cache_evictions: 0,
@@ -955,6 +959,8 @@ pub(crate) fn prepare_scan(
   let mut storage = PreparedStorageBuilder::new();
   let mut updated_sessions = 0usize;
   let mut source_bytes_read = 0u64;
+  let mut tail_parsed_files = 0usize;
+  let mut fully_parsed_files = 0usize;
 
   for session_file in changed_files {
     let source_path = session_file.path.to_string_lossy().to_string();
@@ -986,8 +992,14 @@ pub(crate) fn prepare_scan(
       Ok(None)
     };
     let parsed_result = match tail_candidate {
-      Ok(Some(result)) => Ok(result),
-      Ok(None) => parse_session_file_counted(&session_file, &titles),
+      Ok(Some(result)) => {
+        tail_parsed_files += 1;
+        Ok(result)
+      }
+      Ok(None) => {
+        fully_parsed_files += 1;
+        parse_session_file_counted(&session_file, &titles)
+      }
       Err(error) => Err(error),
     };
     let (mut parsed, bytes_read) = match parsed_result {
@@ -1090,6 +1102,8 @@ pub(crate) fn prepare_scan(
   let storage = storage.finish()?;
   let stats = PreparedScanStats {
     source_bytes_read,
+    tail_parsed_files,
+    fully_parsed_files,
     used_spool: matches!(&storage, PreparedStorage::Spool { .. }),
     parent_replay_cache_evictions,
     parent_replay_cache_oversized_bypasses,
@@ -1325,6 +1339,15 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
     imported_sessions,
     updated_sessions,
     missing_sessions,
+    scan_kind: match effective_kind {
+      ScanKind::Full => "full",
+      ScanKind::Reconcile => "reconcile",
+      ScanKind::Incremental => "incremental",
+    }
+    .to_string(),
+    source_bytes_read: stats.source_bytes_read,
+    tail_parsed_files: stats.tail_parsed_files,
+    fully_parsed_files: stats.fully_parsed_files,
     last_completed_at: completed_at,
   })
 }
@@ -7227,6 +7250,110 @@ mod tests {
     assert_eq!(
       session_usage_totals(&conn, session_id),
       (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn reconcile_scan_reads_only_completed_tail_after_checkpoint() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "56565656-5656-5656-5656-565656565656";
+    let session_path = sessions_dir.join("reconciled-growing.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let filler = "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"ignored\",\"payload\":{}}\n";
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open initial session for append");
+    for _ in 0..4_096 {
+      file.write_all(filler.as_bytes()).expect("append filler");
+    }
+    drop(file);
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial full scan");
+
+    let appended = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:01:01Z",
+      total: (180, 40, 45, 225),
+      last: (80, 20, 20, 100),
+    });
+    std::fs::OpenOptions::new()
+      .append(true)
+      .open(&session_path)
+      .expect("open growing session")
+      .write_all(appended.as_bytes())
+      .expect("append completed token line");
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Reconcile,
+    )
+    .expect("prepare reconcile tail");
+    assert_eq!(prepared.stats().tail_parsed_files, 1);
+    assert_eq!(prepared.stats().fully_parsed_files, 0);
+    assert!(
+      prepared.stats().source_bytes_read < appended.len() as u64 * 4,
+      "reconcile should avoid rereading the historical prefix; read {} bytes",
+      prepared.stats().source_bytes_read
+    );
+    commit_prepared_scan(prepared).expect("commit reconcile tail");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, session_id),
+      (180, 40, 45, 225, 2)
+    );
+  }
+
+  #[test]
+  fn reconcile_scan_discovers_new_archived_session() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archives_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archives_dir).expect("archives dir");
+
+    let initial_id = "67676767-6767-6767-6767-676767676767";
+    write_session_file(
+      &sessions_dir.join("initial.jsonl"),
+      initial_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("initial full scan");
+
+    let archived_id = "78787878-7878-7878-7878-787878787878";
+    write_session_file(
+      &archives_dir.join("new-archive.jsonl"),
+      archived_id,
+      &[("2026-03-24T01:00:01Z", 200, 40, 50, 250)],
+    );
+
+    let prepared = prepare_scan(
+      &db_path,
+      Some(codex_home.to_string_lossy().to_string()),
+      ScanKind::Reconcile,
+    )
+    .expect("prepare reconcile scan");
+    assert_eq!(prepared.stats().fully_parsed_files, 1);
+    commit_prepared_scan(prepared).expect("commit reconcile scan");
+
+    let conn = open_connection(&db_path).expect("open database");
+    assert_eq!(
+      session_usage_totals(&conn, archived_id),
+      (200, 40, 50, 250, 1)
     );
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -154,6 +154,7 @@ pub(crate) fn release_unused_process_memory() {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScanKind {
   Full,
+  Reconcile,
   Incremental,
 }
 
@@ -874,6 +875,7 @@ pub(crate) fn prepare_scan(
 
   let (session_files, active_paths_kept_for_archive_retry) = match effective_kind {
     ScanKind::Full => (collect_session_files(&codex_home), HashSet::new()),
+    ScanKind::Reconcile => (collect_session_files(&codex_home), HashSet::new()),
     ScanKind::Incremental => {
       collect_incremental_session_files(&codex_home, &import_state, &pending_repair_session_ids)
     }
@@ -939,7 +941,7 @@ pub(crate) fn prepare_scan(
     changed_files.push(session_file.clone());
   }
 
-  let titles = if effective_kind == ScanKind::Full || !changed_files.is_empty() {
+  let titles = if effective_kind != ScanKind::Incremental || !changed_files.is_empty() {
     load_session_index(&codex_home)
   } else {
     HashMap::new()
@@ -962,7 +964,7 @@ pub(crate) fn prepare_scan(
       needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
     let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
       || pending_fork_replay_v3_repair_paths.contains(&source_path);
-    let tail_candidate = if effective_kind == ScanKind::Incremental
+    let tail_candidate = if effective_kind != ScanKind::Full
       && !file_needs_rate_limit_repair
       && !file_needs_token_v2_repair
       && !file_needs_fork_replay_v3_repair
@@ -1066,7 +1068,7 @@ pub(crate) fn prepare_scan(
     updated_sessions += 1;
   }
 
-  let titles = if effective_kind == ScanKind::Full {
+  let titles = if effective_kind != ScanKind::Incremental {
     titles
   } else {
     HashMap::new()
@@ -1254,7 +1256,7 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
     }
   }
 
-  if effective_kind == ScanKind::Full {
+  if effective_kind != ScanKind::Incremental {
     refresh_session_titles(&tx, &titles).map_err(|error| error.to_string())?;
   }
   apply_missing_source_plan(&tx, missing_plan).map_err(|error| error.to_string())?;
@@ -1295,8 +1297,8 @@ pub(crate) fn commit_prepared_scan(prepared: PreparedScan) -> Result<ScanResult,
       &completed_at,
       source_identity.key.selector.as_deref(),
       &resolved_codex_home,
-      effective_kind == ScanKind::Full && !skipped_session_files,
-      effective_kind == ScanKind::Full && skipped_session_files,
+      effective_kind != ScanKind::Incremental && !skipped_session_files,
+      effective_kind != ScanKind::Incremental && skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
@@ -1500,7 +1502,7 @@ fn prepare_missing_source_plan(
   let mut plan = MissingSourcePlan::default();
 
   match scan_kind {
-    ScanKind::Full => {
+    ScanKind::Full | ScanKind::Reconcile => {
       for source in existing_sources {
         if !present_paths.contains(&source.source_path)
           && (reconcile_existing_absent_sources || !Path::new(&source.source_path).exists())
@@ -1631,7 +1633,7 @@ fn effective_scan_scope(
   {
     ScanKind::Full
   } else {
-    ScanKind::Incremental
+    requested_scope
   }
 }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -137,6 +137,14 @@ fn perform_scan_with_scope(
     data_repair_is_pending(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
   let pending_fork_replay_v3_repair_paths =
     load_pending_data_repair_paths(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let pending_token_v2_repair_session_ids =
+    pending_repair_session_ids(&import_state, &pending_token_v2_repair_paths);
+  let pending_fork_replay_v3_repair_session_ids =
+    pending_repair_session_ids(&import_state, &pending_fork_replay_v3_repair_paths);
+  let pending_token_repair_session_ids = pending_token_v2_repair_session_ids
+    .union(&pending_fork_replay_v3_repair_session_ids)
+    .cloned()
+    .collect::<HashSet<_>>();
   let needs_token_usage_repair_sweep =
     needs_token_usage_v2_repair_sweep || needs_fork_replay_v3_repair_sweep;
   let effective_scope = effective_scan_scope(
@@ -149,7 +157,9 @@ fn perform_scan_with_scope(
 
   let (session_files, active_paths_kept_for_archive_retry) = match effective_scope {
     ScanScope::Full => (collect_session_files(&codex_home), HashSet::new()),
-    ScanScope::Incremental => collect_incremental_session_files(&codex_home, &import_state),
+    ScanScope::Incremental => {
+      collect_incremental_session_files(&codex_home, &import_state, &pending_token_repair_session_ids)
+    }
   };
   let session_source_paths =
     load_session_source_paths(&conn, &import_state, &session_files).map_err(|error| error.to_string())?;
@@ -165,11 +175,23 @@ fn perform_scan_with_scope(
   let mut changed_files = Vec::new();
   for session_file in &session_files {
     let source_path = session_file.path.to_string_lossy().to_string();
+    let session_id = import_state
+      .get(&source_path)
+      .and_then(|state| state.session_id.clone())
+      .or_else(|| fallback_session_id_from_filename(&session_file.path));
+    let session_has_pending_token_v2_repair = session_id
+      .as_ref()
+      .is_some_and(|session_id| pending_token_v2_repair_session_ids.contains(session_id));
+    let session_has_pending_fork_replay_v3_repair = session_id
+      .as_ref()
+      .is_some_and(|session_id| pending_fork_replay_v3_repair_session_ids.contains(session_id));
     if needs_rate_limit_backfill
       || pending_rate_limit_repair_paths.contains(&source_path)
       || needs_token_usage_repair_sweep
       || pending_token_v2_repair_paths.contains(&source_path)
       || pending_fork_replay_v3_repair_paths.contains(&source_path)
+      || session_has_pending_token_v2_repair
+      || session_has_pending_fork_replay_v3_repair
     {
       changed_files.push(session_file);
       continue;
@@ -208,9 +230,9 @@ fn perform_scan_with_scope(
       let source_path = session_file.path.to_string_lossy().to_string();
       let file_needs_rate_limit_repair =
         needs_rate_limit_backfill || pending_rate_limit_repair_paths.contains(&source_path);
-      let file_needs_token_v2_repair =
+      let mut file_needs_token_v2_repair =
         needs_token_usage_v2_repair_sweep || pending_token_v2_repair_paths.contains(&source_path);
-      let file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
+      let mut file_needs_fork_replay_v3_repair = needs_fork_replay_v3_repair_sweep
         || pending_fork_replay_v3_repair_paths.contains(&source_path);
       let mut parsed = match parse_session_file(session_file, &titles) {
         Ok(parsed) => parsed,
@@ -241,6 +263,18 @@ fn perform_scan_with_scope(
         &session_source_paths,
         &mut parent_snapshot_cache,
       );
+      let related_pending_token_v2_paths = pending_repair_paths_for_session(
+        &import_state,
+        &pending_token_v2_repair_paths,
+        &parsed.raw_session.session_id,
+      );
+      let related_pending_fork_replay_v3_paths = pending_repair_paths_for_session(
+        &import_state,
+        &pending_fork_replay_v3_repair_paths,
+        &parsed.raw_session.session_id,
+      );
+      file_needs_token_v2_repair |= !related_pending_token_v2_paths.is_empty();
+      file_needs_fork_replay_v3_repair |= !related_pending_fork_replay_v3_paths.is_empty();
       imported_session_ids.insert(parsed.raw_session.session_id.clone());
 
       match classify_topology_maintenance(
@@ -265,10 +299,18 @@ fn perform_scan_with_scope(
       if file_needs_token_v2_repair {
         clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &source_path)
           .map_err(|error| error.to_string())?;
+        for related_source_path in related_pending_token_v2_paths {
+          clear_pending_data_repair_file(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &related_source_path)
+            .map_err(|error| error.to_string())?;
+        }
       }
       if file_needs_fork_replay_v3_repair {
         clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &source_path)
           .map_err(|error| error.to_string())?;
+        for related_source_path in related_pending_fork_replay_v3_paths {
+          clear_pending_data_repair_file(&conn, TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY, &related_source_path)
+            .map_err(|error| error.to_string())?;
+        }
       }
       changed_sessions += 1;
     }
@@ -593,6 +635,7 @@ fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
 fn collect_incremental_session_files(
   codex_home: &Path,
   import_state: &HashMap<String, ImportState>,
+  pending_repair_session_ids: &HashSet<String>,
 ) -> (Vec<SessionFile>, HashSet<String>) {
   let mut files = collect_active_session_files(codex_home);
   let mut collected_paths = files
@@ -609,7 +652,14 @@ fn collect_incremental_session_files(
       ) else {
         continue;
       };
-      if state.file_size == session_file.file_size && state.file_mtime_ms == session_file.file_mtime_ms {
+      let session_has_pending_repair = state
+        .session_id
+        .as_ref()
+        .is_some_and(|session_id| pending_repair_session_ids.contains(session_id));
+      if state.file_size == session_file.file_size
+        && state.file_mtime_ms == session_file.file_mtime_ms
+        && !session_has_pending_repair
+      {
         continue;
       }
       if collected_paths.insert(session_file.path.to_string_lossy().to_string()) {
@@ -1625,6 +1675,40 @@ fn load_pending_data_repair_paths(conn: &Connection, repair_key: &str) -> rusqli
     paths.insert(row?);
   }
   Ok(paths)
+}
+
+fn pending_repair_paths_for_session(
+  import_state: &HashMap<String, ImportState>,
+  pending_paths: &HashSet<String>,
+  session_id: &str,
+) -> Vec<String> {
+  pending_paths
+    .iter()
+    .filter(|source_path| {
+      let import_state_session_id = import_state
+        .get(*source_path)
+        .and_then(|state| state.session_id.as_deref());
+      import_state_session_id == Some(session_id)
+        || (import_state_session_id.is_none()
+          && fallback_session_id_from_filename(Path::new(source_path)).as_deref() == Some(session_id))
+    })
+    .cloned()
+    .collect()
+}
+
+fn pending_repair_session_ids(
+  import_state: &HashMap<String, ImportState>,
+  pending_paths: &HashSet<String>,
+) -> HashSet<String> {
+  pending_paths
+    .iter()
+    .filter_map(|source_path| {
+      import_state
+        .get(source_path)
+        .and_then(|state| state.session_id.clone())
+        .or_else(|| fallback_session_id_from_filename(Path::new(source_path)))
+    })
+    .collect()
 }
 
 fn mark_data_repair_file_pending(
@@ -3580,6 +3664,85 @@ mod tests {
         WHERE repair_key = 'token_usage_fork_replay_v3'
         ",
         [],
+        |row| row.get(0),
+      )
+      .expect("count pending v3 repair files");
+    assert_eq!(pending_v3_count, 0);
+  }
+
+  #[test]
+  fn moved_archive_clears_v3_pending_active_source() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions/2026/07/10");
+    let archived_sessions_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_sessions_dir).expect("archived sessions dir");
+
+    let session_id = "59595959-5959-4959-8959-595959595959";
+    let filename = format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl");
+    let active_path = sessions_dir.join(&filename);
+    let archived_path = archived_sessions_dir.join(&filename);
+    write_session_file(
+      &active_path,
+      session_id,
+      &[("2026-07-10T00:00:01Z", 80, 0, 20, 100)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("initial scan");
+    std::fs::rename(&active_path, &archived_path).expect("archive session during repair");
+    perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("record archived source before stale pending retry");
+
+    let conn = open_connection(&db_path).expect("open db");
+    conn
+      .execute(
+        "DELETE FROM usage_events WHERE session_id = ?1",
+        params![session_id],
+      )
+      .expect("delete corrected usage");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens, output_tokens,
+          reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective
+        )
+        VALUES (?1, '2026-07-10T00:00:01Z', 'gpt-5.4', 160, 0, 40, 0, 200, 0.0, 0, 0)
+        ",
+        params![session_id],
+      )
+      .expect("insert stale usage");
+    conn
+      .execute(
+        "
+        INSERT INTO data_repair_pending_files (repair_key, source_path, last_error, updated_at)
+        VALUES (?1, ?2, 'source moved during repair', ?3)
+        ",
+        params![
+          TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY,
+          active_path.to_string_lossy().to_string(),
+          now_utc_string(),
+        ],
+      )
+      .expect("insert pending active source");
+    drop(conn);
+
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("repair moved archive");
+
+    let conn = open_connection(&db_path).expect("open repaired db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, session_id).3, 100);
+    let pending_v3_count: i64 = conn
+      .query_row(
+        "
+        SELECT COUNT(*)
+        FROM data_repair_pending_files
+        WHERE repair_key = ?1
+        ",
+        params![TOKEN_USAGE_FORK_REPLAY_REPAIR_KEY],
         |row| row.get(0),
       )
       .expect("count pending v3 repair files");

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 
 use crate::database::{
   bool_to_i64, get_sync_settings, init_db, now_utc_string, open_connection,
-  replace_session_rate_limit_samples, set_last_scan_completed, set_last_scan_started,
+  replace_session_rate_limit_samples, set_last_full_scan_completed, set_last_scan_completed, set_last_scan_started,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
@@ -62,8 +62,27 @@ enum SessionParseError {
 }
 
 const TOKEN_USAGE_MONOTONIC_REPAIR_KEY: &str = "token_usage_monotonic_v2";
+const RATE_LIMIT_SAMPLE_BACKFILL_KEY: &str = "rate_limit_sample_backfill_v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScanScope {
+  Full,
+  Incremental,
+}
 
 pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
+  perform_scan_with_scope(db_path, codex_home_override, ScanScope::Full)
+}
+
+pub fn perform_incremental_scan(db_path: &Path, codex_home_override: Option<String>) -> Result<ScanResult, String> {
+  perform_scan_with_scope(db_path, codex_home_override, ScanScope::Incremental)
+}
+
+fn perform_scan_with_scope(
+  db_path: &Path,
+  codex_home_override: Option<String>,
+  requested_scope: ScanScope,
+) -> Result<ScanResult, String> {
   let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
   seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
@@ -72,18 +91,30 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
   let scan_started_at = now_utc_string();
   set_last_scan_started(&conn, &scan_started_at).map_err(|error| error.to_string())?;
 
-  let session_files = collect_session_files(&codex_home);
-  let present_paths: HashSet<String> = session_files
-    .iter()
-    .map(|item| item.path.to_string_lossy().to_string())
-    .collect();
-
   let import_state = load_import_state(&conn).map_err(|error| error.to_string())?;
   let needs_rate_limit_backfill = needs_rate_limit_sample_backfill(&conn).map_err(|error| error.to_string())?;
   let needs_token_usage_repair_sweep =
     data_repair_is_pending(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
   let pending_token_repair_paths =
     load_pending_data_repair_paths(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY).map_err(|error| error.to_string())?;
+  let effective_scope = if requested_scope == ScanScope::Full
+    || import_state.is_empty()
+    || needs_rate_limit_backfill
+    || needs_token_usage_repair_sweep
+  {
+    ScanScope::Full
+  } else {
+    ScanScope::Incremental
+  };
+
+  let session_files = match effective_scope {
+    ScanScope::Full => collect_session_files(&codex_home),
+    ScanScope::Incremental => collect_active_session_files(&codex_home),
+  };
+  let present_paths: HashSet<String> = session_files
+    .iter()
+    .map(|item| item.path.to_string_lossy().to_string())
+    .collect();
 
   let mut changed_sessions = 0usize;
   let mut imported_session_ids = HashSet::new();
@@ -163,8 +194,12 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
     }
   }
 
-  mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
-  prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
+  if effective_scope == ScanScope::Full {
+    mark_missing_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
+    prune_import_state(&conn, &present_paths).map_err(|error| error.to_string())?;
+  } else {
+    mark_missing_active_sources(&conn, &present_paths).map_err(|error| error.to_string())?;
+  }
   if topology_dirty {
     recompute_conversation_links(&conn).map_err(|error| error.to_string())?;
   } else if !new_root_session_ids.is_empty() {
@@ -180,9 +215,16 @@ pub fn perform_scan(db_path: &Path, codex_home_override: Option<String>) -> Resu
     .map_err(|error| error.to_string())? as usize;
 
   let completed_at = now_utc_string();
+  if needs_rate_limit_backfill {
+    mark_data_repair_complete(&conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY, &completed_at)
+      .map_err(|error| error.to_string())?;
+  }
   if needs_token_usage_repair_sweep {
     mark_data_repair_complete(&conn, TOKEN_USAGE_MONOTONIC_REPAIR_KEY, &completed_at)
       .map_err(|error| error.to_string())?;
+  }
+  if effective_scope == ScanScope::Full {
+    set_last_full_scan_completed(&conn, &completed_at).map_err(|error| error.to_string())?;
   }
   set_last_scan_completed(&conn, &completed_at).map_err(|error| error.to_string())?;
 
@@ -348,33 +390,55 @@ fn collect_session_files(codex_home: &Path) -> Vec<SessionFile> {
       continue;
     }
     for entry in WalkDir::new(base).into_iter().filter_map(Result::ok) {
-      if !entry.file_type().is_file() {
-        continue;
+      if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), bucket) {
+        files.push(session_file);
       }
-      if entry.path().extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
-        continue;
-      }
-      let Ok(metadata) = entry.metadata() else {
-        continue;
-      };
-      let file_size = metadata.len() as i64;
-      let file_mtime_ms = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|duration| duration.as_millis() as i64)
-        .unwrap_or_default();
-
-      files.push(SessionFile {
-        path: entry.path().to_path_buf(),
-        bucket: bucket.to_string(),
-        file_size,
-        file_mtime_ms,
-      });
     }
   }
   files.sort_by(|left, right| left.path.cmp(&right.path));
   files
+}
+
+fn collect_active_session_files(codex_home: &Path) -> Vec<SessionFile> {
+  let sessions_root = codex_home.join("sessions");
+  if !sessions_root.exists() {
+    return Vec::new();
+  }
+
+  let mut files = Vec::new();
+  for entry in WalkDir::new(sessions_root).into_iter().filter_map(Result::ok) {
+    if let Some(session_file) = session_file_from_path(entry.path().to_path_buf(), "active") {
+      files.push(session_file);
+    }
+  }
+  files.sort_by(|left, right| left.path.cmp(&right.path));
+  files
+}
+
+fn session_file_from_path(path: PathBuf, bucket: &str) -> Option<SessionFile> {
+  if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+    return None;
+  }
+
+  let metadata = std::fs::metadata(&path).ok()?;
+  if !metadata.is_file() {
+    return None;
+  }
+
+  let file_size = metadata.len() as i64;
+  let file_mtime_ms = metadata
+    .modified()
+    .ok()
+    .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+    .map(|duration| duration.as_millis() as i64)
+    .unwrap_or_default();
+
+  Some(SessionFile {
+    path,
+    bucket: bucket.to_string(),
+    file_size,
+    file_mtime_ms,
+  })
 }
 
 fn parse_session_file(
@@ -921,16 +985,7 @@ fn load_import_state(conn: &Connection) -> rusqlite::Result<HashMap<String, Impo
 }
 
 fn needs_rate_limit_sample_backfill(conn: &Connection) -> rusqlite::Result<bool> {
-  let count = conn.query_row(
-    "
-    SELECT COUNT(*)
-    FROM rate_limit_samples
-    WHERE source_kind = 'session'
-    ",
-    [],
-    |row| row.get::<_, i64>(0),
-  )?;
-  Ok(count == 0)
+  data_repair_is_pending(conn, RATE_LIMIT_SAMPLE_BACKFILL_KEY)
 }
 
 fn data_repair_is_pending(conn: &Connection, repair_key: &str) -> rusqlite::Result<bool> {
@@ -1055,6 +1110,37 @@ fn mark_missing_sources(conn: &Connection, present_paths: &HashSet<String>) -> r
         WHERE session_id = ?2
         ",
         params![now_utc_string(), session_id],
+      )?;
+    }
+  }
+  Ok(())
+}
+
+fn mark_missing_active_sources(conn: &Connection, present_paths: &HashSet<String>) -> rusqlite::Result<()> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, source_path
+    FROM sessions
+    WHERE source_state = 'active' AND source_bucket = 'active' AND source_path IS NOT NULL
+    ",
+  )?;
+  let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
+
+  for row in rows {
+    let (session_id, source_path) = row?;
+    if !present_paths.contains(&source_path) && !Path::new(&source_path).exists() {
+      let now = now_utc_string();
+      conn.execute(
+        "
+        UPDATE sessions
+        SET source_state = 'missing', imported_at = ?1
+        WHERE session_id = ?2
+        ",
+        params![now, session_id],
+      )?;
+      conn.execute(
+        "DELETE FROM import_state WHERE source_path = ?1",
+        params![source_path],
       )?;
     }
   }
@@ -1695,6 +1781,194 @@ mod tests {
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
     assert_eq!(session_source_state(&conn, session_id), Some("archived".to_string()));
+  }
+
+  #[test]
+  fn incremental_scan_skips_archived_session_changes() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    let archived_dir = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::create_dir_all(&archived_dir).expect("archived dir");
+
+    let active_session_id = "12121212-3434-5656-7878-909090909090";
+    let archived_session_id = "abababab-cdcd-efef-1212-343434343434";
+    write_session_file(
+      &sessions_dir.join("active.jsonl"),
+      active_session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let archived_path = archived_dir.join("archived.jsonl");
+    write_session_file(
+      &archived_path,
+      archived_session_id,
+      &[("2026-03-24T00:00:01Z", 150, 30, 40, 190)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+    write_session_file(
+      &archived_path,
+      archived_session_id,
+      &[
+        ("2026-03-24T00:00:01Z", 150, 30, 40, 190),
+        ("2026-03-24T00:10:01Z", 300, 60, 80, 380),
+      ],
+    );
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 0);
+    assert_eq!(session_usage_totals(&conn, active_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_usage_totals(&conn, archived_session_id), (150, 30, 40, 190, 1));
+  }
+
+  #[test]
+  fn incremental_scan_discovers_new_recent_active_session() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let existing_session_id = "99999999-8888-7777-6666-555555555555";
+    write_session_file(
+      &sessions_dir.join("existing.jsonl"),
+      existing_session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+
+    let today = Local::now();
+    let recent_dir = sessions_dir
+      .join(today.format("%Y").to_string())
+      .join(today.format("%m").to_string())
+      .join(today.format("%d").to_string());
+    std::fs::create_dir_all(&recent_dir).expect("recent sessions dir");
+    let new_session_id = "44444444-3333-2222-1111-000000000000";
+    write_session_file(
+      &recent_dir.join("new.jsonl"),
+      new_session_id,
+      &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
+    );
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+  }
+
+  #[test]
+  fn incremental_scan_discovers_new_old_dated_active_session() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let existing_session_id = "10101010-2020-3030-4040-505050505050";
+    write_session_file(
+      &sessions_dir.join("existing.jsonl"),
+      existing_session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+
+    let old_dir = sessions_dir.join("2025").join("11").join("05");
+    std::fs::create_dir_all(&old_dir).expect("old sessions dir");
+    let new_session_id = "60606060-7070-8080-9090-a0a0a0a0a0a0";
+    write_session_file(
+      &old_dir.join("old-new.jsonl"),
+      new_session_id,
+      &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
+    );
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_usage_totals(&conn, new_session_id), (180, 40, 45, 225, 1));
+  }
+
+  #[test]
+  fn incremental_scan_marks_missing_active_source() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let session_id = "b0b0b0b0-c0c0-d0d0-e0e0-f0f0f0f0f0f0";
+    let session_path = sessions_dir.join("sample.jsonl");
+    write_session_file(
+      &session_path,
+      session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+    std::fs::remove_file(&session_path).expect("remove active session");
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 0);
+    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_source_state(&conn, session_id), Some("missing".to_string()));
+  }
+
+  #[test]
+  fn incremental_scan_retries_pending_repair_path_without_import_state() {
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+    let existing_session_id = "77777777-8888-9999-aaaa-bbbbbbbbbbbb";
+    write_session_file(
+      &sessions_dir.join("existing.jsonl"),
+      existing_session_id,
+      &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
+    );
+    let pending_path = sessions_dir.join("unparseable.jsonl");
+    std::fs::write(&pending_path, "not json\n").expect("write bad session");
+
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+
+    let recovered_session_id = "88888888-9999-aaaa-bbbb-cccccccccccc";
+    write_session_file(
+      &pending_path,
+      recovered_session_id,
+      &[("2026-03-24T00:10:01Z", 180, 40, 45, 225)],
+    );
+
+    let result =
+      perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("incremental scan");
+
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, existing_session_id), (100, 20, 25, 125, 1));
+    assert_eq!(session_usage_totals(&conn, recovered_session_id), (180, 40, 45, 225, 1));
+    let pending_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repair_pending_files WHERE repair_key = ?1",
+        params![TOKEN_USAGE_MONOTONIC_REPAIR_KEY],
+        |row| row.get(0),
+      )
+      .expect("query pending repairs");
+    assert_eq!(pending_count, 0);
   }
 
   #[test]

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -472,6 +472,21 @@ fn collect_incremental_session_files(
   let mut active_paths_kept_for_archive_retry = HashSet::new();
 
   for state in import_state.values() {
+    if state.source_bucket == "archived" {
+      let Some(session_file) = session_file_from_path(
+        PathBuf::from(&state.source_path),
+        "archived",
+      ) else {
+        continue;
+      };
+      if state.file_size == session_file.file_size && state.file_mtime_ms == session_file.file_mtime_ms {
+        continue;
+      }
+      if collected_paths.insert(session_file.path.to_string_lossy().to_string()) {
+        files.push(session_file);
+      }
+      continue;
+    }
     if state.source_bucket != "active" || collected_paths.contains(&state.source_path) {
       continue;
     }
@@ -1936,7 +1951,7 @@ mod tests {
   }
 
   #[test]
-  fn incremental_scan_skips_archived_session_changes() {
+  fn incremental_scan_does_not_walk_archived_directory_for_untracked_files() {
     let directory = tempdir().expect("tempdir");
     let codex_home = directory.path().join("codex-home");
     let sessions_dir = codex_home.join("sessions");
@@ -1951,15 +1966,9 @@ mod tests {
       active_session_id,
       &[("2026-03-24T00:00:01Z", 100, 20, 25, 125)],
     );
-    let archived_path = archived_dir.join("archived.jsonl");
-    write_session_file(
-      &archived_path,
-      archived_session_id,
-      &[("2026-03-24T00:00:01Z", 150, 30, 40, 190)],
-    );
-
     let db_path = directory.path().join("usage.sqlite");
     perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("full scan");
+    let archived_path = archived_dir.join("archived.jsonl");
     write_session_file(
       &archived_path,
       archived_session_id,
@@ -1975,7 +1984,7 @@ mod tests {
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(result.updated_sessions, 0);
     assert_eq!(session_usage_totals(&conn, active_session_id), (100, 20, 25, 125, 1));
-    assert_eq!(session_usage_totals(&conn, archived_session_id), (150, 30, 40, 190, 1));
+    assert_eq!(session_usage_totals(&conn, archived_session_id), (0, 0, 0, 0, 0));
   }
 
   #[test]
@@ -2743,6 +2752,78 @@ mod tests {
 
     let conn = open_connection(&db_path).expect("open db");
     assert_eq!(session_usage_totals(&conn, session_id).3, 200);
+    assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
+  }
+
+  #[test]
+  fn incremental_scan_reimports_archived_file_after_incomplete_tail_is_finished() {
+    use std::io::Write;
+
+    let directory = tempdir().expect("tempdir");
+    let codex_home = directory.path().join("codex-home");
+    let sessions = codex_home.join("sessions");
+    let archived = codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&sessions).expect("sessions");
+    std::fs::create_dir_all(&archived).expect("archive");
+    let session_id = "a0a0a0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0";
+    let active_path = sessions.join(format!("rollout-2026-07-10T00-00-00-{session_id}.jsonl"));
+    let archived_path = archived.join(active_path.file_name().expect("filename"));
+    write_session_file(&active_path, session_id, &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)]);
+    let db_path = directory.path().join("usage.sqlite");
+    perform_scan(&db_path, Some(codex_home.to_string_lossy().to_string())).expect("first scan");
+
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&active_path)
+      .expect("open active session");
+    file
+      .write_all(
+        concat!(
+          "{\"timestamp\":\"2026-07-10T00:01:00Z\",\"type\":\"event_msg\",\"payload\":{",
+          "\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
+          "\"input_tokens\":180,\"cached_input_tokens\":40,\"output_tokens\":20,"
+        )
+        .as_bytes(),
+      )
+      .expect("write incomplete tail");
+    drop(file);
+    std::fs::rename(&active_path, &archived_path).expect("archive session");
+
+    let first_result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("import complete prefix from archive");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(first_result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, session_id), (100, 20, 10, 110, 1));
+    let archived_state: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM import_state WHERE source_path = ?1 AND source_bucket = 'archived'",
+        params![archived_path.to_string_lossy().to_string()],
+        |row| row.get(0),
+      )
+      .expect("query archived state");
+    assert_eq!(archived_state, 1);
+    drop(conn);
+
+    let mut file = std::fs::OpenOptions::new()
+      .append(true)
+      .open(&archived_path)
+      .expect("open archived session");
+    file
+      .write_all(
+        concat!(
+          "\"reasoning_output_tokens\":0,\"total_tokens\":200}}",
+          ",\"rate_limits\":{\"plan_type\":\"pro\"}}}\n"
+        )
+        .as_bytes(),
+      )
+      .expect("finish archived tail");
+    drop(file);
+
+    let result = perform_incremental_scan(&db_path, Some(codex_home.to_string_lossy().to_string()))
+      .expect("reimport finished archive");
+    let conn = open_connection(&db_path).expect("open db");
+    assert_eq!(result.updated_sessions, 1);
+    assert_eq!(session_usage_totals(&conn, session_id), (180, 40, 20, 200, 2));
     assert_eq!(session_source_state(&conn, session_id).as_deref(), Some("archived"));
   }
 

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -14,14 +14,16 @@ use serde_json::Value;
 use walkdir::WalkDir;
 
 use crate::database::{
-  bool_to_i64, init_db, now_utc_string, open_connection, preview_scan_freshness_for_source,
+  bool_to_i64, now_utc_string, open_connection, preview_scan_freshness_for_source,
   replace_session_rate_limit_samples, set_last_scan_started_for_source_in_transaction,
   set_scan_completed_for_source,
 };
 use crate::models::{RateLimitSampleRecord, RawSession, ScanResult, TokenUsage, UsageSnapshot};
 use crate::pricing::{
-  calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing, seed_pricing_catalog,
+  calculate_value_usd, load_catalog_map, normalize_model_id, resolve_pricing,
 };
+#[cfg(test)]
+use crate::{database::init_db, pricing::seed_pricing_catalog};
 
 #[derive(Debug, Clone)]
 struct SessionFile {
@@ -713,6 +715,7 @@ fn estimated_usage_snapshots_bytes(snapshots: &Vec<UsageSnapshot>) -> usize {
     }))
 }
 
+#[cfg(test)]
 pub fn perform_scan(
   db_path: &Path,
   codex_home_override: Option<String>,
@@ -720,6 +723,7 @@ pub fn perform_scan(
   perform_scan_with_kind(db_path, codex_home_override, ScanKind::Full)
 }
 
+#[cfg(test)]
 pub fn perform_incremental_scan(
   db_path: &Path,
   codex_home_override: Option<String>,
@@ -727,6 +731,7 @@ pub fn perform_incremental_scan(
   perform_scan_with_kind(db_path, codex_home_override, ScanKind::Incremental)
 }
 
+#[cfg(test)]
 fn perform_scan_with_kind(
   db_path: &Path,
   codex_home_override: Option<String>,

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -177,6 +177,7 @@ fn perform_scan_with_scope(
 
   let mut topology_dirty = false;
   let mut new_root_session_ids = Vec::new();
+  let mut skipped_session_files = false;
   if !changed_files.is_empty() {
     let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
     let existing_relations = load_existing_session_relations(&conn).map_err(|error| error.to_string())?;
@@ -188,6 +189,7 @@ fn perform_scan_with_scope(
       let parsed = match parse_session_file(session_file, &titles) {
         Ok(parsed) => parsed,
         Err(error) => {
+          skipped_session_files = true;
           log::warn!(
             "Skipping unreadable session file {}: {}",
             session_file.path.display(),
@@ -265,7 +267,7 @@ fn perform_scan_with_scope(
       &completed_at,
       scan_source_selector.as_deref(),
       &resolved_codex_home,
-      effective_scope == ScanScope::Full,
+      effective_scope == ScanScope::Full && !skipped_session_files,
     )
     .map_err(|error| error.to_string())?;
   }
@@ -1443,7 +1445,9 @@ struct ImportState {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::database::{init_db, now_utc_string, open_connection, save_sync_settings};
+  use crate::database::{
+    get_last_full_scan_completed, init_db, now_utc_string, open_connection, save_sync_settings,
+  };
   use rusqlite::OptionalExtension;
   use std::ffi::OsString;
   use std::sync::Mutex;
@@ -3010,6 +3014,57 @@ mod tests {
     assert_eq!(result.scanned_files, 1);
     assert_eq!(session_usage_totals(&conn, second_session_id).3, 220);
     assert_eq!(session_usage_totals(&conn, first_session_id).3, 110);
+  }
+
+  #[test]
+  fn skipped_archive_keeps_moved_default_source_due_for_full_retry() {
+    let _environment_lock = CODEX_HOME_ENV_LOCK.lock().expect("lock CODEX_HOME");
+    let directory = tempdir().expect("tempdir");
+    let first_codex_home = directory.path().join("codex-home-a");
+    let second_codex_home = directory.path().join("codex-home-b");
+    let first_sessions = first_codex_home.join("sessions");
+    let second_sessions = second_codex_home.join("sessions");
+    let second_archives = second_codex_home.join("archived_sessions");
+    std::fs::create_dir_all(&first_sessions).expect("first sessions");
+    std::fs::create_dir_all(&second_sessions).expect("second sessions");
+    std::fs::create_dir_all(&second_archives).expect("second archives");
+
+    write_session_file(
+      &first_sessions.join("first.jsonl"),
+      "38383838-3838-3838-3838-383838383838",
+      &[("2026-07-10T00:00:00Z", 100, 20, 10, 110)],
+    );
+    write_session_file(
+      &second_sessions.join("tracked.jsonl"),
+      "48484848-4848-4848-4848-484848484848",
+      &[("2026-07-10T01:00:00Z", 150, 30, 15, 165)],
+    );
+    let repaired_session_id = "58585858-5858-5858-5858-585858585858";
+    let repaired_archive = second_archives.join("repaired.jsonl");
+    std::fs::write(&repaired_archive, [0xff, 0xfe, 0xfd]).expect("write unreadable archive");
+
+    let db_path = directory.path().join("usage.sqlite");
+    let _environment = CodexHomeEnvGuard::set(&first_codex_home);
+    perform_scan(&db_path, None).expect("scan first default source");
+
+    std::env::set_var("CODEX_HOME", &second_codex_home);
+    let partial = perform_incremental_scan(&db_path, None).expect("scan moved source with skipped archive");
+    assert_eq!(partial.scanned_files, 2);
+
+    let conn = open_connection(&db_path).expect("open partial database");
+    assert_eq!(get_last_full_scan_completed(&conn).expect("load full freshness"), None);
+    drop(conn);
+
+    write_session_file(
+      &repaired_archive,
+      repaired_session_id,
+      &[("2026-07-10T01:30:00Z", 200, 40, 20, 220)],
+    );
+    let retry = perform_incremental_scan(&db_path, None).expect("retry repaired archive");
+
+    let conn = open_connection(&db_path).expect("open repaired database");
+    assert_eq!(retry.scanned_files, 2);
+    assert_eq!(session_usage_totals(&conn, repaired_session_id).3, 220);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,9 @@ mod queries;
 mod rate_limits;
 mod refresh;
 
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ struct AppState {
   app_handle: Option<AppHandle>,
   db_path: PathBuf,
   scan_in_progress: Arc<AtomicBool>,
+  usage_mutation_lock: Arc<Mutex<()>>,
   live_refresh_in_progress: Arc<AtomicBool>,
   menu_bar_refresh_in_progress: Arc<AtomicBool>,
   daily_value_tray: Option<TrayIcon>,
@@ -121,6 +122,13 @@ fn try_acquire_flag(flag: &Arc<AtomicBool>, busy_message: &str) -> Result<Atomic
   Ok(AtomicFlagGuard {
     flag: Arc::clone(flag),
   })
+}
+
+fn lock_usage_mutations(state: &AppState) -> std::sync::MutexGuard<'_, ()> {
+  state
+    .usage_mutation_lock
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[cfg(target_os = "macos")]
@@ -185,10 +193,18 @@ fn refreshPricing(state: State<'_, AppState>) -> Result<Vec<PricingCatalogEntry>
       None
     }
   };
-  let mut conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  let catalog = refresh_pricing_catalog_atomically(&mut conn, official_entries.as_deref())?;
+  let catalog = refresh_pricing_catalog_for_state(state.inner(), official_entries.as_deref())?;
   refresh_daily_value_menu_bar(state.inner());
   Ok(catalog)
+}
+
+fn refresh_pricing_catalog_for_state(
+  state: &AppState,
+  official_entries: Option<&[PricingCatalogEntry]>,
+) -> Result<Vec<PricingCatalogEntry>, String> {
+  let _mutation_guard = lock_usage_mutations(state);
+  let mut conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  refresh_pricing_catalog_atomically(&mut conn, official_entries)
 }
 
 fn refresh_pricing_catalog_atomically(
@@ -471,8 +487,10 @@ where
   F: FnOnce(&Path, Option<String>) -> Result<ScanResult, String>,
 {
   let guard = try_acquire_flag(&state.scan_in_progress, "A scan is already running.")?;
+  let mutation_guard = lock_usage_mutations(&state);
 
   let result = scan(&state.db_path, codex_home);
+  drop(mutation_guard);
   drop(guard);
   refresh_daily_value_menu_bar_with_live_refresh(&state, allow_menu_bar_live_refresh);
   result
@@ -2118,6 +2136,7 @@ pub fn run() {
         app_handle: Some(app_handle.clone()),
         db_path,
         scan_in_progress: Arc::new(AtomicBool::new(false)),
+        usage_mutation_lock: Arc::new(Mutex::new(())),
         live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         daily_value_tray,
@@ -2449,6 +2468,7 @@ mod tests {
       app_handle: None,
       db_path: db_path.clone(),
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
@@ -2979,6 +2999,119 @@ mod tests {
   }
 
   #[test]
+  fn pricing_refresh_waits_for_active_scan_before_recalculating() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let created_at = database::now_utc_string();
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, parent_session_id, title, source_state, source_path,
+          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+        )
+        VALUES ('refresh-race', 'refresh-race', NULL, NULL, 'active', NULL, 'active',
+          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?1, ?1)
+        ",
+        params![created_at],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('refresh-race', '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
+          0, 0, 1000000, 0, 1000000, 30.0, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage event");
+    let mut official_sol = load_catalog(&conn)
+      .expect("load catalog")
+      .into_iter()
+      .find(|entry| entry.model_id == "gpt-5.6-sol")
+      .expect("load GPT-5.6 Sol");
+    official_sol.output_price_per_million = 42.0;
+    official_sol.is_official = true;
+    official_sol.note = Some("serialized refresh test".to_string());
+    official_sol.updated_at = "serialized-refresh-test".to_string();
+    drop(conn);
+
+    let state = AppState {
+      app_handle: None,
+      db_path: db_path.clone(),
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+    let (scan_loaded_sender, scan_loaded_receiver) = std::sync::mpsc::channel();
+    let (release_scan_sender, release_scan_receiver) = std::sync::mpsc::channel();
+    let scan_state = state.clone();
+    let scan_thread = std::thread::spawn(move || {
+      run_scan_if_idle_with_live_refresh(scan_state, None, false, |db_path, _| {
+        let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+        let stale_output_price: f64 = conn
+          .query_row(
+            "SELECT output_price_per_million FROM pricing_catalog WHERE model_id = 'gpt-5.6-sol'",
+            [],
+            |row| row.get(0),
+          )
+          .map_err(|error| error.to_string())?;
+        scan_loaded_sender.send(()).map_err(|error| error.to_string())?;
+        release_scan_receiver.recv().map_err(|error| error.to_string())?;
+        conn
+          .execute(
+            "UPDATE usage_events SET value_usd = ?1 WHERE session_id = 'refresh-race'",
+            params![stale_output_price],
+          )
+          .map_err(|error| error.to_string())?;
+        Ok(ScanResult {
+          codex_home: "test".to_string(),
+          scanned_files: 1,
+          imported_sessions: 1,
+          updated_sessions: 1,
+          missing_sessions: 0,
+          last_completed_at: database::now_utc_string(),
+        })
+      })
+    });
+    scan_loaded_receiver.recv().expect("scan loaded stale pricing");
+    let release_thread = std::thread::spawn(move || {
+      std::thread::sleep(Duration::from_millis(100));
+      release_scan_sender.send(()).expect("release scan");
+    });
+
+    refresh_pricing_catalog_for_state(&state, Some(&[official_sol]))
+      .expect("refresh pricing after scan");
+    release_thread.join().expect("join release thread");
+    scan_thread
+      .join()
+      .expect("join scan thread")
+      .expect("complete scan");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let value_usd: f64 = conn
+      .query_row(
+        "SELECT value_usd FROM usage_events WHERE session_id = 'refresh-race'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load final value");
+    assert_eq!(value_usd, 42.0);
+  }
+
+  #[test]
   fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
@@ -3015,6 +3148,7 @@ mod tests {
       app_handle: None,
       db_path,
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
@@ -3077,6 +3211,7 @@ mod tests {
       app_handle: None,
       db_path,
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
@@ -3140,6 +3275,7 @@ mod tests {
       app_handle: None,
       db_path,
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
@@ -3209,6 +3345,7 @@ mod tests {
       app_handle: None,
       db_path,
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,7 +20,8 @@ use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
 use rusqlite::params;
 use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
-  insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
+  insert_live_rate_limit_snapshot, load_latest_rate_limits, open_connection,
+  save_subscription_profile, save_sync_settings,
 };
 use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
 use models::{
@@ -157,7 +158,9 @@ struct AppLiveQuotaPersister {
 impl refresh::LiveQuotaPersister for AppLiveQuotaPersister {
   fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
     let conn = open_connection(&self.db_path).map_err(|error| error.to_string())?;
-    insert_live_rate_limit_snapshot(&conn, snapshot).map_err(|error| error.to_string())
+    insert_live_rate_limit_snapshot(&conn, snapshot)
+      .map(|_| ())
+      .map_err(|error| error.to_string())
   }
 }
 
@@ -1361,6 +1364,9 @@ fn load_persisted_live_rate_limits_from_connection(
   conn: &rusqlite::Connection,
   source_kind: Option<&str>,
 ) -> Option<LiveRateLimitSnapshot> {
+  if let Ok(Some(snapshot)) = load_latest_rate_limits(conn, source_kind) {
+    return Some(snapshot);
+  }
   let mut primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
     .ok()
     .flatten();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,7 +60,6 @@ const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 const SCHEDULER_MAX_SLEEP_SECONDS: u64 = 5;
-const FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS: u64 = 5;
 const PRICING_VALUE_RESOLUTION_REPAIR_KEY: &str = "pricing_value_resolution_v2";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,12 +68,6 @@ enum BackgroundRefreshDecision {
   Wait(Duration),
   Incremental,
   Full,
-}
-
-#[derive(Clone)]
-struct CachedRateLimitSnapshot {
-  fetched_at: Instant,
-  snapshot: LiveRateLimitSnapshot,
 }
 
 #[derive(Clone)]
@@ -92,7 +85,7 @@ struct AppState {
   live_refresh_in_progress: Arc<AtomicBool>,
   menu_bar_refresh_in_progress: Arc<AtomicBool>,
   daily_value_tray: Option<TrayIcon>,
-  live_rate_limits: Arc<Mutex<Option<CachedRateLimitSnapshot>>>,
+  live_rate_limits: refresh::LiveQuotaCache,
   menu_bar_popup_anchor: Arc<Mutex<Option<MenuBarPopupAnchor>>>,
 }
 
@@ -1052,74 +1045,86 @@ fn get_live_rate_limits_cached(state: &AppState) -> Result<LiveRateLimitSnapshot
 }
 
 fn get_live_rate_limits(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_with_fallback(
-    state,
-    force_refresh,
-    true,
-    live_rate_limit_foreground_query_timeout(),
-  )
+  get_live_rate_limits_with_fallback(state, force_refresh, live_rate_limit_foreground_query_timeout())
 }
 
 fn get_live_rate_limits_background(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  let ttl = live_rate_limit_cache_ttl(state);
-  get_live_rate_limits_with_fallback(
-    state,
-    force_refresh,
-    false,
-    live_rate_limit_background_query_timeout_for_interval(ttl),
-  )
+  get_live_rate_limits_with_fallback(state, force_refresh, live_rate_limit_background_query_timeout())
 }
 
 fn get_live_rate_limits_with_fallback(
   state: &AppState,
   force_refresh: bool,
-  refresh_history_on_failure: bool,
   query_timeout: Duration,
 ) -> Result<LiveRateLimitSnapshot, String> {
-  let ttl = live_rate_limit_cache_ttl(state);
-
-  if !force_refresh {
-    let cache = state
-      .live_rate_limits
-      .lock()
-      .map_err(|_| "Live rate-limit cache is unavailable.".to_string())?;
-    if let Some(snapshot) = cache.as_ref() {
-      if snapshot.fetched_at.elapsed() <= ttl {
-        return Ok(snapshot.snapshot.clone());
-      }
-    }
+  if let Some(snapshot) =
+    get_fresh_cached_live_rate_limits(state, force_refresh, || live_rate_limit_cache_ttl(state))
+  {
+    return Ok(snapshot);
   }
 
+  state.live_rate_limits.set_refreshing(true);
   let query_result = {
     let _activity = begin_scheduler_activity();
     query_live_rate_limits(query_timeout)
   };
   match query_result {
-    Ok(snapshot) => {
-      {
+    Ok(snapshot) => Ok(publish_live_rate_limits_and_persist(
+      state,
+      snapshot,
+      |snapshot| {
         let _activity = begin_scheduler_activity();
         let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-        insert_live_rate_limit_snapshot(&conn, &snapshot).map_err(|error| error.to_string())?;
-      }
-      store_live_rate_limits_cache(state, &snapshot)?;
-      Ok(snapshot)
-    }
+        insert_live_rate_limit_snapshot(&conn, snapshot).map_err(|error| error.to_string())
+      },
+    )),
     Err(error) => {
       log::warn!("Failed to refresh live rate limits from Codex app-server: {error}");
-      let fallback = if refresh_history_on_failure {
-        get_live_rate_limits_history_fallback(state)
-      } else {
-        get_live_rate_limits_stored_fallback(state)
-      };
-      if let Some(snapshot) = fallback {
-        if let Err(cache_error) = store_live_rate_limits_cache(state, &snapshot) {
-          log::warn!("Failed to cache fallback live rate limits: {cache_error}");
+      if let Some(fallback) = get_live_rate_limits_stored_fallback(state) {
+        state.live_rate_limits.publish_fallback(
+          Arc::new(fallback),
+          Instant::now(),
+          Utc::now(),
+        );
+        if let Some(effective) = get_cached_live_rate_limits(state) {
+          return Ok(effective);
         }
-        return Ok(snapshot);
       }
+      state.live_rate_limits.set_refreshing(false);
       Err(error)
     }
   }
+}
+
+fn get_fresh_cached_live_rate_limits(
+  state: &AppState,
+  force_refresh: bool,
+  load_ttl: impl FnOnce() -> Duration,
+) -> Option<LiveRateLimitSnapshot> {
+  if force_refresh {
+    return None;
+  }
+  let ttl = load_ttl();
+  if state.live_rate_limits.needs_live_refresh(ttl, Instant::now()) {
+    None
+  } else {
+    get_cached_live_rate_limits(state)
+  }
+}
+
+fn publish_live_rate_limits_and_persist(
+  state: &AppState,
+  snapshot: LiveRateLimitSnapshot,
+  persist: impl FnOnce(&LiveRateLimitSnapshot) -> Result<(), String>,
+) -> LiveRateLimitSnapshot {
+  let snapshot = Arc::new(snapshot);
+  state
+    .live_rate_limits
+    .publish_live(Arc::clone(&snapshot), Instant::now(), Utc::now());
+  if let Err(error) = persist(&snapshot) {
+    log::warn!("Failed to persist live rate-limit snapshot: {error}");
+  }
+  snapshot.as_ref().clone()
 }
 
 #[derive(Clone)]
@@ -1196,19 +1201,24 @@ fn load_latest_persisted_rate_limit_window(
   }))
 }
 
+#[cfg(test)]
 fn load_persisted_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
   load_persisted_live_rate_limits_for_source(state, None)
 }
 
-fn load_history_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  load_persisted_live_rate_limits_for_source(state, Some("session"))
-}
-
+#[cfg(test)]
 fn load_persisted_live_rate_limits_for_source(
   state: &AppState,
   source_kind: Option<&str>,
 ) -> Option<LiveRateLimitSnapshot> {
   let conn = open_connection(&state.db_path).ok()?;
+  load_persisted_live_rate_limits_from_connection(&conn, source_kind)
+}
+
+fn load_persisted_live_rate_limits_from_connection(
+  conn: &rusqlite::Connection,
+  source_kind: Option<&str>,
+) -> Option<LiveRateLimitSnapshot> {
   let mut primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
     .ok()
     .flatten();
@@ -1258,47 +1268,67 @@ fn load_persisted_live_rate_limits_for_source(
 }
 
 fn get_live_rate_limits_local(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  get_cached_live_rate_limits(state).or_else(|| load_persisted_live_rate_limits(state))
+  if let Some(cached) = get_cached_live_rate_limits(state) {
+    return Some(cached);
+  }
+  let fallback = get_live_rate_limits_stored_fallback(state)?;
+  state.live_rate_limits.publish_fallback(
+    Arc::new(fallback),
+    Instant::now(),
+    Utc::now(),
+  );
+  get_cached_live_rate_limits(state)
 }
 
 fn get_live_rate_limits_stored_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  load_persisted_live_rate_limits(state)
-    .or_else(|| load_history_live_rate_limits(state))
-    .or_else(|| get_cached_live_rate_limits(state))
-}
-
-fn get_live_rate_limits_history_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  refresh_rate_limit_history_if_idle(state);
-  get_live_rate_limits_stored_fallback(state)
-}
-
-fn refresh_rate_limit_history_if_idle(state: &AppState) {
-  if let Err(error) = run_background_incremental_scan_if_idle(state.clone(), None) {
-    if error == "A scan is already running." {
-      return;
-    }
-    log::warn!("Failed to refresh Codex history rate-limit samples: {error}");
-  }
+  let memory = get_cached_live_rate_limits(state);
+  let Ok(conn) = open_connection(&state.db_path) else {
+    return memory;
+  };
+  let persisted = load_persisted_live_rate_limits_from_connection(&conn, None);
+  let session_only = if persisted.is_none() {
+    load_persisted_live_rate_limits_from_connection(&conn, Some("session"))
+  } else {
+    None
+  };
+  newest_live_rate_limit_snapshot([memory, persisted, session_only])
 }
 
 fn get_cached_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
   state
     .live_rate_limits
-    .lock()
-    .ok()
-    .and_then(|cache| cache.as_ref().map(|snapshot| snapshot.snapshot.clone()))
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone())
 }
 
-fn store_live_rate_limits_cache(state: &AppState, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
-  let mut cache = state
-    .live_rate_limits
-    .lock()
-    .map_err(|_| "Live rate-limit cache is unavailable.".to_string())?;
-  *cache = Some(CachedRateLimitSnapshot {
-    fetched_at: Instant::now(),
-    snapshot: snapshot.clone(),
-  });
-  Ok(())
+fn newest_live_rate_limit_snapshot(
+  snapshots: impl IntoIterator<Item = Option<LiveRateLimitSnapshot>>,
+) -> Option<LiveRateLimitSnapshot> {
+  snapshots.into_iter().flatten().fold(None, |newest, candidate| {
+    let Some(current) = newest else {
+      return Some(candidate);
+    };
+    if live_snapshot_is_newer(&candidate, &current) {
+      Some(candidate)
+    } else {
+      Some(current)
+    }
+  })
+}
+
+fn live_snapshot_is_newer(
+  candidate: &LiveRateLimitSnapshot,
+  current: &LiveRateLimitSnapshot,
+) -> bool {
+  match (
+    DateTime::parse_from_rfc3339(&candidate.fetched_at).ok(),
+    DateTime::parse_from_rfc3339(&current.fetched_at).ok(),
+  ) {
+    (Some(candidate), Some(current)) => candidate > current,
+    (Some(_), None) => true,
+    (None, Some(_)) => false,
+    (None, None) => candidate.fetched_at > current.fetched_at,
+  }
 }
 
 fn best_effort_live_rate_limits(state: &AppState, force_refresh: bool) -> Option<LiveRateLimitSnapshot> {
@@ -1462,13 +1492,11 @@ fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
 }
 
 fn live_rate_limit_foreground_query_timeout() -> Duration {
-  Duration::from_secs(FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS)
+  refresh::LIVE_QUERY_TIMEOUT
 }
 
-fn live_rate_limit_background_query_timeout_for_interval(interval: Duration) -> Duration {
-  interval
-    .checked_sub(Duration::from_secs(FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS))
-    .unwrap_or_else(|| Duration::from_secs(1))
+fn live_rate_limit_background_query_timeout() -> Duration {
+  refresh::LIVE_QUERY_TIMEOUT
 }
 
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
@@ -2109,7 +2137,7 @@ pub fn run() {
         live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         daily_value_tray,
-        live_rate_limits: Arc::new(Mutex::new(None)),
+        live_rate_limits: refresh::LiveQuotaCache::new(),
         menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
       };
       app.manage(state.clone());
@@ -2263,20 +2291,81 @@ mod tests {
   }
 
   #[test]
-  fn live_rate_limit_query_timeout_finishes_before_next_refresh() {
+  fn live_rate_limit_background_query_timeout_is_fixed() {
     assert_eq!(
-      live_rate_limit_background_query_timeout_for_interval(Duration::from_secs(60)),
-      Duration::from_secs(55)
-    );
-    assert_eq!(
-      live_rate_limit_background_query_timeout_for_interval(Duration::from_secs(180)),
-      Duration::from_secs(175)
+      live_rate_limit_background_query_timeout(),
+      Duration::from_secs(10)
     );
   }
 
   #[test]
   fn live_rate_limit_foreground_query_timeout_stays_short() {
-    assert_eq!(live_rate_limit_foreground_query_timeout(), Duration::from_secs(5));
+    assert_eq!(live_rate_limit_foreground_query_timeout(), Duration::from_secs(10));
+  }
+
+  #[test]
+  fn legacy_live_publication_survives_persistence_failure() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: refresh::LiveQuotaCache::new(),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+    let snapshot = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: None,
+      fetched_at: "2026-07-11T00:00:00Z".to_string(),
+    };
+
+    let returned = publish_live_rate_limits_and_persist(&state, snapshot, |_| {
+      Err("intentional persistence failure".to_string())
+    });
+
+    assert_eq!(returned.fetched_at, "2026-07-11T00:00:00Z");
+    assert_eq!(
+      get_cached_live_rate_limits(&state)
+        .expect("fresh cache survives persistence failure")
+        .fetched_at,
+      "2026-07-11T00:00:00Z"
+    );
+  }
+
+  #[test]
+  fn forced_live_refresh_does_not_read_cache_ttl() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: refresh::LiveQuotaCache::new(),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+    let ttl_reads = std::cell::Cell::new(0_u32);
+
+    let cached = get_fresh_cached_live_rate_limits(&state, true, || {
+      ttl_reads.set(ttl_reads.get() + 1);
+      Duration::from_secs(300)
+    });
+
+    assert!(cached.is_none());
+    assert_eq!(ttl_reads.get(), 0);
   }
 
   #[test]
@@ -2441,7 +2530,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 
@@ -3021,7 +3110,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
     let (scan_loaded_sender, scan_loaded_receiver) = std::sync::mpsc::channel();
@@ -3081,54 +3170,6 @@ mod tests {
   }
 
   #[test]
-  fn history_fallback_scan_waits_for_usage_mutation_lock() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    let codex_home = directory.path().join("codex-home");
-    std::fs::create_dir_all(&codex_home).expect("create Codex home");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let conn = open_connection(&db_path).expect("open database");
-    let settings = SyncSettings {
-      codex_home: Some(codex_home.to_string_lossy().to_string()),
-      ..get_sync_settings(&conn).expect("load settings")
-    };
-    save_sync_settings(&conn, &settings).expect("save settings");
-    drop(conn);
-
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-    let mutation_guard = lock_usage_mutations(&state);
-    let (completed_sender, completed_receiver) = std::sync::mpsc::channel();
-    let scan_state = state.clone();
-    let scan_thread = std::thread::spawn(move || {
-      refresh_rate_limit_history_if_idle(&scan_state);
-      completed_sender.send(()).expect("report completion");
-    });
-
-    let completed_while_locked = completed_receiver
-      .recv_timeout(Duration::from_millis(100))
-      .is_ok();
-    drop(mutation_guard);
-    if !completed_while_locked {
-      completed_receiver
-        .recv_timeout(Duration::from_secs(2))
-        .expect("history scan should complete after unlock");
-    }
-    scan_thread.join().expect("join history scan");
-
-    assert!(!completed_while_locked, "history scan bypassed the shared usage mutation lock");
-  }
-
-  #[test]
   fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
@@ -3169,7 +3210,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 
@@ -3179,6 +3220,10 @@ mod tests {
 
     assert_eq!(api_value_title, None);
     assert_eq!(live_metric_title.as_deref(), Some("88%"));
+    assert!(state.live_rate_limits.state().is_fallback);
+    assert!(state
+      .live_rate_limits
+      .needs_live_refresh(Duration::from_secs(300), Instant::now()));
   }
 
   #[test]
@@ -3232,7 +3277,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 
@@ -3242,6 +3287,31 @@ mod tests {
     assert_eq!(
       snapshot.primary.as_ref().map(|window| window.remaining_percent),
       Some(88)
+    );
+
+    state.live_rate_limits.publish_live(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 23,
+          remaining_percent: 77,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-03-27T05:10:00+08:00".to_string()),
+          window_start: Some("2026-03-27T00:10:00+08:00".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-03-27T00:10:00+08:00".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+    let memory = get_live_rate_limits_stored_fallback(&state).expect("prefer newer memory");
+    assert_eq!(memory.fetched_at, "2026-03-27T00:10:00+08:00");
+    assert_eq!(
+      memory.primary.as_ref().map(|window| window.remaining_percent),
+      Some(77)
     );
   }
 
@@ -3296,7 +3366,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 
@@ -3366,7 +3436,7 @@ mod tests {
       live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
-      live_rate_limits: Arc::new(Mutex::new(None)),
+      live_rate_limits: refresh::LiveQuotaCache::new(),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -489,14 +489,20 @@ fn run_due_background_refresh(
 }
 
 fn prepare_app_database(db_path: &Path) -> Result<(), String> {
-  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
   init_db(&conn).map_err(|error| error.to_string())?;
-  let pricing_signature_before = load_pricing_value_signature(&conn).map_err(|error| error.to_string())?;
-  seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
-  let pricing_signature_after = load_pricing_value_signature(&conn).map_err(|error| error.to_string())?;
+  let transaction = conn
+    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+    .map_err(|error| error.to_string())?;
+  let pricing_signature_before =
+    load_pricing_value_signature(&transaction).map_err(|error| error.to_string())?;
+  seed_pricing_catalog(&transaction).map_err(|error| error.to_string())?;
+  let pricing_signature_after =
+    load_pricing_value_signature(&transaction).map_err(|error| error.to_string())?;
   if pricing_signature_before != pricing_signature_after {
-    recalculate_all_session_values(&conn).map_err(|error| error.to_string())?;
+    recalculate_all_session_values(&transaction).map_err(|error| error.to_string())?;
   }
+  transaction.commit().map_err(|error| error.to_string())?;
   Ok(())
 }
 
@@ -2612,6 +2618,128 @@ mod tests {
       .expect("load usage value");
 
     assert_eq!(value_usd, 30.0);
+  }
+
+  #[test]
+  fn startup_database_prepare_rolls_back_pricing_when_recalculation_fails() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    conn
+      .execute(
+        "
+        UPDATE pricing_catalog
+        SET output_price_per_million = 6.25,
+            is_official = 1,
+            note = 'malformed-official',
+            updated_at = 'malformed-official'
+        WHERE model_id = 'gpt-5.6-sol'
+        ",
+        [],
+      )
+      .expect("seed malformed GPT-5.6 Sol pricing");
+    let created_at = database::now_utc_string();
+    for (session_id, sentinel_value) in [("recalc-a", 11.0), ("recalc-b", 22.0)] {
+      conn
+        .execute(
+          "
+          INSERT INTO sessions (
+            session_id, root_session_id, parent_session_id, title, source_state, source_path,
+            source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+            fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+          )
+          VALUES (?1, ?1, NULL, NULL, 'active', NULL, 'active',
+            NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?2, ?2)
+          ",
+          params![session_id, created_at],
+        )
+        .expect("insert session");
+      conn
+        .execute(
+          "
+          INSERT INTO usage_events (
+            session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+            output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+            fast_mode_auto, fast_mode_effective
+          )
+          VALUES (?1, '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
+            0, 0, 1000000, 0, 1000000, ?2, 0, 0)
+          ",
+          params![session_id, sentinel_value],
+        )
+        .expect("insert usage event");
+    }
+    conn
+      .execute_batch(
+        "
+        CREATE TRIGGER fail_second_session_recalculation
+        BEFORE UPDATE OF value_usd ON usage_events
+        WHEN OLD.session_id = 'recalc-b'
+        BEGIN
+          SELECT RAISE(ABORT, 'injected recalculation failure');
+        END;
+        ",
+      )
+      .expect("create failure trigger");
+    drop(conn);
+
+    let error = prepare_app_database(&db_path).expect_err("recalculation should fail");
+    assert!(error.contains("injected recalculation failure"));
+
+    let conn = open_connection(&db_path).expect("reopen failed database");
+    let (output_price, is_official): (f64, i64) = conn
+      .query_row(
+        "
+        SELECT output_price_per_million, is_official
+        FROM pricing_catalog
+        WHERE model_id = 'gpt-5.6-sol'
+        ",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+      )
+      .expect("load rolled back pricing");
+    let failed_values = conn
+      .prepare("SELECT session_id, value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare failed values")
+      .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?)))
+      .expect("query failed values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect failed values");
+
+    assert_eq!(output_price, 6.25);
+    assert_eq!(is_official, 1);
+    assert_eq!(
+      failed_values,
+      vec![("recalc-a".to_string(), 11.0), ("recalc-b".to_string(), 22.0)]
+    );
+
+    conn
+      .execute_batch("DROP TRIGGER fail_second_session_recalculation;")
+      .expect("drop failure trigger");
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("retry prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen repaired database");
+    let repaired_output: f64 = conn
+      .query_row(
+        "SELECT output_price_per_million FROM pricing_catalog WHERE model_id = 'gpt-5.6-sol'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load repaired pricing");
+    let repaired_values = conn
+      .prepare("SELECT value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare repaired values")
+      .query_map([], |row| row.get::<_, f64>(0))
+      .expect("query repaired values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect repaired values");
+
+    assert_eq!(repaired_output, 30.0);
+    assert_eq!(repaired_values, vec![30.0, 30.0]);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1193,8 +1193,8 @@ fn get_live_rate_limits_local(state: &AppState) -> Option<LiveRateLimitSnapshot>
 }
 
 fn get_live_rate_limits_stored_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  load_history_live_rate_limits(state)
-    .or_else(|| load_persisted_live_rate_limits(state))
+  load_persisted_live_rate_limits(state)
+    .or_else(|| load_history_live_rate_limits(state))
     .or_else(|| get_cached_live_rate_limits(state))
 }
 
@@ -2526,6 +2526,69 @@ mod tests {
 
     assert_eq!(api_value_title, None);
     assert_eq!(live_metric_title.as_deref(), Some("88%"));
+  }
+
+  #[test]
+  fn background_live_rate_limit_fallback_prefers_newest_persisted_sample() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    database::replace_session_rate_limit_samples(
+      &conn,
+      "session-1",
+      &[crate::models::RateLimitSampleRecord {
+        source_kind: "session".to_string(),
+        source_session_id: Some("session-1".to_string()),
+        bucket: "five_hour".to_string(),
+        sample_timestamp: "2026-03-27T00:00:00+08:00".to_string(),
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        window_start: "2026-03-27T00:00:00+08:00".to_string(),
+        resets_at: "2026-03-27T05:00:00+08:00".to_string(),
+        used_percent: 80,
+        remaining_percent: 20,
+      }],
+    )
+    .expect("insert session sample");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 12,
+          remaining_percent: 88,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-03-27T05:05:00+08:00".to_string()),
+          window_start: Some("2026-03-27T00:05:00+08:00".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-03-27T00:05:00+08:00".to_string(),
+      },
+    )
+    .expect("insert live sample");
+    drop(conn);
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+
+    let snapshot = get_live_rate_limits_stored_fallback(&state).expect("load fallback");
+
+    assert_eq!(snapshot.fetched_at, "2026-03-27T00:05:00+08:00");
+    assert_eq!(
+      snapshot.primary.as_ref().map(|window| window.remaining_percent),
+      Some(88)
+    );
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ mod refresh;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{
-  atomic::{AtomicBool, Ordering},
+  atomic::{AtomicBool, AtomicU8, Ordering},
   Arc, Mutex,
 };
 use std::time::{Duration, Instant};
@@ -20,7 +20,7 @@ use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
   insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
 };
-use importer::{perform_incremental_scan, perform_scan, recalculate_all_session_values};
+use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
 use models::{
   ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
@@ -35,7 +35,6 @@ use queries::{
   get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
 };
 use rate_limits::query_live_rate_limits;
-use refresh::begin_scheduler_activity;
 use tauri::{
   Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
   WebviewWindowBuilder,
@@ -59,16 +58,10 @@ const MENU_BAR_POPUP_OFFSET_Y: i32 = 8;
 const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
-const SCHEDULER_MAX_SLEEP_SECONDS: u64 = 5;
 const PRICING_VALUE_RESOLUTION_REPAIR_KEY: &str = "pricing_value_resolution_v2";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BackgroundRefreshDecision {
-  Disabled(Duration),
-  Wait(Duration),
-  Incremental,
-  Full,
-}
+const MENU_RENDER_IDLE: u8 = 0;
+const MENU_RENDER_RUNNING: u8 = 1;
+const MENU_RENDER_PENDING: u8 = 2;
 
 #[derive(Clone)]
 struct MenuBarPopupAnchor {
@@ -80,61 +73,198 @@ struct MenuBarPopupAnchor {
 struct AppState {
   app_handle: Option<AppHandle>,
   db_path: PathBuf,
-  scan_in_progress: Arc<AtomicBool>,
-  usage_mutation_lock: Arc<Mutex<()>>,
-  live_refresh_in_progress: Arc<AtomicBool>,
-  menu_bar_refresh_in_progress: Arc<AtomicBool>,
+  refresh: AppRefreshHandle,
+  usage_mutations: refresh::UsageMutationCoordinator,
+  menu_bar_render_state: Arc<AtomicU8>,
   daily_value_tray: Option<TrayIcon>,
   live_rate_limits: refresh::LiveQuotaCache,
+  menu_bar_popup_visible: Arc<AtomicBool>,
   menu_bar_popup_anchor: Arc<Mutex<Option<MenuBarPopupAnchor>>>,
 }
 
-struct AtomicFlagGuard {
-  flag: Arc<AtomicBool>,
+#[cfg(not(test))]
+type AppRefreshHandle = refresh::RefreshCoordinatorHandle;
+#[cfg(test)]
+type AppRefreshHandle = Option<refresh::RefreshCoordinatorHandle>;
+
+#[cfg(not(test))]
+fn installed_refresh_handle(handle: refresh::RefreshCoordinatorHandle) -> AppRefreshHandle {
+  handle
 }
 
-impl Drop for AtomicFlagGuard {
-  fn drop(&mut self) {
-    self.flag.store(false, Ordering::SeqCst);
+#[cfg(test)]
+fn installed_refresh_handle(handle: refresh::RefreshCoordinatorHandle) -> AppRefreshHandle {
+  Some(handle)
+}
+
+#[derive(Clone)]
+struct AppTokenRefreshExecutor {
+  db_path: PathBuf,
+}
+
+impl refresh::TokenRefreshExecutor for AppTokenRefreshExecutor {
+  fn parse(
+    &self,
+    request: refresh::TokenExecutionRequest,
+  ) -> Result<refresh::PreparedTokenRefresh, String> {
+    let started_at = Utc::now();
+    let scan_kind = effective_token_scan_kind(
+      &self.db_path,
+      request.request.kind,
+      started_at,
+    )?;
+    let prepared_scan = prepare_scan(
+      &self.db_path,
+      request.request.codex_home,
+      scan_kind,
+    )?;
+    Ok(refresh::PreparedTokenRefresh::new(
+      request.generation,
+      request.source_generation,
+      started_at,
+      prepared_scan,
+    ))
+  }
+
+  fn commit(&self, prepared: refresh::PreparedTokenRefresh) -> Result<ScanResult, String> {
+    commit_prepared_scan(prepared.prepared_scan)
   }
 }
 
-fn try_acquire_flag(flag: &Arc<AtomicBool>, busy_message: &str) -> Result<AtomicFlagGuard, String> {
-  if flag
-    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-    .is_err()
-  {
-    return Err(busy_message.to_string());
-  }
-
-  Ok(AtomicFlagGuard {
-    flag: Arc::clone(flag),
-  })
+#[derive(Clone)]
+struct AppLiveQuotaFetcher {
+  db_path: PathBuf,
+  live_cache: refresh::LiveQuotaCache,
 }
 
-fn lock_usage_mutations(state: &AppState) -> std::sync::MutexGuard<'_, ()> {
+impl refresh::LiveQuotaFetcher for AppLiveQuotaFetcher {
+  fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+    query_live_rate_limits(timeout)
+  }
+
+  fn fallback(&self) -> Option<LiveRateLimitSnapshot> {
+    load_display_live_rate_limit_fallback(&self.db_path, &self.live_cache)
+  }
+}
+
+#[derive(Clone)]
+struct AppLiveQuotaPersister {
+  db_path: PathBuf,
+}
+
+impl refresh::LiveQuotaPersister for AppLiveQuotaPersister {
+  fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
+    let conn = open_connection(&self.db_path).map_err(|error| error.to_string())?;
+    insert_live_rate_limit_snapshot(&conn, snapshot).map_err(|error| error.to_string())
+  }
+}
+
+#[derive(Clone)]
+struct TauriRefreshEventSink {
+  app_handle: AppHandle,
+}
+
+impl refresh::RefreshEventSink for TauriRefreshEventSink {
+  fn publish_invalidation(&self, _: refresh::DisplayInvalidation) {
+    let Some(state) = self.app_handle.try_state::<AppState>() else {
+      return;
+    };
+    let popup_visible = state.menu_bar_popup_visible.load(Ordering::Acquire);
+    refresh_daily_value_menu_bar(state.inner());
+    if popup_visible {
+      if let Some(window) = self.app_handle.get_webview_window(MENU_BAR_POPUP_WINDOW_LABEL) {
+        let _ = window.emit(MENU_BAR_POPUP_REFRESH_EVENT, ());
+      }
+    }
+  }
+
+  fn publish_completion(&self, value: refresh::RefreshCompletedEvent) {
+    if let Err(error) = self
+      .app_handle
+      .emit("codex-counter://refresh-completed", value)
+    {
+      log::warn!("Failed to emit refresh completion: {error}");
+    }
+  }
+}
+
+#[cfg(not(test))]
+fn refresh_handle(state: &AppState) -> Result<&refresh::RefreshCoordinatorHandle, String> {
+  Ok(&state.refresh)
+}
+
+#[cfg(test)]
+fn refresh_handle(state: &AppState) -> Result<&refresh::RefreshCoordinatorHandle, String> {
   state
-    .usage_mutation_lock
-    .lock()
-    .unwrap_or_else(std::sync::PoisonError::into_inner)
+    .refresh
+    .as_ref()
+    .ok_or_else(|| "Refresh coordinator is unavailable.".to_string())
+}
+
+fn refresh_error_message(error: refresh::RefreshError) -> String {
+  format!("{error:?}")
+}
+
+fn run_manual_scan_with_coordinator(
+  refresh: &refresh::RefreshCoordinatorHandle,
+  codex_home: Option<String>,
+) -> Result<ScanResult, String> {
+  let ticket = refresh
+    .request_manual_token(codex_home)
+    .map_err(refresh_error_message)?;
+  ticket
+    .wait()
+    .map(|result| result.as_ref().clone())
+    .map_err(refresh_error_message)
+}
+
+fn get_passive_live_rate_limits(
+  cache: &refresh::LiveQuotaCache,
+) -> Result<LiveRateLimitSnapshot, String> {
+  cache
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone())
+    .ok_or_else(|| "Live rate limits are unavailable.".to_string())
 }
 
 #[allow(non_snake_case)]
 #[tauri::command(rename_all = "camelCase")]
-fn scanCodexUsage(state: State<'_, AppState>, codex_home: Option<String>) -> Result<ScanResult, String> {
-  run_scan_if_idle(state.inner().clone(), codex_home)
+async fn scanCodexUsage(
+  state: State<'_, AppState>,
+  codex_home: Option<String>,
+) -> Result<ScanResult, String> {
+  let refresh = refresh_handle(state.inner())?.clone();
+  tauri::async_runtime::spawn_blocking(move || {
+    run_manual_scan_with_coordinator(&refresh, codex_home)
+  })
+  .await
+  .map_err(|error| format!("Failed to join manual refresh: {error}"))?
 }
 
 #[allow(non_snake_case)]
 #[tauri::command]
 fn getScanInProgress(state: State<'_, AppState>) -> bool {
-  state.inner().scan_in_progress.load(Ordering::SeqCst)
+  refresh_handle(state.inner())
+    .map(|refresh| {
+      let status = refresh.status();
+      status.token.running || status.token.pending
+    })
+    .unwrap_or(false)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+fn getRefreshStatus(state: State<'_, AppState>) -> Result<refresh::RefreshStatus, String> {
+  Ok(refresh_handle(state.inner())?.status())
 }
 
 #[allow(non_snake_case)]
 #[tauri::command]
 fn refreshBackgroundData(state: State<'_, AppState>) -> Result<Option<ScanResult>, String> {
-  run_due_background_refresh(state.inner().clone(), Utc::now())
+  match refresh_handle(state.inner())?.wake() {
+    Ok(()) | Err(refresh::RefreshError::Busy) => Ok(None),
+    Err(error) => Err(refresh_error_message(error)),
+  }
 }
 
 #[allow(non_snake_case)]
@@ -158,9 +288,26 @@ fn refresh_pricing_catalog_for_state(
   state: &AppState,
   official_entries: Option<&[PricingCatalogEntry]>,
 ) -> Result<Vec<PricingCatalogEntry>, String> {
-  let _mutation_guard = lock_usage_mutations(state);
-  let mut conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  refresh_pricing_catalog_atomically(&mut conn, official_entries)
+  refresh_pricing_catalog_with_runner(
+    &state.db_path,
+    official_entries,
+    |priority, mutation| state.usage_mutations.run(priority, mutation).value,
+  )
+}
+
+fn refresh_pricing_catalog_with_runner(
+  db_path: &Path,
+  official_entries: Option<&[PricingCatalogEntry]>,
+  run: impl FnOnce(
+    refresh::MutationPriority,
+    &mut dyn FnMut() -> Result<Vec<PricingCatalogEntry>, String>,
+  ) -> Result<Vec<PricingCatalogEntry>, String>,
+) -> Result<Vec<PricingCatalogEntry>, String> {
+  let mut mutation = || {
+    let mut conn = open_connection(db_path).map_err(|error| error.to_string())?;
+    refresh_pricing_catalog_atomically(&mut conn, official_entries)
+  };
+  run(refresh::MutationPriority::Pricing, &mut mutation)
 }
 
 fn refresh_pricing_catalog_atomically(
@@ -218,16 +365,24 @@ fn listConversations(
 #[allow(non_snake_case)]
 #[tauri::command]
 fn getLiveRateLimits(state: State<'_, AppState>) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_cached(state.inner())
+  get_passive_live_rate_limits(&state.live_rate_limits)
 }
 
 #[allow(non_snake_case)]
 #[tauri::command(rename_all = "camelCase")]
-fn getMenuBarPopupSnapshot(
+async fn getMenuBarPopupSnapshot(
   state: State<'_, AppState>,
   force_refresh: Option<bool>,
 ) -> Result<MenuBarPopupSnapshot, String> {
-  build_due_menu_bar_popup_snapshot(state.inner(), force_refresh.unwrap_or(false), Utc::now())
+  let state = state.inner().clone();
+  tauri::async_runtime::spawn_blocking(move || {
+    if force_refresh.unwrap_or(false) {
+      refresh_popup_data(&state)?;
+    }
+    build_passive_menu_bar_popup_snapshot(&state.db_path, &state.live_rate_limits)
+  })
+  .await
+  .map_err(|error| format!("Failed to join popup refresh: {error}"))?
 }
 
 #[allow(non_snake_case)]
@@ -306,7 +461,7 @@ fn getConversationDetail(
 
 #[allow(non_snake_case)]
 #[tauri::command(rename_all = "camelCase")]
-fn handleMenuBarPopupAction(
+async fn handleMenuBarPopupAction(
   app: AppHandle,
   state: State<'_, AppState>,
   action: String,
@@ -330,7 +485,10 @@ fn handleMenuBarPopupAction(
       Ok(true)
     }
     "refresh" => {
-      let _ = build_due_menu_bar_popup_snapshot(state.inner(), true, Utc::now())?;
+      let refresh_state = state.inner().clone();
+      tauri::async_runtime::spawn_blocking(move || refresh_popup_data(&refresh_state))
+        .await
+        .map_err(|error| format!("Failed to join popup refresh: {error}"))??;
       refresh_daily_value_menu_bar(state.inner());
       Ok(true)
     }
@@ -349,7 +507,6 @@ fn save_normalized_sync_settings(
   conn: &rusqlite::Connection,
   payload: SyncSettings,
 ) -> rusqlite::Result<SyncSettings> {
-  let current = get_sync_settings(conn)?;
   let auto_scan_interval_minutes = payload.auto_scan_interval_minutes.max(1);
   let updated = SyncSettings {
     codex_home: payload.codex_home,
@@ -373,11 +530,41 @@ fn save_normalized_sync_settings(
     menu_bar_popup_modules: normalize_menu_bar_popup_modules(&payload.menu_bar_popup_modules),
     menu_bar_popup_show_reset_timeline: payload.menu_bar_popup_show_reset_timeline,
     menu_bar_popup_show_actions: payload.menu_bar_popup_show_actions,
-    last_scan_started_at: current.last_scan_started_at,
-    last_scan_completed_at: current.last_scan_completed_at,
-    updated_at: current.updated_at,
+    last_scan_started_at: payload.last_scan_started_at,
+    last_scan_completed_at: payload.last_scan_completed_at,
+    updated_at: payload.updated_at,
   };
   save_sync_settings(conn, &updated)
+}
+
+fn refresh_config_from_saved_settings(
+  settings: &SyncSettings,
+  live_last_success_at: Option<&str>,
+) -> refresh::RefreshConfig {
+  refresh::RefreshConfig {
+    auto_scan_enabled: settings.auto_scan_enabled,
+    interval: Duration::from_secs(
+      unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
+    ),
+    codex_home: settings.codex_home.clone(),
+    token_last_success_wall: refresh::parse_persisted_success_wall(
+      settings.last_scan_completed_at.as_deref(),
+    ),
+    live_last_success_wall: refresh::parse_persisted_success_wall(live_last_success_at),
+  }
+}
+
+fn update_coordinator_from_saved_settings(
+  coordinator: &refresh::RefreshCoordinatorHandle,
+  settings: &SyncSettings,
+) -> Result<(), String> {
+  let live_last_success_at = coordinator.status().live.last_success_at;
+  coordinator
+    .update_settings(refresh_config_from_saved_settings(
+      settings,
+      live_last_success_at.as_deref(),
+    ))
+    .map_err(refresh_error_message)
 }
 
 #[allow(non_snake_case)]
@@ -389,6 +576,8 @@ fn updateSyncSettings(
 ) -> Result<SyncSettings, String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let saved = save_normalized_sync_settings(&conn, payload).map_err(|error| error.to_string())?;
+  drop(conn);
+  update_coordinator_from_saved_settings(refresh_handle(state.inner())?, &saved)?;
   refresh_daily_value_menu_bar(state.inner());
   apply_dock_icon_visibility(&app, &saved, state.daily_value_tray.is_some());
   Ok(saved)
@@ -416,80 +605,6 @@ fn updateSubscriptionProfile(
     updated_at: payload.updated_at,
   };
   save_subscription_profile(&conn, &updated).map_err(|error| error.to_string())
-}
-
-fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
-  run_scan_if_idle_with_live_refresh(state, codex_home, true, perform_scan)
-}
-
-fn run_background_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
-  run_scan_if_idle_with_live_refresh(state, codex_home, false, perform_scan)
-}
-
-fn run_background_incremental_scan_if_idle(
-  state: AppState,
-  codex_home: Option<String>,
-) -> Result<ScanResult, String> {
-  run_scan_if_idle_with_live_refresh(state, codex_home, false, perform_incremental_scan)
-}
-
-fn run_scan_if_idle_with_live_refresh<F>(
-  state: AppState,
-  codex_home: Option<String>,
-  allow_menu_bar_live_refresh: bool,
-  scan: F,
-) -> Result<ScanResult, String>
-where
-  F: FnOnce(&Path, Option<String>) -> Result<ScanResult, String>,
-{
-  let guard = try_acquire_flag(&state.scan_in_progress, "A scan is already running.")?;
-  let mutation_guard = lock_usage_mutations(&state);
-
-  let result = {
-    let _activity = begin_scheduler_activity();
-    scan(&state.db_path, codex_home)
-  };
-  drop(mutation_guard);
-  drop(guard);
-  refresh_daily_value_menu_bar_with_live_refresh(&state, allow_menu_bar_live_refresh);
-  result
-}
-
-fn run_due_background_refresh(
-  state: AppState,
-  now: chrono::DateTime<chrono::Utc>,
-) -> Result<Option<ScanResult>, String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
-  let last_full_scan_completed = get_last_full_scan_completed(&conn).map_err(|error| error.to_string())?;
-  let decision = background_refresh_decision(&settings, last_full_scan_completed.as_deref(), now);
-  drop(conn);
-
-  match decision {
-    BackgroundRefreshDecision::Full => {
-      let result = if state.scan_in_progress.load(Ordering::SeqCst) {
-        Ok(None)
-      } else {
-        run_background_scan_if_idle(state.clone(), settings.codex_home.clone()).map(Some)
-      };
-      if background_live_rate_limits_enabled(&settings) {
-        spawn_live_rate_limits_refresh_if_idle(state, true);
-      }
-      result
-    }
-    BackgroundRefreshDecision::Incremental => {
-      let result = if state.scan_in_progress.load(Ordering::SeqCst) {
-        Ok(None)
-      } else {
-        run_background_incremental_scan_if_idle(state.clone(), settings.codex_home.clone()).map(Some)
-      };
-      if background_live_rate_limits_enabled(&settings) {
-        spawn_live_rate_limits_refresh_if_idle(state, true);
-      }
-      result
-    }
-    BackgroundRefreshDecision::Disabled(_) | BackgroundRefreshDecision::Wait(_) => Ok(None),
-  }
 }
 
 fn prepare_app_database(db_path: &Path) -> Result<(), String> {
@@ -566,55 +681,116 @@ fn load_pricing_value_signature(conn: &rusqlite::Connection) -> rusqlite::Result
   rows.collect()
 }
 
-fn refresh_daily_value_menu_bar(state: &AppState) {
-  refresh_daily_value_menu_bar_with_live_refresh(state, true);
+fn claim_menu_bar_render(state: &AtomicU8) -> bool {
+  claim_menu_bar_render_with_hook(state, |_| {})
 }
 
-fn refresh_daily_value_menu_bar_with_live_refresh(state: &AppState, allow_live_refresh: bool) {
+fn claim_menu_bar_render_with_hook(
+  state: &AtomicU8,
+  mut before_transition: impl FnMut(u8),
+) -> bool {
+  loop {
+    let current = state.load(Ordering::Acquire);
+    before_transition(current);
+    match current {
+      MENU_RENDER_IDLE => {
+        if state
+          .compare_exchange(
+            MENU_RENDER_IDLE,
+            MENU_RENDER_RUNNING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+          )
+          .is_ok()
+        {
+          return true;
+        }
+      }
+      MENU_RENDER_RUNNING => {
+        if state
+          .compare_exchange(
+            MENU_RENDER_RUNNING,
+            MENU_RENDER_PENDING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+          )
+          .is_ok()
+        {
+          return false;
+        }
+      }
+      MENU_RENDER_PENDING => return false,
+      _ => {
+        state.store(MENU_RENDER_PENDING, Ordering::Release);
+        return false;
+      }
+    }
+  }
+}
+
+fn complete_menu_bar_render(state: &AtomicU8) -> bool {
+  state.swap(MENU_RENDER_IDLE, Ordering::AcqRel) == MENU_RENDER_PENDING
+}
+
+fn refresh_daily_value_menu_bar(state: &AppState) {
   let Some(app_handle) = state.app_handle.as_ref().cloned() else {
-    if let Err(error) = update_daily_value_menu_bar(state, allow_live_refresh) {
+    if let Err(error) = update_daily_value_menu_bar(state) {
       log::warn!("Failed to update menu bar display: {error}");
     }
     return;
   };
 
-  let Ok(guard) = try_acquire_flag(
-    &state.menu_bar_refresh_in_progress,
-    "A menu bar refresh is already running.",
-  ) else {
+  if !claim_menu_bar_render(&state.menu_bar_render_state) {
     return;
-  };
+  }
   let state = state.clone();
+  let scheduled_state = state.clone();
   if let Err(error) = app_handle.run_on_main_thread(move || {
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-      update_daily_value_menu_bar(&state, allow_live_refresh)
-    }));
-    drop(guard);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| update_daily_value_menu_bar(&state)));
+    let pending = complete_menu_bar_render(&state.menu_bar_render_state);
     match result {
       Ok(Ok(())) => {}
       Ok(Err(error)) => log::warn!("Failed to update menu bar display: {error}"),
       Err(_) => log::warn!("Menu bar display update panicked."),
     }
+    if pending {
+      refresh_daily_value_menu_bar(&state);
+    }
   }) {
+    let pending = complete_menu_bar_render(&scheduled_state.menu_bar_render_state);
     log::warn!("Failed to schedule menu bar display update: {error}");
+    if pending {
+      refresh_daily_value_menu_bar(&scheduled_state);
+    }
   }
 }
 
-fn update_daily_value_menu_bar(state: &AppState, allow_live_refresh: bool) -> Result<(), String> {
+fn update_daily_value_menu_bar(state: &AppState) -> Result<(), String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+  render_daily_value_menu_bar(state, &settings)
+}
+
+fn render_daily_value_menu_bar(
+  state: &AppState,
+  settings: &SyncSettings,
+) -> Result<(), String> {
   let Some(tray) = state.daily_value_tray.as_ref() else {
     return Ok(());
   };
 
-  if !menu_bar_has_visible_content(&settings) {
+  if !menu_bar_has_visible_content(settings) {
     tray.set_visible(false).map_err(|error| error.to_string())?;
     return Ok(());
   }
 
   apply_menu_bar_icon(tray, settings.show_menu_bar_logo)?;
-  let (api_value_title, live_metric_title) =
-    current_menu_bar_title_parts_with_live_refresh(state, &settings, allow_live_refresh)?;
+  let live_rate_limits = state.live_rate_limits.rate_limits();
+  let (api_value_title, live_metric_title) = current_menu_bar_title_parts(
+    state,
+    settings,
+    live_rate_limits.as_deref(),
+  )?;
   match menu_bar_title(api_value_title.as_deref(), live_metric_title.as_deref()) {
     Some(title) => tray.set_title(Some(&title)).map_err(|error| error.to_string())?,
     None => tray
@@ -622,11 +798,10 @@ fn update_daily_value_menu_bar(state: &AppState, allow_live_refresh: bool) -> Re
       .map_err(|error| error.to_string())?,
   }
   tray
-    .set_tooltip(Some(menu_bar_tooltip_with_live_refresh(
-      &settings,
+    .set_tooltip(Some(menu_bar_tooltip(
+      settings,
       api_value_title.as_deref(),
-      state,
-      allow_live_refresh,
+      live_rate_limits.as_deref(),
     )?))
     .map_err(|error| error.to_string())?;
   tray.set_visible(true).map_err(|error| error.to_string())?;
@@ -637,13 +812,6 @@ fn menu_bar_has_visible_content(settings: &SyncSettings) -> bool {
   settings.show_menu_bar_logo
     || settings.show_menu_bar_daily_api_value
     || settings.show_menu_bar_live_quota_percent
-}
-
-fn background_live_rate_limits_enabled(settings: &SyncSettings) -> bool {
-  let menu_bar_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
-  settings.show_menu_bar_live_quota_percent
-    || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&menu_bar_bucket))
-    || settings.menu_bar_popup_enabled
 }
 
 fn should_hide_dock_icon(settings: &SyncSettings) -> bool {
@@ -681,17 +849,17 @@ fn apply_menu_bar_icon(tray: &TrayIcon, show_logo: bool) -> Result<(), String> {
   Ok(())
 }
 
-fn current_menu_bar_title_parts_with_live_refresh(
+fn current_menu_bar_title_parts(
   state: &AppState,
   settings: &SyncSettings,
-  allow_live_refresh: bool,
+  cached_live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<(Option<String>, Option<String>), String> {
   let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let anchor = Local::now().format("%Y-%m-%d").to_string();
   let live_rate_limits = if settings.show_menu_bar_live_quota_percent
     || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&bucket))
   {
-    maybe_live_rate_limits_for_bucket_with_live_refresh(state, Some(&bucket), None, allow_live_refresh)?
+    cached_live_rate_limits
   } else {
     None
   };
@@ -702,7 +870,7 @@ fn current_menu_bar_title_parts_with_live_refresh(
       if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
       None,
       None,
-      live_rate_limits.clone(),
+      live_rate_limits.cloned(),
       None,
     )?;
     Some(format!("${:.1}", api_value_usd))
@@ -711,13 +879,11 @@ fn current_menu_bar_title_parts_with_live_refresh(
   };
   let live_metric_title = if settings.show_menu_bar_live_quota_percent {
     menu_bar_live_quota_snapshot(
-      state,
       settings,
       &settings.menu_bar_live_quota_bucket,
       &settings.menu_bar_live_quota_metric,
       live_rate_limits,
       Local::now(),
-      allow_live_refresh,
     )?
   } else {
     None
@@ -792,11 +958,10 @@ fn normalize_menu_bar_popup_modules(modules: &[String]) -> Vec<String> {
   normalized
 }
 
-fn menu_bar_tooltip_with_live_refresh(
+fn menu_bar_tooltip(
   settings: &SyncSettings,
   api_value_title: Option<&str>,
-  state: &AppState,
-  allow_live_refresh: bool,
+  cached_live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<String, String> {
   let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let mut fragments = Vec::new();
@@ -804,14 +969,9 @@ fn menu_bar_tooltip_with_live_refresh(
     fragments.push(format!("{}累计 API 价值：{title}", menu_bar_bucket_label(&bucket)));
   }
   if settings.show_menu_bar_live_quota_percent {
-    let snapshot = if allow_live_refresh {
-      Some(get_live_rate_limits_cached(state)?)
-    } else {
-      get_live_rate_limits_local(state)
-    };
-    if let Some(snapshot) = snapshot {
+    if let Some(snapshot) = cached_live_rate_limits {
       if let Some(fragment) = menu_bar_live_quota_tooltip(
-        &snapshot,
+        snapshot,
         settings,
         &settings.menu_bar_live_quota_bucket,
         &settings.menu_bar_live_quota_metric,
@@ -850,25 +1010,16 @@ fn bucket_uses_anchor(bucket: &str) -> bool {
 }
 
 fn menu_bar_live_quota_snapshot(
-  state: &AppState,
   settings: &SyncSettings,
   bucket: &str,
   metric: &str,
-  existing_snapshot: Option<LiveRateLimitSnapshot>,
+  existing_snapshot: Option<&LiveRateLimitSnapshot>,
   now: DateTime<Local>,
-  allow_live_refresh: bool,
 ) -> Result<Option<String>, String> {
-  let snapshot = match existing_snapshot {
-    Some(snapshot) => snapshot,
-    None if allow_live_refresh => get_live_rate_limits_cached(state)?,
-    None => {
-      let Some(snapshot) = get_live_rate_limits_local(state) else {
-        return Ok(None);
-      };
-      snapshot
-    }
+  let Some(snapshot) = existing_snapshot else {
+    return Ok(None);
   };
-  Ok(menu_bar_live_quota_title(&snapshot, settings, bucket, metric, now))
+  Ok(menu_bar_live_quota_title(snapshot, settings, bucket, metric, now))
 }
 
 fn selected_menu_bar_live_quota_window<'a>(
@@ -1015,15 +1166,6 @@ fn maybe_live_rate_limits_for_bucket(
   bucket: Option<&str>,
   live_window_offset: Option<i64>,
 ) -> Result<Option<LiveRateLimitSnapshot>, String> {
-  maybe_live_rate_limits_for_bucket_with_live_refresh(state, bucket, live_window_offset, true)
-}
-
-fn maybe_live_rate_limits_for_bucket_with_live_refresh(
-  state: &AppState,
-  bucket: Option<&str>,
-  live_window_offset: Option<i64>,
-  allow_live_refresh: bool,
-) -> Result<Option<LiveRateLimitSnapshot>, String> {
   let Some(bucket) = bucket else {
     return Ok(None);
   };
@@ -1033,102 +1175,17 @@ fn maybe_live_rate_limits_for_bucket_with_live_refresh(
   if live_window_offset.unwrap_or(0) > 0 {
     return Ok(None);
   }
-  if allow_live_refresh {
-    Ok(Some(get_live_rate_limits_cached(state)?))
-  } else {
-    Ok(get_live_rate_limits_local(state))
-  }
-}
-
-fn get_live_rate_limits_cached(state: &AppState) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits(state, false)
-}
-
-fn get_live_rate_limits(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_with_fallback(state, force_refresh, live_rate_limit_foreground_query_timeout())
-}
-
-fn get_live_rate_limits_background(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_with_fallback(state, force_refresh, live_rate_limit_background_query_timeout())
-}
-
-fn get_live_rate_limits_with_fallback(
-  state: &AppState,
-  force_refresh: bool,
-  query_timeout: Duration,
-) -> Result<LiveRateLimitSnapshot, String> {
-  if let Some(snapshot) =
-    get_fresh_cached_live_rate_limits(state, force_refresh, || live_rate_limit_cache_ttl(state))
-  {
-    return Ok(snapshot);
-  }
-
-  state.live_rate_limits.set_refreshing(true);
-  let query_result = {
-    let _activity = begin_scheduler_activity();
-    query_live_rate_limits(query_timeout)
-  };
-  match query_result {
-    Ok(snapshot) => Ok(publish_live_rate_limits_and_persist(
-      state,
-      snapshot,
-      |snapshot| {
-        let _activity = begin_scheduler_activity();
-        let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-        insert_live_rate_limit_snapshot(&conn, snapshot).map_err(|error| error.to_string())
-      },
-    )),
-    Err(error) => {
-      log::warn!("Failed to refresh live rate limits from Codex app-server: {error}");
-      if let Some(fallback) = get_live_rate_limits_stored_fallback(state) {
-        state.live_rate_limits.publish_fallback(
-          Arc::new(fallback),
-          Instant::now(),
-          Utc::now(),
-        );
-        if let Some(effective) = get_cached_live_rate_limits(state) {
-          return Ok(effective);
-        }
-      }
-      state.live_rate_limits.set_refreshing(false);
-      Err(error)
-    }
-  }
-}
-
-fn get_fresh_cached_live_rate_limits(
-  state: &AppState,
-  force_refresh: bool,
-  load_ttl: impl FnOnce() -> Duration,
-) -> Option<LiveRateLimitSnapshot> {
-  if force_refresh {
-    return None;
-  }
-  let ttl = load_ttl();
-  if state.live_rate_limits.needs_live_refresh(ttl, Instant::now()) {
-    None
-  } else {
-    get_cached_live_rate_limits(state)
-  }
-}
-
-fn publish_live_rate_limits_and_persist(
-  state: &AppState,
-  snapshot: LiveRateLimitSnapshot,
-  persist: impl FnOnce(&LiveRateLimitSnapshot) -> Result<(), String>,
-) -> LiveRateLimitSnapshot {
-  let snapshot = Arc::new(snapshot);
-  state
+  Ok(state
     .live_rate_limits
-    .publish_live(Arc::clone(&snapshot), Instant::now(), Utc::now());
-  if let Err(error) = persist(&snapshot) {
-    log::warn!("Failed to persist live rate-limit snapshot: {error}");
-  }
-  snapshot.as_ref().clone()
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone()))
 }
 
 #[derive(Clone)]
 struct PersistedRateLimitWindow {
+  row_id: i64,
+  source_kind: String,
+  source_session_id: String,
   snapshot: RateLimitWindowSnapshot,
   fetched_at: String,
   limit_id: Option<String>,
@@ -1144,7 +1201,8 @@ fn load_latest_persisted_rate_limit_window(
   let mut stmt = conn
     .prepare(
       "
-      SELECT sample_timestamp, limit_id, limit_name, plan_type, window_start, resets_at, used_percent, remaining_percent
+      SELECT id, source_kind, source_session_id, sample_timestamp, limit_id, limit_name, plan_type,
+             window_start, resets_at, used_percent, remaining_percent
       FROM rate_limit_samples
       WHERE bucket = ?1 AND (?2 IS NULL OR source_kind = ?2)
       ORDER BY julianday(sample_timestamp) DESC, id DESC
@@ -1160,23 +1218,26 @@ fn load_latest_persisted_rate_limit_window(
     return Ok(None);
   };
 
-  let sample_timestamp = row.get::<_, String>(0).map_err(|error| error.to_string())?;
+  let row_id = row.get::<_, i64>(0).map_err(|error| error.to_string())?;
+  let source_kind = row.get::<_, String>(1).map_err(|error| error.to_string())?;
+  let source_session_id = row.get::<_, String>(2).map_err(|error| error.to_string())?;
+  let sample_timestamp = row.get::<_, String>(3).map_err(|error| error.to_string())?;
   let limit_id = row
-    .get::<_, String>(1)
+    .get::<_, String>(4)
     .ok()
     .and_then(|value| (!value.is_empty()).then_some(value));
   let limit_name = row
-    .get::<_, String>(2)
+    .get::<_, String>(5)
     .ok()
     .and_then(|value| (!value.is_empty()).then_some(value));
   let plan_type = row
-    .get::<_, String>(3)
+    .get::<_, String>(6)
     .ok()
     .and_then(|value| (!value.is_empty()).then_some(value));
-  let window_start = row.get::<_, String>(4).map_err(|error| error.to_string())?;
-  let resets_at = row.get::<_, String>(5).map_err(|error| error.to_string())?;
-  let used_percent = row.get::<_, i64>(6).map_err(|error| error.to_string())?;
-  let remaining_percent = row.get::<_, i64>(7).map_err(|error| error.to_string())?;
+  let window_start = row.get::<_, String>(7).map_err(|error| error.to_string())?;
+  let resets_at = row.get::<_, String>(8).map_err(|error| error.to_string())?;
+  let used_percent = row.get::<_, i64>(9).map_err(|error| error.to_string())?;
+  let remaining_percent = row.get::<_, i64>(10).map_err(|error| error.to_string())?;
 
   let window_duration_mins = match (
     parse_rfc3339_local(&window_start),
@@ -1187,6 +1248,9 @@ fn load_latest_persisted_rate_limit_window(
   };
 
   Ok(Some(PersistedRateLimitWindow {
+    row_id,
+    source_kind,
+    source_session_id,
     snapshot: RateLimitWindowSnapshot {
       used_percent,
       remaining_percent,
@@ -1201,20 +1265,6 @@ fn load_latest_persisted_rate_limit_window(
   }))
 }
 
-#[cfg(test)]
-fn load_persisted_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  load_persisted_live_rate_limits_for_source(state, None)
-}
-
-#[cfg(test)]
-fn load_persisted_live_rate_limits_for_source(
-  state: &AppState,
-  source_kind: Option<&str>,
-) -> Option<LiveRateLimitSnapshot> {
-  let conn = open_connection(&state.db_path).ok()?;
-  load_persisted_live_rate_limits_from_connection(&conn, source_kind)
-}
-
 fn load_persisted_live_rate_limits_from_connection(
   conn: &rusqlite::Connection,
   source_kind: Option<&str>,
@@ -1225,21 +1275,25 @@ fn load_persisted_live_rate_limits_from_connection(
   let mut secondary = load_latest_persisted_rate_limit_window(&conn, "seven_day", source_kind)
     .ok()
     .flatten();
-  let primary_instant = primary
+  let newest = match (primary.as_ref(), secondary.as_ref()) {
+    (Some(primary), Some(secondary)) => {
+      if persisted_window_is_newer(secondary, primary) { secondary } else { primary }
+    }
+    (Some(primary), None) => primary,
+    (None, Some(secondary)) => secondary,
+    (None, None) => return None,
+  };
+  let keep_primary = primary
     .as_ref()
-    .and_then(|window| DateTime::parse_from_rfc3339(&window.fetched_at).ok());
-  let secondary_instant = secondary
+    .is_some_and(|window| same_persisted_sample(window, newest));
+  let keep_secondary = secondary
     .as_ref()
-    .and_then(|window| DateTime::parse_from_rfc3339(&window.fetched_at).ok());
-  let newest_instant = [primary_instant.as_ref(), secondary_instant.as_ref()]
-    .into_iter()
-    .flatten()
-    .max()?;
+    .is_some_and(|window| same_persisted_sample(window, newest));
 
-  if primary_instant.as_ref() != Some(newest_instant) {
+  if !keep_primary {
     primary = None;
   }
-  if secondary_instant.as_ref() != Some(newest_instant) {
+  if !keep_secondary {
     secondary = None;
   }
 
@@ -1267,22 +1321,47 @@ fn load_persisted_live_rate_limits_from_connection(
   })
 }
 
-fn get_live_rate_limits_local(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  if let Some(cached) = get_cached_live_rate_limits(state) {
-    return Some(cached);
+fn persisted_window_is_newer(
+  candidate: &PersistedRateLimitWindow,
+  current: &PersistedRateLimitWindow,
+) -> bool {
+  match (
+    DateTime::parse_from_rfc3339(&candidate.fetched_at).ok(),
+    DateTime::parse_from_rfc3339(&current.fetched_at).ok(),
+  ) {
+    (Some(candidate_time), Some(current_time)) if candidate_time != current_time => {
+      candidate_time > current_time
+    }
+    (Some(_), Some(_)) => candidate.row_id > current.row_id,
+    (Some(_), None) => true,
+    (None, Some(_)) => false,
+    (None, None) if candidate.fetched_at != current.fetched_at => {
+      candidate.fetched_at > current.fetched_at
+    }
+    (None, None) => candidate.row_id > current.row_id,
   }
-  let fallback = get_live_rate_limits_stored_fallback(state)?;
-  state.live_rate_limits.publish_fallback(
-    Arc::new(fallback),
-    Instant::now(),
-    Utc::now(),
-  );
-  get_cached_live_rate_limits(state)
 }
 
-fn get_live_rate_limits_stored_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  let memory = get_cached_live_rate_limits(state);
-  let Ok(conn) = open_connection(&state.db_path) else {
+fn same_persisted_sample(
+  left: &PersistedRateLimitWindow,
+  right: &PersistedRateLimitWindow,
+) -> bool {
+  left.source_kind == right.source_kind
+    && left.source_session_id == right.source_session_id
+    && left.fetched_at == right.fetched_at
+    && left.limit_id == right.limit_id
+    && left.limit_name == right.limit_name
+    && left.plan_type == right.plan_type
+}
+
+fn load_display_live_rate_limit_fallback(
+  db_path: &Path,
+  live_cache: &refresh::LiveQuotaCache,
+) -> Option<LiveRateLimitSnapshot> {
+  let memory = live_cache
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone());
+  let Ok(conn) = open_connection(db_path) else {
     return memory;
   };
   let persisted = load_persisted_live_rate_limits_from_connection(&conn, None);
@@ -1292,13 +1371,6 @@ fn get_live_rate_limits_stored_fallback(state: &AppState) -> Option<LiveRateLimi
     None
   };
   newest_live_rate_limit_snapshot([memory, persisted, session_only])
-}
-
-fn get_cached_live_rate_limits(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  state
-    .live_rate_limits
-    .rate_limits()
-    .map(|snapshot| snapshot.as_ref().clone())
 }
 
 fn newest_live_rate_limit_snapshot(
@@ -1331,31 +1403,20 @@ fn live_snapshot_is_newer(
   }
 }
 
-fn best_effort_live_rate_limits(state: &AppState, force_refresh: bool) -> Option<LiveRateLimitSnapshot> {
-  match get_live_rate_limits(state, force_refresh) {
-    Ok(snapshot) => Some(snapshot),
-    Err(error) => {
-      log::warn!("Failed to refresh live rate limits for popup: {error}");
-      get_live_rate_limits_local(state)
-    }
-  }
-}
-
-fn build_menu_bar_popup_snapshot(
-  state: &AppState,
-  force_refresh: bool,
+fn build_passive_menu_bar_popup_snapshot(
+  db_path: &Path,
+  live_cache: &refresh::LiveQuotaCache,
 ) -> Result<MenuBarPopupSnapshot, String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
-  let live_rate_limits = if force_refresh {
-    best_effort_live_rate_limits(state, true)
-  } else {
-    get_live_rate_limits_local(state)
-  };
+  drop(conn);
+  let live_rate_limits = live_cache
+    .rate_limits()
+    .map(|snapshot| snapshot.as_ref().clone());
   let selected_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let anchor = bucket_uses_anchor(&selected_bucket).then(|| Local::now().format("%Y-%m-%d").to_string());
   let overview = get_overview(
-    &state.db_path,
+    db_path,
     Some(selected_bucket.clone()),
     anchor,
     None,
@@ -1374,7 +1435,7 @@ fn build_menu_bar_popup_snapshot(
       .map(|value| value.quota_trend.clone())
       .unwrap_or_default()
   } else {
-    get_quota_trend(&state.db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
+    get_quota_trend(db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
   };
 
   Ok(MenuBarPopupSnapshot {
@@ -1409,15 +1470,21 @@ fn build_menu_bar_popup_snapshot(
   })
 }
 
-fn build_due_menu_bar_popup_snapshot(
-  state: &AppState,
-  force_refresh: bool,
-  now: chrono::DateTime<chrono::Utc>,
-) -> Result<MenuBarPopupSnapshot, String> {
-  if let Err(error) = run_due_background_refresh(state.clone(), now) {
-    log::warn!("Failed to run due background refresh before menu bar snapshot: {error}");
+fn refresh_popup_data(state: &AppState) -> Result<(), String> {
+  let coordinator = refresh_handle(state)?;
+  let token_ticket = coordinator.request_manual_token(None);
+  let live_ticket = coordinator.request_manual_live();
+
+  let token_result = token_ticket.and_then(|ticket| ticket.wait());
+  let live_result = live_ticket.and_then(|ticket| ticket.wait());
+  match (token_result, live_result) {
+    (Ok(_), Ok(_)) => Ok(()),
+    (token, live) => Err(format!(
+      "Popup refresh failed (token: {:?}, live: {:?})",
+      token.err(),
+      live.err()
+    )),
   }
-  build_menu_bar_popup_snapshot(state, force_refresh)
 }
 
 fn menu_bar_popup_quota_snapshot(window: &RateLimitWindowSnapshot) -> MenuBarPopupQuotaSnapshot {
@@ -1481,24 +1548,6 @@ fn usage_velocity_status(percent: f64, fast_threshold: f64, slow_threshold: f64)
   }
 }
 
-fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
-  open_connection(&state.db_path)
-    .ok()
-    .and_then(|conn| get_sync_settings(&conn).ok())
-    .map(|settings| {
-      Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64)
-    })
-    .unwrap_or(Duration::from_secs(300))
-}
-
-fn live_rate_limit_foreground_query_timeout() -> Duration {
-  refresh::LIVE_QUERY_TIMEOUT
-}
-
-fn live_rate_limit_background_query_timeout() -> Duration {
-  refresh::LIVE_QUERY_TIMEOUT
-}
-
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
   auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
@@ -1526,7 +1575,15 @@ fn build_menu_bar_popup_window(app: &AppHandle) -> Result<WebviewWindow, String>
 
 fn hide_menu_bar_popup(app: &AppHandle) {
   if let Some(window) = app.get_webview_window(MENU_BAR_POPUP_WINDOW_LABEL) {
-    let _ = window.hide();
+    if window.hide().is_ok() {
+      set_menu_bar_popup_visibility(app, false);
+    }
+  }
+}
+
+fn set_menu_bar_popup_visibility(app: &AppHandle, visible: bool) {
+  if let Some(state) = app.try_state::<AppState>() {
+    state.menu_bar_popup_visible.store(visible, Ordering::Release);
   }
 }
 
@@ -1538,8 +1595,10 @@ fn toggle_menu_bar_popup(
   let state = app.state::<AppState>();
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+  drop(conn);
   if !settings.menu_bar_popup_enabled {
     clear_menu_bar_popup_anchor(state.inner());
+    hide_menu_bar_popup(app);
     show_main_window(app);
     return Ok(());
   }
@@ -1548,12 +1607,14 @@ fn toggle_menu_bar_popup(
   if window.is_visible().map_err(|error| error.to_string())? {
     clear_menu_bar_popup_anchor(state.inner());
     window.hide().map_err(|error| error.to_string())?;
+    state.menu_bar_popup_visible.store(false, Ordering::Release);
     return Ok(());
   }
 
   store_menu_bar_popup_anchor(state.inner(), rect, click_position);
   position_menu_bar_popup(&window, rect, click_position)?;
   window.show().map_err(|error| error.to_string())?;
+  state.menu_bar_popup_visible.store(true, Ordering::Release);
   window.set_focus().map_err(|error| error.to_string())?;
   window
     .emit(MENU_BAR_POPUP_REFRESH_EVENT, ())
@@ -1845,9 +1906,7 @@ fn tray_rect_size_to_physical(size: tauri::Size, scale_factor: f64) -> tauri::Ph
   }
 }
 
-fn build_daily_value_menu_bar(app: &AppHandle, db_path: &PathBuf) -> Result<TrayIcon, String> {
-  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+fn build_daily_value_menu_bar(app: &AppHandle, settings: &SyncSettings) -> Result<TrayIcon, String> {
   let initial_title = String::new();
 
   let show_window = MenuItem::with_id(
@@ -1917,136 +1976,6 @@ fn show_main_window(app: &AppHandle) {
   }
 }
 
-fn spawn_initial_scan(state: AppState) {
-  std::thread::Builder::new()
-    .name("codex-pacer-initial-scan".to_string())
-    .spawn(move || {
-      let _ = run_background_incremental_scan_if_idle(state, None);
-    })
-    .expect("failed to spawn initial scan thread");
-}
-
-fn spawn_live_rate_limits_refresh_if_idle(state: AppState, force_refresh: bool) {
-  let Ok(guard) = try_acquire_flag(&state.live_refresh_in_progress, "A live quota refresh is already running.") else {
-    return;
-  };
-
-  if let Err(error) = std::thread::Builder::new()
-    .name("codex-pacer-live-quota-refresh".to_string())
-    .spawn(move || {
-      let result = get_live_rate_limits_background(&state, force_refresh);
-      drop(guard);
-      if let Err(error) = result {
-        log::warn!("Failed to refresh live quota in background: {error}");
-      }
-      refresh_daily_value_menu_bar_with_live_refresh(&state, false);
-    })
-  {
-    log::warn!("Failed to spawn live quota refresh thread: {error}");
-  }
-}
-
-fn spawn_scheduler(state: AppState) {
-  std::thread::Builder::new()
-    .name("codex-pacer-scheduler".to_string())
-    .spawn(move || {
-      loop {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_scheduler_tick(&state)));
-        let delay = match result {
-          Ok(delay) => delay,
-          Err(_) => {
-            log::warn!("Background scheduler tick panicked; continuing on the next interval.");
-            Duration::from_secs(60)
-          }
-        };
-        std::thread::sleep(scheduler_sleep_duration(delay));
-      }
-    })
-    .expect("failed to spawn background scheduler thread");
-}
-
-fn scheduler_sleep_duration(delay: Duration) -> Duration {
-  let max_sleep = Duration::from_secs(SCHEDULER_MAX_SLEEP_SECONDS);
-  if delay > max_sleep { max_sleep } else { delay }
-}
-
-fn run_scheduler_tick(state: &AppState) -> Duration {
-  let Ok(conn) = open_connection(&state.db_path) else {
-    return Duration::from_secs(60);
-  };
-  let Ok(settings) = get_sync_settings(&conn) else {
-    return Duration::from_secs(60);
-  };
-  let now = Utc::now();
-  let last_full_scan_completed = get_last_full_scan_completed(&conn).unwrap_or(None);
-  let decision = background_refresh_decision(&settings, last_full_scan_completed.as_deref(), now);
-  drop(conn);
-
-  match decision {
-    BackgroundRefreshDecision::Disabled(delay) | BackgroundRefreshDecision::Wait(delay) => delay,
-    BackgroundRefreshDecision::Full | BackgroundRefreshDecision::Incremental => {
-      if !state.scan_in_progress.load(Ordering::SeqCst) {
-        let result = match decision {
-          BackgroundRefreshDecision::Full => run_background_scan_if_idle(state.clone(), settings.codex_home.clone()),
-          BackgroundRefreshDecision::Incremental => {
-            run_background_incremental_scan_if_idle(state.clone(), settings.codex_home.clone())
-          }
-          BackgroundRefreshDecision::Disabled(_) | BackgroundRefreshDecision::Wait(_) => unreachable!(),
-        };
-        if let Err(error) = result {
-          log::warn!("Failed to run background Codex scan: {error}");
-        }
-      }
-      if background_live_rate_limits_enabled(&settings) {
-        spawn_live_rate_limits_refresh_if_idle(state.clone(), true);
-      }
-      Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64)
-    }
-  }
-}
-
-fn background_refresh_decision(
-  settings: &SyncSettings,
-  last_full_scan_completed_at: Option<&str>,
-  now: chrono::DateTime<chrono::Utc>,
-) -> BackgroundRefreshDecision {
-  let interval = Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64);
-  if !settings.auto_scan_enabled {
-    return BackgroundRefreshDecision::Disabled(interval);
-  }
-
-  let delay = scheduler_delay_until_next_refresh(settings, now);
-  if !delay.is_zero() {
-    return BackgroundRefreshDecision::Wait(delay);
-  }
-
-  if full_maintenance_due(last_full_scan_completed_at, now) {
-    BackgroundRefreshDecision::Full
-  } else {
-    BackgroundRefreshDecision::Incremental
-  }
-}
-
-fn scheduler_delay_until_next_refresh(settings: &SyncSettings, now: chrono::DateTime<chrono::Utc>) -> Duration {
-  let interval_seconds = unified_refresh_interval_seconds(settings.auto_scan_interval_minutes);
-  if !settings.auto_scan_enabled {
-    return Duration::from_secs(interval_seconds as u64);
-  }
-
-  let Some(last_completed_at) = settings.last_scan_completed_at.as_deref() else {
-    return Duration::ZERO;
-  };
-  let Some(last_completed_at) = chrono::DateTime::parse_from_rfc3339(last_completed_at).ok() else {
-    return Duration::ZERO;
-  };
-  let elapsed_seconds = now
-    .signed_duration_since(last_completed_at.with_timezone(&chrono::Utc))
-    .num_seconds()
-    .max(0);
-  let remaining_seconds = interval_seconds.saturating_sub(elapsed_seconds);
-  Duration::from_secs(remaining_seconds as u64)
-}
-
 fn full_maintenance_due(last_completed_at: Option<&str>, now: chrono::DateTime<chrono::Utc>) -> bool {
   let Some(last_completed_at) = last_completed_at else {
     return true;
@@ -2060,9 +1989,28 @@ fn full_maintenance_due(last_completed_at: Option<&str>, now: chrono::DateTime<c
     >= FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS
 }
 
+fn effective_token_scan_kind(
+  db_path: &Path,
+  requested: refresh::TokenScanKind,
+  now: DateTime<Utc>,
+) -> Result<ScanKind, String> {
+  if requested == refresh::TokenScanKind::Full {
+    return Ok(ScanKind::Full);
+  }
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  let last_full = get_last_full_scan_completed(&conn).map_err(|error| error.to_string())?;
+  Ok(if full_maintenance_due(last_full.as_deref(), now) {
+    ScanKind::Full
+  } else {
+    ScanKind::Incremental
+  })
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
+  let runtime_owner = Arc::new(Mutex::new(None::<refresh::RefreshRuntime>));
+  let setup_runtime_owner = Arc::clone(&runtime_owner);
+  let app = tauri::Builder::default()
     .plugin(
       tauri_plugin_log::Builder::default()
         .level(if cfg!(debug_assertions) {
@@ -2077,10 +2025,14 @@ pub fn run() {
         match event {
           tauri::WindowEvent::CloseRequested { api, .. } => {
             api.prevent_close();
-            let _ = window.hide();
+            if window.hide().is_ok() {
+              set_menu_bar_popup_visibility(window.app_handle(), false);
+            }
           }
           tauri::WindowEvent::Focused(false) => {
-            let _ = window.hide();
+            if window.hide().is_ok() {
+              set_menu_bar_popup_visibility(window.app_handle(), false);
+            }
           }
           _ => {}
         }
@@ -2109,7 +2061,7 @@ pub fn run() {
         let _ = window.hide();
       }
     })
-    .setup(|app| {
+    .setup(move |app| {
       let app_data_dir = app
         .path()
         .app_data_dir()
@@ -2120,9 +2072,50 @@ pub fn run() {
 
       prepare_app_database(&db_path)?;
       let conn = open_connection(&db_path).map_err(|error| error.to_string())?;
+      let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+      let display_fallback = load_persisted_live_rate_limits_from_connection(&conn, None)
+        .or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")));
+      let live_last_success_at = load_persisted_live_rate_limits_from_connection(&conn, Some("live"))
+        .map(|snapshot| snapshot.fetched_at);
+      drop(conn);
+
+      let live_rate_limits = refresh::LiveQuotaCache::new();
+      if let Some(fallback) = display_fallback {
+        live_rate_limits.publish_fallback(
+          Arc::new(fallback),
+          Instant::now(),
+          Utc::now(),
+        );
+      }
 
       let app_handle = app.app_handle();
-      let daily_value_tray = match build_daily_value_menu_bar(&app_handle, &db_path) {
+      let usage_mutations = refresh::UsageMutationCoordinator::new();
+      let runtime = refresh::RefreshRuntime::start(
+        refresh::RefreshRuntimeDependencies::with_system_defaults(
+          refresh_config_from_saved_settings(&settings, live_last_success_at.as_deref()),
+          Arc::new(AppTokenRefreshExecutor {
+            db_path: db_path.clone(),
+          }),
+          Arc::new(AppLiveQuotaFetcher {
+            db_path: db_path.clone(),
+            live_cache: live_rate_limits.clone(),
+          }),
+          Arc::new(AppLiveQuotaPersister {
+            db_path: db_path.clone(),
+          }),
+          live_rate_limits.clone(),
+          Arc::new(TauriRefreshEventSink {
+            app_handle: app_handle.clone(),
+          }),
+          usage_mutations.clone(),
+        ),
+      )?;
+      let refresh = runtime.handle();
+      *setup_runtime_owner
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(runtime);
+
+      let daily_value_tray = match build_daily_value_menu_bar(&app_handle, &settings) {
         Ok(tray) => Some(tray),
         Err(error) => {
           log::warn!("Failed to set up menu bar API value: {error}");
@@ -2132,36 +2125,29 @@ pub fn run() {
       let state = AppState {
         app_handle: Some(app_handle.clone()),
         db_path,
-        scan_in_progress: Arc::new(AtomicBool::new(false)),
-        usage_mutation_lock: Arc::new(Mutex::new(())),
-        live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-        menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+        refresh: installed_refresh_handle(refresh),
+        usage_mutations,
+        menu_bar_render_state: Arc::new(AtomicU8::new(MENU_RENDER_IDLE)),
         daily_value_tray,
-        live_rate_limits: refresh::LiveQuotaCache::new(),
+        live_rate_limits,
+        menu_bar_popup_visible: Arc::new(AtomicBool::new(false)),
         menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
       };
       app.manage(state.clone());
-      let should_refresh_live_on_startup = if let Ok(settings) = get_sync_settings(&conn) {
-        apply_dock_icon_visibility(&app_handle, &settings, state.daily_value_tray.is_some());
-        background_live_rate_limits_enabled(&settings)
-      } else {
-        false
-      };
+      apply_dock_icon_visibility(&app_handle, &settings, state.daily_value_tray.is_some());
       if let Err(error) = build_menu_bar_popup_window(&app_handle) {
         log::warn!("Failed to set up menu bar popup window: {error}");
       }
-      refresh_daily_value_menu_bar_with_live_refresh(&state, false);
-      if should_refresh_live_on_startup {
-        spawn_live_rate_limits_refresh_if_idle(state.clone(), true);
+      if let Err(error) = render_daily_value_menu_bar(&state, &settings) {
+        log::warn!("Failed to render initial menu bar display: {error}");
       }
-      spawn_initial_scan(state.clone());
-      spawn_scheduler(state);
 
       Ok(())
     })
     .invoke_handler(tauri::generate_handler![
       scanCodexUsage,
       getScanInProgress,
+      getRefreshStatus,
       refreshBackgroundData,
       refreshPricing,
       getOverview,
@@ -2177,14 +2163,220 @@ pub fn run() {
       getSubscriptionProfile,
       updateSubscriptionProfile,
     ])
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    .build(tauri::generate_context!())
+    .expect("error while building tauri application");
+
+  app.run(move |app_handle, event| match event {
+    tauri::RunEvent::Resumed => {
+      if let Some(state) = app_handle.try_state::<AppState>() {
+        match refresh_handle(state.inner()) {
+          Ok(refresh) => match refresh.try_wake() {
+            Ok(()) | Err(refresh::RefreshError::Busy) => {}
+            Err(error) => log::warn!("Failed to wake refresh coordinator after resume: {error:?}"),
+          },
+          Err(error) => log::warn!("Failed to wake refresh coordinator after resume: {error}"),
+        }
+      }
+    }
+    tauri::RunEvent::Exit => {
+      let runtime = runtime_owner
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take();
+      if let Some(runtime) = runtime {
+        if let Err(error) = runtime.shutdown_and_join() {
+          log::warn!("Failed to shut down refresh runtime: {error:?}");
+        }
+      }
+    }
+    _ => {}
+  });
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::sync::mpsc::{self, Receiver, Sender};
+  use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
   use tempfile::tempdir;
+
+  struct RecordingTokenExecutor {
+    requests: Sender<refresh::TokenExecutionRequest>,
+  }
+
+  impl refresh::TokenRefreshExecutor for RecordingTokenExecutor {
+    fn parse(
+      &self,
+      request: refresh::TokenExecutionRequest,
+    ) -> Result<refresh::PreparedTokenRefresh, String> {
+      self
+        .requests
+        .send(request)
+        .map_err(|error| error.to_string())?;
+      Err("recording token executor stops after parse intake".to_string())
+    }
+
+    fn commit(&self, _: refresh::PreparedTokenRefresh) -> Result<ScanResult, String> {
+      Err("recording token executor does not commit".to_string())
+    }
+  }
+
+  struct RecordingAppTokenExecutor {
+    inner: AppTokenRefreshExecutor,
+    parsed: Sender<(u64, u64, refresh::TokenScanKind)>,
+    committed: Sender<u64>,
+  }
+
+  impl refresh::TokenRefreshExecutor for RecordingAppTokenExecutor {
+    fn parse(
+      &self,
+      request: refresh::TokenExecutionRequest,
+    ) -> Result<refresh::PreparedTokenRefresh, String> {
+      self
+        .parsed
+        .send((
+          request.generation,
+          request.source_generation,
+          request.request.kind,
+        ))
+        .map_err(|error| error.to_string())?;
+      self.inner.parse(request)
+    }
+
+    fn commit(
+      &self,
+      prepared: refresh::PreparedTokenRefresh,
+    ) -> Result<ScanResult, String> {
+      self
+        .committed
+        .send(prepared.generation)
+        .map_err(|error| error.to_string())?;
+      self.inner.commit(prepared)
+    }
+  }
+
+  struct CountingLiveFetcher {
+    calls: Arc<AtomicUsize>,
+  }
+
+  impl refresh::LiveQuotaFetcher for CountingLiveFetcher {
+    fn fetch(&self, _: Duration) -> Result<LiveRateLimitSnapshot, String> {
+      self.calls.fetch_add(1, AtomicOrdering::AcqRel);
+      Err("counting live fetcher should not run".to_string())
+    }
+  }
+
+  struct NoopLivePersister;
+
+  impl refresh::LiveQuotaPersister for NoopLivePersister {
+    fn persist(&self, _: &LiveRateLimitSnapshot) -> Result<(), String> {
+      Ok(())
+    }
+  }
+
+  struct NoopRefreshEvents;
+
+  impl refresh::RefreshEventSink for NoopRefreshEvents {
+    fn publish_invalidation(&self, _: refresh::DisplayInvalidation) {}
+
+    fn publish_completion(&self, _: refresh::RefreshCompletedEvent) {}
+  }
+
+  struct GatedFailingTokenExecutor {
+    entered: Sender<()>,
+    release: Mutex<Receiver<()>>,
+  }
+
+  impl refresh::TokenRefreshExecutor for GatedFailingTokenExecutor {
+    fn parse(
+      &self,
+      _: refresh::TokenExecutionRequest,
+    ) -> Result<refresh::PreparedTokenRefresh, String> {
+      self.entered.send(()).map_err(|error| error.to_string())?;
+      self
+        .release
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .recv()
+        .map_err(|error| error.to_string())?;
+      Err("injected popup token failure".to_string())
+    }
+
+    fn commit(&self, _: refresh::PreparedTokenRefresh) -> Result<ScanResult, String> {
+      Err("injected popup token commit failure".to_string())
+    }
+  }
+
+  struct GatedFailingLiveFetcher {
+    entered: Sender<()>,
+    release: Mutex<Receiver<()>>,
+  }
+
+  impl refresh::LiveQuotaFetcher for GatedFailingLiveFetcher {
+    fn fetch(&self, _: Duration) -> Result<LiveRateLimitSnapshot, String> {
+      self.entered.send(()).map_err(|error| error.to_string())?;
+      self
+        .release
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .recv()
+        .map_err(|error| error.to_string())?;
+      Err("injected popup live failure".to_string())
+    }
+  }
+
+  fn start_recording_runtime(
+    config: refresh::RefreshConfig,
+  ) -> (
+    refresh::RefreshRuntime,
+    Receiver<refresh::TokenExecutionRequest>,
+    Arc<AtomicUsize>,
+  ) {
+    let (requests, received) = mpsc::channel();
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let dependencies = refresh::RefreshRuntimeDependencies::with_system_defaults(
+      config,
+      Arc::new(RecordingTokenExecutor { requests }),
+      Arc::new(CountingLiveFetcher {
+        calls: Arc::clone(&live_calls),
+      }),
+      Arc::new(NoopLivePersister),
+      refresh::LiveQuotaCache::new(),
+      Arc::new(NoopRefreshEvents),
+      refresh::UsageMutationCoordinator::new(),
+    );
+    let runtime = refresh::RefreshRuntime::start(dependencies).expect("start recording runtime");
+    (runtime, received, live_calls)
+  }
+
+  fn disabled_refresh_config(codex_home: Option<String>) -> refresh::RefreshConfig {
+    refresh::RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(3600),
+      codex_home,
+      token_last_success_wall: None,
+      live_last_success_wall: None,
+    }
+  }
+
+  fn test_app_state(
+    db_path: PathBuf,
+    refresh: refresh::RefreshCoordinatorHandle,
+    usage_mutations: refresh::UsageMutationCoordinator,
+    live_rate_limits: refresh::LiveQuotaCache,
+  ) -> AppState {
+    AppState {
+      app_handle: None,
+      db_path,
+      refresh: Some(refresh),
+      usage_mutations,
+      menu_bar_render_state: Arc::new(AtomicU8::new(MENU_RENDER_IDLE)),
+      daily_value_tray: None,
+      live_rate_limits,
+      menu_bar_popup_visible: Arc::new(AtomicBool::new(false)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    }
+  }
 
   fn speed_test_settings() -> SyncSettings {
     SyncSettings {
@@ -2211,22 +2403,335 @@ mod tests {
       .with_timezone(&chrono::Utc)
   }
 
+  #[test]
+  fn settings_change_wakes_coordinator_immediately() {
+    let initial = refresh::RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(3600),
+      codex_home: None,
+      token_last_success_wall: None,
+      live_last_success_wall: None,
+    };
+    let (runtime, token_requests, _) = start_recording_runtime(initial);
+    let handle = runtime.handle();
+    let saved = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 60,
+      ..SyncSettings::default()
+    };
+
+    update_coordinator_from_saved_settings(&handle, &saved).expect("deliver settings update");
+
+    assert!(handle.status().auto_scan_enabled);
+    token_requests
+      .recv_timeout(Duration::from_secs(2))
+      .expect("enabled overdue settings wake token lane");
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn codex_home_change_requests_full_scan() {
+    let initial = refresh::RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(3600),
+      codex_home: Some("/tmp/codex-home-before".to_string()),
+      token_last_success_wall: None,
+      live_last_success_wall: None,
+    };
+    let (runtime, token_requests, _) = start_recording_runtime(initial);
+    let handle = runtime.handle();
+    let source_generation_before = handle.status().source_generation;
+    let saved = SyncSettings {
+      codex_home: Some("/tmp/codex-home-after".to_string()),
+      auto_scan_enabled: false,
+      auto_scan_interval_minutes: 60,
+      ..SyncSettings::default()
+    };
+
+    update_coordinator_from_saved_settings(&handle, &saved).expect("deliver source change");
+
+    let request = token_requests
+      .recv_timeout(Duration::from_secs(2))
+      .expect("source change starts protected token refresh");
+    assert_eq!(request.request.kind, refresh::TokenScanKind::Full);
+    assert!(request
+      .request
+      .reasons
+      .contains(refresh::RefreshReason::SettingsChanged));
+    assert_eq!(
+      request.request.codex_home.as_deref(),
+      Some("/tmp/codex-home-after")
+    );
+    assert_eq!(handle.status().source_generation, source_generation_before + 1);
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn passive_live_getter_does_not_start_fetch() {
+    let (runtime, token_requests, live_calls) =
+      start_recording_runtime(disabled_refresh_config(None));
+    let status_before = runtime.handle().status();
+    let cache = refresh::LiveQuotaCache::new();
+    cache.publish_fallback(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: None,
+        secondary: None,
+        fetched_at: "2026-07-11T00:00:00Z".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+
+    let snapshot = get_passive_live_rate_limits(&cache).expect("read cached quota");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-11T00:00:00Z");
+    assert!(cache.needs_live_refresh(Duration::from_secs(3600), Instant::now()));
+    assert!(matches!(token_requests.try_recv(), Err(mpsc::TryRecvError::Empty)));
+    assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
+    let status_after = runtime.handle().status();
+    assert_eq!(status_after.source_generation, status_before.source_generation);
+    assert!(!status_after.token.running && !status_after.token.pending);
+    assert!(!status_after.live.running && !status_after.live.pending);
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn popup_snapshot_read_does_not_start_scan() {
+    let (runtime, token_requests, live_calls) =
+      start_recording_runtime(disabled_refresh_config(None));
+    let status_before = runtime.handle().status();
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let cache = refresh::LiveQuotaCache::new();
+
+    let snapshot = build_passive_menu_bar_popup_snapshot(&db_path, &cache)
+      .expect("build passive popup snapshot");
+
+    assert_eq!(snapshot.total_tokens_selected_bucket, 0);
+    let conn = open_connection(&db_path).expect("open database");
+    let event_count: i64 = conn
+      .query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0))
+      .expect("count usage events");
+    assert_eq!(event_count, 0);
+    assert!(matches!(token_requests.try_recv(), Err(mpsc::TryRecvError::Empty)));
+    assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
+    let status_after = runtime.handle().status();
+    assert_eq!(status_after.source_generation, status_before.source_generation);
+    assert!(!status_after.token.running && !status_after.token.pending);
+    assert!(!status_after.live.running && !status_after.live.pending);
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn forced_popup_requests_token_and_live_before_waiting() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let live_cache = refresh::LiveQuotaCache::new();
+    live_cache.publish_fallback(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("cached".to_string()),
+        limit_name: None,
+        plan_type: None,
+        primary: None,
+        secondary: None,
+        fetched_at: "2026-07-11T00:00:00Z".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+    let mutation = refresh::UsageMutationCoordinator::new();
+    let (token_entered_tx, token_entered_rx) = mpsc::channel();
+    let (token_release_tx, token_release_rx) = mpsc::channel();
+    let (live_entered_tx, live_entered_rx) = mpsc::channel();
+    let (live_release_tx, live_release_rx) = mpsc::channel();
+    let runtime = refresh::RefreshRuntime::start(
+      refresh::RefreshRuntimeDependencies::with_system_defaults(
+        disabled_refresh_config(None),
+        Arc::new(GatedFailingTokenExecutor {
+          entered: token_entered_tx,
+          release: Mutex::new(token_release_rx),
+        }),
+        Arc::new(GatedFailingLiveFetcher {
+          entered: live_entered_tx,
+          release: Mutex::new(live_release_rx),
+        }),
+        Arc::new(NoopLivePersister),
+        live_cache.clone(),
+        Arc::new(NoopRefreshEvents),
+        mutation.clone(),
+      ),
+    )
+    .expect("start popup runtime");
+    let state = test_app_state(
+      db_path,
+      runtime.handle(),
+      mutation,
+      live_cache.clone(),
+    );
+    let refresh_thread = std::thread::spawn(move || refresh_popup_data(&state));
+
+    token_entered_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("token lane starts");
+    live_entered_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("live lane starts before token wait completes");
+    token_release_tx.send(()).expect("release token lane");
+    live_release_tx.send(()).expect("release live lane");
+    assert!(refresh_thread
+      .join()
+      .expect("join forced popup refresh")
+      .is_err());
+    assert_eq!(
+      live_cache
+        .rate_limits()
+        .expect("old fallback remains cached")
+        .fetched_at,
+      "2026-07-11T00:00:00Z"
+    );
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn manual_scan_uses_coordinator_generation() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("create Codex home");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let (parsed_tx, parsed_rx) = mpsc::channel();
+    let (committed_tx, committed_rx) = mpsc::channel();
+    let token_executor = RecordingAppTokenExecutor {
+      inner: AppTokenRefreshExecutor {
+        db_path: db_path.clone(),
+      },
+      parsed: parsed_tx,
+      committed: committed_tx,
+    };
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let dependencies = refresh::RefreshRuntimeDependencies::with_system_defaults(
+      disabled_refresh_config(Some(codex_home.to_string_lossy().to_string())),
+      Arc::new(token_executor),
+      Arc::new(CountingLiveFetcher {
+        calls: Arc::clone(&live_calls),
+      }),
+      Arc::new(NoopLivePersister),
+      refresh::LiveQuotaCache::new(),
+      Arc::new(NoopRefreshEvents),
+      refresh::UsageMutationCoordinator::new(),
+    );
+    let runtime = refresh::RefreshRuntime::start(dependencies).expect("start runtime");
+    let handle = runtime.handle();
+
+    let result = run_manual_scan_with_coordinator(
+      &handle,
+      Some(codex_home.to_string_lossy().to_string()),
+    )
+    .expect("manual scan succeeds through coordinator");
+
+    let (parsed_generation, source_generation, kind) = parsed_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("manual scan reaches production adapter");
+    let committed_generation = committed_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("prepared generation reaches commit");
+    assert!(parsed_generation > 0);
+    assert_eq!(parsed_generation, committed_generation);
+    assert_eq!(source_generation, handle.status().source_generation);
+    assert_eq!(kind, refresh::TokenScanKind::Full);
+    assert_eq!(result.codex_home, codex_home.to_string_lossy());
+    assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn pricing_recalculation_uses_lower_priority_mutation_ticket() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let coordinator = refresh::UsageMutationCoordinator::new();
+    let blocker = coordinator.clone();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let blocker_thread = std::thread::spawn(move || {
+      blocker.run(refresh::MutationPriority::Refresh, || {
+        entered_tx.send(()).expect("report refresh slot");
+        release_rx.recv().expect("release refresh slot");
+      });
+    });
+    entered_rx.recv().expect("refresh mutation enters first");
+
+    let pricing_coordinator = coordinator.clone();
+    let (result_tx, result_rx) = mpsc::channel();
+    let pricing_thread = std::thread::spawn(move || {
+      let result = refresh_pricing_catalog_with_runner(
+        &db_path,
+        None,
+        |priority, mutation| pricing_coordinator.run(priority, mutation).value,
+      );
+      result_tx.send(result).expect("send pricing result");
+    });
+
+    assert!(matches!(
+      result_rx.recv_timeout(Duration::from_millis(50)),
+      Err(mpsc::RecvTimeoutError::Timeout)
+    ));
+    release_tx.send(()).expect("release refresh mutation");
+    result_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("pricing runs after refresh slot")
+      .expect("pricing refresh succeeds");
+    blocker_thread.join().expect("join refresh blocker");
+    pricing_thread.join().expect("join pricing refresh");
+  }
+
+  #[test]
+  fn menu_render_coalescer_retries_failed_running_transition() {
+    let state = AtomicU8::new(MENU_RENDER_RUNNING);
+    let transitioned = std::cell::Cell::new(false);
+
+    let claimed = claim_menu_bar_render_with_hook(&state, |observed| {
+      if observed == MENU_RENDER_RUNNING && !transitioned.replace(true) {
+        state.store(MENU_RENDER_IDLE, Ordering::Release);
+      }
+    });
+
+    assert!(claimed, "failed RUNNING to PENDING CAS must retry from IDLE");
+    assert_eq!(state.load(Ordering::Acquire), MENU_RENDER_RUNNING);
+    assert!(!claim_menu_bar_render(&state));
+    assert_eq!(state.load(Ordering::Acquire), MENU_RENDER_PENDING);
+    assert!(complete_menu_bar_render(&state));
+    assert_eq!(state.load(Ordering::Acquire), MENU_RENDER_IDLE);
+  }
+
   fn seed_scan_freshness(conn: &rusqlite::Connection, codex_home: &str) -> SyncSettings {
     let initial = SyncSettings {
       codex_home: Some(codex_home.to_string()),
       ..get_sync_settings(conn).expect("load settings")
     };
     save_sync_settings(conn, &initial).expect("save initial source");
-
-    let settings = SyncSettings {
-      last_scan_started_at: Some("2026-07-10T08:00:00Z".to_string()),
-      last_scan_completed_at: Some("2026-07-10T08:01:00Z".to_string()),
-      ..get_sync_settings(conn).expect("reload initial source")
-    };
-    let saved = save_sync_settings(conn, &settings).expect("save scan freshness");
-    database::set_last_full_scan_completed(conn, "2026-07-10T08:01:00Z")
-      .expect("set full scan");
-    saved
+    database::set_last_scan_started_for_source(
+      conn,
+      "2026-07-10T08:00:00Z",
+      Some(codex_home),
+      codex_home,
+    )
+    .expect("set scan start");
+    assert!(database::set_scan_completed_for_source(
+      conn,
+      "2026-07-10T08:01:00Z",
+      Some(codex_home),
+      codex_home,
+      true,
+      false,
+    )
+    .expect("set full scan completion"));
+    get_sync_settings(conn).expect("reload scan freshness")
   }
 
   #[test]
@@ -2267,296 +2772,6 @@ mod tests {
   }
 
   #[test]
-  fn scheduler_uses_auto_scan_interval_when_disabled() {
-    let settings = SyncSettings {
-      auto_scan_enabled: false,
-      auto_scan_interval_minutes: 7,
-      last_scan_completed_at: None,
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
-      Duration::from_secs(420)
-    );
-  }
-
-  #[test]
-  fn scheduler_caps_actual_sleep_duration() {
-    assert_eq!(
-      scheduler_sleep_duration(Duration::from_secs(60)),
-      Duration::from_secs(SCHEDULER_MAX_SLEEP_SECONDS)
-    );
-    assert_eq!(scheduler_sleep_duration(Duration::from_secs(2)), Duration::from_secs(2));
-  }
-
-  #[test]
-  fn live_rate_limit_background_query_timeout_is_fixed() {
-    assert_eq!(
-      live_rate_limit_background_query_timeout(),
-      Duration::from_secs(10)
-    );
-  }
-
-  #[test]
-  fn live_rate_limit_foreground_query_timeout_stays_short() {
-    assert_eq!(live_rate_limit_foreground_query_timeout(), Duration::from_secs(10));
-  }
-
-  #[test]
-  fn legacy_live_publication_survives_persistence_failure() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-    let snapshot = LiveRateLimitSnapshot {
-      limit_id: Some("codex".to_string()),
-      limit_name: Some("Codex".to_string()),
-      plan_type: Some("pro".to_string()),
-      primary: None,
-      secondary: None,
-      fetched_at: "2026-07-11T00:00:00Z".to_string(),
-    };
-
-    let returned = publish_live_rate_limits_and_persist(&state, snapshot, |_| {
-      Err("intentional persistence failure".to_string())
-    });
-
-    assert_eq!(returned.fetched_at, "2026-07-11T00:00:00Z");
-    assert_eq!(
-      get_cached_live_rate_limits(&state)
-        .expect("fresh cache survives persistence failure")
-        .fetched_at,
-      "2026-07-11T00:00:00Z"
-    );
-  }
-
-  #[test]
-  fn forced_live_refresh_does_not_read_cache_ttl() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-    let ttl_reads = std::cell::Cell::new(0_u32);
-
-    let cached = get_fresh_cached_live_rate_limits(&state, true, || {
-      ttl_reads.set(ttl_reads.get() + 1);
-      Duration::from_secs(300)
-    });
-
-    assert!(cached.is_none());
-    assert_eq!(ttl_reads.get(), 0);
-  }
-
-  #[test]
-  fn default_menu_bar_popup_requires_background_live_rate_limits() {
-    assert!(background_live_rate_limits_enabled(&SyncSettings::default()));
-  }
-
-  #[test]
-  fn scheduler_runs_immediately_without_previous_scan() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 7,
-      last_scan_completed_at: None,
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
-      Duration::ZERO
-    );
-  }
-
-  #[test]
-  fn scheduler_waits_remaining_auto_scan_interval() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 7,
-      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:03:00Z")),
-      Duration::from_secs(240)
-    );
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:07:00Z")),
-      Duration::ZERO
-    );
-  }
-
-  #[test]
-  fn scheduler_honors_auto_scan_intervals_above_one_hour() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 180,
-      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T01:00:00Z")),
-      Duration::from_secs(7200)
-    );
-    assert_eq!(
-      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T03:00:00Z")),
-      Duration::ZERO
-    );
-  }
-
-  #[test]
-  fn background_refresh_decision_skips_when_auto_scan_is_disabled() {
-    let settings = SyncSettings {
-      auto_scan_enabled: false,
-      auto_scan_interval_minutes: 7,
-      last_scan_completed_at: None,
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      background_refresh_decision(&settings, None, utc_time("2026-03-27T00:00:00Z")),
-      BackgroundRefreshDecision::Disabled(Duration::from_secs(420))
-    );
-  }
-
-  #[test]
-  fn background_refresh_decision_runs_incremental_when_interval_is_due() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 5,
-      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      background_refresh_decision(
-        &settings,
-        Some("2026-03-27T00:00:00Z"),
-        utc_time("2026-03-27T00:05:00Z")
-      ),
-      BackgroundRefreshDecision::Incremental
-    );
-  }
-
-  #[test]
-  fn background_refresh_decision_runs_full_when_daily_maintenance_is_due() {
-    let settings = SyncSettings {
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 5,
-      last_scan_completed_at: Some("2026-03-27T23:55:00Z".to_string()),
-      ..SyncSettings::default()
-    };
-
-    assert_eq!(
-      background_refresh_decision(
-        &settings,
-        Some("2026-03-27T00:00:00Z"),
-        utc_time("2026-03-28T00:00:00Z")
-      ),
-      BackgroundRefreshDecision::Full
-    );
-  }
-
-  #[test]
-  fn menu_bar_popup_snapshot_runs_due_background_refresh() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    let codex_home = directory.path().join("codex-home");
-    let sessions_dir = codex_home
-      .join("sessions")
-      .join(Local::now().format("%Y").to_string())
-      .join(Local::now().format("%m").to_string())
-      .join(Local::now().format("%d").to_string());
-    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
-    let session_id = "abcdefab-1234-5678-90ab-abcdefabcdef";
-    std::fs::write(
-      sessions_dir.join("new.jsonl"),
-      format!(
-        concat!(
-          "{{\"timestamp\":\"2026-03-27T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\"}}}}\n",
-          "{{\"timestamp\":\"2026-03-27T00:00:00Z\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n",
-          "{{\"timestamp\":\"2026-03-27T00:00:01Z\",\"type\":\"event_msg\",\"payload\":{{",
-          "\"type\":\"token_count\",",
-          "\"info\":{{\"total_token_usage\":{{",
-          "\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":25,",
-          "\"reasoning_output_tokens\":0,\"total_tokens\":125",
-          "}}}},",
-          "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
-          "}}}}\n"
-        ),
-        session_id
-      ),
-    )
-    .expect("write session");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let conn = open_connection(&db_path).expect("open database");
-    let settings = SyncSettings {
-      codex_home: Some(codex_home.to_string_lossy().to_string()),
-      auto_scan_enabled: true,
-      auto_scan_interval_minutes: 1,
-      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
-      ..get_sync_settings(&conn).expect("load settings")
-    };
-    save_sync_settings(&conn, &settings).expect("save settings");
-    database::set_last_full_scan_completed(&conn, "2026-03-27T00:00:30Z").expect("set full scan");
-    drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path: db_path.clone(),
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-
-    let snapshot = build_due_menu_bar_popup_snapshot(
-      &state,
-      false,
-      utc_time("2026-03-27T00:01:00Z"),
-    )
-    .expect("load snapshot");
-
-    let conn = open_connection(&db_path).expect("reopen database");
-    let event_count: i64 = conn
-      .query_row(
-        "SELECT COUNT(*) FROM usage_events WHERE session_id = ?1",
-        params![session_id],
-        |row| row.get(0),
-      )
-      .expect("count events");
-    assert_eq!(event_count, 1);
-    assert_ne!(
-      snapshot.last_scan_completed_at.as_deref(),
-      Some("2026-03-27T00:00:00Z")
-    );
-  }
-
-  #[test]
   fn full_maintenance_is_due_without_previous_full_scan() {
     assert!(full_maintenance_due(None, utc_time("2026-03-27T00:00:00Z")));
   }
@@ -2571,6 +2786,36 @@ mod tests {
       Some("2026-03-27T00:00:00Z"),
       utc_time("2026-03-28T00:00:00Z")
     ));
+  }
+
+  #[test]
+  fn automatic_incremental_request_upgrades_to_full_after_daily_maintenance() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    database::set_last_full_scan_completed(&conn, "2026-07-10T00:00:00Z")
+      .expect("seed full scan freshness");
+    drop(conn);
+
+    assert_eq!(
+      effective_token_scan_kind(
+        &db_path,
+        refresh::TokenScanKind::Incremental,
+        utc_time("2026-07-11T00:00:00Z"),
+      )
+      .expect("select scan kind"),
+      ScanKind::Full
+    );
+    assert_eq!(
+      effective_token_scan_kind(
+        &db_path,
+        refresh::TokenScanKind::Incremental,
+        utc_time("2026-07-10T23:59:59Z"),
+      )
+      .expect("select recent scan kind"),
+      ScanKind::Incremental
+    );
   }
 
   #[test]
@@ -3057,176 +3302,6 @@ mod tests {
   }
 
   #[test]
-  fn pricing_refresh_waits_for_active_scan_before_recalculating() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let conn = open_connection(&db_path).expect("open database");
-    let created_at = database::now_utc_string();
-    conn
-      .execute(
-        "
-        INSERT INTO sessions (
-          session_id, root_session_id, parent_session_id, title, source_state, source_path,
-          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
-          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
-        )
-        VALUES ('refresh-race', 'refresh-race', NULL, NULL, 'active', NULL, 'active',
-          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?1, ?1)
-        ",
-        params![created_at],
-      )
-      .expect("insert session");
-    conn
-      .execute(
-        "
-        INSERT INTO usage_events (
-          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
-          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
-          fast_mode_auto, fast_mode_effective
-        )
-        VALUES ('refresh-race', '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
-          0, 0, 1000000, 0, 1000000, 30.0, 0, 0)
-        ",
-        [],
-      )
-      .expect("insert usage event");
-    let mut official_sol = load_catalog(&conn)
-      .expect("load catalog")
-      .into_iter()
-      .find(|entry| entry.model_id == "gpt-5.6-sol")
-      .expect("load GPT-5.6 Sol");
-    official_sol.output_price_per_million = 42.0;
-    official_sol.is_official = true;
-    official_sol.note = Some("serialized refresh test".to_string());
-    official_sol.updated_at = "serialized-refresh-test".to_string();
-    drop(conn);
-
-    let state = AppState {
-      app_handle: None,
-      db_path: db_path.clone(),
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-    let (scan_loaded_sender, scan_loaded_receiver) = std::sync::mpsc::channel();
-    let (release_scan_sender, release_scan_receiver) = std::sync::mpsc::channel();
-    let scan_state = state.clone();
-    let scan_thread = std::thread::spawn(move || {
-      run_scan_if_idle_with_live_refresh(scan_state, None, false, |db_path, _| {
-        let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-        let stale_output_price: f64 = conn
-          .query_row(
-            "SELECT output_price_per_million FROM pricing_catalog WHERE model_id = 'gpt-5.6-sol'",
-            [],
-            |row| row.get(0),
-          )
-          .map_err(|error| error.to_string())?;
-        scan_loaded_sender.send(()).map_err(|error| error.to_string())?;
-        release_scan_receiver.recv().map_err(|error| error.to_string())?;
-        conn
-          .execute(
-            "UPDATE usage_events SET value_usd = ?1 WHERE session_id = 'refresh-race'",
-            params![stale_output_price],
-          )
-          .map_err(|error| error.to_string())?;
-        Ok(ScanResult {
-          codex_home: "test".to_string(),
-          scanned_files: 1,
-          imported_sessions: 1,
-          updated_sessions: 1,
-          missing_sessions: 0,
-          last_completed_at: database::now_utc_string(),
-        })
-      })
-    });
-    scan_loaded_receiver.recv().expect("scan loaded stale pricing");
-    let release_thread = std::thread::spawn(move || {
-      std::thread::sleep(Duration::from_millis(100));
-      release_scan_sender.send(()).expect("release scan");
-    });
-
-    refresh_pricing_catalog_for_state(&state, Some(&[official_sol]))
-      .expect("refresh pricing after scan");
-    release_thread.join().expect("join release thread");
-    scan_thread
-      .join()
-      .expect("join scan thread")
-      .expect("complete scan");
-
-    let conn = open_connection(&db_path).expect("reopen database");
-    let value_usd: f64 = conn
-      .query_row(
-        "SELECT value_usd FROM usage_events WHERE session_id = 'refresh-race'",
-        [],
-        |row| row.get(0),
-      )
-      .expect("load final value");
-    assert_eq!(value_usd, 42.0);
-  }
-
-  #[test]
-  fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
-    let directory = tempdir().expect("tempdir");
-    let db_path = directory.path().join("usage.sqlite");
-    prepare_app_database(&db_path).expect("prepare app database");
-    let conn = open_connection(&db_path).expect("open database");
-    let settings = SyncSettings {
-      show_menu_bar_daily_api_value: false,
-      show_menu_bar_live_quota_percent: true,
-      menu_bar_live_quota_metric: "remaining_percent".to_string(),
-      menu_bar_live_quota_bucket: "five_hour".to_string(),
-      ..get_sync_settings(&conn).expect("load settings")
-    };
-    save_sync_settings(&conn, &settings).expect("save settings");
-    insert_live_rate_limit_snapshot(
-      &conn,
-      &LiveRateLimitSnapshot {
-        limit_id: Some("codex".to_string()),
-        limit_name: Some("Codex".to_string()),
-        plan_type: Some("pro".to_string()),
-        primary: Some(RateLimitWindowSnapshot {
-          used_percent: 12,
-          remaining_percent: 88,
-          window_duration_mins: Some(300),
-          resets_at: Some("2026-03-27T05:00:00+08:00".to_string()),
-          window_start: Some("2026-03-27T00:00:00+08:00".to_string()),
-        }),
-        secondary: None,
-        fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
-      },
-    )
-    .expect("insert live limits");
-    drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
-
-    let (api_value_title, live_metric_title) =
-      current_menu_bar_title_parts_with_live_refresh(&state, &settings, false)
-        .expect("build title");
-
-    assert_eq!(api_value_title, None);
-    assert_eq!(live_metric_title.as_deref(), Some("88%"));
-    assert!(state.live_rate_limits.state().is_fallback);
-    assert!(state
-      .live_rate_limits
-      .needs_live_refresh(Duration::from_secs(300), Instant::now()));
-  }
-
-  #[test]
   fn background_live_rate_limit_fallback_prefers_newest_persisted_sample() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
@@ -3269,19 +3344,10 @@ mod tests {
     )
     .expect("insert live sample");
     drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
+    let live_cache = refresh::LiveQuotaCache::new();
 
-    let snapshot = get_live_rate_limits_stored_fallback(&state).expect("load fallback");
+    let snapshot = load_display_live_rate_limit_fallback(&db_path, &live_cache)
+      .expect("load fallback");
 
     assert_eq!(snapshot.fetched_at, "2026-03-27T00:05:00+08:00");
     assert_eq!(
@@ -3289,7 +3355,7 @@ mod tests {
       Some(88)
     );
 
-    state.live_rate_limits.publish_live(
+    live_cache.publish_live(
       Arc::new(LiveRateLimitSnapshot {
         limit_id: Some("codex".to_string()),
         limit_name: Some("Codex".to_string()),
@@ -3307,7 +3373,8 @@ mod tests {
       Instant::now(),
       Utc::now(),
     );
-    let memory = get_live_rate_limits_stored_fallback(&state).expect("prefer newer memory");
+    let memory = load_display_live_rate_limit_fallback(&db_path, &live_cache)
+      .expect("prefer newer memory");
     assert_eq!(memory.fetched_at, "2026-03-27T00:10:00+08:00");
     assert_eq!(
       memory.primary.as_ref().map(|window| window.remaining_percent),
@@ -3357,20 +3424,9 @@ mod tests {
       },
     )
     .expect("insert later UTC sample");
-    drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
 
-    let snapshot = load_persisted_live_rate_limits(&state).expect("load persisted sample");
+    let snapshot = load_persisted_live_rate_limits_from_connection(&conn, None)
+      .expect("load persisted sample");
 
     assert_eq!(snapshot.fetched_at, "2026-07-10T02:00:00Z");
     assert_eq!(
@@ -3385,30 +3441,39 @@ mod tests {
     let db_path = directory.path().join("usage.sqlite");
     prepare_app_database(&db_path).expect("prepare app database");
     let conn = open_connection(&db_path).expect("open database");
-    insert_live_rate_limit_snapshot(
+    database::replace_session_rate_limit_samples(
       &conn,
-      &LiveRateLimitSnapshot {
-        limit_id: Some("codex".to_string()),
-        limit_name: Some("Codex".to_string()),
-        plan_type: Some("pro".to_string()),
-        primary: Some(RateLimitWindowSnapshot {
+      "session-same-instant",
+      &[
+        crate::models::RateLimitSampleRecord {
+          source_kind: "session".to_string(),
+          source_session_id: Some("session-same-instant".to_string()),
+          bucket: "five_hour".to_string(),
+          sample_timestamp: "2026-07-10T10:00:00+08:00".to_string(),
+          limit_id: Some("codex".to_string()),
+          limit_name: Some("Codex".to_string()),
+          plan_type: Some("pro".to_string()),
+          window_start: "2026-07-10T10:00:00+08:00".to_string(),
+          resets_at: "2026-07-10T15:00:00+08:00".to_string(),
           used_percent: 30,
           remaining_percent: 70,
-          window_duration_mins: Some(300),
-          resets_at: Some("2026-07-10T06:00:00Z".to_string()),
-          window_start: Some("2026-07-10T01:00:00Z".to_string()),
-        }),
-        secondary: Some(RateLimitWindowSnapshot {
+        },
+        crate::models::RateLimitSampleRecord {
+          source_kind: "session".to_string(),
+          source_session_id: Some("session-same-instant".to_string()),
+          bucket: "seven_day".to_string(),
+          sample_timestamp: "2026-07-10T10:00:00+08:00".to_string(),
+          limit_id: Some("codex".to_string()),
+          limit_name: Some("Codex".to_string()),
+          plan_type: Some("pro".to_string()),
+          window_start: "2026-07-10T10:00:00+08:00".to_string(),
+          resets_at: "2026-07-17T10:00:00+08:00".to_string(),
           used_percent: 40,
           remaining_percent: 60,
-          window_duration_mins: Some(10_080),
-          resets_at: Some("2026-07-17T01:00:00Z".to_string()),
-          window_start: Some("2026-07-10T01:00:00Z".to_string()),
-        }),
-        fetched_at: "2026-07-10T01:00:00Z".to_string(),
-      },
+        },
+      ],
     )
-    .expect("insert older complete sample");
+    .expect("insert complete session sample");
     insert_live_rate_limit_snapshot(
       &conn,
       &LiveRateLimitSnapshot {
@@ -3426,21 +3491,10 @@ mod tests {
         fetched_at: "2026-07-10T02:00:00Z".to_string(),
       },
     )
-    .expect("insert newer primary-only sample");
-    drop(conn);
-    let state = AppState {
-      app_handle: None,
-      db_path,
-      scan_in_progress: Arc::new(AtomicBool::new(false)),
-      usage_mutation_lock: Arc::new(Mutex::new(())),
-      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
-      daily_value_tray: None,
-      live_rate_limits: refresh::LiveQuotaCache::new(),
-      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
-    };
+    .expect("insert later primary-only row at the same instant");
 
-    let snapshot = load_persisted_live_rate_limits(&state).expect("load persisted sample");
+    let snapshot = load_persisted_live_rate_limits_from_connection(&conn, None)
+      .expect("load persisted sample");
 
     assert_eq!(snapshot.fetched_at, "2026-07-10T02:00:00Z");
     assert_eq!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,20 +6,20 @@ mod queries;
 mod rate_limits;
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{
   atomic::{AtomicBool, Ordering},
   Arc, Mutex,
 };
 use std::time::{Duration, Instant};
 
-use chrono::{DateTime, Duration as ChronoDuration, Local};
+use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
 use rusqlite::params;
 use database::{
-  canonical_subscription_currency, get_subscription_profile, get_sync_settings, init_db,
+  canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
   insert_live_rate_limit_snapshot, open_connection, save_subscription_profile, save_sync_settings,
 };
-use importer::{perform_scan, recalculate_all_session_values};
+use importer::{perform_incremental_scan, perform_scan, recalculate_all_session_values};
 use models::{
   ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
@@ -27,7 +27,9 @@ use models::{
   ScanResult, SubscriptionProfile, SyncSettings,
 };
 use pricing::{load_catalog, refresh_pricing_catalog_from_openai, seed_pricing_catalog};
-use queries::{get_conversation_detail, get_overview, get_quota_trend, list_conversations, load_dashboard_data};
+use queries::{
+  get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
+};
 use rate_limits::query_live_rate_limits;
 use tauri::{
   Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
@@ -51,6 +53,7 @@ const MENU_BAR_POPUP_MAX_HEIGHT: f64 = 760.0;
 const MENU_BAR_POPUP_OFFSET_Y: i32 = 8;
 const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
+const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 #[derive(Clone)]
 struct CachedRateLimitSnapshot {
   fetched_at: Instant,
@@ -270,11 +273,12 @@ fn updateSyncSettings(
 ) -> Result<SyncSettings, String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let current = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+  let auto_scan_interval_minutes = payload.auto_scan_interval_minutes.max(1);
   let updated = SyncSettings {
     codex_home: payload.codex_home,
     auto_scan_enabled: payload.auto_scan_enabled,
-    auto_scan_interval_minutes: payload.auto_scan_interval_minutes.max(1),
-    live_quota_refresh_interval_seconds: payload.live_quota_refresh_interval_seconds.clamp(60, 3600),
+    auto_scan_interval_minutes,
+    live_quota_refresh_interval_seconds: unified_refresh_interval_seconds(auto_scan_interval_minutes),
     hide_dock_icon_when_menu_bar_visible: payload.hide_dock_icon_when_menu_bar_visible,
     show_menu_bar_logo: payload.show_menu_bar_logo,
     show_menu_bar_daily_api_value: payload.show_menu_bar_daily_api_value,
@@ -339,6 +343,64 @@ fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanR
   state.scan_in_progress.store(false, Ordering::SeqCst);
   refresh_daily_value_menu_bar(&state);
   result
+}
+
+fn run_incremental_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
+  if state
+    .scan_in_progress
+    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+    .is_err()
+  {
+    return Err("A scan is already running.".to_string());
+  }
+
+  let result = perform_incremental_scan(&state.db_path, codex_home);
+  state.scan_in_progress.store(false, Ordering::SeqCst);
+  refresh_daily_value_menu_bar(&state);
+  result
+}
+
+fn prepare_app_database(db_path: &Path) -> Result<(), String> {
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  init_db(&conn).map_err(|error| error.to_string())?;
+  let pricing_signature_before = load_pricing_value_signature(&conn).map_err(|error| error.to_string())?;
+  seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
+  let pricing_signature_after = load_pricing_value_signature(&conn).map_err(|error| error.to_string())?;
+  if pricing_signature_before != pricing_signature_after {
+    recalculate_all_session_values(&conn).map_err(|error| error.to_string())?;
+  }
+  Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+struct PricingValueSignatureEntry {
+  model_id: String,
+  input_price_per_million: f64,
+  cached_input_price_per_million: f64,
+  output_price_per_million: f64,
+  effective_model_id: String,
+}
+
+fn load_pricing_value_signature(conn: &rusqlite::Connection) -> rusqlite::Result<Vec<PricingValueSignatureEntry>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT model_id, input_price_per_million, cached_input_price_per_million,
+           output_price_per_million, effective_model_id
+    FROM pricing_catalog
+    ORDER BY model_id
+    ",
+  )?;
+  let rows = stmt.query_map([], |row| {
+    Ok(PricingValueSignatureEntry {
+      model_id: row.get(0)?,
+      input_price_per_million: row.get(1)?,
+      cached_input_price_per_million: row.get(2)?,
+      output_price_per_million: row.get(3)?,
+      effective_model_id: row.get(4)?,
+    })
+  })?;
+
+  rows.collect()
 }
 
 fn refresh_daily_value_menu_bar(state: &AppState) {
@@ -429,16 +491,16 @@ fn current_menu_bar_title_parts(
     None
   };
   let api_value_title = if settings.show_menu_bar_daily_api_value {
-    let overview = get_overview(
+    let api_value_usd = get_window_api_value(
       &state.db_path,
-      Some(bucket.clone()),
+      bucket.clone(),
       if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
       None,
       None,
       live_rate_limits.clone(),
       None,
     )?;
-    Some(format!("${:.1}", overview.stats.api_value_usd))
+    Some(format!("${:.1}", api_value_usd))
   } else {
     None
   };
@@ -926,7 +988,7 @@ fn refresh_rate_limit_history_if_idle(state: &AppState) {
     return;
   }
 
-  let result = perform_scan(&state.db_path, None);
+  let result = perform_incremental_scan(&state.db_path, None);
   state.scan_in_progress.store(false, Ordering::SeqCst);
   if let Err(error) = result {
     log::warn!("Failed to refresh Codex history rate-limit samples: {error}");
@@ -1001,7 +1063,7 @@ fn build_menu_bar_popup_snapshot(
 
   Ok(MenuBarPopupSnapshot {
     fetched_at: Local::now().to_rfc3339(),
-    refresh_interval_seconds: settings.live_quota_refresh_interval_seconds,
+    refresh_interval_seconds: unified_refresh_interval_seconds(settings.auto_scan_interval_minutes),
     selected_bucket,
     quota_5h: live_rate_limits
       .as_ref()
@@ -1096,8 +1158,14 @@ fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
   open_connection(&state.db_path)
     .ok()
     .and_then(|conn| get_sync_settings(&conn).ok())
-    .map(|settings| Duration::from_secs(settings.live_quota_refresh_interval_seconds.clamp(60, 3600) as u64))
+    .map(|settings| {
+      Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64)
+    })
     .unwrap_or(Duration::from_secs(300))
+}
+
+fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
+  auto_scan_interval_minutes.max(1).saturating_mul(60).max(60)
 }
 
 fn build_menu_bar_popup_window(app: &AppHandle) -> Result<WebviewWindow, String> {
@@ -1516,50 +1584,77 @@ fn show_main_window(app: &AppHandle) {
 
 fn spawn_initial_scan(state: AppState) {
   tauri::async_runtime::spawn(async move {
-    let _ = run_scan_if_idle(state, None);
+    let _ = run_incremental_scan_if_idle(state, None);
   });
 }
 
 fn spawn_scheduler(state: AppState) {
   tauri::async_runtime::spawn(async move {
     loop {
-      tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-
-      if state.scan_in_progress.load(Ordering::SeqCst) {
-        continue;
-      }
-
       let Ok(conn) = open_connection(&state.db_path) else {
+        tokio::time::sleep(Duration::from_secs(60)).await;
         continue;
       };
       let Ok(settings) = get_sync_settings(&conn) else {
+        tokio::time::sleep(Duration::from_secs(60)).await;
         continue;
       };
-      if menu_bar_has_visible_content(&settings) {
-        refresh_daily_value_menu_bar(&state);
-      }
-      if !settings.auto_scan_enabled {
+      let now = Utc::now();
+      let delay = scheduler_delay_until_next_refresh(&settings, now);
+      if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
         continue;
       }
+      let should_run_full = get_last_full_scan_completed(&conn)
+        .map(|last_completed_at| full_maintenance_due(last_completed_at.as_deref(), now))
+        .unwrap_or(true);
+      drop(conn);
 
-      let should_scan = match settings.last_scan_completed_at.as_deref() {
-        Some(last_completed_at) => {
-          chrono::DateTime::parse_from_rfc3339(last_completed_at)
-            .ok()
-            .map(|last| {
-              let elapsed = chrono::Utc::now().signed_duration_since(last.with_timezone(&chrono::Utc));
-              elapsed.num_minutes() >= settings.auto_scan_interval_minutes.max(1)
-            })
-            .unwrap_or(true)
-        }
-        None => true,
-      };
-
-      if should_scan {
+      if state.scan_in_progress.load(Ordering::SeqCst) {
+        tokio::time::sleep(Duration::from_secs(
+          unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
+        ))
+        .await;
+      } else if should_run_full {
         let _ = run_scan_if_idle(state.clone(), settings.codex_home.clone());
+      } else {
+        let _ = run_incremental_scan_if_idle(state.clone(), settings.codex_home.clone());
       }
     }
   });
+}
+
+fn scheduler_delay_until_next_refresh(settings: &SyncSettings, now: chrono::DateTime<chrono::Utc>) -> Duration {
+  let interval_seconds = unified_refresh_interval_seconds(settings.auto_scan_interval_minutes);
+  if !settings.auto_scan_enabled {
+    return Duration::from_secs(interval_seconds as u64);
+  }
+
+  let Some(last_completed_at) = settings.last_scan_completed_at.as_deref() else {
+    return Duration::ZERO;
+  };
+  let Some(last_completed_at) = chrono::DateTime::parse_from_rfc3339(last_completed_at).ok() else {
+    return Duration::ZERO;
+  };
+  let elapsed_seconds = now
+    .signed_duration_since(last_completed_at.with_timezone(&chrono::Utc))
+    .num_seconds()
+    .max(0);
+  let remaining_seconds = interval_seconds.saturating_sub(elapsed_seconds);
+  Duration::from_secs(remaining_seconds as u64)
+}
+
+fn full_maintenance_due(last_completed_at: Option<&str>, now: chrono::DateTime<chrono::Utc>) -> bool {
+  let Some(last_completed_at) = last_completed_at else {
+    return true;
+  };
+  let Some(last_completed_at) = chrono::DateTime::parse_from_rfc3339(last_completed_at).ok() else {
+    return true;
+  };
+  now
+    .signed_duration_since(last_completed_at.with_timezone(&chrono::Utc))
+    .num_seconds()
+    >= FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -1620,10 +1715,8 @@ pub fn run() {
         .map_err(|error| format!("Failed to create app data dir {}: {error}", app_data_dir.display()))?;
       let db_path = app_data_dir.join("codex-counter.sqlite");
 
+      prepare_app_database(&db_path)?;
       let conn = open_connection(&db_path).map_err(|error| error.to_string())?;
-      init_db(&conn).map_err(|error| error.to_string())?;
-      seed_pricing_catalog(&conn).map_err(|error| error.to_string())?;
-      recalculate_all_session_values(&conn).map_err(|error| error.to_string())?;
 
       let app_handle = app.app_handle();
       let daily_value_tray = match build_daily_value_menu_bar(&app_handle, &db_path) {
@@ -1677,6 +1770,7 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use tempfile::tempdir;
 
   fn speed_test_settings() -> SyncSettings {
     SyncSettings {
@@ -1695,6 +1789,211 @@ mod tests {
     DateTime::parse_from_rfc3339(value)
       .expect("parse test timestamp")
       .with_timezone(&Local)
+  }
+
+  fn utc_time(value: &str) -> chrono::DateTime<chrono::Utc> {
+    DateTime::parse_from_rfc3339(value)
+      .expect("parse test timestamp")
+      .with_timezone(&chrono::Utc)
+  }
+
+  #[test]
+  fn scheduler_uses_auto_scan_interval_when_disabled() {
+    let settings = SyncSettings {
+      auto_scan_enabled: false,
+      auto_scan_interval_minutes: 7,
+      last_scan_completed_at: None,
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
+      Duration::from_secs(420)
+    );
+  }
+
+  #[test]
+  fn scheduler_runs_immediately_without_previous_scan() {
+    let settings = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 7,
+      last_scan_completed_at: None,
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
+      Duration::ZERO
+    );
+  }
+
+  #[test]
+  fn scheduler_waits_remaining_auto_scan_interval() {
+    let settings = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 7,
+      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:03:00Z")),
+      Duration::from_secs(240)
+    );
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:07:00Z")),
+      Duration::ZERO
+    );
+  }
+
+  #[test]
+  fn scheduler_honors_auto_scan_intervals_above_one_hour() {
+    let settings = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 180,
+      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T01:00:00Z")),
+      Duration::from_secs(7200)
+    );
+    assert_eq!(
+      scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T03:00:00Z")),
+      Duration::ZERO
+    );
+  }
+
+  #[test]
+  fn full_maintenance_is_due_without_previous_full_scan() {
+    assert!(full_maintenance_due(None, utc_time("2026-03-27T00:00:00Z")));
+  }
+
+  #[test]
+  fn full_maintenance_waits_until_daily_interval() {
+    assert!(!full_maintenance_due(
+      Some("2026-03-27T00:00:00Z"),
+      utc_time("2026-03-27T23:59:59Z")
+    ));
+    assert!(full_maintenance_due(
+      Some("2026-03-27T00:00:00Z"),
+      utc_time("2026-03-28T00:00:00Z")
+    ));
+  }
+
+  #[test]
+  fn startup_database_prepare_does_not_recalculate_usage_values() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    let created_at = database::now_utc_string();
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, parent_session_id, title, source_state, source_path,
+          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+        )
+        VALUES ('startup-session', 'startup-session', NULL, NULL, 'active', NULL, 'active',
+          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.4', 0, ?1, ?1)
+        ",
+        params![created_at],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('startup-session', '2026-03-26T04:30:00Z', 'gpt-5.4',
+          100, 0, 10, 0, 110, 123.45, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage event");
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let value_usd: f64 = conn
+      .query_row(
+        "SELECT value_usd FROM usage_events WHERE session_id = 'startup-session'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load usage value");
+
+    assert_eq!(value_usd, 123.45);
+  }
+
+  #[test]
+  fn startup_database_prepare_recalculates_usage_values_when_seed_pricing_changes() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    conn
+      .execute(
+        "
+        UPDATE pricing_catalog
+        SET input_price_per_million = 1.00
+        WHERE model_id = 'gpt-5.4'
+        ",
+        [],
+      )
+      .expect("seed stale pricing");
+    let created_at = database::now_utc_string();
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, parent_session_id, title, source_state, source_path,
+          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+        )
+        VALUES ('startup-session', 'startup-session', NULL, NULL, 'active', NULL, 'active',
+          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.4', 0, ?1, ?1)
+        ",
+        params![created_at],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('startup-session', '2026-03-26T04:30:00Z', 'gpt-5.4',
+          1000000, 0, 0, 0, 1000000, 123.45, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage event");
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let value_usd: f64 = conn
+      .query_row(
+        "SELECT value_usd FROM usage_events WHERE session_id = 'startup-session'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load usage value");
+
+    assert_eq!(value_usd, 2.50);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,8 @@ use std::sync::{
   atomic::{AtomicBool, AtomicU8, Ordering},
   Arc, Mutex,
 };
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
@@ -159,9 +161,36 @@ impl refresh::LiveQuotaPersister for AppLiveQuotaPersister {
   }
 }
 
-#[derive(Clone)]
 struct AppEpochMaintenanceExecutor {
   db_path: PathBuf,
+  connection: Mutex<Option<rusqlite::Connection>>,
+  #[cfg(test)]
+  open_count: AtomicUsize,
+}
+
+impl AppEpochMaintenanceExecutor {
+  fn new(db_path: PathBuf) -> Self {
+    Self {
+      db_path,
+      connection: Mutex::new(None),
+      #[cfg(test)]
+      open_count: AtomicUsize::new(0),
+    }
+  }
+
+  #[cfg(test)]
+  fn open_count_for_test(&self) -> usize {
+    self.open_count.load(Ordering::Acquire)
+  }
+
+  #[cfg(test)]
+  fn connection_is_open_for_test(&self) -> bool {
+    self
+      .connection
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner)
+      .is_some()
+  }
 }
 
 impl refresh::EpochMaintenanceExecutor for AppEpochMaintenanceExecutor {
@@ -170,21 +199,41 @@ impl refresh::EpochMaintenanceExecutor for AppEpochMaintenanceExecutor {
     limit: usize,
     cancellation: Arc<AtomicBool>,
   ) -> Result<refresh::EpochMaintenanceBatch, String> {
-    let conn = database::open_epoch_maintenance_connection(&self.db_path)
-      .map_err(|error| error.to_string())?;
+    if cancellation.load(Ordering::Acquire) {
+      return Ok(refresh::EpochMaintenanceBatch::Cancelled);
+    }
+    let mut connection = self
+      .connection
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if connection.is_none() {
+      let opened = database::open_epoch_maintenance_connection(&self.db_path)
+        .map_err(|error| error.to_string())?;
+      #[cfg(test)]
+      self.open_count.fetch_add(1, Ordering::AcqRel);
+      *connection = Some(opened);
+    }
     let progress = database::backfill_epoch_batch_cancellable(
-      &conn,
+      connection
+        .as_ref()
+        .expect("epoch maintenance connection was initialized"),
       limit,
       cancellation.as_ref(),
     )
     .map_err(|error| error.to_string())?;
     Ok(match progress {
-      Some(progress) => refresh::EpochMaintenanceBatch::Progress {
-        processed_rows: progress
-          .usage_rows_updated
-          .saturating_add(progress.quota_rows_updated),
-        complete: progress.complete,
-      },
+      Some(progress) => {
+        let result = refresh::EpochMaintenanceBatch::Progress {
+          processed_rows: progress
+            .usage_rows_updated
+            .saturating_add(progress.quota_rows_updated),
+          complete: progress.complete,
+        };
+        if progress.complete {
+          *connection = None;
+        }
+        result
+      }
       None => refresh::EpochMaintenanceBatch::Cancelled,
     })
   }
@@ -196,7 +245,7 @@ fn configure_epoch_maintenance(
   pending: bool,
 ) -> refresh::RefreshRuntimeDependencies {
   if pending {
-    dependencies.with_epoch_maintenance(Arc::new(AppEpochMaintenanceExecutor { db_path }))
+    dependencies.with_epoch_maintenance(Arc::new(AppEpochMaintenanceExecutor::new(db_path)))
   } else {
     dependencies
   }
@@ -2342,7 +2391,7 @@ mod tests {
       WITH RECURSIVE rows(value) AS (
         SELECT 1
         UNION ALL
-        SELECT value + 1 FROM rows WHERE value < 1501
+        SELECT value + 1 FROM rows WHERE value < 2501
       )
       INSERT INTO usage_events (
         session_id, timestamp, timestamp_ms, model_id,
@@ -2360,9 +2409,7 @@ mod tests {
     assert!(database::epoch_backfill_pending(&conn).expect("read repair marker"));
     drop(conn);
 
-    let first_adapter = AppEpochMaintenanceExecutor {
-      db_path: db_path.clone(),
-    };
+    let first_adapter = AppEpochMaintenanceExecutor::new(db_path.clone());
     let first = refresh::EpochMaintenanceExecutor::run_batch(
       &first_adapter,
       1_000,
@@ -2376,6 +2423,29 @@ mod tests {
         complete: false,
       }
     );
+    assert_eq!(first_adapter.open_count_for_test(), 1);
+    assert!(first_adapter.connection_is_open_for_test());
+
+    let second = refresh::EpochMaintenanceExecutor::run_batch(
+      &first_adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect("run second production slice on the same adapter");
+    assert_eq!(
+      second,
+      refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: 1_000,
+        complete: false,
+      }
+    );
+    assert_eq!(
+      first_adapter.open_count_for_test(),
+      1,
+      "incomplete slices reuse one WAL connection"
+    );
+    assert!(first_adapter.connection_is_open_for_test());
+
     let reopened = open_connection(&db_path).expect("reopen after first slice");
     let cursor: i64 = reopened
       .query_row(
@@ -2384,10 +2454,11 @@ mod tests {
         |row| row.get(0),
       )
       .expect("load persisted cursor");
-    assert_eq!(cursor, 1_000);
+    assert_eq!(cursor, 2_000);
     drop(reopened);
+    drop(first_adapter);
 
-    let resumed_adapter = AppEpochMaintenanceExecutor { db_path };
+    let resumed_adapter = AppEpochMaintenanceExecutor::new(db_path);
     let resumed = refresh::EpochMaintenanceExecutor::run_batch(
       &resumed_adapter,
       1_000,
@@ -2401,6 +2472,92 @@ mod tests {
         complete: true,
       }
     );
+    assert_eq!(resumed_adapter.open_count_for_test(), 1);
+    assert!(
+      !resumed_adapter.connection_is_open_for_test(),
+      "completed repair releases its WAL connection"
+    );
+  }
+
+  #[test]
+  fn pre_cancelled_epoch_maintenance_adapter_does_not_open_database() {
+    let directory = tempdir().expect("create cancelled adapter directory");
+    let adapter = AppEpochMaintenanceExecutor::new(
+      directory.path().join("pre-cancelled.sqlite3"),
+    );
+
+    let result = refresh::EpochMaintenanceExecutor::run_batch(
+      &adapter,
+      1_000,
+      Arc::new(AtomicBool::new(true)),
+    )
+    .expect("observe pre-cancelled adapter call");
+
+    assert_eq!(result, refresh::EpochMaintenanceBatch::Cancelled);
+    assert_eq!(adapter.open_count_for_test(), 0);
+    assert!(!adapter.connection_is_open_for_test());
+  }
+
+  #[test]
+  fn failed_epoch_maintenance_slice_keeps_connection_for_retry() {
+    let directory = tempdir().expect("create retry adapter directory");
+    let db_path = directory.path().join("retry.sqlite3");
+    let conn = open_connection(&db_path).expect("open retry database");
+    init_db(&conn).expect("initialize retry database");
+    conn.execute_batch(
+      "
+      INSERT INTO usage_events (
+        session_id, timestamp, timestamp_ms, model_id,
+        input_tokens, cached_input_tokens, output_tokens,
+        reasoning_output_tokens, total_tokens, value_usd,
+        fast_mode_auto, fast_mode_effective
+      )
+      VALUES (
+        'legacy', '2026-07-10T03:00:00Z', NULL, 'gpt-5',
+        1, 0, 1, 0, 2, 0.01, 0, 0
+      );
+      CREATE TRIGGER fail_epoch_retry
+      BEFORE UPDATE OF timestamp_ms ON usage_events
+      BEGIN
+        SELECT RAISE(ABORT, 'injected epoch retry failure');
+      END;
+      ",
+    )
+    .expect("seed retry failure");
+    drop(conn);
+    let adapter = AppEpochMaintenanceExecutor::new(db_path.clone());
+
+    let error = refresh::EpochMaintenanceExecutor::run_batch(
+      &adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect_err("inject first slice failure");
+    assert!(error.contains("injected epoch retry failure"));
+    assert_eq!(adapter.open_count_for_test(), 1);
+    assert!(adapter.connection_is_open_for_test());
+
+    let repair = open_connection(&db_path).expect("open trigger repair connection");
+    repair
+      .execute_batch("DROP TRIGGER fail_epoch_retry;")
+      .expect("remove injected failure");
+    drop(repair);
+    let retried = refresh::EpochMaintenanceExecutor::run_batch(
+      &adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect("retry with retained connection");
+
+    assert_eq!(
+      retried,
+      refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: 1,
+        complete: true,
+      }
+    );
+    assert_eq!(adapter.open_count_for_test(), 1);
+    assert!(!adapter.connection_is_open_for_test());
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,13 +15,6 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
-#[cfg(target_os = "macos")]
-use objc2::{
-  rc::Retained,
-  runtime::{NSObjectProtocol, ProtocolObject},
-};
-#[cfg(target_os = "macos")]
-use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
 use rusqlite::params;
 use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
@@ -42,6 +35,7 @@ use queries::{
   get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
 };
 use rate_limits::query_live_rate_limits;
+use refresh::begin_scheduler_activity;
 use tauri::{
   Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
   WebviewWindowBuilder,
@@ -130,38 +124,6 @@ fn lock_usage_mutations(state: &AppState) -> std::sync::MutexGuard<'_, ()> {
     .usage_mutation_lock
     .lock()
     .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-#[cfg(target_os = "macos")]
-struct SchedulerActivity {
-  activity: Retained<ProtocolObject<dyn NSObjectProtocol>>,
-}
-
-#[cfg(target_os = "macos")]
-impl Drop for SchedulerActivity {
-  fn drop(&mut self) {
-    unsafe {
-      NSProcessInfo::processInfo().endActivity(&self.activity);
-    }
-  }
-}
-
-#[cfg(target_os = "macos")]
-fn begin_scheduler_activity() -> Option<SchedulerActivity> {
-  let reason = NSString::from_str("Codex Pacer background refresh");
-  let activity = NSProcessInfo::processInfo().beginActivityWithOptions_reason(
-    NSActivityOptions::UserInitiatedAllowingIdleSystemSleep,
-    &reason,
-  );
-  Some(SchedulerActivity { activity })
-}
-
-#[cfg(not(target_os = "macos"))]
-struct SchedulerActivity;
-
-#[cfg(not(target_os = "macos"))]
-fn begin_scheduler_activity() -> Option<SchedulerActivity> {
-  None
 }
 
 #[allow(non_snake_case)]
@@ -490,7 +452,10 @@ where
   let guard = try_acquire_flag(&state.scan_in_progress, "A scan is already running.")?;
   let mutation_guard = lock_usage_mutations(&state);
 
-  let result = scan(&state.db_path, codex_home);
+  let result = {
+    let _activity = begin_scheduler_activity();
+    scan(&state.db_path, codex_home)
+  };
   drop(mutation_guard);
   drop(guard);
   refresh_daily_value_menu_bar_with_live_refresh(&state, allow_menu_bar_live_refresh);
@@ -1125,10 +1090,17 @@ fn get_live_rate_limits_with_fallback(
     }
   }
 
-  match query_live_rate_limits(query_timeout) {
+  let query_result = {
+    let _activity = begin_scheduler_activity();
+    query_live_rate_limits(query_timeout)
+  };
+  match query_result {
     Ok(snapshot) => {
-      let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-      insert_live_rate_limit_snapshot(&conn, &snapshot).map_err(|error| error.to_string())?;
+      {
+        let _activity = begin_scheduler_activity();
+        let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+        insert_live_rate_limit_snapshot(&conn, &snapshot).map_err(|error| error.to_string())?;
+      }
       store_live_rate_limits_cache(state, &snapshot)?;
       Ok(snapshot)
     }
@@ -1950,7 +1922,6 @@ fn spawn_scheduler(state: AppState) {
   std::thread::Builder::new()
     .name("codex-pacer-scheduler".to_string())
     .spawn(move || {
-      let _scheduler_activity = begin_scheduler_activity();
       loop {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_scheduler_tick(&state)));
         let delay = match result {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -861,9 +861,13 @@ fn refresh_daily_value_menu_bar(state: &AppState) {
 }
 
 fn update_daily_value_menu_bar(state: &AppState) -> Result<(), String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
-  render_daily_value_menu_bar(state, &settings)
+  let result = (|| {
+    let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+    let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+    render_daily_value_menu_bar(state, &settings)
+  })();
+  importer::release_unused_process_memory();
+  result
 }
 
 fn render_daily_value_menu_bar(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1086,7 +1086,7 @@ fn load_latest_persisted_rate_limit_window(
       SELECT sample_timestamp, limit_id, limit_name, plan_type, window_start, resets_at, used_percent, remaining_percent
       FROM rate_limit_samples
       WHERE bucket = ?1 AND (?2 IS NULL OR source_kind = ?2)
-      ORDER BY sample_timestamp DESC
+      ORDER BY julianday(sample_timestamp) DESC, id DESC
       LIMIT 1
       ",
     )
@@ -1153,21 +1153,34 @@ fn load_persisted_live_rate_limits_for_source(
   source_kind: Option<&str>,
 ) -> Option<LiveRateLimitSnapshot> {
   let conn = open_connection(&state.db_path).ok()?;
-  let primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
+  let mut primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
     .ok()
     .flatten();
-  let secondary = load_latest_persisted_rate_limit_window(&conn, "seven_day", source_kind)
+  let mut secondary = load_latest_persisted_rate_limit_window(&conn, "seven_day", source_kind)
     .ok()
     .flatten();
-  if primary.is_none() && secondary.is_none() {
-    return None;
+  let primary_instant = primary
+    .as_ref()
+    .and_then(|window| DateTime::parse_from_rfc3339(&window.fetched_at).ok());
+  let secondary_instant = secondary
+    .as_ref()
+    .and_then(|window| DateTime::parse_from_rfc3339(&window.fetched_at).ok());
+  let newest_instant = [primary_instant.as_ref(), secondary_instant.as_ref()]
+    .into_iter()
+    .flatten()
+    .max()?;
+
+  if primary_instant.as_ref() != Some(newest_instant) {
+    primary = None;
+  }
+  if secondary_instant.as_ref() != Some(newest_instant) {
+    secondary = None;
   }
 
   let fetched_at = primary
     .as_ref()
     .map(|window| window.fetched_at.clone())
-    .or_else(|| secondary.as_ref().map(|window| window.fetched_at.clone()))
-    .unwrap_or_else(|| Local::now().to_rfc3339());
+    .or_else(|| secondary.as_ref().map(|window| window.fetched_at.clone()))?;
 
   Some(LiveRateLimitSnapshot {
     limit_id: primary
@@ -2652,6 +2665,139 @@ mod tests {
       snapshot.primary.as_ref().map(|window| window.remaining_percent),
       Some(88)
     );
+  }
+
+  #[test]
+  fn persisted_live_rate_limits_order_mixed_rfc3339_offsets_by_instant() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 10,
+          remaining_percent: 90,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-10T14:00:00+08:00".to_string()),
+          window_start: Some("2026-07-10T09:00:00+08:00".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-07-10T09:00:00+08:00".to_string(),
+      },
+    )
+    .expect("insert earlier offset sample");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 20,
+          remaining_percent: 80,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-10T07:00:00Z".to_string()),
+          window_start: Some("2026-07-10T02:00:00Z".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-07-10T02:00:00Z".to_string(),
+      },
+    )
+    .expect("insert later UTC sample");
+    drop(conn);
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+
+    let snapshot = load_persisted_live_rate_limits(&state).expect("load persisted sample");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-10T02:00:00Z");
+    assert_eq!(
+      snapshot.primary.as_ref().map(|window| window.remaining_percent),
+      Some(80)
+    );
+  }
+
+  #[test]
+  fn persisted_live_rate_limits_do_not_combine_windows_from_different_samples() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 30,
+          remaining_percent: 70,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-10T06:00:00Z".to_string()),
+          window_start: Some("2026-07-10T01:00:00Z".to_string()),
+        }),
+        secondary: Some(RateLimitWindowSnapshot {
+          used_percent: 40,
+          remaining_percent: 60,
+          window_duration_mins: Some(10_080),
+          resets_at: Some("2026-07-17T01:00:00Z".to_string()),
+          window_start: Some("2026-07-10T01:00:00Z".to_string()),
+        }),
+        fetched_at: "2026-07-10T01:00:00Z".to_string(),
+      },
+    )
+    .expect("insert older complete sample");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 25,
+          remaining_percent: 75,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-10T07:00:00Z".to_string()),
+          window_start: Some("2026-07-10T02:00:00Z".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-07-10T02:00:00Z".to_string(),
+      },
+    )
+    .expect("insert newer primary-only sample");
+    drop(conn);
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+
+    let snapshot = load_persisted_live_rate_limits(&state).expect("load persisted sample");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-10T02:00:00Z");
+    assert_eq!(
+      snapshot.primary.as_ref().map(|window| window.remaining_percent),
+      Some(75)
+    );
+    assert!(snapshot.secondary.is_none());
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -346,15 +346,11 @@ fn getSyncSettings(state: State<'_, AppState>) -> Result<SyncSettings, String> {
   get_sync_settings(&conn).map_err(|error| error.to_string())
 }
 
-#[allow(non_snake_case)]
-#[tauri::command(rename_all = "camelCase")]
-fn updateSyncSettings(
-  app: AppHandle,
-  state: State<'_, AppState>,
+fn save_normalized_sync_settings(
+  conn: &rusqlite::Connection,
   payload: SyncSettings,
-) -> Result<SyncSettings, String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  let current = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+) -> rusqlite::Result<SyncSettings> {
+  let current = get_sync_settings(conn)?;
   let auto_scan_interval_minutes = payload.auto_scan_interval_minutes.max(1);
   let updated = SyncSettings {
     codex_home: payload.codex_home,
@@ -382,7 +378,18 @@ fn updateSyncSettings(
     last_scan_completed_at: current.last_scan_completed_at,
     updated_at: current.updated_at,
   };
-  let saved = save_sync_settings(&conn, &updated).map_err(|error| error.to_string())?;
+  save_sync_settings(conn, &updated)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command(rename_all = "camelCase")]
+fn updateSyncSettings(
+  app: AppHandle,
+  state: State<'_, AppState>,
+  payload: SyncSettings,
+) -> Result<SyncSettings, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  let saved = save_normalized_sync_settings(&conn, payload).map_err(|error| error.to_string())?;
   refresh_daily_value_menu_bar(state.inner());
   apply_dock_icon_visibility(&app, &saved, state.daily_value_tray.is_some());
   Ok(saved)
@@ -2128,6 +2135,61 @@ mod tests {
     DateTime::parse_from_rfc3339(value)
       .expect("parse test timestamp")
       .with_timezone(&chrono::Utc)
+  }
+
+  fn seed_scan_freshness(conn: &rusqlite::Connection, codex_home: &str) -> SyncSettings {
+    let initial = SyncSettings {
+      codex_home: Some(codex_home.to_string()),
+      ..get_sync_settings(conn).expect("load settings")
+    };
+    save_sync_settings(conn, &initial).expect("save initial source");
+
+    let settings = SyncSettings {
+      last_scan_started_at: Some("2026-07-10T08:00:00Z".to_string()),
+      last_scan_completed_at: Some("2026-07-10T08:01:00Z".to_string()),
+      ..get_sync_settings(conn).expect("reload initial source")
+    };
+    let saved = save_sync_settings(conn, &settings).expect("save scan freshness");
+    database::set_last_full_scan_completed(conn, "2026-07-10T08:01:00Z")
+      .expect("set full scan");
+    saved
+  }
+
+  #[test]
+  fn changing_codex_home_clears_scan_freshness() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let settings = seed_scan_freshness(&conn, "/tmp/codex-home-before");
+
+    let changed = SyncSettings {
+      codex_home: Some("/tmp/codex-home-after".to_string()),
+      ..settings
+    };
+    let saved = save_normalized_sync_settings(&conn, changed).expect("save changed settings");
+
+    assert_eq!(saved.last_scan_started_at, None);
+    assert_eq!(saved.last_scan_completed_at, None);
+    assert_eq!(get_last_full_scan_completed(&conn).expect("load full scan"), None);
+  }
+
+  #[test]
+  fn unchanged_codex_home_preserves_scan_freshness() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let settings = seed_scan_freshness(&conn, "/tmp/codex-home");
+
+    let saved = save_normalized_sync_settings(&conn, settings).expect("save unchanged source");
+
+    assert_eq!(saved.last_scan_started_at.as_deref(), Some("2026-07-10T08:00:00Z"));
+    assert_eq!(saved.last_scan_completed_at.as_deref(), Some("2026-07-10T08:01:00Z"));
+    assert_eq!(
+      get_last_full_scan_completed(&conn).expect("load full scan").as_deref(),
+      Some("2026-07-10T08:01:00Z")
+    );
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,13 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
+#[cfg(target_os = "macos")]
+use objc2::{
+  rc::Retained,
+  runtime::{NSObjectProtocol, ProtocolObject},
+};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
 use rusqlite::params;
 use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
@@ -54,6 +61,7 @@ const MENU_BAR_POPUP_OFFSET_Y: i32 = 8;
 const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
+const SCHEDULER_MAX_SLEEP_SECONDS: u64 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackgroundRefreshDecision {
@@ -77,11 +85,69 @@ struct MenuBarPopupAnchor {
 
 #[derive(Clone)]
 struct AppState {
+  app_handle: Option<AppHandle>,
   db_path: PathBuf,
   scan_in_progress: Arc<AtomicBool>,
+  live_refresh_in_progress: Arc<AtomicBool>,
+  menu_bar_refresh_in_progress: Arc<AtomicBool>,
   daily_value_tray: Option<TrayIcon>,
   live_rate_limits: Arc<Mutex<Option<CachedRateLimitSnapshot>>>,
   menu_bar_popup_anchor: Arc<Mutex<Option<MenuBarPopupAnchor>>>,
+}
+
+struct AtomicFlagGuard {
+  flag: Arc<AtomicBool>,
+}
+
+impl Drop for AtomicFlagGuard {
+  fn drop(&mut self) {
+    self.flag.store(false, Ordering::SeqCst);
+  }
+}
+
+fn try_acquire_flag(flag: &Arc<AtomicBool>, busy_message: &str) -> Result<AtomicFlagGuard, String> {
+  if flag
+    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+    .is_err()
+  {
+    return Err(busy_message.to_string());
+  }
+
+  Ok(AtomicFlagGuard {
+    flag: Arc::clone(flag),
+  })
+}
+
+#[cfg(target_os = "macos")]
+struct SchedulerActivity {
+  activity: Retained<ProtocolObject<dyn NSObjectProtocol>>,
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for SchedulerActivity {
+  fn drop(&mut self) {
+    unsafe {
+      NSProcessInfo::processInfo().endActivity(&self.activity);
+    }
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn begin_scheduler_activity() -> Option<SchedulerActivity> {
+  let reason = NSString::from_str("Codex Pacer background refresh");
+  let activity = NSProcessInfo::processInfo().beginActivityWithOptions_reason(
+    NSActivityOptions::UserInitiatedAllowingIdleSystemSleep,
+    &reason,
+  );
+  Some(SchedulerActivity { activity })
+}
+
+#[cfg(not(target_os = "macos"))]
+struct SchedulerActivity;
+
+#[cfg(not(target_os = "macos"))]
+fn begin_scheduler_activity() -> Option<SchedulerActivity> {
+  None
 }
 
 #[allow(non_snake_case)]
@@ -346,32 +412,34 @@ fn updateSubscriptionProfile(
 }
 
 fn run_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
-  if state
-    .scan_in_progress
-    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-    .is_err()
-  {
-    return Err("A scan is already running.".to_string());
-  }
-
-  let result = perform_scan(&state.db_path, codex_home);
-  state.scan_in_progress.store(false, Ordering::SeqCst);
-  refresh_daily_value_menu_bar(&state);
-  result
+  run_scan_if_idle_with_live_refresh(state, codex_home, true, perform_scan)
 }
 
-fn run_incremental_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
-  if state
-    .scan_in_progress
-    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-    .is_err()
-  {
-    return Err("A scan is already running.".to_string());
-  }
+fn run_background_scan_if_idle(state: AppState, codex_home: Option<String>) -> Result<ScanResult, String> {
+  run_scan_if_idle_with_live_refresh(state, codex_home, false, perform_scan)
+}
 
-  let result = perform_incremental_scan(&state.db_path, codex_home);
-  state.scan_in_progress.store(false, Ordering::SeqCst);
-  refresh_daily_value_menu_bar(&state);
+fn run_background_incremental_scan_if_idle(
+  state: AppState,
+  codex_home: Option<String>,
+) -> Result<ScanResult, String> {
+  run_scan_if_idle_with_live_refresh(state, codex_home, false, perform_incremental_scan)
+}
+
+fn run_scan_if_idle_with_live_refresh<F>(
+  state: AppState,
+  codex_home: Option<String>,
+  allow_menu_bar_live_refresh: bool,
+  scan: F,
+) -> Result<ScanResult, String>
+where
+  F: FnOnce(&Path, Option<String>) -> Result<ScanResult, String>,
+{
+  let guard = try_acquire_flag(&state.scan_in_progress, "A scan is already running.")?;
+
+  let result = scan(&state.db_path, codex_home);
+  drop(guard);
+  refresh_daily_value_menu_bar_with_live_refresh(&state, allow_menu_bar_live_refresh);
   result
 }
 
@@ -386,8 +454,28 @@ fn run_due_background_refresh(
   drop(conn);
 
   match decision {
-    BackgroundRefreshDecision::Full => run_scan_if_idle(state, settings.codex_home).map(Some),
-    BackgroundRefreshDecision::Incremental => run_incremental_scan_if_idle(state, settings.codex_home).map(Some),
+    BackgroundRefreshDecision::Full => {
+      let result = if state.scan_in_progress.load(Ordering::SeqCst) {
+        Ok(None)
+      } else {
+        run_background_scan_if_idle(state.clone(), settings.codex_home.clone()).map(Some)
+      };
+      if background_live_rate_limits_enabled(&settings) {
+        spawn_live_rate_limits_refresh_if_idle(state, true);
+      }
+      result
+    }
+    BackgroundRefreshDecision::Incremental => {
+      let result = if state.scan_in_progress.load(Ordering::SeqCst) {
+        Ok(None)
+      } else {
+        run_background_incremental_scan_if_idle(state.clone(), settings.codex_home.clone()).map(Some)
+      };
+      if background_live_rate_limits_enabled(&settings) {
+        spawn_live_rate_limits_refresh_if_idle(state, true);
+      }
+      result
+    }
     BackgroundRefreshDecision::Disabled(_) | BackgroundRefreshDecision::Wait(_) => Ok(None),
   }
 }
@@ -436,12 +524,40 @@ fn load_pricing_value_signature(conn: &rusqlite::Connection) -> rusqlite::Result
 }
 
 fn refresh_daily_value_menu_bar(state: &AppState) {
-  if let Err(error) = update_daily_value_menu_bar(state) {
-    log::warn!("Failed to update menu bar display: {error}");
+  refresh_daily_value_menu_bar_with_live_refresh(state, true);
+}
+
+fn refresh_daily_value_menu_bar_with_live_refresh(state: &AppState, allow_live_refresh: bool) {
+  let Some(app_handle) = state.app_handle.as_ref().cloned() else {
+    if let Err(error) = update_daily_value_menu_bar(state, allow_live_refresh) {
+      log::warn!("Failed to update menu bar display: {error}");
+    }
+    return;
+  };
+
+  let Ok(guard) = try_acquire_flag(
+    &state.menu_bar_refresh_in_progress,
+    "A menu bar refresh is already running.",
+  ) else {
+    return;
+  };
+  let state = state.clone();
+  if let Err(error) = app_handle.run_on_main_thread(move || {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+      update_daily_value_menu_bar(&state, allow_live_refresh)
+    }));
+    drop(guard);
+    match result {
+      Ok(Ok(())) => {}
+      Ok(Err(error)) => log::warn!("Failed to update menu bar display: {error}"),
+      Err(_) => log::warn!("Menu bar display update panicked."),
+    }
+  }) {
+    log::warn!("Failed to schedule menu bar display update: {error}");
   }
 }
 
-fn update_daily_value_menu_bar(state: &AppState) -> Result<(), String> {
+fn update_daily_value_menu_bar(state: &AppState, allow_live_refresh: bool) -> Result<(), String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
   let Some(tray) = state.daily_value_tray.as_ref() else {
@@ -454,7 +570,8 @@ fn update_daily_value_menu_bar(state: &AppState) -> Result<(), String> {
   }
 
   apply_menu_bar_icon(tray, settings.show_menu_bar_logo)?;
-  let (api_value_title, live_metric_title) = current_menu_bar_title_parts(state, &settings)?;
+  let (api_value_title, live_metric_title) =
+    current_menu_bar_title_parts_with_live_refresh(state, &settings, allow_live_refresh)?;
   match menu_bar_title(api_value_title.as_deref(), live_metric_title.as_deref()) {
     Some(title) => tray.set_title(Some(&title)).map_err(|error| error.to_string())?,
     None => tray
@@ -462,7 +579,12 @@ fn update_daily_value_menu_bar(state: &AppState) -> Result<(), String> {
       .map_err(|error| error.to_string())?,
   }
   tray
-    .set_tooltip(Some(menu_bar_tooltip(&settings, api_value_title.as_deref(), state)?))
+    .set_tooltip(Some(menu_bar_tooltip_with_live_refresh(
+      &settings,
+      api_value_title.as_deref(),
+      state,
+      allow_live_refresh,
+    )?))
     .map_err(|error| error.to_string())?;
   tray.set_visible(true).map_err(|error| error.to_string())?;
   Ok(())
@@ -472,6 +594,17 @@ fn menu_bar_has_visible_content(settings: &SyncSettings) -> bool {
   settings.show_menu_bar_logo
     || settings.show_menu_bar_daily_api_value
     || settings.show_menu_bar_live_quota_percent
+}
+
+fn background_live_rate_limits_enabled(settings: &SyncSettings) -> bool {
+  let menu_bar_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  settings.show_menu_bar_live_quota_percent
+    || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&menu_bar_bucket))
+    || (settings.menu_bar_popup_enabled
+      && settings
+        .menu_bar_popup_modules
+        .iter()
+        .any(|module| module == "live_quota_freshness"))
 }
 
 fn should_hide_dock_icon(settings: &SyncSettings) -> bool {
@@ -509,16 +642,17 @@ fn apply_menu_bar_icon(tray: &TrayIcon, show_logo: bool) -> Result<(), String> {
   Ok(())
 }
 
-fn current_menu_bar_title_parts(
+fn current_menu_bar_title_parts_with_live_refresh(
   state: &AppState,
   settings: &SyncSettings,
+  allow_live_refresh: bool,
 ) -> Result<(Option<String>, Option<String>), String> {
   let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let anchor = Local::now().format("%Y-%m-%d").to_string();
   let live_rate_limits = if settings.show_menu_bar_live_quota_percent
     || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&bucket))
   {
-    maybe_live_rate_limits_for_bucket(state, Some(&bucket), None)?
+    maybe_live_rate_limits_for_bucket_with_live_refresh(state, Some(&bucket), None, allow_live_refresh)?
   } else {
     None
   };
@@ -544,6 +678,7 @@ fn current_menu_bar_title_parts(
       &settings.menu_bar_live_quota_metric,
       live_rate_limits,
       Local::now(),
+      allow_live_refresh,
     )?
   } else {
     None
@@ -618,10 +753,11 @@ fn normalize_menu_bar_popup_modules(modules: &[String]) -> Vec<String> {
   normalized
 }
 
-fn menu_bar_tooltip(
+fn menu_bar_tooltip_with_live_refresh(
   settings: &SyncSettings,
   api_value_title: Option<&str>,
   state: &AppState,
+  allow_live_refresh: bool,
 ) -> Result<String, String> {
   let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let mut fragments = Vec::new();
@@ -629,15 +765,21 @@ fn menu_bar_tooltip(
     fragments.push(format!("{}累计 API 价值：{title}", menu_bar_bucket_label(&bucket)));
   }
   if settings.show_menu_bar_live_quota_percent {
-    let snapshot = get_live_rate_limits_cached(state)?;
-    if let Some(fragment) = menu_bar_live_quota_tooltip(
-      &snapshot,
-      settings,
-      &settings.menu_bar_live_quota_bucket,
-      &settings.menu_bar_live_quota_metric,
-      Local::now(),
-    ) {
-      fragments.push(fragment);
+    let snapshot = if allow_live_refresh {
+      Some(get_live_rate_limits_cached(state)?)
+    } else {
+      get_live_rate_limits_local(state)
+    };
+    if let Some(snapshot) = snapshot {
+      if let Some(fragment) = menu_bar_live_quota_tooltip(
+        &snapshot,
+        settings,
+        &settings.menu_bar_live_quota_bucket,
+        &settings.menu_bar_live_quota_metric,
+        Local::now(),
+      ) {
+        fragments.push(fragment);
+      }
     }
   }
   if fragments.is_empty() {
@@ -675,10 +817,17 @@ fn menu_bar_live_quota_snapshot(
   metric: &str,
   existing_snapshot: Option<LiveRateLimitSnapshot>,
   now: DateTime<Local>,
+  allow_live_refresh: bool,
 ) -> Result<Option<String>, String> {
   let snapshot = match existing_snapshot {
     Some(snapshot) => snapshot,
-    None => get_live_rate_limits_cached(state)?,
+    None if allow_live_refresh => get_live_rate_limits_cached(state)?,
+    None => {
+      let Some(snapshot) = get_live_rate_limits_local(state) else {
+        return Ok(None);
+      };
+      snapshot
+    }
   };
   Ok(menu_bar_live_quota_title(&snapshot, settings, bucket, metric, now))
 }
@@ -827,6 +976,15 @@ fn maybe_live_rate_limits_for_bucket(
   bucket: Option<&str>,
   live_window_offset: Option<i64>,
 ) -> Result<Option<LiveRateLimitSnapshot>, String> {
+  maybe_live_rate_limits_for_bucket_with_live_refresh(state, bucket, live_window_offset, true)
+}
+
+fn maybe_live_rate_limits_for_bucket_with_live_refresh(
+  state: &AppState,
+  bucket: Option<&str>,
+  live_window_offset: Option<i64>,
+  allow_live_refresh: bool,
+) -> Result<Option<LiveRateLimitSnapshot>, String> {
   let Some(bucket) = bucket else {
     return Ok(None);
   };
@@ -836,7 +994,11 @@ fn maybe_live_rate_limits_for_bucket(
   if live_window_offset.unwrap_or(0) > 0 {
     return Ok(None);
   }
-  Ok(Some(get_live_rate_limits_cached(state)?))
+  if allow_live_refresh {
+    Ok(Some(get_live_rate_limits_cached(state)?))
+  } else {
+    Ok(get_live_rate_limits_local(state))
+  }
 }
 
 fn get_live_rate_limits_cached(state: &AppState) -> Result<LiveRateLimitSnapshot, String> {
@@ -844,6 +1006,18 @@ fn get_live_rate_limits_cached(state: &AppState) -> Result<LiveRateLimitSnapshot
 }
 
 fn get_live_rate_limits(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
+  get_live_rate_limits_with_fallback(state, force_refresh, true)
+}
+
+fn get_live_rate_limits_background(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
+  get_live_rate_limits_with_fallback(state, force_refresh, false)
+}
+
+fn get_live_rate_limits_with_fallback(
+  state: &AppState,
+  force_refresh: bool,
+  refresh_history_on_failure: bool,
+) -> Result<LiveRateLimitSnapshot, String> {
   let ttl = live_rate_limit_cache_ttl(state);
 
   if !force_refresh {
@@ -867,7 +1041,12 @@ fn get_live_rate_limits(state: &AppState, force_refresh: bool) -> Result<LiveRat
     }
     Err(error) => {
       log::warn!("Failed to refresh live rate limits from Codex app-server: {error}");
-      if let Some(snapshot) = get_live_rate_limits_history_fallback(state) {
+      let fallback = if refresh_history_on_failure {
+        get_live_rate_limits_history_fallback(state)
+      } else {
+        get_live_rate_limits_stored_fallback(state)
+      };
+      if let Some(snapshot) = fallback {
         if let Err(cache_error) = store_live_rate_limits_cache(state, &snapshot) {
           log::warn!("Failed to cache fallback live rate limits: {cache_error}");
         }
@@ -1004,24 +1183,24 @@ fn get_live_rate_limits_local(state: &AppState) -> Option<LiveRateLimitSnapshot>
   get_cached_live_rate_limits(state).or_else(|| load_persisted_live_rate_limits(state))
 }
 
-fn get_live_rate_limits_history_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
-  refresh_rate_limit_history_if_idle(state);
+fn get_live_rate_limits_stored_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
   load_history_live_rate_limits(state)
     .or_else(|| load_persisted_live_rate_limits(state))
     .or_else(|| get_cached_live_rate_limits(state))
 }
 
+fn get_live_rate_limits_history_fallback(state: &AppState) -> Option<LiveRateLimitSnapshot> {
+  refresh_rate_limit_history_if_idle(state);
+  get_live_rate_limits_stored_fallback(state)
+}
+
 fn refresh_rate_limit_history_if_idle(state: &AppState) {
-  if state
-    .scan_in_progress
-    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-    .is_err()
-  {
+  let Ok(guard) = try_acquire_flag(&state.scan_in_progress, "A scan is already running.") else {
     return;
-  }
+  };
 
   let result = perform_incremental_scan(&state.db_path, None);
-  state.scan_in_progress.store(false, Ordering::SeqCst);
+  drop(guard);
   if let Err(error) = result {
     log::warn!("Failed to refresh Codex history rate-limit samples: {error}");
   }
@@ -1629,48 +1808,89 @@ fn spawn_initial_scan(state: AppState) {
   std::thread::Builder::new()
     .name("codex-pacer-initial-scan".to_string())
     .spawn(move || {
-      let _ = run_incremental_scan_if_idle(state, None);
+      let _ = run_background_incremental_scan_if_idle(state, None);
     })
     .expect("failed to spawn initial scan thread");
+}
+
+fn spawn_live_rate_limits_refresh_if_idle(state: AppState, force_refresh: bool) {
+  let Ok(guard) = try_acquire_flag(&state.live_refresh_in_progress, "A live quota refresh is already running.") else {
+    return;
+  };
+
+  if let Err(error) = std::thread::Builder::new()
+    .name("codex-pacer-live-quota-refresh".to_string())
+    .spawn(move || {
+      let result = get_live_rate_limits_background(&state, force_refresh);
+      drop(guard);
+      if let Err(error) = result {
+        log::warn!("Failed to refresh live quota in background: {error}");
+      }
+      refresh_daily_value_menu_bar_with_live_refresh(&state, false);
+    })
+  {
+    log::warn!("Failed to spawn live quota refresh thread: {error}");
+  }
 }
 
 fn spawn_scheduler(state: AppState) {
   std::thread::Builder::new()
     .name("codex-pacer-scheduler".to_string())
-    .spawn(move || loop {
-      let Ok(conn) = open_connection(&state.db_path) else {
-        std::thread::sleep(Duration::from_secs(60));
-        continue;
-      };
-      let Ok(settings) = get_sync_settings(&conn) else {
-        std::thread::sleep(Duration::from_secs(60));
-        continue;
-      };
-      let now = Utc::now();
-      let last_full_scan_completed = get_last_full_scan_completed(&conn).unwrap_or(None);
-      let decision = background_refresh_decision(&settings, last_full_scan_completed.as_deref(), now);
-      drop(conn);
-
-      match decision {
-        BackgroundRefreshDecision::Disabled(delay) | BackgroundRefreshDecision::Wait(delay) => {
-          std::thread::sleep(delay);
-        }
-        BackgroundRefreshDecision::Full | BackgroundRefreshDecision::Incremental
-          if state.scan_in_progress.load(Ordering::SeqCst) =>
-        {
-          std::thread::sleep(Duration::from_secs(
-            unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
-          ));
-        }
-        BackgroundRefreshDecision::Full => {
-          let _ = run_scan_if_idle(state.clone(), settings.codex_home.clone());
-        }
-        BackgroundRefreshDecision::Incremental => {
-          let _ = run_incremental_scan_if_idle(state.clone(), settings.codex_home.clone());
-        }
+    .spawn(move || {
+      let _scheduler_activity = begin_scheduler_activity();
+      loop {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_scheduler_tick(&state)));
+        let delay = match result {
+          Ok(delay) => delay,
+          Err(_) => {
+            log::warn!("Background scheduler tick panicked; continuing on the next interval.");
+            Duration::from_secs(60)
+          }
+        };
+        std::thread::sleep(scheduler_sleep_duration(delay));
       }
     })
     .expect("failed to spawn background scheduler thread");
+}
+
+fn scheduler_sleep_duration(delay: Duration) -> Duration {
+  let max_sleep = Duration::from_secs(SCHEDULER_MAX_SLEEP_SECONDS);
+  if delay > max_sleep { max_sleep } else { delay }
+}
+
+fn run_scheduler_tick(state: &AppState) -> Duration {
+  let Ok(conn) = open_connection(&state.db_path) else {
+    return Duration::from_secs(60);
+  };
+  let Ok(settings) = get_sync_settings(&conn) else {
+    return Duration::from_secs(60);
+  };
+  let now = Utc::now();
+  let last_full_scan_completed = get_last_full_scan_completed(&conn).unwrap_or(None);
+  let decision = background_refresh_decision(&settings, last_full_scan_completed.as_deref(), now);
+  drop(conn);
+
+  match decision {
+    BackgroundRefreshDecision::Disabled(delay) | BackgroundRefreshDecision::Wait(delay) => delay,
+    BackgroundRefreshDecision::Full | BackgroundRefreshDecision::Incremental => {
+      if !state.scan_in_progress.load(Ordering::SeqCst) {
+        let result = match decision {
+          BackgroundRefreshDecision::Full => run_background_scan_if_idle(state.clone(), settings.codex_home.clone()),
+          BackgroundRefreshDecision::Incremental => {
+            run_background_incremental_scan_if_idle(state.clone(), settings.codex_home.clone())
+          }
+          BackgroundRefreshDecision::Disabled(_) | BackgroundRefreshDecision::Wait(_) => unreachable!(),
+        };
+        if let Err(error) = result {
+          log::warn!("Failed to run background Codex scan: {error}");
+        }
+      }
+      if background_live_rate_limits_enabled(&settings) {
+        spawn_live_rate_limits_refresh_if_idle(state.clone(), true);
+      }
+      Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64)
+    }
+  }
 }
 
 fn background_refresh_decision(
@@ -1798,20 +2018,29 @@ pub fn run() {
         }
       };
       let state = AppState {
+        app_handle: Some(app_handle.clone()),
         db_path,
         scan_in_progress: Arc::new(AtomicBool::new(false)),
+        live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+        menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
         daily_value_tray,
         live_rate_limits: Arc::new(Mutex::new(None)),
         menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
       };
       app.manage(state.clone());
-      if let Ok(settings) = get_sync_settings(&conn) {
+      let should_refresh_live_on_startup = if let Ok(settings) = get_sync_settings(&conn) {
         apply_dock_icon_visibility(&app_handle, &settings, state.daily_value_tray.is_some());
-      }
+        background_live_rate_limits_enabled(&settings)
+      } else {
+        false
+      };
       if let Err(error) = build_menu_bar_popup_window(&app_handle) {
         log::warn!("Failed to set up menu bar popup window: {error}");
       }
-      refresh_daily_value_menu_bar(&state);
+      refresh_daily_value_menu_bar_with_live_refresh(&state, false);
+      if should_refresh_live_on_startup {
+        spawn_live_rate_limits_refresh_if_idle(state.clone(), true);
+      }
       spawn_initial_scan(state.clone());
       spawn_scheduler(state);
 
@@ -1882,6 +2111,15 @@ mod tests {
       scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T00:00:00Z")),
       Duration::from_secs(420)
     );
+  }
+
+  #[test]
+  fn scheduler_caps_actual_sleep_duration() {
+    assert_eq!(
+      scheduler_sleep_duration(Duration::from_secs(60)),
+      Duration::from_secs(SCHEDULER_MAX_SLEEP_SECONDS)
+    );
+    assert_eq!(scheduler_sleep_duration(Duration::from_secs(2)), Duration::from_secs(2));
   }
 
   #[test]
@@ -2034,8 +2272,11 @@ mod tests {
     database::set_last_full_scan_completed(&conn, "2026-03-27T00:00:30Z").expect("set full scan");
     drop(conn);
     let state = AppState {
+      app_handle: None,
       db_path: db_path.clone(),
       scan_in_progress: Arc::new(AtomicBool::new(false)),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
       daily_value_tray: None,
       live_rate_limits: Arc::new(Mutex::new(None)),
       menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
@@ -2192,6 +2433,58 @@ mod tests {
       .expect("load usage value");
 
     assert_eq!(value_usd, 2.50);
+  }
+
+  #[test]
+  fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let settings = SyncSettings {
+      show_menu_bar_daily_api_value: false,
+      show_menu_bar_live_quota_percent: true,
+      menu_bar_live_quota_metric: "remaining_percent".to_string(),
+      menu_bar_live_quota_bucket: "five_hour".to_string(),
+      ..get_sync_settings(&conn).expect("load settings")
+    };
+    save_sync_settings(&conn, &settings).expect("save settings");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 12,
+          remaining_percent: 88,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-03-27T05:00:00+08:00".to_string()),
+          window_start: Some("2026-03-27T00:00:00+08:00".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
+      },
+    )
+    .expect("insert live limits");
+    drop(conn);
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+
+    let (api_value_title, live_metric_title) =
+      current_menu_bar_title_parts_with_live_refresh(&state, &settings, false)
+        .expect("build title");
+
+    assert_eq!(api_value_title, None);
+    assert_eq!(live_metric_title.as_deref(), Some("88%"));
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ use database::{
 };
 use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
 use models::{
-  ConversationDetail, ConversationFilters, ConversationListItem, DashboardSnapshot,
+  ConversationDetail, ConversationFilters, ConversationPage, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
   ScanResult, SubscriptionProfile, SyncSettings,
@@ -451,7 +451,7 @@ fn getOverview(
 fn listConversations(
   state: State<'_, AppState>,
   filters: Option<ConversationFilters>,
-) -> Result<Vec<ConversationListItem>, String> {
+) -> Result<ConversationPage, String> {
   let live_rate_limits = maybe_live_rate_limits_for_bucket(
     state.inner(),
     filters.as_ref().and_then(|value| value.bucket.as_deref()),
@@ -520,7 +520,7 @@ async fn loadDashboard(
 ) -> Result<DashboardSnapshot, String> {
   let state = state.inner().clone();
   tauri::async_runtime::spawn_blocking(move || {
-    let normalized_bucket = bucket.clone().unwrap_or_else(|| "subscription_month".to_string());
+    let normalized_bucket = bucket.clone().unwrap_or_else(|| "seven_day".to_string());
     let live_rate_limits =
       maybe_live_rate_limits_for_bucket(&state, Some(&normalized_bucket), live_window_offset)?;
     let snapshot = load_dashboard_data(
@@ -538,7 +538,7 @@ async fn loadDashboard(
 
     Ok(DashboardSnapshot {
       overview: snapshot.overview,
-      conversations: snapshot.conversations,
+      conversation_page: snapshot.conversation_page,
       sync_settings,
       subscription_profile: snapshot.subscription_profile,
       live_rate_limits,
@@ -553,8 +553,9 @@ async fn loadDashboard(
 fn getConversationDetail(
   state: State<'_, AppState>,
   root_session_id: String,
+  turn_cursor: Option<usize>,
 ) -> Result<ConversationDetail, String> {
-  get_conversation_detail(&state.db_path, &root_session_id)
+  get_conversation_detail(&state.db_path, &root_session_id, turn_cursor)
 }
 
 #[allow(non_snake_case)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -766,6 +766,13 @@ fn updateSubscriptionProfile(
   state: State<'_, AppState>,
   payload: SubscriptionProfile,
 ) -> Result<SubscriptionProfile, String> {
+  update_subscription_profile_for_state(state.inner(), payload)
+}
+
+fn update_subscription_profile_for_state(
+  state: &AppState,
+  payload: SubscriptionProfile,
+) -> Result<SubscriptionProfile, String> {
   let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let updated = SubscriptionProfile {
     plan_type: payload.plan_type,
@@ -774,7 +781,13 @@ fn updateSubscriptionProfile(
     billing_anchor_day: payload.billing_anchor_day.clamp(1, 28),
     updated_at: payload.updated_at,
   };
-  save_subscription_profile(&conn, &updated).map_err(|error| error.to_string())
+  let saved = save_subscription_profile(&conn, &updated).map_err(|error| error.to_string())?;
+  state.settings_revision.fetch_add(1, Ordering::AcqRel);
+  *state
+    .overview_cache
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+  Ok(saved)
 }
 
 fn prepare_app_database(db_path: &Path) -> Result<(), String> {
@@ -3134,6 +3147,53 @@ mod tests {
       snapshot.quota_7d.map(|window| window.remaining_percent),
       Some(79)
     );
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn subscription_profile_update_invalidates_cached_overview() {
+    let (runtime, _, _) = start_recording_runtime(disabled_refresh_config(None));
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let state = test_app_state(
+      db_path,
+      runtime.handle(),
+      refresh::UsageMutationCoordinator::new(),
+      refresh::LiveQuotaCache::new(),
+    );
+    cached_overview(
+      &state,
+      Some("seven_day".to_string()),
+      None,
+      None,
+      None,
+      None,
+      None,
+    )
+    .expect("populate overview cache");
+    assert!(state
+      .overview_cache
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner)
+      .is_some());
+
+    let saved = update_subscription_profile_for_state(
+      &state,
+      SubscriptionProfile {
+        monthly_price: 250.0,
+        ..SubscriptionProfile::default()
+      },
+    )
+    .expect("update subscription profile");
+
+    assert_eq!(saved.monthly_price, 250.0);
+    assert_eq!(state.settings_revision.load(Ordering::Acquire), 1);
+    assert!(state
+      .overview_cache
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner)
+      .is_none());
     runtime.shutdown_and_join().expect("shutdown runtime");
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod models;
 mod pricing;
 mod queries;
 mod rate_limits;
+mod refresh;
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,7 +40,7 @@ use pricing::{
 use queries::{
   get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
 };
-use rate_limits::query_live_rate_limits;
+use rate_limits::LiveRateLimitClient;
 use tauri::{
   Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Rect, WebviewUrl, WebviewWindow,
   WebviewWindowBuilder,
@@ -141,11 +141,12 @@ impl refresh::TokenRefreshExecutor for AppTokenRefreshExecutor {
 struct AppLiveQuotaFetcher {
   db_path: PathBuf,
   live_cache: refresh::LiveQuotaCache,
+  client: Arc<LiveRateLimitClient>,
 }
 
 impl refresh::LiveQuotaFetcher for AppLiveQuotaFetcher {
   fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
-    query_live_rate_limits(timeout)
+    self.client.query(timeout)
   }
 
   fn fallback(&self) -> Option<LiveRateLimitSnapshot> {
@@ -2244,6 +2245,7 @@ pub fn run() {
           Arc::new(AppLiveQuotaFetcher {
             db_path: db_path.clone(),
             live_cache: live_rate_limits.clone(),
+            client: Arc::new(LiveRateLimitClient::new()),
           }),
           Arc::new(AppLiveQuotaPersister {
             db_path: db_path.clone(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2477,6 +2477,69 @@ mod tests {
   }
 
   #[test]
+  fn startup_database_prepare_recalculates_new_gpt_56_values() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    conn
+      .execute(
+        "
+        UPDATE pricing_catalog
+        SET output_price_per_million = 6.25,
+            is_official = 1
+        WHERE model_id = 'gpt-5.6-sol'
+        ",
+        [],
+      )
+      .expect("seed malformed GPT-5.6 Sol pricing");
+    let created_at = database::now_utc_string();
+    conn
+      .execute(
+        "
+        INSERT INTO sessions (
+          session_id, root_session_id, parent_session_id, title, source_state, source_path,
+          source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+          fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+        )
+        VALUES ('gpt-56-startup-session', 'gpt-56-startup-session', NULL, NULL, 'active', NULL, 'active',
+          NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?1, ?1)
+        ",
+        params![created_at],
+      )
+      .expect("insert session");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES ('gpt-56-startup-session', '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
+          0, 0, 1000000, 0, 1000000, 0.0, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage event");
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let value_usd: f64 = conn
+      .query_row(
+        "SELECT value_usd FROM usage_events WHERE session_id = 'gpt-56-startup-session'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load usage value");
+
+    assert_eq!(value_usd, 30.0);
+  }
+
+  #[test]
   fn menu_bar_title_parts_can_use_local_live_rate_limits_without_refresh() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1555,8 +1555,9 @@ fn build_passive_menu_bar_popup_snapshot(
   drop(conn);
   let live_rate_limits = live_cache
     .rate_limits()
-    .map(|snapshot| snapshot.as_ref().clone());
-  let selected_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+    .map(|snapshot| normalize_live_rate_limit_snapshot(snapshot.as_ref().clone()));
+  let configured_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  let selected_bucket = effective_menu_bar_api_bucket(&configured_bucket, live_rate_limits.as_ref());
   let anchor = bucket_uses_anchor(&selected_bucket).then(|| Local::now().format("%Y-%m-%d").to_string());
   let overview = get_overview(
     db_path,
@@ -2890,6 +2891,48 @@ mod tests {
     assert!(!status_after.token.running && !status_after.token.pending);
     assert!(!status_after.live.running && !status_after.live.pending);
     runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn popup_snapshot_uses_seven_day_bucket_when_five_hour_quota_is_absent() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.menu_bar_bucket = "five_hour".to_string();
+    save_sync_settings(&conn, &settings).expect("save menu bar bucket");
+    drop(conn);
+
+    let cache = refresh::LiveQuotaCache::new();
+    cache.publish_fallback(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: None,
+        secondary: Some(RateLimitWindowSnapshot {
+          used_percent: 21,
+          remaining_percent: 79,
+          window_duration_mins: Some(10_080),
+          resets_at: Some("2026-07-20T00:00:00+08:00".to_string()),
+          window_start: Some("2026-07-13T00:00:00+08:00".to_string()),
+        }),
+        fetched_at: "2026-07-13T10:00:00+08:00".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+
+    let snapshot = build_passive_menu_bar_popup_snapshot(&db_path, &cache)
+      .expect("build popup snapshot");
+
+    assert_eq!(snapshot.selected_bucket, "seven_day");
+    assert!(snapshot.quota_5h.is_none());
+    assert_eq!(
+      snapshot.quota_7d.map(|window| window.remaining_percent),
+      Some(79)
+    );
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 const SCHEDULER_MAX_SLEEP_SECONDS: u64 = 5;
+const FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS: u64 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackgroundRefreshDecision {
@@ -600,11 +601,7 @@ fn background_live_rate_limits_enabled(settings: &SyncSettings) -> bool {
   let menu_bar_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   settings.show_menu_bar_live_quota_percent
     || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&menu_bar_bucket))
-    || (settings.menu_bar_popup_enabled
-      && settings
-        .menu_bar_popup_modules
-        .iter()
-        .any(|module| module == "live_quota_freshness"))
+    || settings.menu_bar_popup_enabled
 }
 
 fn should_hide_dock_icon(settings: &SyncSettings) -> bool {
@@ -1006,17 +1003,29 @@ fn get_live_rate_limits_cached(state: &AppState) -> Result<LiveRateLimitSnapshot
 }
 
 fn get_live_rate_limits(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_with_fallback(state, force_refresh, true)
+  get_live_rate_limits_with_fallback(
+    state,
+    force_refresh,
+    true,
+    live_rate_limit_foreground_query_timeout(),
+  )
 }
 
 fn get_live_rate_limits_background(state: &AppState, force_refresh: bool) -> Result<LiveRateLimitSnapshot, String> {
-  get_live_rate_limits_with_fallback(state, force_refresh, false)
+  let ttl = live_rate_limit_cache_ttl(state);
+  get_live_rate_limits_with_fallback(
+    state,
+    force_refresh,
+    false,
+    live_rate_limit_background_query_timeout_for_interval(ttl),
+  )
 }
 
 fn get_live_rate_limits_with_fallback(
   state: &AppState,
   force_refresh: bool,
   refresh_history_on_failure: bool,
+  query_timeout: Duration,
 ) -> Result<LiveRateLimitSnapshot, String> {
   let ttl = live_rate_limit_cache_ttl(state);
 
@@ -1032,7 +1041,7 @@ fn get_live_rate_limits_with_fallback(
     }
   }
 
-  match query_live_rate_limits(live_rate_limit_query_timeout_for_interval(ttl)) {
+  match query_live_rate_limits(query_timeout) {
     Ok(snapshot) => {
       let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
       insert_live_rate_limit_snapshot(&conn, &snapshot).map_err(|error| error.to_string())?;
@@ -1386,9 +1395,13 @@ fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
     .unwrap_or(Duration::from_secs(300))
 }
 
-fn live_rate_limit_query_timeout_for_interval(interval: Duration) -> Duration {
+fn live_rate_limit_foreground_query_timeout() -> Duration {
+  Duration::from_secs(FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS)
+}
+
+fn live_rate_limit_background_query_timeout_for_interval(interval: Duration) -> Duration {
   interval
-    .checked_sub(Duration::from_secs(5))
+    .checked_sub(Duration::from_secs(FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS))
     .unwrap_or_else(|| Duration::from_secs(1))
 }
 
@@ -2131,13 +2144,23 @@ mod tests {
   #[test]
   fn live_rate_limit_query_timeout_finishes_before_next_refresh() {
     assert_eq!(
-      live_rate_limit_query_timeout_for_interval(Duration::from_secs(60)),
+      live_rate_limit_background_query_timeout_for_interval(Duration::from_secs(60)),
       Duration::from_secs(55)
     );
     assert_eq!(
-      live_rate_limit_query_timeout_for_interval(Duration::from_secs(180)),
+      live_rate_limit_background_query_timeout_for_interval(Duration::from_secs(180)),
       Duration::from_secs(175)
     );
+  }
+
+  #[test]
+  fn live_rate_limit_foreground_query_timeout_stays_short() {
+    assert_eq!(live_rate_limit_foreground_query_timeout(), Duration::from_secs(5));
+  }
+
+  #[test]
+  fn default_menu_bar_popup_requires_background_live_rate_limits() {
+    assert!(background_live_rate_limits_enabled(&SyncSettings::default()));
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2144,7 +2144,7 @@ fn effective_token_scan_kind(
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let last_full = get_last_full_scan_completed(&conn).map_err(|error| error.to_string())?;
   Ok(if full_maintenance_due(last_full.as_deref(), now) {
-    ScanKind::Full
+    ScanKind::Reconcile
   } else {
     ScanKind::Incremental
   })
@@ -3052,7 +3052,7 @@ mod tests {
     assert!(parsed_generation > 0);
     assert_eq!(parsed_generation, committed_generation);
     assert_eq!(source_generation, handle.status().source_generation);
-    assert_eq!(kind, refresh::TokenScanKind::Full);
+    assert_eq!(kind, refresh::TokenScanKind::Incremental);
     assert_eq!(result.codex_home, codex_home.to_string_lossy());
     assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
     runtime.shutdown_and_join().expect("shutdown runtime");
@@ -3214,7 +3214,7 @@ mod tests {
         utc_time("2026-07-11T00:00:00Z"),
       )
       .expect("select scan kind"),
-      ScanKind::Full
+      ScanKind::Reconcile
     );
     assert_eq!(
       effective_token_scan_kind(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,15 @@ const MENU_BAR_POPUP_OFFSET_Y: i32 = 8;
 const TRAY_ICON_MIN_LOGICAL_HEIGHT: f64 = 16.0;
 const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackgroundRefreshDecision {
+  Disabled(Duration),
+  Wait(Duration),
+  Incremental,
+  Full,
+}
+
 #[derive(Clone)]
 struct CachedRateLimitSnapshot {
   fetched_at: Instant,
@@ -85,6 +94,12 @@ fn scanCodexUsage(state: State<'_, AppState>, codex_home: Option<String>) -> Res
 #[tauri::command]
 fn getScanInProgress(state: State<'_, AppState>) -> bool {
   state.inner().scan_in_progress.load(Ordering::SeqCst)
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+fn refreshBackgroundData(state: State<'_, AppState>) -> Result<Option<ScanResult>, String> {
+  run_due_background_refresh(state.inner().clone(), Utc::now())
 }
 
 #[allow(non_snake_case)]
@@ -358,6 +373,23 @@ fn run_incremental_scan_if_idle(state: AppState, codex_home: Option<String>) -> 
   state.scan_in_progress.store(false, Ordering::SeqCst);
   refresh_daily_value_menu_bar(&state);
   result
+}
+
+fn run_due_background_refresh(
+  state: AppState,
+  now: chrono::DateTime<chrono::Utc>,
+) -> Result<Option<ScanResult>, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+  let last_full_scan_completed = get_last_full_scan_completed(&conn).map_err(|error| error.to_string())?;
+  let decision = background_refresh_decision(&settings, last_full_scan_completed.as_deref(), now);
+  drop(conn);
+
+  match decision {
+    BackgroundRefreshDecision::Full => run_scan_if_idle(state, settings.codex_home).map(Some),
+    BackgroundRefreshDecision::Incremental => run_incremental_scan_if_idle(state, settings.codex_home).map(Some),
+    BackgroundRefreshDecision::Disabled(_) | BackgroundRefreshDecision::Wait(_) => Ok(None),
+  }
 }
 
 fn prepare_app_database(db_path: &Path) -> Result<(), String> {
@@ -1600,28 +1632,53 @@ fn spawn_scheduler(state: AppState) {
         continue;
       };
       let now = Utc::now();
-      let delay = scheduler_delay_until_next_refresh(&settings, now);
-      if !delay.is_zero() {
-        tokio::time::sleep(delay).await;
-        continue;
-      }
-      let should_run_full = get_last_full_scan_completed(&conn)
-        .map(|last_completed_at| full_maintenance_due(last_completed_at.as_deref(), now))
-        .unwrap_or(true);
+      let last_full_scan_completed = get_last_full_scan_completed(&conn).unwrap_or(None);
+      let decision = background_refresh_decision(&settings, last_full_scan_completed.as_deref(), now);
       drop(conn);
 
-      if state.scan_in_progress.load(Ordering::SeqCst) {
-        tokio::time::sleep(Duration::from_secs(
-          unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
-        ))
-        .await;
-      } else if should_run_full {
-        let _ = run_scan_if_idle(state.clone(), settings.codex_home.clone());
-      } else {
-        let _ = run_incremental_scan_if_idle(state.clone(), settings.codex_home.clone());
+      match decision {
+        BackgroundRefreshDecision::Disabled(delay) | BackgroundRefreshDecision::Wait(delay) => {
+          tokio::time::sleep(delay).await;
+        }
+        BackgroundRefreshDecision::Full | BackgroundRefreshDecision::Incremental
+          if state.scan_in_progress.load(Ordering::SeqCst) =>
+        {
+          tokio::time::sleep(Duration::from_secs(
+            unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
+          ))
+          .await;
+        }
+        BackgroundRefreshDecision::Full => {
+          let _ = run_scan_if_idle(state.clone(), settings.codex_home.clone());
+        }
+        BackgroundRefreshDecision::Incremental => {
+          let _ = run_incremental_scan_if_idle(state.clone(), settings.codex_home.clone());
+        }
       }
     }
   });
+}
+
+fn background_refresh_decision(
+  settings: &SyncSettings,
+  last_full_scan_completed_at: Option<&str>,
+  now: chrono::DateTime<chrono::Utc>,
+) -> BackgroundRefreshDecision {
+  let interval = Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64);
+  if !settings.auto_scan_enabled {
+    return BackgroundRefreshDecision::Disabled(interval);
+  }
+
+  let delay = scheduler_delay_until_next_refresh(settings, now);
+  if !delay.is_zero() {
+    return BackgroundRefreshDecision::Wait(delay);
+  }
+
+  if full_maintenance_due(last_full_scan_completed_at, now) {
+    BackgroundRefreshDecision::Full
+  } else {
+    BackgroundRefreshDecision::Incremental
+  }
 }
 
 fn scheduler_delay_until_next_refresh(settings: &SyncSettings, now: chrono::DateTime<chrono::Utc>) -> Duration {
@@ -1749,6 +1806,7 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       scanCodexUsage,
       getScanInProgress,
+      refreshBackgroundData,
       refreshPricing,
       getOverview,
       listConversations,
@@ -1862,6 +1920,59 @@ mod tests {
     assert_eq!(
       scheduler_delay_until_next_refresh(&settings, utc_time("2026-03-27T03:00:00Z")),
       Duration::ZERO
+    );
+  }
+
+  #[test]
+  fn background_refresh_decision_skips_when_auto_scan_is_disabled() {
+    let settings = SyncSettings {
+      auto_scan_enabled: false,
+      auto_scan_interval_minutes: 7,
+      last_scan_completed_at: None,
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      background_refresh_decision(&settings, None, utc_time("2026-03-27T00:00:00Z")),
+      BackgroundRefreshDecision::Disabled(Duration::from_secs(420))
+    );
+  }
+
+  #[test]
+  fn background_refresh_decision_runs_incremental_when_interval_is_due() {
+    let settings = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 5,
+      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      background_refresh_decision(
+        &settings,
+        Some("2026-03-27T00:00:00Z"),
+        utc_time("2026-03-27T00:05:00Z")
+      ),
+      BackgroundRefreshDecision::Incremental
+    );
+  }
+
+  #[test]
+  fn background_refresh_decision_runs_full_when_daily_maintenance_is_due() {
+    let settings = SyncSettings {
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 5,
+      last_scan_completed_at: Some("2026-03-27T23:55:00Z".to_string()),
+      ..SyncSettings::default()
+    };
+
+    assert_eq!(
+      background_refresh_decision(
+        &settings,
+        Some("2026-03-27T00:00:00Z"),
+        utc_time("2026-03-28T00:00:00Z")
+      ),
+      BackgroundRefreshDecision::Full
     );
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1626,20 +1626,24 @@ fn show_main_window(app: &AppHandle) {
 }
 
 fn spawn_initial_scan(state: AppState) {
-  tauri::async_runtime::spawn(async move {
-    let _ = run_incremental_scan_if_idle(state, None);
-  });
+  std::thread::Builder::new()
+    .name("codex-pacer-initial-scan".to_string())
+    .spawn(move || {
+      let _ = run_incremental_scan_if_idle(state, None);
+    })
+    .expect("failed to spawn initial scan thread");
 }
 
 fn spawn_scheduler(state: AppState) {
-  tauri::async_runtime::spawn(async move {
-    loop {
+  std::thread::Builder::new()
+    .name("codex-pacer-scheduler".to_string())
+    .spawn(move || loop {
       let Ok(conn) = open_connection(&state.db_path) else {
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        std::thread::sleep(Duration::from_secs(60));
         continue;
       };
       let Ok(settings) = get_sync_settings(&conn) else {
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        std::thread::sleep(Duration::from_secs(60));
         continue;
       };
       let now = Utc::now();
@@ -1649,15 +1653,14 @@ fn spawn_scheduler(state: AppState) {
 
       match decision {
         BackgroundRefreshDecision::Disabled(delay) | BackgroundRefreshDecision::Wait(delay) => {
-          tokio::time::sleep(delay).await;
+          std::thread::sleep(delay);
         }
         BackgroundRefreshDecision::Full | BackgroundRefreshDecision::Incremental
           if state.scan_in_progress.load(Ordering::SeqCst) =>
         {
-          tokio::time::sleep(Duration::from_secs(
+          std::thread::sleep(Duration::from_secs(
             unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64,
-          ))
-          .await;
+          ));
         }
         BackgroundRefreshDecision::Full => {
           let _ = run_scan_if_idle(state.clone(), settings.codex_home.clone());
@@ -1666,8 +1669,8 @@ fn spawn_scheduler(state: AppState) {
           let _ = run_incremental_scan_if_idle(state.clone(), settings.codex_home.clone());
         }
       }
-    }
-  });
+    })
+    .expect("failed to spawn background scheduler thread");
 }
 
 fn background_refresh_decision(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{
-  atomic::{AtomicBool, AtomicU8, Ordering},
+  atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
   Arc, Mutex,
 };
 #[cfg(test)]
@@ -20,13 +20,16 @@ use std::sync::atomic::AtomicUsize;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, Local, Utc};
-use rusqlite::params;
+use rusqlite::{params, Connection};
 use database::{
   canonical_subscription_currency, get_last_full_scan_completed, get_subscription_profile, get_sync_settings, init_db,
   insert_live_rate_limit_snapshot, load_latest_rate_limits, open_connection,
   save_subscription_profile, save_sync_settings,
 };
-use importer::{commit_prepared_scan, prepare_scan, recalculate_all_session_values, ScanKind};
+use importer::{
+  commit_prepared_scan, prepare_scan_with_cached_snapshot_connection,
+  recalculate_all_session_values, ScanKind,
+};
 use models::{
   ConversationDetail, ConversationFilters, ConversationPage, DashboardSnapshot,
   LiveRateLimitSnapshot, MenuBarPopupQuotaSnapshot, MenuBarPopupSnapshot,
@@ -38,7 +41,7 @@ use pricing::{
   seed_pricing_catalog, OPENAI_API_PRICING_URL,
 };
 use queries::{
-  get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
+  get_conversation_detail, get_overview_with_connection, get_quota_trend, get_window_api_value, list_conversations,
 };
 use rate_limits::LiveRateLimitClient;
 use tauri::{
@@ -76,12 +79,34 @@ struct MenuBarPopupAnchor {
 }
 
 #[derive(Clone)]
+struct CachedMenuBarApiValue {
+  key: String,
+  usage_revision: u64,
+  title: String,
+}
+
+#[derive(Clone)]
+struct CachedOverview {
+  key: String,
+  usage_revision: u64,
+  quota_revision: u64,
+  settings_revision: u64,
+  value: OverviewResponse,
+}
+
+#[derive(Clone)]
 struct AppState {
   app_handle: Option<AppHandle>,
   db_path: PathBuf,
   refresh: AppRefreshHandle,
   usage_mutations: refresh::UsageMutationCoordinator,
   menu_bar_render_state: Arc<AtomicU8>,
+  menu_bar_usage_revision: Arc<AtomicU64>,
+  quota_revision: Arc<AtomicU64>,
+  settings_revision: Arc<AtomicU64>,
+  menu_bar_api_value_cache: Arc<Mutex<Option<CachedMenuBarApiValue>>>,
+  overview_cache: Arc<Mutex<Option<CachedOverview>>>,
+  overview_connection: Arc<Mutex<Connection>>,
   daily_value_tray: Option<TrayIcon>,
   live_rate_limits: refresh::LiveQuotaCache,
   menu_bar_popup_visible: Arc<AtomicBool>,
@@ -106,6 +131,7 @@ fn installed_refresh_handle(handle: refresh::RefreshCoordinatorHandle) -> AppRef
 #[derive(Clone)]
 struct AppTokenRefreshExecutor {
   db_path: PathBuf,
+  preparation_connection: Arc<Mutex<Option<Connection>>>,
 }
 
 impl refresh::TokenRefreshExecutor for AppTokenRefreshExecutor {
@@ -119,10 +145,15 @@ impl refresh::TokenRefreshExecutor for AppTokenRefreshExecutor {
       request.request.kind,
       started_at,
     )?;
-    let prepared_scan = prepare_scan(
+    let mut preparation_connection = self
+      .preparation_connection
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let prepared_scan = prepare_scan_with_cached_snapshot_connection(
       &self.db_path,
       request.request.codex_home,
       scan_kind,
+      &mut preparation_connection,
     )?;
     Ok(refresh::PreparedTokenRefresh::new(
       request.generation,
@@ -264,10 +295,17 @@ struct TauriRefreshEventSink {
 }
 
 impl refresh::RefreshEventSink for TauriRefreshEventSink {
-  fn publish_invalidation(&self, _: refresh::DisplayInvalidation) {
+  fn publish_invalidation(&self, value: refresh::DisplayInvalidation) {
     let Some(state) = self.app_handle.try_state::<AppState>() else {
       return;
     };
+    state
+      .menu_bar_usage_revision
+      .store(value.usage_revision, Ordering::Release);
+    state.quota_revision.store(value.quota_revision, Ordering::Release);
+    state
+      .settings_revision
+      .store(value.settings_revision, Ordering::Release);
     let popup_visible = state.menu_bar_popup_visible.load(Ordering::Acquire);
     refresh_daily_value_menu_bar(state.inner());
     if popup_visible {
@@ -379,6 +417,14 @@ fn refreshPricing(state: State<'_, AppState>) -> Result<Vec<PricingCatalogEntry>
     }
   };
   let catalog = refresh_pricing_catalog_for_state(state.inner(), official_entries.as_deref())?;
+  *state
+    .menu_bar_api_value_cache
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+  *state
+    .overview_cache
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
   refresh_daily_value_menu_bar(state.inner());
   Ok(catalog)
 }
@@ -436,8 +482,8 @@ fn getOverview(
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
   let live_rate_limits = maybe_live_rate_limits_for_bucket(state.inner(), bucket.as_deref(), live_window_offset)?;
-  get_overview(
-    &state.db_path,
+  cached_overview(
+    state.inner(),
     bucket,
     anchor,
     custom_start,
@@ -478,7 +524,7 @@ async fn getMenuBarPopupSnapshot(
     if force_refresh.unwrap_or(false) {
       refresh_popup_data(&state)?;
     }
-    build_passive_menu_bar_popup_snapshot(&state.db_path, &state.live_rate_limits)
+    build_passive_menu_bar_popup_snapshot(&state)
   })
   .await
   .map_err(|error| format!("Failed to join popup refresh: {error}"))?
@@ -518,30 +564,54 @@ async fn loadDashboard(
   custom_end: Option<String>,
   search: Option<String>,
   live_window_offset: Option<i64>,
+  include_conversations: Option<bool>,
 ) -> Result<DashboardSnapshot, String> {
   let state = state.inner().clone();
   tauri::async_runtime::spawn_blocking(move || {
     let normalized_bucket = bucket.clone().unwrap_or_else(|| "seven_day".to_string());
     let live_rate_limits =
       maybe_live_rate_limits_for_bucket(&state, Some(&normalized_bucket), live_window_offset)?;
-    let snapshot = load_dashboard_data(
-      &state.db_path,
+    let overview = cached_overview(
+      &state,
       Some(normalized_bucket.clone()),
       anchor.clone(),
       custom_start.clone(),
       custom_end.clone(),
-      search,
       live_rate_limits.clone(),
       live_window_offset,
     )?;
     let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
     let sync_settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
+    let subscription_profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+    drop(conn);
+    let conversation_page = if include_conversations.unwrap_or(false) {
+      list_conversations(
+        &state.db_path,
+        Some(ConversationFilters {
+          bucket: Some(normalized_bucket),
+          anchor,
+          custom_start,
+          custom_end,
+          search,
+          live_window_offset,
+          cursor: None,
+          limit: Some(50),
+        }),
+        live_rate_limits.clone(),
+      )?
+    } else {
+      ConversationPage {
+        items: Vec::new(),
+        next_cursor: None,
+        has_more: false,
+      }
+    };
 
     Ok(DashboardSnapshot {
-      overview: snapshot.overview,
-      conversation_page: snapshot.conversation_page,
+      overview,
+      conversation_page,
       sync_settings,
-      subscription_profile: snapshot.subscription_profile,
+      subscription_profile,
       live_rate_limits,
     })
   })
@@ -969,16 +1039,38 @@ fn current_menu_bar_title_parts(
   };
   let bucket = effective_menu_bar_api_bucket(&configured_bucket, live_rate_limits);
   let api_value_title = if settings.show_menu_bar_daily_api_value {
-    let api_value_usd = get_window_api_value(
-      &state.db_path,
-      bucket.clone(),
-      if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
-      None,
-      None,
-      live_rate_limits.cloned(),
-      None,
-    )?;
-    Some(format!("${:.1}", api_value_usd))
+    let cache_key = menu_bar_api_value_cache_key(&bucket, &anchor, live_rate_limits);
+    let usage_revision = state.menu_bar_usage_revision.load(Ordering::Acquire);
+    let cached_title = state
+      .menu_bar_api_value_cache
+      .lock()
+      .unwrap_or_else(std::sync::PoisonError::into_inner)
+      .as_ref()
+      .filter(|cached| cached.key == cache_key && cached.usage_revision == usage_revision)
+      .map(|cached| cached.title.clone());
+    if let Some(title) = cached_title {
+      Some(title)
+    } else {
+      let api_value_usd = get_window_api_value(
+        &state.db_path,
+        bucket.clone(),
+        if bucket_uses_anchor(&bucket) { Some(anchor) } else { None },
+        None,
+        None,
+        live_rate_limits.cloned(),
+        None,
+      )?;
+      let title = format!("${:.1}", api_value_usd);
+      *state
+        .menu_bar_api_value_cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(CachedMenuBarApiValue {
+        key: cache_key,
+        usage_revision,
+        title: title.clone(),
+      });
+      Some(title)
+    }
   } else {
     None
   };
@@ -994,6 +1086,25 @@ fn current_menu_bar_title_parts(
     None
   };
   Ok((api_value_title, live_metric_title))
+}
+
+fn menu_bar_api_value_cache_key(
+  bucket: &str,
+  anchor: &str,
+  live_rate_limits: Option<&LiveRateLimitSnapshot>,
+) -> String {
+  let live_window = match bucket {
+    "five_hour" => live_rate_limits.and_then(|snapshot| snapshot.primary.as_ref()),
+    "seven_day" => live_rate_limits.and_then(|snapshot| snapshot.secondary.as_ref()),
+    _ => None,
+  };
+  format!(
+    "{}|{}|{}|{}",
+    bucket,
+    if bucket_uses_anchor(bucket) { anchor } else { "" },
+    live_window.and_then(|window| window.window_start.as_deref()).unwrap_or(""),
+    live_window.and_then(|window| window.resets_at.as_deref()).unwrap_or("")
+  )
 }
 
 fn menu_bar_title(api_value_title: Option<&str>, live_metric_title: Option<&str>) -> Option<String> {
@@ -1548,21 +1659,75 @@ fn live_snapshot_is_newer(
   }
 }
 
-fn build_passive_menu_bar_popup_snapshot(
-  db_path: &Path,
-  live_cache: &refresh::LiveQuotaCache,
-) -> Result<MenuBarPopupSnapshot, String> {
-  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+fn cached_overview(
+  state: &AppState,
+  bucket: Option<String>,
+  anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
+  live_rate_limits: Option<LiveRateLimitSnapshot>,
+  live_window_offset: Option<i64>,
+) -> Result<OverviewResponse, String> {
+  let key = serde_json::to_string(&(
+    &bucket,
+    &anchor,
+    &custom_start,
+    &custom_end,
+    &live_rate_limits,
+    live_window_offset,
+  ))
+  .map_err(|error| error.to_string())?;
+  let usage_revision = state.menu_bar_usage_revision.load(Ordering::Acquire);
+  let quota_revision = state.quota_revision.load(Ordering::Acquire);
+  let settings_revision = state.settings_revision.load(Ordering::Acquire);
+  let mut cache = state
+    .overview_cache
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner);
+  if let Some(cached) = cache.as_ref().filter(|cached| {
+    cached.key == key
+      && cached.usage_revision == usage_revision
+      && cached.quota_revision == quota_revision
+      && cached.settings_revision == settings_revision
+  }) {
+    return Ok(cached.value.clone());
+  }
+
+  let connection = state
+    .overview_connection
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner);
+  let value = get_overview_with_connection(
+    &connection,
+    bucket,
+    anchor,
+    custom_start,
+    custom_end,
+    live_rate_limits,
+    live_window_offset,
+  )?;
+  *cache = Some(CachedOverview {
+    key,
+    usage_revision,
+    quota_revision,
+    settings_revision,
+    value: value.clone(),
+  });
+  Ok(value)
+}
+
+fn build_passive_menu_bar_popup_snapshot(state: &AppState) -> Result<MenuBarPopupSnapshot, String> {
+  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
   let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
   drop(conn);
-  let live_rate_limits = live_cache
+  let live_rate_limits = state.live_rate_limits
     .rate_limits()
     .map(|snapshot| normalize_live_rate_limit_snapshot(snapshot.as_ref().clone()));
   let configured_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let selected_bucket = effective_menu_bar_api_bucket(&configured_bucket, live_rate_limits.as_ref());
   let anchor = bucket_uses_anchor(&selected_bucket).then(|| Local::now().format("%Y-%m-%d").to_string());
-  let overview = get_overview(
-    db_path,
+  let overview = cached_overview(
+    state,
     Some(selected_bucket.clone()),
     anchor,
     None,
@@ -1581,7 +1746,7 @@ fn build_passive_menu_bar_popup_snapshot(
       .map(|value| value.quota_trend.clone())
       .unwrap_or_default()
   } else {
-    get_quota_trend(db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
+    get_quota_trend(&state.db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
   };
 
   Ok(MenuBarPopupSnapshot {
@@ -2224,7 +2389,10 @@ pub fn run() {
         .map(|snapshot| snapshot.fetched_at);
       let epoch_backfill_is_pending =
         database::epoch_backfill_pending(&conn).map_err(|error| error.to_string())?;
-      drop(conn);
+      conn
+        .pragma_update(None, "cache_size", -32_768)
+        .map_err(|error| error.to_string())?;
+      let overview_connection = Arc::new(Mutex::new(conn));
 
       let live_rate_limits = refresh::LiveQuotaCache::new();
       if let Some(fallback) = display_fallback {
@@ -2241,6 +2409,7 @@ pub fn run() {
           refresh_config_from_saved_settings(&settings, live_last_success_at.as_deref()),
           Arc::new(AppTokenRefreshExecutor {
             db_path: db_path.clone(),
+            preparation_connection: Arc::new(Mutex::new(None)),
           }),
           Arc::new(AppLiveQuotaFetcher {
             db_path: db_path.clone(),
@@ -2280,6 +2449,12 @@ pub fn run() {
         refresh: installed_refresh_handle(refresh),
         usage_mutations,
         menu_bar_render_state: Arc::new(AtomicU8::new(MENU_RENDER_IDLE)),
+        menu_bar_usage_revision: Arc::new(AtomicU64::new(0)),
+        quota_revision: Arc::new(AtomicU64::new(0)),
+        settings_revision: Arc::new(AtomicU64::new(0)),
+        menu_bar_api_value_cache: Arc::new(Mutex::new(None)),
+        overview_cache: Arc::new(Mutex::new(None)),
+        overview_connection,
         daily_value_tray,
         live_rate_limits,
         menu_bar_popup_visible: Arc::new(AtomicBool::new(false)),
@@ -2735,12 +2910,22 @@ mod tests {
     usage_mutations: refresh::UsageMutationCoordinator,
     live_rate_limits: refresh::LiveQuotaCache,
   ) -> AppState {
+    let overview_connection = open_connection(&db_path).expect("open overview connection");
+    overview_connection
+      .pragma_update(None, "cache_size", -32_768)
+      .expect("configure overview cache");
     AppState {
       app_handle: None,
       db_path,
       refresh: Some(refresh),
       usage_mutations,
       menu_bar_render_state: Arc::new(AtomicU8::new(MENU_RENDER_IDLE)),
+      menu_bar_usage_revision: Arc::new(AtomicU64::new(0)),
+      quota_revision: Arc::new(AtomicU64::new(0)),
+      settings_revision: Arc::new(AtomicU64::new(0)),
+      menu_bar_api_value_cache: Arc::new(Mutex::new(None)),
+      overview_cache: Arc::new(Mutex::new(None)),
+      overview_connection: Arc::new(Mutex::new(overview_connection)),
       daily_value_tray: None,
       live_rate_limits,
       menu_bar_popup_visible: Arc::new(AtomicBool::new(false)),
@@ -2877,8 +3062,14 @@ mod tests {
     let db_path = directory.path().join("usage.sqlite");
     prepare_app_database(&db_path).expect("prepare app database");
     let cache = refresh::LiveQuotaCache::new();
+    let state = test_app_state(
+      db_path.clone(),
+      runtime.handle(),
+      refresh::UsageMutationCoordinator::new(),
+      cache,
+    );
 
-    let snapshot = build_passive_menu_bar_popup_snapshot(&db_path, &cache)
+    let snapshot = build_passive_menu_bar_popup_snapshot(&state)
       .expect("build passive popup snapshot");
 
     assert_eq!(snapshot.total_tokens_selected_bucket, 0);
@@ -2898,6 +3089,7 @@ mod tests {
 
   #[test]
   fn popup_snapshot_uses_seven_day_bucket_when_five_hour_quota_is_absent() {
+    let (runtime, _, _) = start_recording_runtime(disabled_refresh_config(None));
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");
     prepare_app_database(&db_path).expect("prepare app database");
@@ -2926,8 +3118,14 @@ mod tests {
       Instant::now(),
       Utc::now(),
     );
+    let state = test_app_state(
+      db_path,
+      runtime.handle(),
+      refresh::UsageMutationCoordinator::new(),
+      cache,
+    );
 
-    let snapshot = build_passive_menu_bar_popup_snapshot(&db_path, &cache)
+    let snapshot = build_passive_menu_bar_popup_snapshot(&state)
       .expect("build popup snapshot");
 
     assert_eq!(snapshot.selected_bucket, "seven_day");
@@ -2936,6 +3134,7 @@ mod tests {
       snapshot.quota_7d.map(|window| window.remaining_percent),
       Some(79)
     );
+    runtime.shutdown_and_join().expect("shutdown runtime");
   }
 
   #[test]
@@ -3021,6 +3220,7 @@ mod tests {
     let token_executor = RecordingAppTokenExecutor {
       inner: AppTokenRefreshExecutor {
         db_path: db_path.clone(),
+        preparation_connection: Arc::new(Mutex::new(None)),
       },
       parsed: parsed_tx,
       committed: committed_tx,
@@ -3055,7 +3255,7 @@ mod tests {
     assert!(parsed_generation > 0);
     assert_eq!(parsed_generation, committed_generation);
     assert_eq!(source_generation, handle.status().source_generation);
-    assert_eq!(kind, refresh::TokenScanKind::Incremental);
+    assert_eq!(kind, refresh::TokenScanKind::Full);
     assert_eq!(result.codex_home, codex_home.to_string_lossy());
     assert_eq!(live_calls.load(AtomicOrdering::Acquire), 0);
     runtime.shutdown_and_join().expect("shutdown runtime");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -161,7 +161,7 @@ fn getMenuBarPopupSnapshot(
   state: State<'_, AppState>,
   force_refresh: Option<bool>,
 ) -> Result<MenuBarPopupSnapshot, String> {
-  build_menu_bar_popup_snapshot(state.inner(), force_refresh.unwrap_or(false))
+  build_due_menu_bar_popup_snapshot(state.inner(), force_refresh.unwrap_or(false), Utc::now())
 }
 
 #[allow(non_snake_case)]
@@ -264,7 +264,7 @@ fn handleMenuBarPopupAction(
       Ok(true)
     }
     "refresh" => {
-      let _ = build_menu_bar_popup_snapshot(state.inner(), true)?;
+      let _ = build_due_menu_bar_popup_snapshot(state.inner(), true, Utc::now())?;
       refresh_daily_value_menu_bar(state.inner());
       Ok(true)
     }
@@ -1125,6 +1125,17 @@ fn build_menu_bar_popup_snapshot(
   })
 }
 
+fn build_due_menu_bar_popup_snapshot(
+  state: &AppState,
+  force_refresh: bool,
+  now: chrono::DateTime<chrono::Utc>,
+) -> Result<MenuBarPopupSnapshot, String> {
+  if let Err(error) = run_due_background_refresh(state.clone(), now) {
+    log::warn!("Failed to run due background refresh before menu bar snapshot: {error}");
+  }
+  build_menu_bar_popup_snapshot(state, force_refresh)
+}
+
 fn menu_bar_popup_quota_snapshot(window: &RateLimitWindowSnapshot) -> MenuBarPopupQuotaSnapshot {
   MenuBarPopupQuotaSnapshot {
     used_percent: window.used_percent,
@@ -1973,6 +1984,79 @@ mod tests {
         utc_time("2026-03-28T00:00:00Z")
       ),
       BackgroundRefreshDecision::Full
+    );
+  }
+
+  #[test]
+  fn menu_bar_popup_snapshot_runs_due_background_refresh() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let codex_home = directory.path().join("codex-home");
+    let sessions_dir = codex_home
+      .join("sessions")
+      .join(Local::now().format("%Y").to_string())
+      .join(Local::now().format("%m").to_string())
+      .join(Local::now().format("%d").to_string());
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let session_id = "abcdefab-1234-5678-90ab-abcdefabcdef";
+    std::fs::write(
+      sessions_dir.join("new.jsonl"),
+      format!(
+        concat!(
+          "{{\"timestamp\":\"2026-03-27T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\"}}}}\n",
+          "{{\"timestamp\":\"2026-03-27T00:00:00Z\",\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n",
+          "{{\"timestamp\":\"2026-03-27T00:00:01Z\",\"type\":\"event_msg\",\"payload\":{{",
+          "\"type\":\"token_count\",",
+          "\"info\":{{\"total_token_usage\":{{",
+          "\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":25,",
+          "\"reasoning_output_tokens\":0,\"total_tokens\":125",
+          "}}}},",
+          "\"rate_limits\":{{\"plan_type\":\"pro\"}}",
+          "}}}}\n"
+        ),
+        session_id
+      ),
+    )
+    .expect("write session");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let settings = SyncSettings {
+      codex_home: Some(codex_home.to_string_lossy().to_string()),
+      auto_scan_enabled: true,
+      auto_scan_interval_minutes: 1,
+      last_scan_completed_at: Some("2026-03-27T00:00:00Z".to_string()),
+      ..get_sync_settings(&conn).expect("load settings")
+    };
+    save_sync_settings(&conn, &settings).expect("save settings");
+    database::set_last_full_scan_completed(&conn, "2026-03-27T00:00:30Z").expect("set full scan");
+    drop(conn);
+    let state = AppState {
+      db_path: db_path.clone(),
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+
+    let snapshot = build_due_menu_bar_popup_snapshot(
+      &state,
+      false,
+      utc_time("2026-03-27T00:01:00Z"),
+    )
+    .expect("load snapshot");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let event_count: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM usage_events WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+      )
+      .expect("count events");
+    assert_eq!(event_count, 1);
+    assert_ne!(
+      snapshot.last_scan_completed_at.as_deref(),
+      Some("2026-03-27T00:00:00Z")
     );
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,7 +33,10 @@ use models::{
   MenuBarPopupSuggestedSpeed, OverviewResponse, PricingCatalogEntry, RateLimitWindowSnapshot,
   ScanResult, SubscriptionProfile, SyncSettings,
 };
-use pricing::{load_catalog, refresh_pricing_catalog_from_openai, seed_pricing_catalog};
+use pricing::{
+  apply_pricing_catalog_refresh, fetch_official_pricing_catalog, load_catalog,
+  seed_pricing_catalog, OPENAI_API_PRICING_URL,
+};
 use queries::{
   get_conversation_detail, get_overview, get_quota_trend, get_window_api_value, list_conversations, load_dashboard_data,
 };
@@ -63,6 +66,7 @@ const TRAY_ICON_MAX_LOGICAL_HEIGHT: f64 = 40.0;
 const FULL_SCAN_MAINTENANCE_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 const SCHEDULER_MAX_SLEEP_SECONDS: u64 = 5;
 const FOREGROUND_LIVE_RATE_LIMIT_QUERY_TIMEOUT_SECONDS: u64 = 5;
+const PRICING_VALUE_RESOLUTION_REPAIR_KEY: &str = "pricing_value_resolution_v2";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackgroundRefreshDecision {
@@ -172,11 +176,34 @@ fn refreshBackgroundData(state: State<'_, AppState>) -> Result<Option<ScanResult
 #[allow(non_snake_case)]
 #[tauri::command]
 fn refreshPricing(state: State<'_, AppState>) -> Result<Vec<PricingCatalogEntry>, String> {
-  let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
-  refresh_pricing_catalog_from_openai(&conn)?;
-  recalculate_all_session_values(&conn).map_err(|error| error.to_string())?;
-  let catalog = load_catalog(&conn).map_err(|error| error.to_string())?;
+  let official_entries = match fetch_official_pricing_catalog() {
+    Ok(entries) => Some(entries),
+    Err(error) => {
+      log::warn!(
+        "Failed to refresh OpenAI API pricing from {OPENAI_API_PRICING_URL}: {error}; using bundled fallback pricing."
+      );
+      None
+    }
+  };
+  let mut conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
+  let catalog = refresh_pricing_catalog_atomically(&mut conn, official_entries.as_deref())?;
   refresh_daily_value_menu_bar(state.inner());
+  Ok(catalog)
+}
+
+fn refresh_pricing_catalog_atomically(
+  conn: &mut rusqlite::Connection,
+  official_entries: Option<&[PricingCatalogEntry]>,
+) -> Result<Vec<PricingCatalogEntry>, String> {
+  let transaction = conn
+    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+    .map_err(|error| error.to_string())?;
+  apply_pricing_catalog_refresh(&transaction, official_entries)?;
+  recalculate_all_session_values(&transaction).map_err(|error| error.to_string())?;
+  mark_pricing_value_resolution_repair_complete(&transaction)
+    .map_err(|error| error.to_string())?;
+  let catalog = load_catalog(&transaction).map_err(|error| error.to_string())?;
+  transaction.commit().map_err(|error| error.to_string())?;
   Ok(catalog)
 }
 
@@ -494,15 +521,40 @@ fn prepare_app_database(db_path: &Path) -> Result<(), String> {
   let transaction = conn
     .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
     .map_err(|error| error.to_string())?;
+  let resolver_repair_pending =
+    pricing_value_resolution_repair_pending(&transaction).map_err(|error| error.to_string())?;
   let pricing_signature_before =
     load_pricing_value_signature(&transaction).map_err(|error| error.to_string())?;
   seed_pricing_catalog(&transaction).map_err(|error| error.to_string())?;
   let pricing_signature_after =
     load_pricing_value_signature(&transaction).map_err(|error| error.to_string())?;
-  if pricing_signature_before != pricing_signature_after {
+  if resolver_repair_pending || pricing_signature_before != pricing_signature_after {
     recalculate_all_session_values(&transaction).map_err(|error| error.to_string())?;
+    mark_pricing_value_resolution_repair_complete(&transaction)
+      .map_err(|error| error.to_string())?;
   }
   transaction.commit().map_err(|error| error.to_string())?;
+  Ok(())
+}
+
+fn pricing_value_resolution_repair_pending(conn: &rusqlite::Connection) -> rusqlite::Result<bool> {
+  let completed: i64 = conn.query_row(
+    "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+    params![PRICING_VALUE_RESOLUTION_REPAIR_KEY],
+    |row| row.get(0),
+  )?;
+  Ok(completed == 0)
+}
+
+fn mark_pricing_value_resolution_repair_complete(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
+  conn.execute(
+    "
+    INSERT INTO data_repairs (repair_key, completed_at)
+    VALUES (?1, ?2)
+    ON CONFLICT(repair_key) DO UPDATE SET completed_at = excluded.completed_at
+    ",
+    params![PRICING_VALUE_RESOLUTION_REPAIR_KEY, database::now_utc_string()],
+  )?;
   Ok(())
 }
 
@@ -2450,6 +2502,7 @@ mod tests {
     let conn = open_connection(&db_path).expect("open database");
     init_db(&conn).expect("init db");
     seed_pricing_catalog(&conn).expect("seed pricing");
+    mark_pricing_value_resolution_repair_complete(&conn).expect("mark resolver repair complete");
     let created_at = database::now_utc_string();
     conn
       .execute(
@@ -2493,6 +2546,77 @@ mod tests {
       .expect("load usage value");
 
     assert_eq!(value_usd, 123.45);
+  }
+
+  #[test]
+  fn startup_database_prepare_recalculates_gpt_56_aliases_when_resolver_repair_is_pending() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    seed_pricing_catalog(&conn).expect("seed pricing");
+    let created_at = database::now_utc_string();
+    for (session_id, model_id, stale_value) in [
+      ("gpt-56-alias-exact", "gpt-5.6", 6.25),
+      ("gpt-56-alias-dated", "gpt-5.6-2026-07-09", 0.0),
+    ] {
+      conn
+        .execute(
+          "
+          INSERT INTO sessions (
+            session_id, root_session_id, parent_session_id, title, source_state, source_path,
+            source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+            fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+          )
+          VALUES (?1, ?1, NULL, NULL, 'active', NULL, 'active',
+            NULL, NULL, NULL, NULL, NULL, 0, NULL, ?2, 0, ?3, ?3)
+          ",
+          params![session_id, model_id, created_at],
+        )
+        .expect("insert session");
+      conn
+        .execute(
+          "
+          INSERT INTO usage_events (
+            session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+            output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+            fast_mode_auto, fast_mode_effective
+          )
+          VALUES (?1, '2026-07-09T00:00:00Z', ?2,
+            0, 0, 1000000, 0, 1000000, ?3, 0, 0)
+          ",
+          params![session_id, model_id, stale_value],
+        )
+        .expect("insert usage event");
+    }
+    drop(conn);
+
+    prepare_app_database(&db_path).expect("prepare app database");
+
+    let conn = open_connection(&db_path).expect("reopen database");
+    let values = conn
+      .prepare("SELECT session_id, value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare usage values")
+      .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?)))
+      .expect("query usage values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect usage values");
+    let repair_completed: i64 = conn
+      .query_row(
+        "SELECT COUNT(*) FROM data_repairs WHERE repair_key = ?1",
+        params![PRICING_VALUE_RESOLUTION_REPAIR_KEY],
+        |row| row.get(0),
+      )
+      .expect("load repair marker");
+
+    assert_eq!(
+      values,
+      vec![
+        ("gpt-56-alias-dated".to_string(), 30.0),
+        ("gpt-56-alias-exact".to_string(), 30.0),
+      ]
+    );
+    assert_eq!(repair_completed, 1);
   }
 
   #[test]
@@ -2714,6 +2838,7 @@ mod tests {
       failed_values,
       vec![("recalc-a".to_string(), 11.0), ("recalc-b".to_string(), 22.0)]
     );
+    assert!(pricing_value_resolution_repair_pending(&conn).expect("load rolled back repair marker"));
 
     conn
       .execute_batch("DROP TRIGGER fail_second_session_recalculation;")
@@ -2740,6 +2865,117 @@ mod tests {
 
     assert_eq!(repaired_output, 30.0);
     assert_eq!(repaired_values, vec![30.0, 30.0]);
+    assert!(!pricing_value_resolution_repair_pending(&conn).expect("load completed repair marker"));
+  }
+
+  #[test]
+  fn pricing_refresh_rolls_back_catalog_values_and_marker_before_retry() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let mut conn = open_connection(&db_path).expect("open database");
+    let created_at = database::now_utc_string();
+    for (session_id, sentinel_value) in [("refresh-a", 11.0), ("refresh-b", 22.0)] {
+      conn
+        .execute(
+          "
+          INSERT INTO sessions (
+            session_id, root_session_id, parent_session_id, title, source_state, source_path,
+            source_bucket, started_at, updated_at, agent_nickname, agent_role, explicit_fast_mode,
+            fast_mode_default, latest_plan_type, last_model_id, contains_subagents, created_at, imported_at
+          )
+          VALUES (?1, ?1, NULL, NULL, 'active', NULL, 'active',
+            NULL, NULL, NULL, NULL, NULL, 0, NULL, 'gpt-5.6-sol', 0, ?2, ?2)
+          ",
+          params![session_id, created_at],
+        )
+        .expect("insert session");
+      conn
+        .execute(
+          "
+          INSERT INTO usage_events (
+            session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+            output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+            fast_mode_auto, fast_mode_effective
+          )
+          VALUES (?1, '2026-07-09T00:00:00Z', 'gpt-5.6-sol',
+            0, 0, 1000000, 0, 1000000, ?2, 0, 0)
+          ",
+          params![session_id, sentinel_value],
+        )
+        .expect("insert usage event");
+    }
+    conn
+      .execute(
+        "DELETE FROM data_repairs WHERE repair_key = ?1",
+        params![PRICING_VALUE_RESOLUTION_REPAIR_KEY],
+      )
+      .expect("clear repair marker");
+    conn
+      .execute_batch(
+        "
+        CREATE TRIGGER fail_second_refresh_recalculation
+        BEFORE UPDATE OF value_usd ON usage_events
+        WHEN OLD.session_id = 'refresh-b'
+        BEGIN
+          SELECT RAISE(ABORT, 'injected refresh failure');
+        END;
+        ",
+      )
+      .expect("create failure trigger");
+    let mut official_sol = load_catalog(&conn)
+      .expect("load catalog")
+      .into_iter()
+      .find(|entry| entry.model_id == "gpt-5.6-sol")
+      .expect("load GPT-5.6 Sol");
+    official_sol.output_price_per_million = 42.0;
+    official_sol.is_official = true;
+    official_sol.note = Some("atomic refresh test".to_string());
+    official_sol.updated_at = "atomic-refresh-test".to_string();
+    let official_entries = vec![official_sol];
+
+    let error = refresh_pricing_catalog_atomically(&mut conn, Some(&official_entries))
+      .expect_err("refresh should fail");
+    assert!(error.contains("injected refresh failure"));
+
+    let failed_output: f64 = conn
+      .query_row(
+        "SELECT output_price_per_million FROM pricing_catalog WHERE model_id = 'gpt-5.6-sol'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load rolled back pricing");
+    let failed_values = conn
+      .prepare("SELECT value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare failed values")
+      .query_map([], |row| row.get::<_, f64>(0))
+      .expect("query failed values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect failed values");
+    assert_eq!(failed_output, 30.0);
+    assert_eq!(failed_values, vec![11.0, 22.0]);
+    assert!(pricing_value_resolution_repair_pending(&conn).expect("load repair marker"));
+
+    conn
+      .execute_batch("DROP TRIGGER fail_second_refresh_recalculation;")
+      .expect("drop failure trigger");
+    let catalog = refresh_pricing_catalog_atomically(&mut conn, Some(&official_entries))
+      .expect("retry refresh");
+    let refreshed_sol = catalog
+      .iter()
+      .find(|entry| entry.model_id == "gpt-5.6-sol")
+      .expect("load refreshed GPT-5.6 Sol");
+    let refreshed_values = conn
+      .prepare("SELECT value_usd FROM usage_events ORDER BY session_id")
+      .expect("prepare refreshed values")
+      .query_map([], |row| row.get::<_, f64>(0))
+      .expect("query refreshed values")
+      .collect::<rusqlite::Result<Vec<_>>>()
+      .expect("collect refreshed values");
+
+    assert_eq!(refreshed_sol.output_price_per_million, 42.0);
+    assert_eq!(refreshed_values, vec![42.0, 42.0]);
+    assert!(!pricing_value_resolution_repair_pending(&conn).expect("load repair marker"));
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3630,6 +3630,43 @@ mod tests {
     assert!(!pricing_value_resolution_repair_pending(&conn).expect("load repair marker"));
   }
 
+  fn test_live_quota_snapshot(fetched_at: &str, remaining_percent: i64) -> LiveRateLimitSnapshot {
+    LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: Some(RateLimitWindowSnapshot {
+        used_percent: 100 - remaining_percent,
+        remaining_percent,
+        window_duration_mins: Some(300),
+        resets_at: Some("2026-07-12T05:00:00+08:00".to_string()),
+        window_start: Some("2026-07-12T00:00:00+08:00".to_string()),
+      }),
+      secondary: None,
+      fetched_at: fetched_at.to_string(),
+    }
+  }
+
+  fn test_session_quota_sample(
+    session_id: &str,
+    sample_timestamp: &str,
+    remaining_percent: i64,
+  ) -> crate::models::RateLimitSampleRecord {
+    crate::models::RateLimitSampleRecord {
+      source_kind: "session".to_string(),
+      source_session_id: Some(session_id.to_string()),
+      bucket: "five_hour".to_string(),
+      sample_timestamp: sample_timestamp.to_string(),
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      window_start: "2026-07-12T00:00:00+08:00".to_string(),
+      resets_at: "2026-07-12T05:00:00+08:00".to_string(),
+      used_percent: 100 - remaining_percent,
+      remaining_percent,
+    }
+  }
+
   #[test]
   fn background_live_rate_limit_fallback_prefers_newest_persisted_sample() {
     let directory = tempdir().expect("tempdir");
@@ -3709,6 +3746,102 @@ mod tests {
       memory.primary.as_ref().map(|window| window.remaining_percent),
       Some(77)
     );
+  }
+
+  #[test]
+  fn background_live_fallback_keeps_current_live_over_newer_session() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    database::replace_session_rate_limit_samples(
+      &conn,
+      "session-late",
+      &[test_session_quota_sample(
+        "session-late",
+        "2026-07-12T00:10:00+08:00",
+        20,
+      )],
+    )
+    .expect("insert newer session sample");
+    drop(conn);
+
+    let live_cache = refresh::LiveQuotaCache::new();
+    live_cache.publish_live(
+      Arc::new(test_live_quota_snapshot(
+        "2026-07-12T00:05:00+08:00",
+        88,
+      )),
+      Instant::now(),
+      Utc::now(),
+    );
+
+    let snapshot = load_display_live_rate_limit_fallback(&db_path, &live_cache)
+      .expect("load fallback");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-12T00:05:00+08:00");
+    assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(88));
+  }
+
+  #[test]
+  fn background_live_fallback_prefers_persisted_live_over_newer_session() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &test_live_quota_snapshot("2026-07-12T00:05:00+08:00", 88),
+    )
+    .expect("insert persisted live sample");
+    database::replace_session_rate_limit_samples(
+      &conn,
+      "session-late",
+      &[test_session_quota_sample(
+        "session-late",
+        "2026-07-12T00:10:00+08:00",
+        20,
+      )],
+    )
+    .expect("insert newer session sample");
+    drop(conn);
+
+    let snapshot = load_display_live_rate_limit_fallback(
+      &db_path,
+      &refresh::LiveQuotaCache::new(),
+    )
+    .expect("load fallback");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-12T00:05:00+08:00");
+    assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(88));
+  }
+
+  #[test]
+  fn background_live_fallback_uses_session_when_no_live_data_exists() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    database::replace_session_rate_limit_samples(
+      &conn,
+      "session-only",
+      &[test_session_quota_sample(
+        "session-only",
+        "2026-07-12T00:10:00+08:00",
+        20,
+      )],
+    )
+    .expect("insert session sample");
+    drop(conn);
+
+    let snapshot = load_display_live_rate_limit_fallback(
+      &db_path,
+      &refresh::LiveQuotaCache::new(),
+    )
+    .expect("load history fallback");
+
+    assert_eq!(snapshot.fetched_at, "2026-07-12T00:10:00+08:00");
+    assert_eq!(snapshot.primary.map(|window| window.remaining_percent), Some(20));
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -956,15 +956,16 @@ fn current_menu_bar_title_parts(
   settings: &SyncSettings,
   cached_live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<(Option<String>, Option<String>), String> {
-  let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  let configured_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
   let anchor = Local::now().format("%Y-%m-%d").to_string();
   let live_rate_limits = if settings.show_menu_bar_live_quota_percent
-    || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&bucket))
+    || (settings.show_menu_bar_daily_api_value && bucket_uses_live_rate_limits(&configured_bucket))
   {
     cached_live_rate_limits
   } else {
     None
   };
+  let bucket = effective_menu_bar_api_bucket(&configured_bucket, live_rate_limits);
   let api_value_title = if settings.show_menu_bar_daily_api_value {
     let api_value_usd = get_window_api_value(
       &state.db_path,
@@ -1017,6 +1018,19 @@ fn normalize_menu_bar_bucket(bucket: &str) -> String {
   }
 }
 
+fn effective_menu_bar_api_bucket(
+  configured_bucket: &str,
+  live_rate_limits: Option<&LiveRateLimitSnapshot>,
+) -> String {
+  if configured_bucket == "five_hour"
+    && live_rate_limits.is_some_and(|snapshot| snapshot.primary.is_none() && snapshot.secondary.is_some())
+  {
+    "seven_day".to_string()
+  } else {
+    configured_bucket.to_string()
+  }
+}
+
 fn normalize_menu_bar_live_quota_bucket(bucket: &str) -> String {
   match bucket {
     "five_hour" | "seven_day" => bucket.to_string(),
@@ -1065,7 +1079,8 @@ fn menu_bar_tooltip(
   api_value_title: Option<&str>,
   cached_live_rate_limits: Option<&LiveRateLimitSnapshot>,
 ) -> Result<String, String> {
-  let bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  let configured_bucket = normalize_menu_bar_bucket(&settings.menu_bar_bucket);
+  let bucket = effective_menu_bar_api_bucket(&configured_bucket, cached_live_rate_limits);
   let mut fragments = Vec::new();
   if let Some(title) = api_value_title.filter(|value| !value.trim().is_empty()) {
     fragments.push(format!("{}累计 API 价值：{title}", menu_bar_bucket_label(&bucket)));
@@ -4067,6 +4082,52 @@ mod tests {
     assert_eq!(
       menu_bar_title(Some("$12.4"), Some("67%")),
       Some("$12.4 67%".to_string())
+    );
+  }
+
+  #[test]
+  fn menu_bar_api_value_falls_back_to_seven_days_when_five_hour_quota_is_absent() {
+    let snapshot = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: Some(RateLimitWindowSnapshot {
+        used_percent: 21,
+        remaining_percent: 79,
+        window_duration_mins: Some(10_080),
+        resets_at: Some("2026-04-02T00:00:00+08:00".to_string()),
+        window_start: Some("2026-03-26T00:00:00+08:00".to_string()),
+      }),
+      fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
+    };
+
+    assert_eq!(
+      effective_menu_bar_api_bucket("five_hour", Some(&snapshot)),
+      "seven_day"
+    );
+  }
+
+  #[test]
+  fn menu_bar_api_value_keeps_five_hours_when_that_quota_exists() {
+    let snapshot = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: Some(RateLimitWindowSnapshot {
+        used_percent: 12,
+        remaining_percent: 88,
+        window_duration_mins: Some(300),
+        resets_at: Some("2026-03-27T05:00:00+08:00".to_string()),
+        window_start: Some("2026-03-27T00:00:00+08:00".to_string()),
+      }),
+      secondary: None,
+      fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
+    };
+
+    assert_eq!(
+      effective_menu_bar_api_bucket("five_hour", Some(&snapshot)),
+      "five_hour"
     );
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1300,13 +1300,10 @@ fn get_live_rate_limits_history_fallback(state: &AppState) -> Option<LiveRateLim
 }
 
 fn refresh_rate_limit_history_if_idle(state: &AppState) {
-  let Ok(guard) = try_acquire_flag(&state.scan_in_progress, "A scan is already running.") else {
-    return;
-  };
-
-  let result = perform_incremental_scan(&state.db_path, None);
-  drop(guard);
-  if let Err(error) = result {
+  if let Err(error) = run_background_incremental_scan_if_idle(state.clone(), None) {
+    if error == "A scan is already running." {
+      return;
+    }
     log::warn!("Failed to refresh Codex history rate-limit samples: {error}");
   }
 }
@@ -3109,6 +3106,54 @@ mod tests {
       )
       .expect("load final value");
     assert_eq!(value_usd, 42.0);
+  }
+
+  #[test]
+  fn history_fallback_scan_waits_for_usage_mutation_lock() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let codex_home = directory.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("create Codex home");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let settings = SyncSettings {
+      codex_home: Some(codex_home.to_string_lossy().to_string()),
+      ..get_sync_settings(&conn).expect("load settings")
+    };
+    save_sync_settings(&conn, &settings).expect("save settings");
+    drop(conn);
+
+    let state = AppState {
+      app_handle: None,
+      db_path,
+      scan_in_progress: Arc::new(AtomicBool::new(false)),
+      usage_mutation_lock: Arc::new(Mutex::new(())),
+      live_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      menu_bar_refresh_in_progress: Arc::new(AtomicBool::new(false)),
+      daily_value_tray: None,
+      live_rate_limits: Arc::new(Mutex::new(None)),
+      menu_bar_popup_anchor: Arc::new(Mutex::new(None)),
+    };
+    let mutation_guard = lock_usage_mutations(&state);
+    let (completed_sender, completed_receiver) = std::sync::mpsc::channel();
+    let scan_state = state.clone();
+    let scan_thread = std::thread::spawn(move || {
+      refresh_rate_limit_history_if_idle(&scan_state);
+      completed_sender.send(()).expect("report completion");
+    });
+
+    let completed_while_locked = completed_receiver
+      .recv_timeout(Duration::from_millis(100))
+      .is_ok();
+    drop(mutation_guard);
+    if !completed_while_locked {
+      completed_receiver
+        .recv_timeout(Duration::from_secs(2))
+        .expect("history scan should complete after unlock");
+    }
+    scan_thread.join().expect("join history scan");
+
+    assert!(!completed_while_locked, "history scan bypassed the shared usage mutation lock");
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1032,7 +1032,7 @@ fn get_live_rate_limits_with_fallback(
     }
   }
 
-  match query_live_rate_limits() {
+  match query_live_rate_limits(live_rate_limit_query_timeout_for_interval(ttl)) {
     Ok(snapshot) => {
       let conn = open_connection(&state.db_path).map_err(|error| error.to_string())?;
       insert_live_rate_limit_snapshot(&conn, &snapshot).map_err(|error| error.to_string())?;
@@ -1384,6 +1384,12 @@ fn live_rate_limit_cache_ttl(state: &AppState) -> Duration {
       Duration::from_secs(unified_refresh_interval_seconds(settings.auto_scan_interval_minutes) as u64)
     })
     .unwrap_or(Duration::from_secs(300))
+}
+
+fn live_rate_limit_query_timeout_for_interval(interval: Duration) -> Duration {
+  interval
+    .checked_sub(Duration::from_secs(5))
+    .unwrap_or_else(|| Duration::from_secs(1))
 }
 
 fn unified_refresh_interval_seconds(auto_scan_interval_minutes: i64) -> i64 {
@@ -2120,6 +2126,18 @@ mod tests {
       Duration::from_secs(SCHEDULER_MAX_SLEEP_SECONDS)
     );
     assert_eq!(scheduler_sleep_duration(Duration::from_secs(2)), Duration::from_secs(2));
+  }
+
+  #[test]
+  fn live_rate_limit_query_timeout_finishes_before_next_refresh() {
+    assert_eq!(
+      live_rate_limit_query_timeout_for_interval(Duration::from_secs(60)),
+      Duration::from_secs(55)
+    );
+    assert_eq!(
+      live_rate_limit_query_timeout_for_interval(Duration::from_secs(180)),
+      Duration::from_secs(175)
+    );
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1426,6 +1426,13 @@ fn load_persisted_live_rate_limits_from_connection(
   })
 }
 
+fn load_preferred_persisted_live_rate_limits(
+  conn: &rusqlite::Connection,
+) -> Option<LiveRateLimitSnapshot> {
+  load_persisted_live_rate_limits_from_connection(conn, Some("live"))
+    .or_else(|| load_persisted_live_rate_limits_from_connection(conn, Some("session")))
+}
+
 fn persisted_window_is_newer(
   candidate: &PersistedRateLimitWindow,
   current: &PersistedRateLimitWindow,
@@ -1466,16 +1473,18 @@ fn load_display_live_rate_limit_fallback(
   let memory = live_cache
     .rate_limits()
     .map(|snapshot| snapshot.as_ref().clone());
+  let memory_is_live = live_cache.state().last_live_success_at.is_some();
   let Ok(conn) = open_connection(db_path) else {
     return memory;
   };
-  let persisted = load_persisted_live_rate_limits_from_connection(&conn, None);
-  let session_only = if persisted.is_none() {
-    load_persisted_live_rate_limits_from_connection(&conn, Some("session"))
-  } else {
-    None
-  };
-  newest_live_rate_limit_snapshot([memory, persisted, session_only])
+  let persisted_live = load_persisted_live_rate_limits_from_connection(&conn, Some("live"));
+  if memory_is_live {
+    return newest_live_rate_limit_snapshot([memory, persisted_live]);
+  }
+  if persisted_live.is_some() {
+    return persisted_live;
+  }
+  memory.or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")))
 }
 
 fn newest_live_rate_limit_snapshot(
@@ -2178,8 +2187,7 @@ pub fn run() {
       prepare_app_database(&db_path)?;
       let conn = open_connection(&db_path).map_err(|error| error.to_string())?;
       let settings = get_sync_settings(&conn).map_err(|error| error.to_string())?;
-      let display_fallback = load_persisted_live_rate_limits_from_connection(&conn, None)
-        .or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")));
+      let display_fallback = load_preferred_persisted_live_rate_limits(&conn);
       let live_last_success_at = load_persisted_live_rate_limits_from_connection(&conn, Some("live"))
         .map(|snapshot| snapshot.fetched_at);
       let epoch_backfill_is_pending =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1387,7 +1387,7 @@ fn load_persisted_live_rate_limits_from_connection(
   source_kind: Option<&str>,
 ) -> Option<LiveRateLimitSnapshot> {
   if let Ok(Some(snapshot)) = load_latest_rate_limits(conn, source_kind) {
-    return Some(snapshot);
+    return Some(normalize_live_rate_limit_snapshot(snapshot));
   }
   let mut primary = load_latest_persisted_rate_limit_window(&conn, "five_hour", source_kind)
     .ok()
@@ -1422,7 +1422,7 @@ fn load_persisted_live_rate_limits_from_connection(
     .map(|window| window.fetched_at.clone())
     .or_else(|| secondary.as_ref().map(|window| window.fetched_at.clone()))?;
 
-  Some(LiveRateLimitSnapshot {
+  Some(normalize_live_rate_limit_snapshot(LiveRateLimitSnapshot {
     limit_id: primary
       .as_ref()
       .and_then(|window| window.limit_id.clone())
@@ -1438,7 +1438,21 @@ fn load_persisted_live_rate_limits_from_connection(
     primary: primary.map(|window| window.snapshot),
     secondary: secondary.map(|window| window.snapshot),
     fetched_at,
-  })
+  }))
+}
+
+fn normalize_live_rate_limit_snapshot(
+  mut snapshot: LiveRateLimitSnapshot,
+) -> LiveRateLimitSnapshot {
+  if snapshot.secondary.is_none()
+    && snapshot
+      .primary
+      .as_ref()
+      .is_some_and(|window| window.window_duration_mins == Some(7 * 24 * 60))
+  {
+    snapshot.secondary = snapshot.primary.take();
+  }
+  snapshot
 }
 
 fn load_preferred_persisted_live_rate_limits(
@@ -1487,7 +1501,7 @@ fn load_display_live_rate_limit_fallback(
 ) -> Option<LiveRateLimitSnapshot> {
   let memory = live_cache
     .rate_limits()
-    .map(|snapshot| snapshot.as_ref().clone());
+    .map(|snapshot| normalize_live_rate_limit_snapshot(snapshot.as_ref().clone()));
   let memory_is_live = live_cache.state().last_live_success_at.is_some();
   let Ok(conn) = open_connection(db_path) else {
     return memory;
@@ -3768,6 +3782,45 @@ mod tests {
     assert_eq!(
       memory.primary.as_ref().map(|window| window.remaining_percent),
       Some(77)
+    );
+  }
+
+  #[test]
+  fn persisted_primary_only_seven_day_snapshot_is_normalized_for_offline_fallback() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    insert_live_rate_limit_snapshot(
+      &conn,
+      &LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 21,
+          remaining_percent: 79,
+          window_duration_mins: Some(10_080),
+          resets_at: Some("2026-04-02T00:00:00+08:00".to_string()),
+          window_start: Some("2026-03-26T00:00:00+08:00".to_string()),
+        }),
+        secondary: None,
+        fetched_at: "2026-03-27T00:00:00+08:00".to_string(),
+      },
+    )
+    .expect("insert legacy live sample");
+    drop(conn);
+
+    let snapshot = load_display_live_rate_limit_fallback(
+      &db_path,
+      &refresh::LiveQuotaCache::new(),
+    )
+    .expect("load offline fallback");
+
+    assert!(snapshot.primary.is_none());
+    assert_eq!(
+      snapshot.secondary.map(|window| window.remaining_percent),
+      Some(79)
     );
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,6 +160,49 @@ impl refresh::LiveQuotaPersister for AppLiveQuotaPersister {
 }
 
 #[derive(Clone)]
+struct AppEpochMaintenanceExecutor {
+  db_path: PathBuf,
+}
+
+impl refresh::EpochMaintenanceExecutor for AppEpochMaintenanceExecutor {
+  fn run_batch(
+    &self,
+    limit: usize,
+    cancellation: Arc<AtomicBool>,
+  ) -> Result<refresh::EpochMaintenanceBatch, String> {
+    let conn = database::open_epoch_maintenance_connection(&self.db_path)
+      .map_err(|error| error.to_string())?;
+    let progress = database::backfill_epoch_batch_cancellable(
+      &conn,
+      limit,
+      cancellation.as_ref(),
+    )
+    .map_err(|error| error.to_string())?;
+    Ok(match progress {
+      Some(progress) => refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: progress
+          .usage_rows_updated
+          .saturating_add(progress.quota_rows_updated),
+        complete: progress.complete,
+      },
+      None => refresh::EpochMaintenanceBatch::Cancelled,
+    })
+  }
+}
+
+fn configure_epoch_maintenance(
+  dependencies: refresh::RefreshRuntimeDependencies,
+  db_path: PathBuf,
+  pending: bool,
+) -> refresh::RefreshRuntimeDependencies {
+  if pending {
+    dependencies.with_epoch_maintenance(Arc::new(AppEpochMaintenanceExecutor { db_path }))
+  } else {
+    dependencies
+  }
+}
+
+#[derive(Clone)]
 struct TauriRefreshEventSink {
   app_handle: AppHandle,
 }
@@ -2077,6 +2120,8 @@ pub fn run() {
         .or_else(|| load_persisted_live_rate_limits_from_connection(&conn, Some("session")));
       let live_last_success_at = load_persisted_live_rate_limits_from_connection(&conn, Some("live"))
         .map(|snapshot| snapshot.fetched_at);
+      let epoch_backfill_is_pending =
+        database::epoch_backfill_pending(&conn).map_err(|error| error.to_string())?;
       drop(conn);
 
       let live_rate_limits = refresh::LiveQuotaCache::new();
@@ -2090,8 +2135,7 @@ pub fn run() {
 
       let app_handle = app.app_handle();
       let usage_mutations = refresh::UsageMutationCoordinator::new();
-      let runtime = refresh::RefreshRuntime::start(
-        refresh::RefreshRuntimeDependencies::with_system_defaults(
+      let runtime_dependencies = refresh::RefreshRuntimeDependencies::with_system_defaults(
           refresh_config_from_saved_settings(&settings, live_last_success_at.as_deref()),
           Arc::new(AppTokenRefreshExecutor {
             db_path: db_path.clone(),
@@ -2108,8 +2152,13 @@ pub fn run() {
             app_handle: app_handle.clone(),
           }),
           usage_mutations.clone(),
-        ),
-      )?;
+        );
+      let runtime_dependencies = configure_epoch_maintenance(
+        runtime_dependencies,
+        db_path.clone(),
+        epoch_backfill_is_pending,
+      );
+      let runtime = refresh::RefreshRuntime::start(runtime_dependencies)?;
       let refresh = runtime.handle();
       *setup_runtime_owner
         .lock()
@@ -2197,7 +2246,7 @@ pub fn run() {
 mod tests {
   use super::*;
   use std::sync::mpsc::{self, Receiver, Sender};
-  use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+  use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
   use tempfile::tempdir;
 
   struct RecordingTokenExecutor {
@@ -2280,6 +2329,116 @@ mod tests {
     fn publish_invalidation(&self, _: refresh::DisplayInvalidation) {}
 
     fn publish_completion(&self, _: refresh::RefreshCompletedEvent) {}
+  }
+
+  #[test]
+  fn production_epoch_maintenance_adapter_is_bounded_and_resumes_from_cursor() {
+    let directory = tempdir().expect("create adapter test directory");
+    let db_path = directory.path().join("epoch-maintenance.sqlite3");
+    let conn = open_connection(&db_path).expect("open adapter database");
+    init_db(&conn).expect("initialize adapter database");
+    conn.execute_batch(
+      "
+      WITH RECURSIVE rows(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM rows WHERE value < 1501
+      )
+      INSERT INTO usage_events (
+        session_id, timestamp, timestamp_ms, model_id,
+        input_tokens, cached_input_tokens, output_tokens,
+        reasoning_output_tokens, total_tokens, value_usd,
+        fast_mode_auto, fast_mode_effective
+      )
+      SELECT
+        'legacy-' || value, '2026-07-10T03:00:00Z', NULL, 'gpt-5',
+        1, 0, 1, 0, 2, 0.01, 0, 0
+      FROM rows;
+      ",
+    )
+    .expect("seed legacy epoch rows");
+    assert!(database::epoch_backfill_pending(&conn).expect("read repair marker"));
+    drop(conn);
+
+    let first_adapter = AppEpochMaintenanceExecutor {
+      db_path: db_path.clone(),
+    };
+    let first = refresh::EpochMaintenanceExecutor::run_batch(
+      &first_adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect("run first production slice");
+    assert_eq!(
+      first,
+      refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: 1_000,
+        complete: false,
+      }
+    );
+    let reopened = open_connection(&db_path).expect("reopen after first slice");
+    let cursor: i64 = reopened
+      .query_row(
+        "SELECT progress_value FROM data_repair_progress WHERE repair_key = 'epoch_timestamp_backfill_v1' AND stream_key = 'usage_events'",
+        [],
+        |row| row.get(0),
+      )
+      .expect("load persisted cursor");
+    assert_eq!(cursor, 1_000);
+    drop(reopened);
+
+    let resumed_adapter = AppEpochMaintenanceExecutor { db_path };
+    let resumed = refresh::EpochMaintenanceExecutor::run_batch(
+      &resumed_adapter,
+      1_000,
+      Arc::new(AtomicBool::new(false)),
+    )
+    .expect("resume production slice");
+    assert_eq!(
+      resumed,
+      refresh::EpochMaintenanceBatch::Progress {
+        processed_rows: 501,
+        complete: true,
+      }
+    );
+  }
+
+  #[test]
+  fn completed_epoch_repair_does_not_inject_a_runtime_worker() {
+    let directory = tempdir().expect("create completed repair directory");
+    let db_path = directory.path().join("completed.sqlite3");
+    let conn = open_connection(&db_path).expect("open completed database");
+    init_db(&conn).expect("initialize completed database");
+    conn.execute(
+      "INSERT INTO data_repairs (repair_key, completed_at) VALUES ('epoch_timestamp_backfill_v1', '2026-07-11T00:00:00Z')",
+      [],
+    )
+    .expect("mark epoch repair complete");
+    let pending = database::epoch_backfill_pending(&conn).expect("check completion marker");
+    drop(conn);
+    let (requests, _) = mpsc::channel();
+    let dependencies = refresh::RefreshRuntimeDependencies::with_system_defaults(
+      refresh::RefreshConfig {
+        auto_scan_enabled: false,
+        interval: Duration::from_secs(60),
+        codex_home: None,
+        token_last_success_wall: None,
+        live_last_success_wall: None,
+      },
+      Arc::new(RecordingTokenExecutor { requests }),
+      Arc::new(CountingLiveFetcher {
+        calls: Arc::new(AtomicUsize::new(0)),
+      }),
+      Arc::new(NoopLivePersister),
+      refresh::LiveQuotaCache::new(),
+      Arc::new(NoopRefreshEvents),
+      refresh::UsageMutationCoordinator::new(),
+    );
+
+    let dependencies = configure_epoch_maintenance(dependencies, db_path, pending);
+
+    assert!(!pending);
+    assert!(dependencies.epoch_maintenance_executor.is_none());
   }
 
   struct GatedFailingTokenExecutor {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -33,6 +33,8 @@ pub struct UsageSnapshot {
   pub timestamp: String,
   pub model_id: String,
   pub usage: TokenUsage,
+  #[serde(skip)]
+  pub last_token_usage: Option<TokenUsage>,
   pub plan_type: Option<String>,
   pub limit_id: Option<String>,
   pub limit_name: Option<String>,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -223,6 +223,17 @@ pub struct LiveRateLimitSnapshot {
   pub fetched_at: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveQuotaState {
+  pub rate_limits: Option<LiveRateLimitSnapshot>,
+  pub source_fetched_at: Option<String>,
+  pub cached_at: String,
+  pub is_fallback: bool,
+  pub last_live_success_at: Option<String>,
+  pub refreshing: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MenuBarPopupQuotaSnapshot {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -165,6 +165,8 @@ pub struct ConversationFilters {
   pub custom_end: Option<String>,
   pub search: Option<String>,
   pub live_window_offset: Option<i64>,
+  pub cursor: Option<String>,
+  pub limit: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -333,10 +335,18 @@ pub struct OverviewResponse {
 #[serde(rename_all = "camelCase")]
 pub struct DashboardSnapshot {
   pub overview: OverviewResponse,
-  pub conversations: Vec<ConversationListItem>,
+  pub conversation_page: ConversationPage,
   pub sync_settings: SyncSettings,
   pub subscription_profile: SubscriptionProfile,
   pub live_rate_limits: Option<LiveRateLimitSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationPage {
+  pub items: Vec<ConversationListItem>,
+  pub next_cursor: Option<String>,
+  pub has_more: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -423,6 +433,8 @@ pub struct ConversationDetail {
   pub source_states: Vec<String>,
   pub sessions: Vec<ConversationSessionSummary>,
   pub turns: Vec<ConversationTurnPoint>,
+  pub next_turn_cursor: Option<usize>,
+  pub has_more_turns: bool,
   pub model_breakdown: Vec<ModelShare>,
   pub composition_breakdown: Vec<CompositionShare>,
 }
@@ -435,5 +447,9 @@ pub struct ScanResult {
   pub imported_sessions: usize,
   pub updated_sessions: usize,
   pub missing_sessions: usize,
+  pub scan_kind: String,
+  pub source_bytes_read: u64,
+  pub tail_parsed_files: usize,
+  pub fully_parsed_files: usize,
   pub last_completed_at: String,
 }

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -48,14 +48,7 @@ fn pricing_seed() -> Vec<PricingCatalogEntry> {
             source_url: OPENAI_API_PRICING_URL.to_string(),
             updated_at: updated_at.clone(),
         },
-        fallback_entry(
-            "gpt-5.6-sol",
-            "GPT-5.6 Sol",
-            5.00,
-            0.50,
-            30.00,
-            &updated_at,
-        ),
+        fallback_entry("gpt-5.6-sol", "GPT-5.6 Sol", 5.00, 0.50, 30.00, &updated_at),
         fallback_entry(
             "gpt-5.6-terra",
             "GPT-5.6 Terra",
@@ -196,33 +189,28 @@ fn official_entry(row: OfficialPricingRow, updated_at: &str) -> PricingCatalogEn
 
 pub fn seed_pricing_catalog(conn: &Connection) -> rusqlite::Result<Vec<PricingCatalogEntry>> {
     let entries = pricing_seed();
-    repair_misparsed_gpt_56_output_prices(conn, &entries)?;
+    repair_misparsed_gpt_56_output_prices(conn)?;
     upsert_pricing_entries(conn, &entries, PricingUpsertMode::PreserveOfficial)?;
     load_catalog(conn)
 }
 
-fn repair_misparsed_gpt_56_output_prices(
-    conn: &Connection,
-    entries: &[PricingCatalogEntry],
-) -> rusqlite::Result<()> {
-    for entry in entries {
-        if !matches!(
-            entry.model_id.as_str(),
-            "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
-        ) {
-            continue;
-        }
+fn repair_misparsed_gpt_56_output_prices(conn: &Connection) -> rusqlite::Result<()> {
+    for (model_id, input, cached_input, bad_output) in [
+        ("gpt-5.6-sol", 5.0, 0.5, 6.25),
+        ("gpt-5.6-terra", 2.5, 0.25, 3.125),
+        ("gpt-5.6-luna", 1.0, 0.1, 1.25),
+    ] {
         conn.execute(
             "
             UPDATE pricing_catalog
-            SET output_price_per_million = ?2
+            SET is_official = 0
             WHERE model_id = ?1
               AND is_official = 1
-              AND ABS(
-                output_price_per_million - input_price_per_million * 1.25
-              ) <= 1e-9
+              AND ABS(input_price_per_million - ?2) <= 1e-9
+              AND ABS(cached_input_price_per_million - ?3) <= 1e-9
+              AND ABS(output_price_per_million - ?4) <= 1e-9
             ",
-            params![entry.model_id, entry.output_price_per_million],
+            params![model_id, input, cached_input, bad_output],
         )?;
     }
 
@@ -576,7 +564,9 @@ pub fn resolve_pricing(
     model_id: &str,
 ) -> Option<ResolvedPricing> {
     let normalized = normalize_model_id(model_id);
-    let entry = if let Some(entry) = catalog.get(&normalized) {
+    let entry = if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6") {
+        catalog.get("gpt-5.6-sol")?.clone()
+    } else if let Some(entry) = catalog.get(&normalized) {
         entry.clone()
     } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-sol") {
         catalog.get("gpt-5.6-sol")?.clone()
@@ -820,6 +810,7 @@ mod tests {
 
         for (model, input, cached, output) in [
             ("gpt-5.6", 5.0, 0.5, 30.0),
+            ("gpt-5.6-2026-07-09", 5.0, 0.5, 30.0),
             ("gpt-5.6-sol", 5.0, 0.5, 30.0),
             ("gpt-5.6-sol-2026-07-09", 5.0, 0.5, 30.0),
             ("gpt-5.6-terra", 2.5, 0.25, 15.0),
@@ -850,6 +841,29 @@ mod tests {
     }
 
     #[test]
+    fn resolve_pricing_routes_gpt_56_aliases_to_current_sol_row() {
+        let mut catalog = pricing_seed()
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+        let alias = catalog.get_mut("gpt-5.6").expect("GPT-5.6 alias");
+        alias.input_price_per_million = 4.0;
+        alias.cached_input_price_per_million = 0.4;
+        alias.output_price_per_million = 24.0;
+        let sol = catalog.get_mut("gpt-5.6-sol").expect("GPT-5.6 Sol");
+        sol.input_price_per_million = 7.0;
+        sol.cached_input_price_per_million = 0.7;
+        sol.output_price_per_million = 42.0;
+
+        for model_id in ["gpt-5.6", "gpt-5.6-2026-07-09"] {
+            let pricing = resolve_pricing(&catalog, model_id).expect(model_id);
+            assert_eq!(pricing.input_price_per_million, 7.0);
+            assert_eq!(pricing.cached_input_price_per_million, 0.7);
+            assert_eq!(pricing.output_price_per_million, 42.0);
+        }
+    }
+
+    #[test]
     fn resolve_pricing_does_not_guess_unknown_gpt_56_ids() {
         let catalog = pricing_seed()
             .into_iter()
@@ -860,7 +874,9 @@ mod tests {
             "gpt-5.6-solaris",
             "gpt-5.6-neptune",
             "gpt-5.60",
-            "gpt-5.6-2026-07-09",
+            "gpt-5.6-2026-02-30",
+            "gpt-5.6-2026-7-09",
+            "gpt-5.6-2026-07-09-preview",
             "gpt-5.6-sol-2026-02-30",
             "gpt-5.6-sol-2026-7-09",
             "gpt-5.6-sol-2026-07-09-preview",
@@ -914,37 +930,98 @@ mod tests {
             .map(|entry| (entry.model_id.clone(), entry))
             .collect::<HashMap<_, _>>();
 
-        for (model_id, display_name, output, provenance, source_url) in [
-            (
-                "gpt-5.6-sol",
-                "Official Sol",
-                30.0,
-                "official-sol",
-                "https://example.com/sol",
-            ),
-            (
-                "gpt-5.6-terra",
-                "Official Terra",
-                15.0,
-                "official-terra",
-                "https://example.com/terra",
-            ),
-            (
-                "gpt-5.6-luna",
-                "Official Luna",
-                6.0,
-                "official-luna",
-                "https://example.com/luna",
-            ),
+        for (model_id, display_name, output, provenance) in [
+            ("gpt-5.6-sol", "GPT-5.6 Sol", 30.0, "official-sol"),
+            ("gpt-5.6-terra", "GPT-5.6 Terra", 15.0, "official-terra"),
+            ("gpt-5.6-luna", "GPT-5.6 Luna", 6.0, "official-luna"),
         ] {
             let entry = &catalog[model_id];
             assert_eq!(entry.output_price_per_million, output);
             assert_eq!(entry.display_name, display_name);
-            assert!(entry.is_official);
-            assert_eq!(entry.note.as_deref(), Some(provenance));
-            assert_eq!(entry.source_url, source_url);
-            assert_eq!(entry.updated_at, provenance);
+            assert!(!entry.is_official);
+            assert_eq!(entry.note.as_deref(), Some(FALLBACK_PRICING_NOTE));
+            assert_eq!(entry.source_url, OPENAI_API_PRICING_URL);
+            assert_ne!(entry.updated_at, provenance);
         }
+    }
+
+    #[test]
+    fn seed_preserves_future_official_gpt_56_price_at_one_point_two_five_ratio() {
+        let conn = Connection::open_in_memory().expect("open database");
+        crate::database::init_db(&conn).expect("init database");
+        conn.execute(
+            "
+            INSERT INTO pricing_catalog (
+                model_id, display_name, input_price_per_million, cached_input_price_per_million,
+                output_price_per_million, effective_model_id, is_official, note, source_url, updated_at
+            )
+            VALUES ('gpt-5.6-sol', 'Future Official Sol', 8.0, 0.8, 10.0,
+                    'gpt-5.6-sol', 1, 'future-official', 'https://example.com/future',
+                    'future-official-sol')
+            ",
+            [],
+        )
+        .expect("insert future official Sol pricing");
+
+        let catalog = seed_pricing_catalog(&conn)
+            .expect("seed pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+        let sol = &catalog["gpt-5.6-sol"];
+
+        assert_eq!(sol.input_price_per_million, 8.0);
+        assert_eq!(sol.cached_input_price_per_million, 0.8);
+        assert_eq!(sol.output_price_per_million, 10.0);
+        assert_eq!(sol.display_name, "Future Official Sol");
+        assert!(sol.is_official);
+        assert_eq!(sol.note.as_deref(), Some("future-official"));
+        assert_eq!(sol.source_url, "https://example.com/future");
+        assert_eq!(sol.updated_at, "future-official-sol");
+    }
+
+    #[test]
+    fn official_refresh_restores_repaired_gpt_56_provenance() {
+        let conn = Connection::open_in_memory().expect("open database");
+        crate::database::init_db(&conn).expect("init database");
+        conn.execute(
+            "
+            INSERT INTO pricing_catalog (
+                model_id, display_name, input_price_per_million, cached_input_price_per_million,
+                output_price_per_million, effective_model_id, is_official, note, source_url, updated_at
+            )
+            VALUES ('gpt-5.6-sol', 'Old Official Sol', 5.0, 0.5, 6.25,
+                    'gpt-5.6-sol', 1, 'old-official', 'https://example.com/old', 'old-official')
+            ",
+            [],
+        )
+        .expect("insert malformed official Sol pricing");
+
+        let repaired = seed_pricing_catalog(&conn).expect("repair malformed pricing");
+        assert!(repaired
+            .iter()
+            .find(|entry| entry.model_id == "gpt-5.6-sol")
+            .is_some_and(|entry| !entry.is_official));
+
+        let official_entries =
+            parse_official_pricing_catalog(&complete_standard_fixture_with_gpt56_rows())
+                .expect("parse official pricing");
+        upsert_pricing_entries(&conn, &official_entries, PricingUpsertMode::Overwrite)
+            .expect("write refreshed official pricing");
+        let catalog = seed_pricing_catalog(&conn)
+            .expect("seed refreshed pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+        let sol = &catalog["gpt-5.6-sol"];
+
+        assert!(sol.is_official);
+        assert_eq!(sol.output_price_per_million, 30.0);
+        assert_eq!(sol.source_url, OPENAI_API_PRICING_URL);
+        assert_eq!(
+            sol.note.as_deref(),
+            Some("OpenAI API Standard short-context pricing.")
+        );
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -36,6 +36,42 @@ struct OfficialPricingRow {
 fn pricing_seed() -> Vec<PricingCatalogEntry> {
     let updated_at = now_utc_string();
     vec![
+        PricingCatalogEntry {
+            model_id: "gpt-5.6".to_string(),
+            display_name: "GPT-5.6".to_string(),
+            input_price_per_million: 5.00,
+            cached_input_price_per_million: 0.50,
+            output_price_per_million: 30.00,
+            effective_model_id: "gpt-5.6-sol".to_string(),
+            is_official: false,
+            note: Some(FALLBACK_PRICING_NOTE.to_string()),
+            source_url: OPENAI_API_PRICING_URL.to_string(),
+            updated_at: updated_at.clone(),
+        },
+        fallback_entry(
+            "gpt-5.6-sol",
+            "GPT-5.6 Sol",
+            5.00,
+            0.50,
+            30.00,
+            &updated_at,
+        ),
+        fallback_entry(
+            "gpt-5.6-terra",
+            "GPT-5.6 Terra",
+            2.50,
+            0.25,
+            15.00,
+            &updated_at,
+        ),
+        fallback_entry(
+            "gpt-5.6-luna",
+            "GPT-5.6 Luna",
+            1.00,
+            0.10,
+            6.00,
+            &updated_at,
+        ),
         fallback_entry("gpt-5.5", "GPT-5.5", 5.00, 0.50, 30.00, &updated_at),
         fallback_entry("gpt-5.4", "GPT-5.4", 2.50, 0.25, 15.00, &updated_at),
         fallback_entry(
@@ -160,8 +196,37 @@ fn official_entry(row: OfficialPricingRow, updated_at: &str) -> PricingCatalogEn
 
 pub fn seed_pricing_catalog(conn: &Connection) -> rusqlite::Result<Vec<PricingCatalogEntry>> {
     let entries = pricing_seed();
+    repair_misparsed_gpt_56_output_prices(conn, &entries)?;
     upsert_pricing_entries(conn, &entries, PricingUpsertMode::PreserveOfficial)?;
     load_catalog(conn)
+}
+
+fn repair_misparsed_gpt_56_output_prices(
+    conn: &Connection,
+    entries: &[PricingCatalogEntry],
+) -> rusqlite::Result<()> {
+    for entry in entries {
+        if !matches!(
+            entry.model_id.as_str(),
+            "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+        ) {
+            continue;
+        }
+        conn.execute(
+            "
+            UPDATE pricing_catalog
+            SET output_price_per_million = ?2
+            WHERE model_id = ?1
+              AND is_official = 1
+              AND ABS(
+                output_price_per_million - input_price_per_million * 1.25
+              ) <= 1e-9
+            ",
+            params![entry.model_id, entry.output_price_per_million],
+        )?;
+    }
+
+    Ok(())
 }
 
 pub fn refresh_pricing_catalog_from_openai(
@@ -209,6 +274,9 @@ pub fn parse_official_pricing_catalog(document: &str) -> Result<Vec<PricingCatal
     }
 
     let required_models = [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -278,15 +346,24 @@ fn extract_pricing_rows(block: &str) -> Vec<OfficialPricingRow> {
         };
         let name_end = name_start + relative_name_end;
         let raw_name = html_unescape(&block[name_start..name_end]);
+        let next_row = block[name_end..]
+            .find(marker)
+            .map(|offset| name_end + offset)
+            .unwrap_or(block.len());
         if !is_standard_short_context_pricing_row(&raw_name) {
-            cursor = name_end;
+            cursor = next_row;
             continue;
         }
-        let mut value_cursor = name_end + "&quot;]".len();
+        let row_source = &block[name_end..next_row];
+        let mut value_cursor = 0usize;
+        let mut values = Vec::new();
+        while let Some(value) = parse_next_pricing_value(row_source, &mut value_cursor) {
+            values.push(value);
+        }
 
-        let input = parse_next_pricing_value(block, &mut value_cursor).flatten();
-        let cached_input = parse_next_pricing_value(block, &mut value_cursor).flatten();
-        let output = parse_next_pricing_value(block, &mut value_cursor).flatten();
+        let input = values.first().copied().flatten();
+        let cached_input = values.get(1).copied().flatten();
+        let output = values.last().copied().flatten();
 
         if let (Some(input), Some(output)) = (input, output) {
             let model_id = normalize_official_model_id(&raw_name);
@@ -300,7 +377,7 @@ fn extract_pricing_rows(block: &str) -> Vec<OfficialPricingRow> {
             }
         }
 
-        cursor = name_end;
+        cursor = next_row;
     }
 
     rows
@@ -501,6 +578,14 @@ pub fn resolve_pricing(
     let normalized = normalize_model_id(model_id);
     let entry = if let Some(entry) = catalog.get(&normalized) {
         entry.clone()
+    } else if normalized.starts_with("gpt-5.6-sol") {
+        catalog.get("gpt-5.6-sol")?.clone()
+    } else if normalized.starts_with("gpt-5.6-terra") {
+        catalog.get("gpt-5.6-terra")?.clone()
+    } else if normalized.starts_with("gpt-5.6-luna") {
+        catalog.get("gpt-5.6-luna")?.clone()
+    } else if normalized.starts_with("gpt-5.6") {
+        catalog.get("gpt-5.6")?.clone()
     } else if normalized.starts_with("gpt-5.5-pro") {
         catalog.get("gpt-5.5-pro")?.clone()
     } else if normalized.starts_with("gpt-5.5") {
@@ -553,6 +638,10 @@ pub fn display_name_for_model(model_id: &str) -> String {
     match normalize_model_id(model_id).as_str() {
         "codex-auto-review" => "Codex Auto Review".to_string(),
         "codex-mini-latest" => "Codex Mini Latest".to_string(),
+        "gpt-5.6" => "GPT-5.6".to_string(),
+        "gpt-5.6-sol" => "GPT-5.6 Sol".to_string(),
+        "gpt-5.6-terra" => "GPT-5.6 Terra".to_string(),
+        "gpt-5.6-luna" => "GPT-5.6 Luna".to_string(),
         "gpt-5.5" => "GPT-5.5".to_string(),
         "gpt-5.5-pro" => "GPT-5.5 Pro".to_string(),
         "gpt-5.4" => "GPT-5.4".to_string(),
@@ -581,6 +670,10 @@ pub fn display_name_for_model(model_id: &str) -> String {
 pub fn model_color(model_id: &str) -> &'static str {
     match normalize_model_id(model_id).as_str() {
         "codex-auto-review" => "#60a5fa",
+        "gpt-5.6" => "#f59e0b",
+        "gpt-5.6-sol" => "#ffd166",
+        "gpt-5.6-terra" => "#2ec4b6",
+        "gpt-5.6-luna" => "#8338ec",
         "gpt-5.5" => "#d946ef",
         "gpt-5.5-pro" => "#c026d3",
         "gpt-5.4" => "#ff6b35",
@@ -699,9 +792,155 @@ mod tests {
     }
 
     #[test]
+    fn resolve_pricing_includes_gpt_56_family_and_alias() {
+        let catalog = pricing_seed()
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        for (model, input, cached, output) in [
+            ("gpt-5.6", 5.0, 0.5, 30.0),
+            ("gpt-5.6-sol-2026-07-09", 5.0, 0.5, 30.0),
+            ("gpt-5.6-terra-2026-07-09", 2.5, 0.25, 15.0),
+            ("gpt-5.6-luna-2026-07-09", 1.0, 0.1, 6.0),
+        ] {
+            let pricing = resolve_pricing(&catalog, model).expect(model);
+            assert_eq!(pricing.input_price_per_million, input);
+            assert_eq!(pricing.cached_input_price_per_million, cached);
+            assert_eq!(pricing.output_price_per_million, output);
+        }
+
+        assert_eq!(catalog["gpt-5.6"].effective_model_id, "gpt-5.6-sol");
+        assert_eq!(catalog["gpt-5.6"].display_name, "GPT-5.6");
+        assert_eq!(catalog["gpt-5.6-sol"].display_name, "GPT-5.6 Sol");
+        assert_eq!(catalog["gpt-5.6-terra"].display_name, "GPT-5.6 Terra");
+        assert_eq!(catalog["gpt-5.6-luna"].display_name, "GPT-5.6 Luna");
+        for (model_id, display_name, color) in [
+            ("gpt-5.6", "GPT-5.6", "#f59e0b"),
+            ("gpt-5.6-sol", "GPT-5.6 Sol", "#ffd166"),
+            ("gpt-5.6-terra", "GPT-5.6 Terra", "#2ec4b6"),
+            ("gpt-5.6-luna", "GPT-5.6 Luna", "#8338ec"),
+        ] {
+            assert_eq!(display_name_for_model(model_id), display_name);
+            assert_eq!(model_color(model_id), color);
+        }
+    }
+
+    #[test]
+    fn parses_gpt_56_cache_write_price_without_treating_it_as_output() {
+        let html = complete_standard_fixture_with_gpt56_rows();
+        let catalog = parse_official_pricing_catalog(&html)
+            .expect("parse pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(catalog["gpt-5.6-sol"].output_price_per_million, 30.0);
+        assert_eq!(catalog["gpt-5.6-terra"].output_price_per_million, 15.0);
+        assert_eq!(catalog["gpt-5.6-luna"].output_price_per_million, 6.0);
+    }
+
+    #[test]
+    fn seed_repairs_misparsed_gpt_56_output_prices() {
+        let conn = Connection::open_in_memory().expect("open database");
+        crate::database::init_db(&conn).expect("init database");
+        conn.execute(
+            "
+            INSERT INTO pricing_catalog (
+                model_id, display_name, input_price_per_million, cached_input_price_per_million,
+                output_price_per_million, effective_model_id, is_official, note, source_url, updated_at
+            )
+            VALUES
+              ('gpt-5.6-sol', 'Official Sol', 5.0, 0.5, 6.25,
+               'gpt-5.6-sol', 1, 'official-sol', 'https://example.com/sol', 'official-sol'),
+              ('gpt-5.6-terra', 'Official Terra', 2.5, 0.25, 3.125,
+               'gpt-5.6-terra', 1, 'official-terra', 'https://example.com/terra', 'official-terra'),
+              ('gpt-5.6-luna', 'Official Luna', 1.0, 0.1, 1.25,
+               'gpt-5.6-luna', 1, 'official-luna', 'https://example.com/luna', 'official-luna')
+            ",
+            [],
+        )
+        .expect("insert malformed GPT-5.6 pricing");
+
+        let catalog = seed_pricing_catalog(&conn)
+            .expect("seed pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        for (model_id, display_name, output, provenance, source_url) in [
+            (
+                "gpt-5.6-sol",
+                "Official Sol",
+                30.0,
+                "official-sol",
+                "https://example.com/sol",
+            ),
+            (
+                "gpt-5.6-terra",
+                "Official Terra",
+                15.0,
+                "official-terra",
+                "https://example.com/terra",
+            ),
+            (
+                "gpt-5.6-luna",
+                "Official Luna",
+                6.0,
+                "official-luna",
+                "https://example.com/luna",
+            ),
+        ] {
+            let entry = &catalog[model_id];
+            assert_eq!(entry.output_price_per_million, output);
+            assert_eq!(entry.display_name, display_name);
+            assert!(entry.is_official);
+            assert_eq!(entry.note.as_deref(), Some(provenance));
+            assert_eq!(entry.source_url, source_url);
+            assert_eq!(entry.updated_at, provenance);
+        }
+    }
+
+    #[test]
+    fn seed_preserves_correct_official_gpt_56_prices() {
+        let conn = Connection::open_in_memory().expect("open database");
+        crate::database::init_db(&conn).expect("init database");
+        conn.execute(
+            "
+            INSERT INTO pricing_catalog (
+                model_id, display_name, input_price_per_million, cached_input_price_per_million,
+                output_price_per_million, effective_model_id, is_official, note, source_url, updated_at
+            )
+            VALUES ('gpt-5.6-terra', 'Official Terra', 2.5, 0.25, 15.0,
+                    'gpt-5.6-terra', 1, 'official', 'https://example.com', 'official-terra')
+            ",
+            [],
+        )
+        .expect("insert correct Terra pricing");
+
+        let catalog = seed_pricing_catalog(&conn)
+            .expect("seed pricing")
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(catalog["gpt-5.6-terra"].output_price_per_million, 15.0);
+        assert_eq!(catalog["gpt-5.6-terra"].display_name, "Official Terra");
+        assert_eq!(catalog["gpt-5.6-terra"].updated_at, "official-terra");
+        assert!(catalog["gpt-5.6-terra"].is_official);
+    }
+
+    fn complete_standard_fixture_with_gpt56_rows() -> String {
+        concat!(
+            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.6-sol&quot;],[0,5],[0,0.5],[0,6.25],[0,30]]],[1,[[0,&quot;gpt-5.6-terra&quot;],[0,2.5],[0,0.25],[0,3.125],[0,15]]],[1,[[0,&quot;gpt-5.6-luna&quot;],[0,1],[0,0.1],[0,1.25],[0,6]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
+            "<astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,1.75],[0,0.175],[0,14]]]]]}]]]}\"></astro-island>"
+        ).to_string()
+    }
+
+    #[test]
     fn parses_official_standard_short_context_pricing_rows() {
         let html = concat!(
-            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.5 (&gt;=272K context length)&quot;],[0,10],[0,1],[0,45]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
+            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.6-sol&quot;],[0,5],[0,0.5],[0,6.25],[0,30]]],[1,[[0,&quot;gpt-5.6-terra&quot;],[0,2.5],[0,0.25],[0,3.125],[0,15]]],[1,[[0,&quot;gpt-5.6-luna&quot;],[0,1],[0,0.1],[0,1.25],[0,6]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.5 (&gt;=272K context length)&quot;],[0,10],[0,1],[0,45]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
             "<astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,1.75],[0,0.175],[0,14]]]]]}]]]}\"></astro-island>"
         );
 
@@ -726,7 +965,7 @@ mod tests {
     #[test]
     fn prefers_standard_short_context_when_pricing_blocks_are_reordered() {
         let html = concat!(
-            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.5 (&gt;=272K context length)&quot;],[0,10],[0,1],[0,45]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
+            "<astro-island component-export=\"TextTokenPricingTables\" props=\"{&quot;tier&quot;:[0,&quot;standard&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.6-sol&quot;],[0,5],[0,0.5],[0,6.25],[0,30]]],[1,[[0,&quot;gpt-5.6-terra&quot;],[0,2.5],[0,0.25],[0,3.125],[0,15]]],[1,[[0,&quot;gpt-5.6-luna&quot;],[0,1],[0,0.1],[0,1.25],[0,6]]],[1,[[0,&quot;gpt-5.5 (&gt;=272K context length)&quot;],[0,10],[0,1],[0,45]]],[1,[[0,&quot;gpt-5.5 (&lt;272K context length)&quot;],[0,5],[0,0.5],[0,30]]],[1,[[0,&quot;gpt-5.4 (&lt;272K context length)&quot;],[0,2.5],[0,0.25],[0,15]]],[1,[[0,&quot;gpt-5.4-mini&quot;],[0,0.75],[0,0.075],[0,4.5]]],[1,[[0,&quot;gpt-5.4-nano&quot;],[0,0.2],[0,0.02],[0,1.25]]]]]}\"></astro-island>",
             "<div data-content-switcher-pane=\"true\" data-value=\"priority\" hidden><div class=\"hidden\">Priority</div><astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,3.5],[0,0.35],[0,28]]]]]}]]]}\"></astro-island></div>",
             "<div data-content-switcher-pane=\"true\" data-value=\"standard\"><div class=\"hidden\">Standard</div><astro-island component-export=\"GroupedPricingTable\" props=\"{&quot;groups&quot;:[1,[[0,{&quot;model&quot;:[0,&quot;Codex&quot;],&quot;rows&quot;:[1,[[1,[[0,&quot;gpt-5.3-codex&quot;],[0,1.75],[0,0.175],[0,14]]]]]}]]]}\"></astro-island></div>"
         );

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -578,14 +578,12 @@ pub fn resolve_pricing(
     let normalized = normalize_model_id(model_id);
     let entry = if let Some(entry) = catalog.get(&normalized) {
         entry.clone()
-    } else if normalized.starts_with("gpt-5.6-sol") {
+    } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-sol") {
         catalog.get("gpt-5.6-sol")?.clone()
-    } else if normalized.starts_with("gpt-5.6-terra") {
+    } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-terra") {
         catalog.get("gpt-5.6-terra")?.clone()
-    } else if normalized.starts_with("gpt-5.6-luna") {
+    } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-luna") {
         catalog.get("gpt-5.6-luna")?.clone()
-    } else if normalized.starts_with("gpt-5.6") {
-        catalog.get("gpt-5.6")?.clone()
     } else if normalized.starts_with("gpt-5.5-pro") {
         catalog.get("gpt-5.5-pro")?.clone()
     } else if normalized.starts_with("gpt-5.5") {
@@ -623,6 +621,28 @@ pub fn resolve_pricing(
         cached_input_price_per_million: entry.cached_input_price_per_million,
         output_price_per_million: entry.output_price_per_million,
     })
+}
+
+fn matches_canonical_or_dated_model_id(model_id: &str, canonical_model_id: &str) -> bool {
+    if model_id == canonical_model_id {
+        return true;
+    }
+
+    let Some(date_suffix) = model_id
+        .strip_prefix(canonical_model_id)
+        .and_then(|suffix| suffix.strip_prefix('-'))
+    else {
+        return false;
+    };
+    let bytes = date_suffix.as_bytes();
+    let has_iso_date_shape = bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && bytes[5..7].iter().all(u8::is_ascii_digit)
+        && bytes[8..].iter().all(u8::is_ascii_digit);
+
+    has_iso_date_shape && chrono::NaiveDate::parse_from_str(date_suffix, "%Y-%m-%d").is_ok()
 }
 
 pub fn normalize_model_id(model_id: &str) -> String {
@@ -800,8 +820,11 @@ mod tests {
 
         for (model, input, cached, output) in [
             ("gpt-5.6", 5.0, 0.5, 30.0),
+            ("gpt-5.6-sol", 5.0, 0.5, 30.0),
             ("gpt-5.6-sol-2026-07-09", 5.0, 0.5, 30.0),
+            ("gpt-5.6-terra", 2.5, 0.25, 15.0),
             ("gpt-5.6-terra-2026-07-09", 2.5, 0.25, 15.0),
+            ("gpt-5.6-luna", 1.0, 0.1, 6.0),
             ("gpt-5.6-luna-2026-07-09", 1.0, 0.1, 6.0),
         ] {
             let pricing = resolve_pricing(&catalog, model).expect(model);
@@ -823,6 +846,29 @@ mod tests {
         ] {
             assert_eq!(display_name_for_model(model_id), display_name);
             assert_eq!(model_color(model_id), color);
+        }
+    }
+
+    #[test]
+    fn resolve_pricing_does_not_guess_unknown_gpt_56_ids() {
+        let catalog = pricing_seed()
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+
+        for model_id in [
+            "gpt-5.6-solaris",
+            "gpt-5.6-neptune",
+            "gpt-5.60",
+            "gpt-5.6-2026-07-09",
+            "gpt-5.6-sol-2026-02-30",
+            "gpt-5.6-sol-2026-7-09",
+            "gpt-5.6-sol-2026-07-09-preview",
+        ] {
+            assert!(
+                resolve_pricing(&catalog, model_id).is_none(),
+                "unexpected guessed pricing for {model_id}"
+            );
         }
     }
 

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -217,25 +217,20 @@ fn repair_misparsed_gpt_56_output_prices(conn: &Connection) -> rusqlite::Result<
     Ok(())
 }
 
-pub fn refresh_pricing_catalog_from_openai(
+pub fn apply_pricing_catalog_refresh(
     conn: &Connection,
-) -> Result<Vec<PricingCatalogEntry>, String> {
-    match fetch_official_pricing_catalog() {
-        Ok(entries) => {
-            upsert_pricing_entries(conn, &entries, PricingUpsertMode::Overwrite)
-                .map_err(|error| error.to_string())?;
-            seed_pricing_catalog(conn).map_err(|error| error.to_string())
-        }
-        Err(error) => {
-            log::warn!(
-                "Failed to refresh OpenAI API pricing from {OPENAI_API_PRICING_URL}: {error}; using bundled fallback pricing."
-            );
-            seed_pricing_catalog(conn).map_err(|error| error.to_string())
-        }
+    official_entries: Option<&[PricingCatalogEntry]>,
+) -> Result<(), String> {
+    if let Some(entries) = official_entries {
+        upsert_pricing_entries(conn, entries, PricingUpsertMode::Overwrite)
+            .map_err(|error| error.to_string())?;
     }
+
+    seed_pricing_catalog(conn).map_err(|error| error.to_string())?;
+    Ok(())
 }
 
-fn fetch_official_pricing_catalog() -> Result<Vec<PricingCatalogEntry>, String> {
+pub fn fetch_official_pricing_catalog() -> Result<Vec<PricingCatalogEntry>, String> {
     let response = ureq::get(OPENAI_API_PRICING_URL)
         .timeout(Duration::from_secs(20))
         .call()

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -297,19 +297,23 @@ fn load_conversation_page_sql(
   };
   let sql = format!(
     "
-    WITH session_groups AS (
-      SELECT root_session_id,
-             COALESCE(NULLIF(MAX(title), ''), root_session_id) AS title,
-             MIN(started_at) AS started_at,
-             MAX(updated_at) AS updated_at,
-             COUNT(*) AS session_count,
-             GROUP_CONCAT(DISTINCT source_state) AS source_states
+    WITH matching_roots AS (
+      SELECT DISTINCT root_session_id
       FROM sessions
       WHERE ?3 IS NULL
          OR lower(COALESCE(title, '')) LIKE ?3
          OR lower(root_session_id) LIKE ?3
          OR lower(session_id) LIKE ?3
-      GROUP BY root_session_id
+    ), session_groups AS (
+      SELECT s.root_session_id,
+             COALESCE(NULLIF(MAX(title), ''), s.root_session_id) AS title,
+             MIN(started_at) AS started_at,
+             MAX(updated_at) AS updated_at,
+             COUNT(*) AS session_count,
+             GROUP_CONCAT(DISTINCT source_state) AS source_states
+      FROM sessions s
+      JOIN matching_roots mr ON mr.root_session_id = s.root_session_id
+      GROUP BY s.root_session_id
     ), event_groups AS (
       SELECT s.root_session_id,
              GROUP_CONCAT(DISTINCT e.model_id) AS model_ids,
@@ -2183,6 +2187,67 @@ mod tests {
     assert_eq!(second.items.len(), 50);
     assert_eq!(second.next_cursor.as_deref(), Some("100"));
     assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("session-069"));
+  }
+
+  #[test]
+  fn conversation_search_aggregates_every_session_in_a_matching_root() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "INSERT INTO sessions (session_id, root_session_id, title, source_state, started_at, created_at, imported_at, updated_at) VALUES ('root', 'root', 'Z Root title', 'active', '2026-07-13T07:00:00Z', '2026-07-13T07:00:00Z', '2026-07-13T07:00:00Z', '2026-07-13T08:00:00Z')",
+        [],
+      )
+      .expect("insert root session");
+    conn
+      .execute(
+        "INSERT INTO sessions (session_id, root_session_id, title, source_state, started_at, created_at, imported_at, updated_at) VALUES ('child-needle', 'root', 'Needle child', 'missing', '2026-07-13T08:00:00Z', '2026-07-13T08:00:00Z', '2026-07-13T08:00:00Z', '2026-07-13T09:00:00Z')",
+        [],
+      )
+      .expect("insert matching child session");
+    for (session_id, total_tokens, value_usd) in [("root", 10, 1.0), ("child-needle", 20, 2.0)] {
+      conn
+        .execute(
+          "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES (?1, '2026-07-13T08:30:00Z', ?2, 'gpt-5.4', ?3, 0, 0, 0, ?3, ?4, 0, 0)",
+          rusqlite::params![
+            session_id,
+            parse_rfc3339_local("2026-07-13T08:30:00Z")
+              .expect("event timestamp")
+              .timestamp_millis(),
+            total_tokens,
+            value_usd,
+          ],
+        )
+        .expect("insert usage event");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T00:00:00Z").expect("end"),
+    };
+
+    let page = load_conversation_page_sql(
+      &conn,
+      &SubscriptionProfile::default(),
+      &window,
+      Some("needle".to_string()),
+      None,
+      50,
+    )
+    .expect("search conversations");
+
+    assert_eq!(page.items.len(), 1);
+    let item = &page.items[0];
+    assert_eq!(item.root_session_id, "root");
+    assert_eq!(item.title, "Z Root title");
+    assert_eq!(item.started_at.as_deref(), Some("2026-07-13T07:00:00Z"));
+    assert_eq!(item.updated_at.as_deref(), Some("2026-07-13T09:00:00Z"));
+    assert_eq!(item.session_count, 2);
+    assert_eq!(item.subagent_count, 1);
+    assert_eq!(item.total_tokens, 30);
+    assert_eq!(item.api_value_usd, 3.0);
+    assert_eq!(item.source_states, vec!["active", "missing"]);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -1812,8 +1812,10 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
         SELECT id
         FROM rate_limit_samples
         WHERE bucket = ?1
-          AND window_start_ms = ?2
-          AND resets_at_ms = ?3
+          AND window_start_ms >= ?2
+          AND window_start_ms < ?2 + 60000
+          AND resets_at_ms >= ?3
+          AND resets_at_ms < ?3 + 60000
           AND sample_timestamp_ms >= bins.bin_start_ms
           AND sample_timestamp_ms < bins.bin_end_ms
         ORDER BY sample_timestamp_ms DESC, id DESC
@@ -2461,6 +2463,49 @@ mod tests {
         .collect::<Vec<_>>(),
       vec![2, 4]
     );
+  }
+
+  #[test]
+  fn backfilled_quota_samples_match_the_normalized_window_minute() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "
+        INSERT INTO rate_limit_samples (
+          source_kind, source_session_id, bucket, sample_timestamp,
+          limit_id, limit_name, plan_type, window_start, resets_at,
+          used_percent, remaining_percent, created_at,
+          sample_timestamp_ms, window_start_ms, resets_at_ms
+        ) VALUES (
+          'live', '', 'seven_day', '2026-07-13T07:00:12Z',
+          '', '', 'pro', '2026-07-13T06:00:36Z', '2026-07-20T06:00:44Z',
+          12, 88, '2026-07-13T07:00:12Z', ?1, ?2, ?3
+        )
+        ",
+        rusqlite::params![
+          parse_rfc3339_local("2026-07-13T07:00:12Z").expect("sample").timestamp_millis(),
+          parse_rfc3339_local("2026-07-13T06:00:36Z").expect("start").timestamp_millis(),
+          parse_rfc3339_local("2026-07-20T06:00:44Z").expect("end").timestamp_millis(),
+        ],
+      )
+      .expect("insert backfilled quota sample");
+    conn
+      .execute(
+        "INSERT INTO data_repairs (repair_key, completed_at) VALUES ('epoch_timestamp_backfill_v1', '2026-07-13T08:00:00Z')",
+        [],
+      )
+      .expect("mark epoch backfill complete");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end"),
+    };
+
+    let samples = load_quota_samples(&conn, &window);
+
+    assert_eq!(samples.iter().map(|sample| sample.used_percent).collect::<Vec<_>>(), vec![12]);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -91,14 +91,16 @@ struct RateLimitWindowSummary {
   end: DateTime<Local>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 pub struct DashboardData {
   pub overview: OverviewResponse,
   pub conversation_page: ConversationPage,
   pub subscription_profile: SubscriptionProfile,
 }
 
-pub fn get_overview(
-  db_path: &Path,
+pub fn get_overview_with_connection(
+  conn: &Connection,
   bucket: Option<String>,
   anchor: Option<String>,
   custom_start: Option<String>,
@@ -106,7 +108,6 @@ pub fn get_overview(
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
-  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let resolved_window = resolve_window(
     &conn,
@@ -210,20 +211,18 @@ pub fn list_conversations(
     live_rate_limits.as_ref(),
     filters.live_window_offset,
   )?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
-  let cursor = filters.cursor.clone();
   let limit = filters.limit.unwrap_or(50).clamp(1, 100);
-  let items = build_conversation_list(
-    &sessions,
-    &events,
+  load_conversation_page_sql(
+    &conn,
     &profile,
     &resolved_window.window,
     filters.search,
-  )?;
-  Ok(paginate_conversations(items, cursor.as_deref(), limit))
+    filters.cursor.as_deref(),
+    limit,
+  )
 }
 
+#[cfg(test)]
 pub fn load_dashboard_data(
   db_path: &Path,
   bucket: Option<String>,
@@ -233,6 +232,7 @@ pub fn load_dashboard_data(
   search: Option<String>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
+  include_conversations: bool,
 ) -> Result<DashboardData, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
@@ -260,41 +260,143 @@ pub fn load_dashboard_data(
     &resolved_window,
     live_rate_limits.clone(),
   )?;
-  let conversations = build_conversation_list(
-    &sessions,
-    &events,
-    &profile,
-    &resolved_window.window,
-    search,
-  )?;
+  let conversation_page = if include_conversations {
+    load_conversation_page_sql(&conn, &profile, &resolved_window.window, search, None, 50)?
+  } else {
+    ConversationPage {
+      items: Vec::new(),
+      next_cursor: None,
+      has_more: false,
+    }
+  };
 
   Ok(DashboardData {
     overview,
-    conversation_page: paginate_conversations(conversations, None, 50),
+    conversation_page,
     subscription_profile: profile,
   })
 }
 
-fn paginate_conversations(
-  items: Vec<ConversationListItem>,
+fn load_conversation_page_sql(
+  conn: &Connection,
+  profile: &SubscriptionProfile,
+  window: &Window,
+  search: Option<String>,
   cursor: Option<&str>,
   limit: usize,
-) -> ConversationPage {
-  let start = cursor
-    .and_then(|cursor| items.iter().position(|item| item.root_session_id == cursor))
-    .map(|index| index.saturating_add(1))
-    .unwrap_or(0);
-  let end = start.saturating_add(limit).min(items.len());
-  let page_items = items[start..end].to_vec();
-  let has_more = end < items.len();
-  let next_cursor = has_more
-    .then(|| page_items.last().map(|item| item.root_session_id.clone()))
-    .flatten();
-  ConversationPage {
-    items: page_items,
-    next_cursor,
+) -> Result<ConversationPage, String> {
+  let offset = cursor.and_then(|value| value.parse::<usize>().ok()).unwrap_or(0);
+  let search_pattern = search
+    .filter(|value| !value.trim().is_empty())
+    .map(|value| format!("%{}%", value.to_ascii_lowercase()));
+  let include_empty = i64::from(window.bucket == "total");
+  let event_filter = if epoch_backfill_complete(conn) || !has_legacy_usage_events(conn).map_err(|error| error.to_string())? {
+    "e.timestamp_ms >= ?1 AND e.timestamp_ms < ?2"
+  } else {
+    "((e.timestamp_ms >= ?1 AND e.timestamp_ms < ?2) OR (e.timestamp_ms IS NULL AND unixepoch(e.timestamp) * 1000 >= ?1 AND unixepoch(e.timestamp) * 1000 < ?2))"
+  };
+  let sql = format!(
+    "
+    WITH session_groups AS (
+      SELECT root_session_id,
+             COALESCE(NULLIF(MAX(title), ''), root_session_id) AS title,
+             MIN(started_at) AS started_at,
+             MAX(updated_at) AS updated_at,
+             COUNT(*) AS session_count,
+             GROUP_CONCAT(DISTINCT source_state) AS source_states
+      FROM sessions
+      WHERE ?3 IS NULL
+         OR lower(COALESCE(title, '')) LIKE ?3
+         OR lower(root_session_id) LIKE ?3
+         OR lower(session_id) LIKE ?3
+      GROUP BY root_session_id
+    ), event_groups AS (
+      SELECT s.root_session_id,
+             GROUP_CONCAT(DISTINCT e.model_id) AS model_ids,
+             SUM(e.input_tokens) AS input_tokens,
+             SUM(e.cached_input_tokens) AS cached_input_tokens,
+             SUM(e.output_tokens) AS output_tokens,
+             SUM(e.reasoning_output_tokens) AS reasoning_output_tokens,
+             SUM(e.total_tokens) AS total_tokens,
+             SUM(e.value_usd) AS api_value_usd,
+             MAX(e.fast_mode_effective) AS has_fast_mode
+      FROM usage_events e
+      JOIN sessions s ON s.session_id = e.session_id
+      WHERE {event_filter}
+      GROUP BY s.root_session_id
+    )
+    SELECT sg.root_session_id, sg.title, sg.started_at, sg.updated_at,
+           COALESCE(eg.model_ids, ''), COALESCE(eg.input_tokens, 0),
+           COALESCE(eg.cached_input_tokens, 0), COALESCE(eg.output_tokens, 0),
+           COALESCE(eg.reasoning_output_tokens, 0), COALESCE(eg.total_tokens, 0),
+           sg.session_count, COALESCE(eg.has_fast_mode, 0),
+           COALESCE(eg.api_value_usd, 0.0), COALESCE(sg.source_states, '')
+    FROM session_groups sg
+    LEFT JOIN event_groups eg ON eg.root_session_id = sg.root_session_id
+    WHERE ?4 = 1 OR COALESCE(eg.total_tokens, 0) > 0
+    ORDER BY COALESCE(eg.api_value_usd, 0.0) DESC, sg.updated_at DESC, sg.root_session_id ASC
+    LIMIT ?5 OFFSET ?6
+    "
+  );
+  let fetch_limit = limit.saturating_add(1);
+  let mut stmt = conn.prepare(&sql).map_err(|error| error.to_string())?;
+  let rows = stmt
+    .query_map(
+      rusqlite::params![
+        window.start.timestamp_millis(),
+        window.end.timestamp_millis(),
+        search_pattern,
+        include_empty,
+        fetch_limit as i64,
+        offset as i64,
+      ],
+      |row| {
+        let session_count = row.get::<_, i64>(10)?.max(0) as usize;
+        let api_value_usd = row.get::<_, f64>(12)?;
+        Ok(ConversationListItem {
+          root_session_id: row.get(0)?,
+          title: row.get(1)?,
+          started_at: row.get(2)?,
+          updated_at: row.get(3)?,
+          model_ids: split_sorted_csv(row.get::<_, String>(4)?),
+          input_tokens: row.get(5)?,
+          cached_input_tokens: row.get(6)?,
+          output_tokens: row.get(7)?,
+          reasoning_output_tokens: row.get(8)?,
+          total_tokens: row.get(9)?,
+          session_count,
+          subagent_count: session_count.saturating_sub(1),
+          has_fast_mode: row.get::<_, i64>(11)? != 0,
+          api_value_usd,
+          subscription_share: if profile.monthly_price > 0.0 {
+            api_value_usd / profile.monthly_price
+          } else {
+            0.0
+          },
+          source_states: split_sorted_csv(row.get::<_, String>(13)?),
+        })
+      },
+    )
+    .map_err(|error| error.to_string())?;
+  let mut items = rows.collect::<rusqlite::Result<Vec<_>>>().map_err(|error| error.to_string())?;
+  let has_more = items.len() > limit;
+  items.truncate(limit);
+  Ok(ConversationPage {
+    items,
+    next_cursor: has_more.then(|| offset.saturating_add(limit).to_string()),
     has_more,
-  }
+  })
+}
+
+fn split_sorted_csv(value: String) -> Vec<String> {
+  let mut values = value
+    .split(',')
+    .filter(|item| !item.is_empty())
+    .map(ToString::to_string)
+    .collect::<Vec<_>>();
+  values.sort();
+  values.dedup();
+  values
 }
 
 fn build_overview(
@@ -369,119 +471,6 @@ fn build_overview(
     composition_shares: composition_breakdown,
     live_rate_limits,
   })
-}
-
-fn build_conversation_list(
-  sessions: &HashMap<String, SessionRow>,
-  events: &[EventRow],
-  profile: &SubscriptionProfile,
-  window: &Window,
-  search: Option<String>,
-) -> Result<Vec<ConversationListItem>, String> {
-  let search = search.unwrap_or_default().to_ascii_lowercase();
-
-  let mut groups: BTreeMap<String, ConversationAccumulator> = BTreeMap::new();
-
-  for session in sessions.values() {
-    let group = groups
-      .entry(session.root_session_id.clone())
-      .or_insert_with(|| ConversationAccumulator {
-        title: session.title.clone(),
-        started_at: session.started_at.clone(),
-        updated_at: session.updated_at.clone(),
-        model_ids: HashSet::new(),
-        input_tokens: 0,
-        cached_input_tokens: 0,
-        output_tokens: 0,
-        reasoning_output_tokens: 0,
-        total_tokens: 0,
-        session_ids: HashSet::new(),
-        fast_session_ids: HashSet::new(),
-        api_value_usd: 0.0,
-        source_states: HashSet::new(),
-      });
-
-    if group.title.is_empty() {
-      group.title = session.title.clone();
-    }
-    group.started_at = min_option_string(group.started_at.take(), session.started_at.clone());
-    group.updated_at = max_option_string(group.updated_at.take(), session.updated_at.clone());
-    group.session_ids.insert(session.session_id.clone());
-    group.source_states.insert(session.source_state.clone());
-  }
-
-  for event in events {
-    let Some(session) = sessions.get(&event.session_id) else {
-      continue;
-    };
-    let group = groups.entry(session.root_session_id.clone()).or_default();
-    group.model_ids.insert(event.model_id.clone());
-    group.input_tokens += event.input_tokens;
-    group.cached_input_tokens += event.cached_input_tokens;
-    group.output_tokens += event.output_tokens;
-    group.reasoning_output_tokens += event.reasoning_output_tokens;
-    group.total_tokens += event.total_tokens;
-    group.api_value_usd += event.value_usd;
-    if event.fast_mode_effective {
-      group.fast_session_ids.insert(event.session_id.clone());
-    }
-  }
-
-  let mut items = Vec::new();
-  for (root_session_id, group) in groups {
-    let title = if group.title.trim().is_empty() {
-      root_session_id.clone()
-    } else {
-      group.title.clone()
-    };
-
-    if !search.is_empty()
-      && !title.to_ascii_lowercase().contains(&search)
-      && !root_session_id.to_ascii_lowercase().contains(&search)
-      && !group
-        .session_ids
-        .iter()
-        .any(|session_id| session_id.to_ascii_lowercase().contains(&search))
-    {
-      continue;
-    }
-
-    if group.total_tokens == 0 && window.bucket != "total" {
-      continue;
-    }
-
-    items.push(ConversationListItem {
-      root_session_id,
-      title,
-      started_at: group.started_at,
-      updated_at: group.updated_at,
-      model_ids: sorted_strings(group.model_ids),
-      input_tokens: group.input_tokens,
-      cached_input_tokens: group.cached_input_tokens,
-      output_tokens: group.output_tokens,
-      reasoning_output_tokens: group.reasoning_output_tokens,
-      total_tokens: group.total_tokens,
-      session_count: group.session_ids.len(),
-      subagent_count: group.session_ids.len().saturating_sub(1),
-      has_fast_mode: !group.fast_session_ids.is_empty(),
-      api_value_usd: group.api_value_usd,
-      subscription_share: if profile.monthly_price > 0.0 {
-        group.api_value_usd / profile.monthly_price
-      } else {
-        0.0
-      },
-      source_states: sorted_strings(group.source_states),
-    });
-  }
-
-  items.sort_by(|left, right| {
-    right
-      .api_value_usd
-      .total_cmp(&left.api_value_usd)
-      .then_with(|| right.updated_at.cmp(&left.updated_at))
-  });
-
-  Ok(items)
 }
 
 pub fn get_conversation_detail(
@@ -1435,7 +1424,21 @@ fn resolve_live_rate_limit_window(
         end: normalize_local_timestamp(active_window.resets_at.as_deref().and_then(parse_rfc3339_local)?),
       })
     });
-  let windows = load_live_rate_limit_windows(conn, bucket, current_window).map_err(|error| error.to_string())?;
+  if requested_offset == 0 {
+    if let Some(window) = current_window {
+      return Ok((window.start, window.end, window.start.date_naive(), 0, 2));
+    }
+  }
+  let requested_window_count = requested_offset
+    .saturating_add(2)
+    .clamp(1, MAX_LIVE_RATE_LIMIT_WINDOWS as i64) as usize;
+  let windows = load_live_rate_limit_windows(
+    conn,
+    bucket,
+    current_window,
+    requested_window_count,
+  )
+  .map_err(|error| error.to_string())?;
 
   if windows.is_empty() {
     return Err(format!(
@@ -1459,6 +1462,7 @@ fn load_live_rate_limit_windows(
   conn: &Connection,
   bucket: &str,
   current_window: Option<RateLimitWindowSummary>,
+  max_windows: usize,
 ) -> rusqlite::Result<Vec<RateLimitWindowSummary>> {
   let mut ordered = Vec::new();
   let mut seen = HashSet::new();
@@ -1473,7 +1477,7 @@ fn load_live_rate_limit_windows(
     }
     let previous_start = window.start;
     ordered.push(window);
-    if ordered.len() >= MAX_LIVE_RATE_LIMIT_WINDOWS {
+    if ordered.len() >= max_windows.clamp(1, MAX_LIVE_RATE_LIMIT_WINDOWS) {
       break;
     }
     cursor = load_previous_rate_limit_window(conn, bucket, previous_start)?;
@@ -1829,7 +1833,7 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     Err(_) => return Vec::new(),
   };
 
-  let samples = rows
+  let mut samples = rows
     .filter_map(Result::ok)
     .filter_map(|(timestamp_ms, used_percent)| {
       Local.timestamp_millis_opt(timestamp_ms).single().map(|timestamp| QuotaSample {
@@ -1838,11 +1842,14 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
       })
     })
     .collect::<Vec<_>>();
-  if !samples.is_empty() || epoch_backfill_complete(conn) {
+  if epoch_backfill_complete(conn) {
     return samples;
   }
 
-  load_legacy_quota_samples(conn, window, target_start, target_end)
+  samples.extend(load_legacy_quota_samples(conn, window, target_start, target_end));
+  samples.sort_by_key(|sample| sample.timestamp);
+  samples.dedup_by(|right, left| right.timestamp == left.timestamp && right.used_percent == left.used_percent);
+  samples
 }
 
 fn epoch_backfill_complete(conn: &Connection) -> bool {
@@ -2028,23 +2035,6 @@ impl CompositionAccumulator {
 }
 
 #[derive(Debug, Default)]
-struct ConversationAccumulator {
-  title: String,
-  started_at: Option<String>,
-  updated_at: Option<String>,
-  model_ids: HashSet<String>,
-  input_tokens: i64,
-  cached_input_tokens: i64,
-  output_tokens: i64,
-  reasoning_output_tokens: i64,
-  total_tokens: i64,
-  session_ids: HashSet<String>,
-  fast_session_ids: HashSet<String>,
-  api_value_usd: f64,
-  source_states: HashSet<String>,
-}
-
-#[derive(Debug, Default)]
 struct ConversationSessionAccumulator {
   parent_session_id: Option<String>,
   agent_nickname: Option<String>,
@@ -2113,42 +2103,53 @@ mod tests {
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
 
-  fn conversation_item(id: &str) -> ConversationListItem {
-    ConversationListItem {
-      root_session_id: id.to_string(),
-      title: id.to_string(),
-      started_at: None,
-      updated_at: None,
-      model_ids: Vec::new(),
-      input_tokens: 0,
-      cached_input_tokens: 0,
-      output_tokens: 0,
-      reasoning_output_tokens: 0,
-      total_tokens: 0,
-      session_count: 1,
-      subagent_count: 0,
-      has_fast_mode: false,
-      api_value_usd: 0.0,
-      subscription_share: 0.0,
-      source_states: Vec::new(),
-    }
-  }
-
   #[test]
-  fn conversation_pages_are_bounded_and_resume_after_the_cursor() {
-    let items = (0..120)
-      .map(|index| conversation_item(&format!("root-{index:03}")))
-      .collect::<Vec<_>>();
+  fn conversation_query_pages_in_sql_without_loading_every_item() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let event_timestamp = "2026-07-13T08:00:00Z";
+    let event_timestamp_ms = parse_rfc3339_local(event_timestamp).expect("event timestamp").timestamp_millis();
+    for index in 0..120 {
+      let session_id = format!("session-{index:03}");
+      conn
+        .execute(
+          "INSERT INTO sessions (session_id, root_session_id, title, source_state, created_at, imported_at, updated_at) VALUES (?1, ?1, ?2, 'active', ?3, ?3, ?3)",
+          rusqlite::params![session_id, format!("Conversation {index:03}"), "2026-07-13T08:00:00Z"],
+        )
+        .expect("insert session");
+      conn
+        .execute(
+          "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES (?1, ?2, ?3, 'gpt-5.4', 1, 0, 1, 0, 2, ?4, 0, 0)",
+          rusqlite::params![session_id, event_timestamp, event_timestamp_ms, index as f64],
+        )
+        .expect("insert usage event");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T00:00:00Z").expect("end"),
+    };
+    let profile = SubscriptionProfile::default();
 
-    let first = paginate_conversations(items.clone(), None, 50);
+    let first = load_conversation_page_sql(&conn, &profile, &window, None, None, 50).expect("first page");
     assert_eq!(first.items.len(), 50);
     assert!(first.has_more);
-    assert_eq!(first.next_cursor.as_deref(), Some("root-049"));
+    assert_eq!(first.next_cursor.as_deref(), Some("50"));
+    assert_eq!(first.items.first().map(|item| item.root_session_id.as_str()), Some("session-119"));
 
-    let second = paginate_conversations(items, first.next_cursor.as_deref(), 50);
+    let second = load_conversation_page_sql(
+      &conn,
+      &profile,
+      &window,
+      None,
+      first.next_cursor.as_deref(),
+      50,
+    )
+    .expect("second page");
     assert_eq!(second.items.len(), 50);
-    assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("root-050"));
-    assert_eq!(second.next_cursor.as_deref(), Some("root-099"));
+    assert_eq!(second.next_cursor.as_deref(), Some("100"));
+    assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("session-069"));
   }
 
   #[test]
@@ -2167,6 +2168,7 @@ mod tests {
       None,
       None,
       None,
+      true,
     )
     .expect("load seven-day dashboard");
     eprintln!(
@@ -2272,6 +2274,28 @@ mod tests {
         [],
       )
       .expect("insert legacy quota sample");
+    conn
+      .execute(
+        "
+        INSERT INTO rate_limit_samples (
+          source_kind, source_session_id, bucket, sample_timestamp,
+          limit_id, limit_name, plan_type, window_start, resets_at,
+          used_percent, remaining_percent, created_at,
+          sample_timestamp_ms, window_start_ms, resets_at_ms
+        ) VALUES (
+          'live', '', 'seven_day', '2026-07-13T06:30:00Z',
+          '', '', 'pro', '2026-07-13T06:00:00Z', '2026-07-20T06:00:00Z',
+          8, 92, '2026-07-13T06:30:00Z',
+          ?1, ?2, ?3
+        )
+        ",
+        rusqlite::params![
+          parse_rfc3339_local("2026-07-13T06:30:00Z").expect("sample").timestamp_millis(),
+          parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start").timestamp_millis(),
+          parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end").timestamp_millis(),
+        ],
+      )
+      .expect("insert normalized quota sample");
     let window = Window {
       bucket: "seven_day".to_string(),
       anchor: "2026-07-13".to_string(),
@@ -2281,8 +2305,7 @@ mod tests {
 
     let samples = load_quota_samples(&conn, &window);
 
-    assert_eq!(samples.len(), 1);
-    assert_eq!(samples[0].used_percent, 12);
+    assert_eq!(samples.iter().map(|sample| sample.used_percent).collect::<Vec<_>>(), vec![8, 12]);
   }
 
   #[test]
@@ -2894,15 +2917,44 @@ mod tests {
       secondary: None,
       fetched_at: "2026-03-26T11:20:00+08:00".to_string(),
     };
+    let older = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: Some(crate::models::RateLimitWindowSnapshot {
+        used_percent: 71,
+        remaining_percent: 29,
+        window_duration_mins: Some(300),
+        resets_at: Some("2026-03-26T06:27:36+08:00".to_string()),
+        window_start: Some("2026-03-26T01:27:36+08:00".to_string()),
+      }),
+      secondary: None,
+      fetched_at: "2026-03-26T06:20:00+08:00".to_string(),
+    };
+    insert_live_rate_limit_snapshot(&conn, &older).expect("insert older live window");
     insert_live_rate_limit_snapshot(&conn, &previous).expect("insert previous live window");
     insert_live_rate_limit_snapshot(&conn, &current).expect("insert current live window");
+
+    let current_window = resolve_window(
+      &conn,
+      Some("five_hour".to_string()),
+      None,
+      None,
+      None,
+      &[],
+      1,
+      Some(&current),
+      Some(0),
+    )
+    .expect("resolve current live window");
+    assert_eq!(current_window.live_window_count, 2);
 
     let window =
       resolve_window(&conn, Some("five_hour".to_string()), None, None, None, &[], 1, Some(&current), Some(1))
         .expect("resolve historical live window");
 
     assert_eq!(window.live_window_offset, 1);
-    assert!(window.live_window_count >= 2);
+    assert_eq!(window.live_window_count, 3);
     assert_eq!(window.window.start.to_rfc3339(), "2026-03-26T06:27:00+08:00");
     assert_eq!(window.window.end.to_rfc3339(), "2026-03-26T11:27:00+08:00");
   }

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::database::{get_subscription_profile, open_connection};
 use crate::models::{
-  CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem,
+  CompositionShare, ConversationDetail, ConversationFilters, ConversationListItem, ConversationPage,
   ConversationSessionSummary, ConversationTurnPoint, LiveRateLimitSnapshot, ModelShare,
   OverviewResponse, OverviewStats, PricingCatalogEntry, QuotaTrendPoint, SubscriptionProfile, TokenUsage,
   TrendPoint,
@@ -24,10 +24,8 @@ use crate::pricing::{
 
 const SQL_SESSIONS: &str = include_str!("../sql/queries/sessions.sql");
 const SQL_SESSIONS_FOR_ROOT: &str = include_str!("../sql/queries/sessions_for_root.sql");
-const SQL_USAGE_EVENTS: &str = include_str!("../sql/queries/usage_events.sql");
 const SQL_USAGE_EVENTS_FOR_ROOT: &str = include_str!("../sql/queries/usage_events_for_root.sql");
 const SQL_RATE_LIMIT_WINDOWS: &str = include_str!("../sql/queries/rate_limit_windows.sql");
-const SQL_QUOTA_SAMPLES: &str = include_str!("../sql/queries/quota_samples.sql");
 
 #[derive(Debug, Clone)]
 struct SessionRow {
@@ -95,7 +93,7 @@ struct RateLimitWindowSummary {
 
 pub struct DashboardData {
   pub overview: OverviewResponse,
-  pub conversations: Vec<ConversationListItem>,
+  pub conversation_page: ConversationPage,
   pub subscription_profile: SubscriptionProfile,
 }
 
@@ -109,9 +107,20 @@ pub fn get_overview(
   live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let resolved_window = resolve_window(
+    &conn,
+    bucket.clone(),
+    anchor.clone(),
+    custom_start.clone(),
+    custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
   build_overview(
     &conn,
@@ -134,7 +143,6 @@ pub fn get_quota_trend(
   live_rate_limits: Option<LiveRateLimitSnapshot>,
 ) -> Result<Vec<QuotaTrendPoint>, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let resolved_window = resolve_window(
     &conn,
@@ -142,17 +150,13 @@ pub fn get_quota_trend(
     None,
     None,
     None,
-    &events,
+    &[],
     profile.billing_anchor_day,
     live_rate_limits.as_ref(),
     None,
   )?;
   let window = &resolved_window.window;
-  let filtered_events: Vec<_> = events
-    .iter()
-    .filter(|event| event_in_window(event, window))
-    .cloned()
-    .collect();
+  let filtered_events = load_events_in_window(&conn, window).map_err(|error| error.to_string())?;
 
   Ok(build_quota_trend(
     &conn,
@@ -195,12 +199,27 @@ pub fn list_conversations(
   db_path: &Path,
   filters: Option<ConversationFilters>,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
-) -> Result<Vec<ConversationListItem>, String> {
+) -> Result<ConversationPage, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
-  build_conversation_list(&conn, &sessions, &events, &profile, filters, live_rate_limits.as_ref())
+  let filters = filters.unwrap_or_default();
+  let resolved_window = resolve_window(
+    &conn,
+    filters.bucket.clone(),
+    filters.anchor.clone(),
+    filters.custom_start.clone(),
+    filters.custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    filters.live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
+  let cursor = filters.cursor.clone();
+  let limit = filters.limit.unwrap_or(50).clamp(1, 100);
+  let items = build_conversation_list(&conn, &sessions, &events, &profile, Some(filters), live_rate_limits.as_ref())?;
+  Ok(paginate_conversations(items, cursor.as_deref(), limit))
 }
 
 pub fn load_dashboard_data(
@@ -214,9 +233,20 @@ pub fn load_dashboard_data(
   live_window_offset: Option<i64>,
 ) -> Result<DashboardData, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
-  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let resolved_window = resolve_window(
+    &conn,
+    bucket.clone(),
+    anchor.clone(),
+    custom_start.clone(),
+    custom_end.clone(),
+    &[],
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    live_window_offset,
+  )?;
+  let sessions = load_sessions(&conn).map_err(|error| error.to_string())?;
+  let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
   let catalog = load_catalog_map(&conn).map_err(|error| error.to_string())?;
 
   let overview = build_overview(
@@ -244,15 +274,39 @@ pub fn load_dashboard_data(
       custom_end,
       search,
       live_window_offset,
+      cursor: None,
+      limit: Some(50),
     }),
     live_rate_limits.as_ref(),
   )?;
 
   Ok(DashboardData {
     overview,
-    conversations,
+    conversation_page: paginate_conversations(conversations, None, 50),
     subscription_profile: profile,
   })
+}
+
+fn paginate_conversations(
+  items: Vec<ConversationListItem>,
+  cursor: Option<&str>,
+  limit: usize,
+) -> ConversationPage {
+  let start = cursor
+    .and_then(|cursor| items.iter().position(|item| item.root_session_id == cursor))
+    .map(|index| index.saturating_add(1))
+    .unwrap_or(0);
+  let end = start.saturating_add(limit).min(items.len());
+  let page_items = items[start..end].to_vec();
+  let has_more = end < items.len();
+  let next_cursor = has_more
+    .then(|| page_items.last().map(|item| item.root_session_id.clone()))
+    .flatten();
+  ConversationPage {
+    items: page_items,
+    next_cursor,
+    has_more,
+  }
 }
 
 fn build_overview(
@@ -479,7 +533,11 @@ fn build_conversation_list(
   Ok(items)
 }
 
-pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<ConversationDetail, String> {
+pub fn get_conversation_detail(
+  db_path: &Path,
+  root_session_id: &str,
+  turn_cursor: Option<usize>,
+) -> Result<ConversationDetail, String> {
   let conn = open_connection(db_path).map_err(|error| error.to_string())?;
   let sessions = load_sessions_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
   let events = load_events_for_root_session(&conn, root_session_id).map_err(|error| error.to_string())?;
@@ -584,6 +642,12 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
       .then_with(|| left.session_id.cmp(&right.session_id))
       .then_with(|| left.turn_id.cmp(&right.turn_id))
   });
+  let already_loaded = turn_cursor.unwrap_or(0);
+  let page_end = detail_turns.len().saturating_sub(already_loaded);
+  let page_start = page_end.saturating_sub(40);
+  let turn_page = detail_turns[page_start..page_end].to_vec();
+  let has_more_turns = page_start > 0;
+  let next_turn_cursor = has_more_turns.then_some(already_loaded.saturating_add(turn_page.len()));
 
   let mut session_summaries = Vec::new();
   for session in conversation_sessions {
@@ -647,7 +711,9 @@ pub fn get_conversation_detail(db_path: &Path, root_session_id: &str) -> Result<
     multiple_agent: session_summaries.len() > 1,
     source_states: sorted_strings(source_states),
     sessions: session_summaries,
-    turns: detail_turns,
+    turns: turn_page,
+    next_turn_cursor,
+    has_more_turns,
     model_breakdown,
     composition_breakdown,
   })
@@ -1149,23 +1215,43 @@ fn load_sessions_for_root_session(
   Ok(sessions)
 }
 
-fn load_events(conn: &Connection) -> rusqlite::Result<Vec<EventRow>> {
-  let mut stmt = conn.prepare(SQL_USAGE_EVENTS)?;
-  let rows = stmt.query_map([], |row| {
-    Ok(EventRow {
-      session_id: row.get(0)?,
-      timestamp: row.get(1)?,
-      model_id: row.get(2)?,
-      input_tokens: row.get(3)?,
-      cached_input_tokens: row.get(4)?,
-      output_tokens: row.get(5)?,
-      reasoning_output_tokens: row.get(6)?,
-      total_tokens: row.get(7)?,
-      value_usd: row.get(8)?,
-      fast_mode_auto: row.get::<_, i64>(9)? != 0,
-      fast_mode_effective: row.get::<_, i64>(10)? != 0,
-    })
-  })?;
+fn load_events_in_window(conn: &Connection, window: &Window) -> rusqlite::Result<Vec<EventRow>> {
+  let mut stmt = conn.prepare(
+    "
+    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
+    UNION ALL
+    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE timestamp_ms IS NULL
+      AND unixepoch(timestamp) * 1000 >= ?1
+      AND unixepoch(timestamp) * 1000 < ?2
+    ORDER BY timestamp ASC
+    ",
+  )?;
+  let rows = stmt.query_map(
+    rusqlite::params![window.start.timestamp_millis(), window.end.timestamp_millis()],
+    |row| {
+      Ok(EventRow {
+        session_id: row.get(0)?,
+        timestamp: row.get(1)?,
+        model_id: row.get(2)?,
+        input_tokens: row.get(3)?,
+        cached_input_tokens: row.get(4)?,
+        output_tokens: row.get(5)?,
+        reasoning_output_tokens: row.get(6)?,
+        total_tokens: row.get(7)?,
+        value_usd: row.get(8)?,
+        fast_mode_auto: row.get::<_, i64>(9)? != 0,
+        fast_mode_effective: row.get::<_, i64>(10)? != 0,
+      })
+    },
+  )?;
 
   rows.collect()
 }
@@ -1227,7 +1313,7 @@ fn resolve_window(
   anchor: Option<String>,
   custom_start: Option<String>,
   custom_end: Option<String>,
-  events: &[EventRow],
+  _events: &[EventRow],
   billing_anchor_day: i64,
   live_rate_limits: Option<&LiveRateLimitSnapshot>,
   live_window_offset: Option<i64>,
@@ -1295,20 +1381,30 @@ fn resolve_window(
       (start, end, start_date, 0, 0)
     }
     "total" => {
-      if events.is_empty() {
+      let bounds = conn
+        .query_row(
+          "
+          SELECT
+            MIN(COALESCE(timestamp_ms, unixepoch(timestamp) * 1000)),
+            MAX(COALESCE(timestamp_ms, unixepoch(timestamp) * 1000))
+          FROM usage_events
+          ",
+          [],
+          |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, Option<i64>>(1)?)),
+        )
+        .map_err(|error| error.to_string())?;
+      if bounds.0.is_none() || bounds.1.is_none() {
         let start = local_midnight(anchor_date)?;
         (start, start + chrono::Duration::days(1), anchor_date, 0, 0)
       } else {
-        let first = events
-          .iter()
-          .filter_map(|event| parse_rfc3339_local(&event.timestamp))
-          .min()
-          .ok_or_else(|| "No valid event timestamps found.".to_string())?;
-        let last = events
-          .iter()
-          .filter_map(|event| parse_rfc3339_local(&event.timestamp))
-          .max()
-          .ok_or_else(|| "No valid event timestamps found.".to_string())?;
+        let first = Local
+          .timestamp_millis_opt(bounds.0.unwrap_or_default())
+          .single()
+          .ok_or_else(|| "No valid first usage timestamp found.".to_string())?;
+        let last = Local
+          .timestamp_millis_opt(bounds.1.unwrap_or_default())
+          .single()
+          .ok_or_else(|| "No valid last usage timestamp found.".to_string())?;
         let start_date = first.date_naive();
         let end_date = last.date_naive().checked_add_days(Days::new(1)).unwrap_or(last.date_naive());
         let start = local_midnight(start_date)?;
@@ -1647,34 +1743,46 @@ fn live_sample(live_rate_limits: &LiveRateLimitSnapshot, bucket: &str) -> Option
 }
 
 fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
-  let mut stmt = match conn.prepare(SQL_QUOTA_SAMPLES) {
+  let target_start = normalize_local_timestamp(window.start);
+  let target_end = normalize_local_timestamp(window.end);
+  let mut stmt = match conn.prepare(
+    "
+    SELECT sample_timestamp, used_percent
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND window_start_ms = ?2
+      AND resets_at_ms = ?3
+    UNION ALL
+    SELECT sample_timestamp, used_percent
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND (window_start_ms IS NULL OR resets_at_ms IS NULL)
+      AND window_start = ?4
+      AND resets_at = ?5
+    ORDER BY sample_timestamp ASC
+    ",
+  ) {
     Ok(stmt) => stmt,
     Err(_) => return Vec::new(),
   };
 
-  let rows = match stmt.query_map(rusqlite::params![window.bucket], |row| {
-    Ok((
-      row.get::<_, String>(0)?,
-      row.get::<_, i64>(1)?,
-      row.get::<_, String>(2)?,
-      row.get::<_, String>(3)?,
-    ))
-  }) {
+  let rows = match stmt.query_map(
+    rusqlite::params![
+      window.bucket,
+      target_start.timestamp_millis(),
+      target_end.timestamp_millis(),
+      target_start.to_rfc3339(),
+      target_end.to_rfc3339(),
+    ],
+    |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+  ) {
     Ok(rows) => rows,
     Err(_) => return Vec::new(),
   };
 
-  let target_start = normalize_local_timestamp(window.start);
-  let target_end = normalize_local_timestamp(window.end);
-
   rows
     .filter_map(Result::ok)
-    .filter_map(|(timestamp, used_percent, window_start, resets_at)| {
-      let sample_window_start = parse_rfc3339_local(&window_start).map(normalize_local_timestamp)?;
-      let sample_window_end = parse_rfc3339_local(&resets_at).map(normalize_local_timestamp)?;
-      if sample_window_start != target_start || sample_window_end != target_end {
-        return None;
-      }
+    .filter_map(|(timestamp, used_percent)| {
       parse_rfc3339_local(&timestamp).map(|timestamp| QuotaSample {
         timestamp,
         used_percent,
@@ -1898,6 +2006,69 @@ mod tests {
   use super::*;
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
+
+  fn conversation_item(id: &str) -> ConversationListItem {
+    ConversationListItem {
+      root_session_id: id.to_string(),
+      title: id.to_string(),
+      started_at: None,
+      updated_at: None,
+      model_ids: Vec::new(),
+      input_tokens: 0,
+      cached_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: 0,
+      session_count: 1,
+      subagent_count: 0,
+      has_fast_mode: false,
+      api_value_usd: 0.0,
+      subscription_share: 0.0,
+      source_states: Vec::new(),
+    }
+  }
+
+  #[test]
+  fn conversation_pages_are_bounded_and_resume_after_the_cursor() {
+    let items = (0..120)
+      .map(|index| conversation_item(&format!("root-{index:03}")))
+      .collect::<Vec<_>>();
+
+    let first = paginate_conversations(items.clone(), None, 50);
+    assert_eq!(first.items.len(), 50);
+    assert!(first.has_more);
+    assert_eq!(first.next_cursor.as_deref(), Some("root-049"));
+
+    let second = paginate_conversations(items, first.next_cursor.as_deref(), 50);
+    assert_eq!(second.items.len(), 50);
+    assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("root-050"));
+    assert_eq!(second.next_cursor.as_deref(), Some("root-099"));
+  }
+
+  #[test]
+  fn window_event_loader_does_not_return_rows_outside_the_requested_range() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    for timestamp in ["2026-07-01T00:00:00Z", "2026-07-10T00:00:00Z"] {
+      let timestamp_ms = parse_rfc3339_local(timestamp).expect("timestamp").timestamp_millis();
+      conn.execute(
+        "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES ('session', ?1, ?2, 'gpt-5.4', 1, 0, 1, 0, 2, 0.0, 0, 0)",
+        rusqlite::params![timestamp, timestamp_ms],
+      )
+      .expect("insert event");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-10".to_string(),
+      start: parse_rfc3339_local("2026-07-09T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-11T00:00:00Z").expect("end"),
+    };
+
+    let events = load_events_in_window(&conn, &window).expect("load window events");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].timestamp, "2026-07-10T00:00:00Z");
+  }
 
   #[test]
   fn groups_modern_snapshots_into_one_turn() {

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -176,7 +176,6 @@ pub fn get_window_api_value(
     return sum_all_api_value(&conn).map_err(|error| error.to_string());
   }
 
-  let events = load_events(&conn).map_err(|error| error.to_string())?;
   let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
   let resolved_window = resolve_window(
     &conn,
@@ -184,12 +183,12 @@ pub fn get_window_api_value(
     anchor,
     custom_start,
     custom_end,
-    &events,
+    &[],
     profile.billing_anchor_day,
     live_rate_limits.as_ref(),
     live_window_offset,
   )?;
-  Ok(sum_window_api_value(&events, &resolved_window.window))
+  sum_window_api_value_sql(&conn, &resolved_window.window).map_err(|error| error.to_string())
 }
 
 pub fn list_conversations(
@@ -1198,12 +1197,28 @@ fn sum_all_api_value(conn: &Connection) -> rusqlite::Result<f64> {
   })
 }
 
-fn sum_window_api_value(events: &[EventRow], window: &Window) -> f64 {
-  events
-    .iter()
-    .filter(|event| event_in_window(event, window))
-    .map(|event| event.value_usd)
-    .sum()
+fn sum_window_api_value_sql(conn: &Connection, window: &Window) -> rusqlite::Result<f64> {
+  let start_ms = window.start.timestamp_millis();
+  let end_ms = window.end.timestamp_millis();
+  conn.query_row(
+    "
+    SELECT
+      COALESCE((
+        SELECT SUM(value_usd)
+        FROM usage_events
+        WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
+      ), 0.0)
+      + COALESCE((
+        SELECT SUM(value_usd)
+        FROM usage_events
+        WHERE timestamp_ms IS NULL
+          AND unixepoch(timestamp) * 1000 >= ?1
+          AND unixepoch(timestamp) * 1000 < ?2
+      ), 0.0)
+    ",
+    rusqlite::params![start_ms, end_ms],
+    |row| row.get(0),
+  )
 }
 
 fn resolve_window(

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -1441,10 +1441,19 @@ fn resolve_live_rate_limit_window(
   .map_err(|error| error.to_string())?;
 
   if windows.is_empty() {
-    return Err(format!(
-      "Live rate limits are unavailable for the {} view. Check that Codex is installed and logged in.",
-      bucket
-    ));
+    let duration = match bucket {
+      "five_hour" => chrono::Duration::hours(5),
+      "seven_day" => chrono::Duration::days(7),
+      _ => {
+        return Err(format!(
+          "Live rate limits are unavailable for the {} view. Check that Codex is installed and logged in.",
+          bucket
+        ))
+      }
+    };
+    let end = normalize_local_timestamp(Local::now());
+    let start = end - duration;
+    return Ok((start, end, start.date_naive(), 0, 1));
   }
 
   let applied_offset = requested_offset.clamp(0, windows.len().saturating_sub(1) as i64);
@@ -2102,6 +2111,30 @@ mod tests {
   use super::*;
   use crate::database::{init_db, insert_live_rate_limit_snapshot};
   use tempfile::tempdir;
+
+  #[test]
+  fn seven_day_overview_without_quota_uses_a_rolling_window() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+
+    let overview = get_overview_with_connection(
+      &conn,
+      Some("seven_day".to_string()),
+      None,
+      None,
+      None,
+      None,
+      None,
+    )
+    .expect("load seven-day overview without quota samples");
+    let start = parse_rfc3339_local(&overview.window_start).expect("parse window start");
+    let end = parse_rfc3339_local(&overview.window_end).expect("parse window end");
+
+    assert_eq!(overview.bucket, "seven_day");
+    assert_eq!((end - start).num_hours(), 7 * 24);
+    assert_eq!(overview.live_window_offset, 0);
+    assert_eq!(overview.live_window_count, 1);
+  }
 
   #[test]
   fn conversation_query_pages_in_sql_without_loading_every_item() {

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -162,6 +162,36 @@ pub fn get_quota_trend(
   ))
 }
 
+pub fn get_window_api_value(
+  db_path: &Path,
+  bucket: String,
+  anchor: Option<String>,
+  custom_start: Option<String>,
+  custom_end: Option<String>,
+  live_rate_limits: Option<LiveRateLimitSnapshot>,
+  live_window_offset: Option<i64>,
+) -> Result<f64, String> {
+  let conn = open_connection(db_path).map_err(|error| error.to_string())?;
+  if bucket == "total" {
+    return sum_all_api_value(&conn).map_err(|error| error.to_string());
+  }
+
+  let events = load_events(&conn).map_err(|error| error.to_string())?;
+  let profile = get_subscription_profile(&conn).map_err(|error| error.to_string())?;
+  let resolved_window = resolve_window(
+    &conn,
+    Some(bucket),
+    anchor,
+    custom_start,
+    custom_end,
+    &events,
+    profile.billing_anchor_day,
+    live_rate_limits.as_ref(),
+    live_window_offset,
+  )?;
+  Ok(sum_window_api_value(&events, &resolved_window.window))
+}
+
 pub fn list_conversations(
   db_path: &Path,
   filters: Option<ConversationFilters>,
@@ -1160,6 +1190,20 @@ fn load_events_for_root_session(conn: &Connection, root_session_id: &str) -> rus
   })?;
 
   rows.collect()
+}
+
+fn sum_all_api_value(conn: &Connection) -> rusqlite::Result<f64> {
+  conn.query_row("SELECT COALESCE(SUM(value_usd), 0.0) FROM usage_events", [], |row| {
+    row.get(0)
+  })
+}
+
+fn sum_window_api_value(events: &[EventRow], window: &Window) -> f64 {
+  events
+    .iter()
+    .filter(|event| event_in_window(event, window))
+    .map(|event| event.value_usd)
+    .sum()
 }
 
 fn resolve_window(
@@ -2266,6 +2310,59 @@ mod tests {
     assert_eq!(window.window.anchor, "2026-03-26");
     assert_eq!(window.window.start.to_rfc3339(), "2026-03-26T11:27:00+08:00");
     assert_eq!(window.window.end.to_rfc3339(), "2026-03-26T16:27:00+08:00");
+  }
+
+  #[test]
+  fn menu_bar_api_value_uses_selected_live_window() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    let conn = open_connection(&db_path).expect("open database");
+    init_db(&conn).expect("init db");
+    conn
+      .execute(
+        "
+        INSERT INTO usage_events (
+          session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+          output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+          fast_mode_auto, fast_mode_effective
+        )
+        VALUES
+          ('inside', '2026-03-26T04:30:00Z', 'gpt-5.4', 0, 0, 0, 0, 0, 2.50, 0, 0),
+          ('inside-offset', '2026-03-26T11:45:00+08:00', 'gpt-5.4', 0, 0, 0, 0, 0, 1.25, 0, 0),
+          ('outside', '2026-03-26T09:30:00Z', 'gpt-5.4', 0, 0, 0, 0, 0, 7.25, 0, 0)
+        ",
+        [],
+      )
+      .expect("insert usage events");
+    let live_rate_limits = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: Some(crate::models::RateLimitWindowSnapshot {
+        used_percent: 8,
+        remaining_percent: 92,
+        window_duration_mins: Some(300),
+        resets_at: Some("2026-03-26T16:27:36+08:00".to_string()),
+        window_start: Some("2026-03-26T11:27:36+08:00".to_string()),
+      }),
+      secondary: None,
+      fetched_at: "2026-03-26T14:33:00+08:00".to_string(),
+    };
+    insert_live_rate_limit_snapshot(&conn, &live_rate_limits).expect("insert live rate limit snapshot");
+    drop(conn);
+
+    let api_value = get_window_api_value(
+      &db_path,
+      "five_hour".to_string(),
+      None,
+      None,
+      None,
+      Some(live_rate_limits),
+      None,
+    )
+    .expect("load menu bar api value");
+
+    assert_eq!(api_value, 3.75);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -1747,8 +1747,8 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     FROM rate_limit_samples
     WHERE bucket = ?1
       AND (window_start_ms IS NULL OR resets_at_ms IS NULL)
-      AND window_start = ?4
-      AND resets_at = ?5
+      AND (unixepoch(window_start) / 60) * 60000 = ?2
+      AND (unixepoch(resets_at) / 60) * 60000 = ?3
     ORDER BY sample_timestamp ASC
     ",
   ) {
@@ -1761,8 +1761,6 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
       window.bucket,
       target_start.timestamp_millis(),
       target_end.timestamp_millis(),
-      target_start.to_rfc3339(),
-      target_end.to_rfc3339(),
     ],
     |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
   ) {
@@ -2084,6 +2082,41 @@ mod tests {
 
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].timestamp, "2026-07-10T00:00:00Z");
+  }
+
+  #[test]
+  fn legacy_quota_samples_match_the_normalized_window_minute() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "
+        INSERT INTO rate_limit_samples (
+          source_kind, source_session_id, bucket, sample_timestamp,
+          limit_id, limit_name, plan_type, window_start, resets_at,
+          used_percent, remaining_percent, created_at,
+          sample_timestamp_ms, window_start_ms, resets_at_ms
+        ) VALUES (
+          'live', '', 'seven_day', '2026-07-13T07:00:12Z',
+          '', '', 'pro', '2026-07-13T06:00:36Z', '2026-07-20T06:00:44Z',
+          12, 88, '2026-07-13T07:00:12Z',
+          NULL, NULL, NULL
+        )
+        ",
+        [],
+      )
+      .expect("insert legacy quota sample");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end"),
+    };
+
+    let samples = load_quota_samples(&conn, &window);
+
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].used_percent, 12);
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -334,18 +334,13 @@ fn build_overview(
     live_window_offset,
   )?;
   let window = &resolved_window.window;
-  let filtered_events: Vec<_> = events
-    .iter()
-    .filter(|event| event_in_window(event, window))
-    .cloned()
-    .collect();
 
   let mut conversation_ids = HashSet::new();
   let mut total_value_usd = 0.0;
   let mut total_tokens = 0i64;
   let mut model_shares: HashMap<String, ModelShareAccumulator> = HashMap::new();
 
-  for event in &filtered_events {
+  for event in events {
     total_value_usd += event.value_usd;
     total_tokens += event.total_tokens;
     if let Some(session) = sessions.get(&event.session_id) {
@@ -365,9 +360,9 @@ fn build_overview(
     0.0
   };
 
-  let trend = build_trend(window, &filtered_events);
-  let quota_trend = build_quota_trend(conn, window, &filtered_events, live_rate_limits.as_ref());
-  let composition_breakdown = build_composition_breakdown(&filtered_events, catalog);
+  let trend = build_trend(window, events);
+  let quota_trend = build_quota_trend(conn, window, events, live_rate_limits.as_ref());
+  let composition_breakdown = build_composition_breakdown(events, catalog);
   let mut model_breakdown = model_shares
     .into_iter()
     .map(|(model_id, value)| ModelShare {
@@ -457,9 +452,6 @@ fn build_conversation_list(
   }
 
   for event in events {
-    if !event_in_window(event, &window) {
-      continue;
-    }
     let Some(session) = sessions.get(&event.session_id) else {
       continue;
     };
@@ -1514,35 +1506,31 @@ fn load_live_rate_limit_windows(
   Ok(ordered)
 }
 
-fn event_in_window(event: &EventRow, window: &Window) -> bool {
-  parse_rfc3339_local(&event.timestamp)
-    .map(|timestamp| timestamp >= window.start && timestamp < window.end)
-    .unwrap_or(false)
-}
-
 fn build_trend(window: &Window, events: &[EventRow]) -> Vec<TrendPoint> {
   let bins = build_bins(window);
-  let mut trend = Vec::new();
-  for bin in bins {
-    let mut api_value_usd = 0.0;
-    let mut total_tokens = 0i64;
-    for event in events {
-      let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
-        continue;
-      };
-      if timestamp >= bin.start && timestamp < bin.end {
-        api_value_usd += event.value_usd;
-        total_tokens += event.total_tokens;
-      }
+  let mut totals = vec![(0.0, 0i64); bins.len()];
+  for event in events {
+    let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
+      continue;
+    };
+    if let Some(index) = bins
+      .iter()
+      .position(|bin| timestamp >= bin.start && timestamp < bin.end)
+    {
+      totals[index].0 += event.value_usd;
+      totals[index].1 += event.total_tokens;
     }
-    trend.push(TrendPoint {
+  }
+  bins
+    .into_iter()
+    .zip(totals)
+    .map(|(bin, (api_value_usd, total_tokens))| TrendPoint {
       label: bin.label,
       timestamp: bin.timestamp,
       api_value_usd,
       total_tokens,
-    });
-  }
-  trend
+    })
+    .collect()
 }
 
 fn build_quota_trend(
@@ -1570,22 +1558,24 @@ fn build_quota_trend(
   samples.dedup_by(|right, left| right.timestamp == left.timestamp && right.used_percent == left.used_percent);
 
   let bins = build_elapsed_bins(window, window.end);
+  let mut bin_totals = vec![(0.0, 0i64); bins.len()];
+  for event in events {
+    let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
+      continue;
+    };
+    if let Some(index) = bins
+      .iter()
+      .position(|bin| timestamp >= bin.start && timestamp < bin.end)
+    {
+      bin_totals[index].0 += event.value_usd;
+      bin_totals[index].1 += event.total_tokens;
+    }
+  }
   let mut trend = Vec::new();
   let mut cumulative_api_value_usd = 0.0;
   let mut cumulative_tokens = 0i64;
 
-  for bin in bins {
-    let mut api_value_usd = 0.0;
-    let mut total_tokens = 0i64;
-    for event in events {
-      let Some(timestamp) = parse_rfc3339_local(&event.timestamp) else {
-        continue;
-      };
-      if timestamp >= bin.start && timestamp < bin.end {
-        api_value_usd += event.value_usd;
-        total_tokens += event.total_tokens;
-      }
-    }
+  for (bin, (api_value_usd, total_tokens)) in bins.into_iter().zip(bin_totals) {
 
     cumulative_api_value_usd += api_value_usd;
     cumulative_tokens += total_tokens;
@@ -2043,6 +2033,32 @@ mod tests {
     assert_eq!(second.items.len(), 50);
     assert_eq!(second.items.first().map(|item| item.root_session_id.as_str()), Some("root-050"));
     assert_eq!(second.next_cursor.as_deref(), Some("root-099"));
+  }
+
+  #[test]
+  #[ignore = "resource profiling helper; requires CODEX_PACER_PROFILE_DB"]
+  fn profile_real_seven_day_dashboard_load() {
+    let db_path = std::env::var_os("CODEX_PACER_PROFILE_DB")
+      .map(std::path::PathBuf::from)
+      .expect("set CODEX_PACER_PROFILE_DB to a database copy");
+    let started = std::time::Instant::now();
+    let data = load_dashboard_data(
+      &db_path,
+      Some("seven_day".to_string()),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+    )
+    .expect("load seven-day dashboard");
+    eprintln!(
+      "profile seven_day elapsed_ms={} first_page={} has_more={}",
+      started.elapsed().as_millis(),
+      data.conversation_page.items.len(),
+      data.conversation_page.has_more
+    );
   }
 
   #[test]

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -7,7 +7,7 @@ use chrono::{
   DateTime, Datelike, Days, Local, LocalResult, Months, NaiveDate, NaiveDateTime, TimeZone,
   Timelike,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde_json::Value;
 
 use crate::database::{get_subscription_profile, open_connection};
@@ -25,7 +25,7 @@ use crate::pricing::{
 const SQL_SESSIONS: &str = include_str!("../sql/queries/sessions.sql");
 const SQL_SESSIONS_FOR_ROOT: &str = include_str!("../sql/queries/sessions_for_root.sql");
 const SQL_USAGE_EVENTS_FOR_ROOT: &str = include_str!("../sql/queries/usage_events_for_root.sql");
-const SQL_RATE_LIMIT_WINDOWS: &str = include_str!("../sql/queries/rate_limit_windows.sql");
+const MAX_LIVE_RATE_LIMIT_WINDOWS: usize = 64;
 
 #[derive(Debug, Clone)]
 struct SessionRow {
@@ -128,12 +128,8 @@ pub fn get_overview(
     &events,
     &profile,
     &catalog,
-    bucket,
-    anchor,
-    custom_start,
-    custom_end,
+    &resolved_window,
     live_rate_limits,
-    live_window_offset,
   )
 }
 
@@ -218,7 +214,13 @@ pub fn list_conversations(
   let events = load_events_in_window(&conn, &resolved_window.window).map_err(|error| error.to_string())?;
   let cursor = filters.cursor.clone();
   let limit = filters.limit.unwrap_or(50).clamp(1, 100);
-  let items = build_conversation_list(&conn, &sessions, &events, &profile, Some(filters), live_rate_limits.as_ref())?;
+  let items = build_conversation_list(
+    &sessions,
+    &events,
+    &profile,
+    &resolved_window.window,
+    filters.search,
+  )?;
   Ok(paginate_conversations(items, cursor.as_deref(), limit))
 }
 
@@ -255,29 +257,15 @@ pub fn load_dashboard_data(
     &events,
     &profile,
     &catalog,
-    bucket.clone(),
-    anchor.clone(),
-    custom_start.clone(),
-    custom_end.clone(),
+    &resolved_window,
     live_rate_limits.clone(),
-    live_window_offset,
   )?;
   let conversations = build_conversation_list(
-    &conn,
     &sessions,
     &events,
     &profile,
-    Some(ConversationFilters {
-      bucket,
-      anchor,
-      custom_start,
-      custom_end,
-      search,
-      live_window_offset,
-      cursor: None,
-      limit: Some(50),
-    }),
-    live_rate_limits.as_ref(),
+    &resolved_window.window,
+    search,
   )?;
 
   Ok(DashboardData {
@@ -315,24 +303,9 @@ fn build_overview(
   events: &[EventRow],
   profile: &SubscriptionProfile,
   catalog: &HashMap<String, PricingCatalogEntry>,
-  bucket: Option<String>,
-  anchor: Option<String>,
-  custom_start: Option<String>,
-  custom_end: Option<String>,
+  resolved_window: &ResolvedWindow,
   live_rate_limits: Option<LiveRateLimitSnapshot>,
-  live_window_offset: Option<i64>,
 ) -> Result<OverviewResponse, String> {
-  let resolved_window = resolve_window(
-    conn,
-    bucket,
-    anchor,
-    custom_start,
-    custom_end,
-    events,
-    profile.billing_anchor_day,
-    live_rate_limits.as_ref(),
-    live_window_offset,
-  )?;
   let window = &resolved_window.window;
 
   let mut conversation_ids = HashSet::new();
@@ -399,27 +372,13 @@ fn build_overview(
 }
 
 fn build_conversation_list(
-  conn: &Connection,
   sessions: &HashMap<String, SessionRow>,
   events: &[EventRow],
   profile: &SubscriptionProfile,
-  filters: Option<ConversationFilters>,
-  live_rate_limits: Option<&LiveRateLimitSnapshot>,
+  window: &Window,
+  search: Option<String>,
 ) -> Result<Vec<ConversationListItem>, String> {
-  let filters = filters.unwrap_or_default();
-  let window = resolve_window(
-    conn,
-    filters.bucket.clone(),
-    filters.anchor.clone(),
-    filters.custom_start.clone(),
-    filters.custom_end.clone(),
-    events,
-    profile.billing_anchor_day,
-    live_rate_limits,
-    filters.live_window_offset,
-  )?
-  .window;
-  let search = filters.search.unwrap_or_default().to_ascii_lowercase();
+  let search = search.unwrap_or_default().to_ascii_lowercase();
 
   let mut groups: BTreeMap<String, ConversationAccumulator> = BTreeMap::new();
 
@@ -1215,14 +1174,6 @@ fn load_events_in_window(conn: &Connection, window: &Window) -> rusqlite::Result
            fast_mode_auto, fast_mode_effective
     FROM usage_events
     WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
-    UNION ALL
-    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
-           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
-           fast_mode_auto, fast_mode_effective
-    FROM usage_events
-    WHERE timestamp_ms IS NULL
-      AND unixepoch(timestamp) * 1000 >= ?1
-      AND unixepoch(timestamp) * 1000 < ?2
     ORDER BY timestamp ASC
     ",
   )?;
@@ -1245,7 +1196,52 @@ fn load_events_in_window(conn: &Connection, window: &Window) -> rusqlite::Result
     },
   )?;
 
-  rows.collect()
+  let mut events = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+  if epoch_backfill_complete(conn) || !has_legacy_usage_events(conn)? {
+    return Ok(events);
+  }
+
+  let mut legacy_stmt = conn.prepare(
+    "
+    SELECT session_id, timestamp, model_id, input_tokens, cached_input_tokens,
+           output_tokens, reasoning_output_tokens, total_tokens, value_usd,
+           fast_mode_auto, fast_mode_effective
+    FROM usage_events
+    WHERE timestamp_ms IS NULL
+      AND unixepoch(timestamp) * 1000 >= ?1
+      AND unixepoch(timestamp) * 1000 < ?2
+    ORDER BY timestamp ASC
+    ",
+  )?;
+  let legacy_rows = legacy_stmt.query_map(
+    rusqlite::params![window.start.timestamp_millis(), window.end.timestamp_millis()],
+    |row| {
+      Ok(EventRow {
+        session_id: row.get(0)?,
+        timestamp: row.get(1)?,
+        model_id: row.get(2)?,
+        input_tokens: row.get(3)?,
+        cached_input_tokens: row.get(4)?,
+        output_tokens: row.get(5)?,
+        reasoning_output_tokens: row.get(6)?,
+        total_tokens: row.get(7)?,
+        value_usd: row.get(8)?,
+        fast_mode_auto: row.get::<_, i64>(9)? != 0,
+        fast_mode_effective: row.get::<_, i64>(10)? != 0,
+      })
+    },
+  )?;
+  events.extend(legacy_rows.collect::<rusqlite::Result<Vec<_>>>()?);
+  events.sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+  Ok(events)
+}
+
+fn has_legacy_usage_events(conn: &Connection) -> rusqlite::Result<bool> {
+  conn.query_row(
+    "SELECT EXISTS (SELECT 1 FROM usage_events WHERE timestamp_ms IS NULL LIMIT 1)",
+    [],
+    |row| Ok(row.get::<_, i64>(0)? != 0),
+  )
 }
 
 fn load_events_for_root_session(conn: &Connection, root_session_id: &str) -> rusqlite::Result<Vec<EventRow>> {
@@ -1278,25 +1274,26 @@ fn sum_all_api_value(conn: &Connection) -> rusqlite::Result<f64> {
 fn sum_window_api_value_sql(conn: &Connection, window: &Window) -> rusqlite::Result<f64> {
   let start_ms = window.start.timestamp_millis();
   let end_ms = window.end.timestamp_millis();
-  conn.query_row(
-    "
-    SELECT
-      COALESCE((
-        SELECT SUM(value_usd)
-        FROM usage_events
-        WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2
-      ), 0.0)
-      + COALESCE((
-        SELECT SUM(value_usd)
-        FROM usage_events
-        WHERE timestamp_ms IS NULL
-          AND unixepoch(timestamp) * 1000 >= ?1
-          AND unixepoch(timestamp) * 1000 < ?2
-      ), 0.0)
-    ",
+  let modern = conn.query_row(
+    "SELECT COALESCE(SUM(value_usd), 0.0) FROM usage_events WHERE timestamp_ms >= ?1 AND timestamp_ms < ?2",
     rusqlite::params![start_ms, end_ms],
     |row| row.get(0),
-  )
+  )?;
+  if epoch_backfill_complete(conn) || !has_legacy_usage_events(conn)? {
+    return Ok(modern);
+  }
+  let legacy = conn.query_row(
+    "
+    SELECT COALESCE(SUM(value_usd), 0.0)
+    FROM usage_events
+    WHERE timestamp_ms IS NULL
+      AND unixepoch(timestamp) * 1000 >= ?1
+      AND unixepoch(timestamp) * 1000 < ?2
+    ",
+    rusqlite::params![start_ms, end_ms],
+    |row| row.get::<_, f64>(0),
+  )?;
+  Ok(modern + legacy)
 }
 
 fn resolve_window(
@@ -1463,47 +1460,88 @@ fn load_live_rate_limit_windows(
   bucket: &str,
   current_window: Option<RateLimitWindowSummary>,
 ) -> rusqlite::Result<Vec<RateLimitWindowSummary>> {
-  let mut stmt = conn.prepare(SQL_RATE_LIMIT_WINDOWS)?;
-  let rows = stmt.query_map(rusqlite::params![bucket], |row| {
-    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-  })?;
-
-  let mut windows = Vec::new();
-  let mut seen = HashSet::new();
-  for row in rows {
-    let (window_start, resets_at) = row?;
-    let Some(start) = parse_rfc3339_local(&window_start).map(normalize_local_timestamp) else {
-      continue;
-    };
-    let Some(end) = parse_rfc3339_local(&resets_at).map(normalize_local_timestamp) else {
-      continue;
-    };
-    let key = (start.to_rfc3339(), end.to_rfc3339());
-    if !seen.insert(key) {
-      continue;
-    }
-    windows.push(RateLimitWindowSummary { start, end });
-  }
-
-  windows.sort_by(|left, right| right.end.cmp(&left.end).then_with(|| right.start.cmp(&left.start)));
-
   let mut ordered = Vec::new();
-  let mut cursor = current_window.or_else(|| windows.first().cloned());
+  let mut seen = HashSet::new();
+  let mut cursor = match current_window {
+    Some(window) => Some(window),
+    None => load_latest_rate_limit_window(conn, bucket)?,
+  };
   while let Some(window) = cursor {
-    if !ordered
-      .iter()
-      .any(|existing: &RateLimitWindowSummary| existing.start == window.start && existing.end == window.end)
-    {
-      ordered.push(window.clone());
+    let key = (window.start.timestamp_millis(), window.end.timestamp_millis());
+    if !seen.insert(key) {
+      break;
     }
-    cursor = windows
-      .iter()
-      .filter(|candidate| candidate.end <= window.start)
-      .max_by(|left, right| left.end.cmp(&right.end).then_with(|| left.start.cmp(&right.start)))
-      .cloned();
+    let previous_start = window.start;
+    ordered.push(window);
+    if ordered.len() >= MAX_LIVE_RATE_LIMIT_WINDOWS {
+      break;
+    }
+    cursor = load_previous_rate_limit_window(conn, bucket, previous_start)?;
   }
 
   Ok(ordered)
+}
+
+fn load_latest_rate_limit_window(
+  conn: &Connection,
+  bucket: &str,
+) -> rusqlite::Result<Option<RateLimitWindowSummary>> {
+  load_rate_limit_window_query(
+    conn,
+    "
+    SELECT window_start_ms, resets_at_ms
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND window_start_ms IS NOT NULL
+      AND resets_at_ms IS NOT NULL
+    ORDER BY window_start_ms DESC, resets_at_ms DESC
+    LIMIT 1
+    ",
+    rusqlite::params![bucket],
+  )
+}
+
+fn load_previous_rate_limit_window(
+  conn: &Connection,
+  bucket: &str,
+  before: DateTime<Local>,
+) -> rusqlite::Result<Option<RateLimitWindowSummary>> {
+  let before_ms = normalize_local_timestamp(before).timestamp_millis();
+  load_rate_limit_window_query(
+    conn,
+    "
+    SELECT window_start_ms, resets_at_ms
+    FROM rate_limit_samples
+    WHERE bucket = ?1
+      AND window_start_ms < ?2
+      AND (resets_at_ms / 60000) * 60000 <= ?2
+    ORDER BY window_start_ms DESC, resets_at_ms DESC
+    LIMIT 1
+    ",
+    rusqlite::params![bucket, before_ms],
+  )
+}
+
+fn load_rate_limit_window_query<P: rusqlite::Params>(
+  conn: &Connection,
+  sql: &str,
+  params: P,
+) -> rusqlite::Result<Option<RateLimitWindowSummary>> {
+  conn
+    .query_row(sql, params, |row| {
+      Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+    })
+    .optional()
+    .map(|row| {
+      row.and_then(|(start_ms, end_ms)| {
+        let start = Local.timestamp_millis_opt(start_ms).single()?;
+        let end = Local.timestamp_millis_opt(end_ms).single()?;
+        Some(RateLimitWindowSummary {
+          start: normalize_local_timestamp(start),
+          end: normalize_local_timestamp(end),
+        })
+      })
+    })
 }
 
 fn build_trend(window: &Window, events: &[EventRow]) -> Vec<TrendPoint> {
@@ -1735,14 +1773,96 @@ fn live_sample(live_rate_limits: &LiveRateLimitSnapshot, bucket: &str) -> Option
 fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
   let target_start = normalize_local_timestamp(window.start);
   let target_end = normalize_local_timestamp(window.end);
+  let sample_start_ms = window.start.timestamp_millis();
+  let sample_end_ms = window.end.timestamp_millis();
+  let bin_duration_ms = match window.bucket.as_str() {
+    "five_hour" => chrono::Duration::minutes(15).num_milliseconds(),
+    "seven_day" => chrono::Duration::hours(1).num_milliseconds(),
+    _ => chrono::Duration::hours(1).num_milliseconds(),
+  };
   let mut stmt = match conn.prepare(
     "
-    SELECT sample_timestamp, used_percent
-    FROM rate_limit_samples
-    WHERE bucket = ?1
-      AND window_start_ms = ?2
-      AND resets_at_ms = ?3
-    UNION ALL
+    WITH RECURSIVE bins(bin_start_ms, bin_end_ms) AS (
+      SELECT ?4, MIN(?4 + ?6, ?5)
+      WHERE ?4 < ?5
+      UNION ALL
+      SELECT bin_end_ms, MIN(bin_end_ms + ?6, ?5)
+      FROM bins
+      WHERE bin_end_ms < ?5
+    ),
+    latest_ids AS MATERIALIZED (
+      SELECT (
+        SELECT id
+        FROM rate_limit_samples
+        WHERE bucket = ?1
+          AND window_start_ms = ?2
+          AND resets_at_ms = ?3
+          AND sample_timestamp_ms >= bins.bin_start_ms
+          AND sample_timestamp_ms < bins.bin_end_ms
+        ORDER BY sample_timestamp_ms DESC, id DESC
+        LIMIT 1
+      ) AS id
+      FROM bins
+    )
+    SELECT sample.sample_timestamp_ms, sample.used_percent
+    FROM latest_ids
+    JOIN rate_limit_samples AS sample ON sample.id = latest_ids.id
+    ORDER BY sample.sample_timestamp_ms ASC
+    ",
+  ) {
+    Ok(stmt) => stmt,
+    Err(_) => return Vec::new(),
+  };
+
+  let rows = match stmt.query_map(
+    rusqlite::params![
+      window.bucket,
+      target_start.timestamp_millis(),
+      target_end.timestamp_millis(),
+      sample_start_ms,
+      sample_end_ms,
+      bin_duration_ms,
+    ],
+    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+  ) {
+    Ok(rows) => rows,
+    Err(_) => return Vec::new(),
+  };
+
+  let samples = rows
+    .filter_map(Result::ok)
+    .filter_map(|(timestamp_ms, used_percent)| {
+      Local.timestamp_millis_opt(timestamp_ms).single().map(|timestamp| QuotaSample {
+        timestamp,
+        used_percent,
+      })
+    })
+    .collect::<Vec<_>>();
+  if !samples.is_empty() || epoch_backfill_complete(conn) {
+    return samples;
+  }
+
+  load_legacy_quota_samples(conn, window, target_start, target_end)
+}
+
+fn epoch_backfill_complete(conn: &Connection) -> bool {
+  conn
+    .query_row(
+      "SELECT EXISTS (SELECT 1 FROM data_repairs WHERE repair_key = 'epoch_timestamp_backfill_v1')",
+      [],
+      |row| Ok(row.get::<_, i64>(0)? != 0),
+    )
+    .unwrap_or(true)
+}
+
+fn load_legacy_quota_samples(
+  conn: &Connection,
+  window: &Window,
+  target_start: DateTime<Local>,
+  target_end: DateTime<Local>,
+) -> Vec<QuotaSample> {
+  let mut stmt = match conn.prepare(
+    "
     SELECT sample_timestamp, used_percent
     FROM rate_limit_samples
     WHERE bucket = ?1
@@ -1755,7 +1875,6 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     Ok(stmt) => stmt,
     Err(_) => return Vec::new(),
   };
-
   let rows = match stmt.query_map(
     rusqlite::params![
       window.bucket,
@@ -1767,7 +1886,6 @@ fn load_quota_samples(conn: &Connection, window: &Window) -> Vec<QuotaSample> {
     Ok(rows) => rows,
     Err(_) => return Vec::new(),
   };
-
   rows
     .filter_map(Result::ok)
     .filter_map(|(timestamp, used_percent)| {
@@ -2085,6 +2203,54 @@ mod tests {
   }
 
   #[test]
+  fn window_event_loader_keeps_legacy_rows_before_epoch_backfill_completes() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn.execute(
+      "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES ('legacy', '2026-07-10T00:00:00Z', NULL, 'gpt-5.4', 1, 0, 1, 0, 2, 1.5, 0, 0)",
+      [],
+    )
+    .expect("insert legacy event");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-10".to_string(),
+      start: parse_rfc3339_local("2026-07-09T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-11T00:00:00Z").expect("end"),
+    };
+
+    let events = load_events_in_window(&conn, &window).expect("load window events");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].session_id, "legacy");
+    assert_eq!(sum_window_api_value_sql(&conn, &window).expect("sum window"), 1.5);
+  }
+
+  #[test]
+  fn completed_epoch_backfill_skips_legacy_usage_event_fallback() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn.execute(
+      "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES ('legacy', '2026-07-10T00:00:00Z', NULL, 'gpt-5.4', 1, 0, 1, 0, 2, 1.5, 0, 0)",
+      [],
+    )
+    .expect("insert legacy event");
+    conn.execute(
+      "INSERT INTO data_repairs (repair_key, completed_at) VALUES ('epoch_timestamp_backfill_v1', '2026-07-13T08:00:00Z')",
+      [],
+    )
+    .expect("mark epoch backfill complete");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-10".to_string(),
+      start: parse_rfc3339_local("2026-07-09T00:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-11T00:00:00Z").expect("end"),
+    };
+
+    assert!(load_events_in_window(&conn, &window).expect("load window events").is_empty());
+    assert_eq!(sum_window_api_value_sql(&conn, &window).expect("sum window"), 0.0);
+  }
+
+  #[test]
   fn legacy_quota_samples_match_the_normalized_window_minute() {
     let conn = Connection::open_in_memory().expect("open database");
     init_db(&conn).expect("initialize database");
@@ -2117,6 +2283,101 @@ mod tests {
 
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].used_percent, 12);
+  }
+
+  #[test]
+  fn quota_samples_keep_only_the_latest_point_in_each_chart_bin() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    let window_start = parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start");
+    let window_end = parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end");
+    for (timestamp, used_percent) in [
+      ("2026-07-13T06:05:00Z", 1),
+      ("2026-07-13T06:55:00Z", 2),
+      ("2026-07-13T07:10:00Z", 3),
+      ("2026-07-13T07:58:00Z", 4),
+    ] {
+      let timestamp_ms = parse_rfc3339_local(timestamp)
+        .expect("sample timestamp")
+        .timestamp_millis();
+      conn
+        .execute(
+          "
+          INSERT INTO rate_limit_samples (
+            source_kind, source_session_id, bucket, sample_timestamp,
+            limit_id, limit_name, plan_type, window_start, resets_at,
+            used_percent, remaining_percent, created_at,
+            sample_timestamp_ms, window_start_ms, resets_at_ms
+          ) VALUES (
+            'session', 'session', 'seven_day', ?1,
+            '', '', 'pro', '2026-07-13T06:00:00Z', '2026-07-20T06:00:00Z',
+            ?2, 100 - ?2, ?1, ?3, ?4, ?5
+          )
+          ",
+          rusqlite::params![
+            timestamp,
+            used_percent,
+            timestamp_ms,
+            window_start.timestamp_millis(),
+            window_end.timestamp_millis(),
+          ],
+        )
+        .expect("insert quota sample");
+    }
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: window_start,
+      end: window_end,
+    };
+
+    let samples = load_quota_samples(&conn, &window);
+
+    assert_eq!(
+      samples
+        .iter()
+        .map(|sample| sample.used_percent)
+        .collect::<Vec<_>>(),
+      vec![2, 4]
+    );
+  }
+
+  #[test]
+  fn completed_epoch_backfill_does_not_scan_legacy_quota_rows() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    conn
+      .execute(
+        "
+        INSERT INTO rate_limit_samples (
+          source_kind, source_session_id, bucket, sample_timestamp,
+          limit_id, limit_name, plan_type, window_start, resets_at,
+          used_percent, remaining_percent, created_at,
+          sample_timestamp_ms, window_start_ms, resets_at_ms
+        ) VALUES (
+          'live', '', 'seven_day', '2026-07-13T07:00:12Z',
+          '', '', 'pro', '2026-07-13T06:00:36Z', '2026-07-20T06:00:44Z',
+          12, 88, '2026-07-13T07:00:12Z',
+          NULL, NULL, NULL
+        )
+        ",
+        [],
+      )
+      .expect("insert legacy quota sample");
+    conn
+      .execute(
+        "INSERT INTO data_repairs (repair_key, completed_at) VALUES ('epoch_timestamp_backfill_v1', '2026-07-13T08:00:00Z')",
+        [],
+      )
+      .expect("mark epoch backfill complete");
+    let window = Window {
+      bucket: "seven_day".to_string(),
+      anchor: "2026-07-13".to_string(),
+      start: parse_rfc3339_local("2026-07-13T06:00:00Z").expect("start"),
+      end: parse_rfc3339_local("2026-07-20T06:00:00Z").expect("end"),
+    };
+
+    assert!(load_quota_samples(&conn, &window).is_empty());
   }
 
   #[test]

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -439,10 +439,24 @@ fn codex_binary_candidates(app_data: Option<&OsStr>, _home_dir: Option<&Path>) -
 
 #[cfg(not(windows))]
 fn codex_binary_candidates(_app_data: Option<&OsStr>, home_dir: Option<&Path>) -> Vec<PathBuf> {
-  let mut candidates = vec![
+  let mut candidates = Vec::new();
+
+  #[cfg(target_os = "macos")]
+  {
+    candidates.push(PathBuf::from("/Applications/ChatGPT.app/Contents/Resources/codex"));
+    if let Some(home_dir) = home_dir {
+      candidates.push(home_dir.join("Applications/ChatGPT.app/Contents/Resources/codex"));
+    }
+    candidates.push(PathBuf::from("/Applications/Codex.app/Contents/Resources/codex"));
+    if let Some(home_dir) = home_dir {
+      candidates.push(home_dir.join("Applications/Codex.app/Contents/Resources/codex"));
+    }
+  }
+
+  candidates.extend([
     PathBuf::from("/opt/homebrew/bin/codex"),
     PathBuf::from("/usr/local/bin/codex"),
-  ];
+  ]);
 
   if let Some(home_dir) = home_dir {
     candidates.push(home_dir.join(".cargo/bin/codex"));
@@ -464,6 +478,7 @@ fn fallback_codex_binary() -> PathBuf {
 #[cfg(test)]
 mod tests {
   use super::convert_window;
+  #[cfg(windows)]
   use std::ffi::OsString;
   use std::path::{Path, PathBuf};
 
@@ -485,6 +500,33 @@ mod tests {
     assert_eq!(converted.window_duration_mins, Some(300));
     assert!(converted.resets_at.is_some());
     assert!(converted.window_start.is_some());
+  }
+
+  #[test]
+  #[cfg(target_os = "macos")]
+  fn resolve_codex_binary_prefers_chatgpt_app_bundle() {
+    let resolved = super::resolve_codex_binary_from_env(
+      None,
+      None,
+      Some(Path::new("/Users/CodexUser")),
+      existing_paths(&[
+        "/Applications/ChatGPT.app/Contents/Resources/codex",
+        "/opt/homebrew/bin/codex",
+      ]),
+    );
+    assert_eq!(resolved, PathBuf::from("/Applications/ChatGPT.app/Contents/Resources/codex"));
+  }
+
+  #[test]
+  #[cfg(target_os = "macos")]
+  fn resolve_codex_binary_uses_legacy_app_when_chatgpt_is_missing() {
+    let resolved = super::resolve_codex_binary_from_env(
+      None,
+      None,
+      Some(Path::new("/Users/CodexUser")),
+      existing_paths(&["/Applications/Codex.app/Contents/Resources/codex"]),
+    );
+    assert_eq!(resolved, PathBuf::from("/Applications/Codex.app/Contents/Resources/codex"));
   }
 
   #[test]

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -362,13 +362,26 @@ fn send_app_server_request(
 }
 
 fn convert_live_rate_limits(snapshot: AppServerRateLimitSnapshot) -> LiveRateLimitSnapshot {
+  let (primary, secondary) = normalize_rate_limit_windows(snapshot.primary, snapshot.secondary);
   LiveRateLimitSnapshot {
     limit_id: snapshot.limit_id,
     limit_name: snapshot.limit_name,
     plan_type: snapshot.plan_type,
-    primary: snapshot.primary.map(convert_window),
-    secondary: snapshot.secondary.map(convert_window),
+    primary: primary.map(convert_window),
+    secondary: secondary.map(convert_window),
     fetched_at: Local::now().to_rfc3339(),
+  }
+}
+
+fn normalize_rate_limit_windows(
+  primary: Option<AppServerRateLimitWindow>,
+  secondary: Option<AppServerRateLimitWindow>,
+) -> (Option<AppServerRateLimitWindow>, Option<AppServerRateLimitWindow>) {
+  match (primary, secondary) {
+    (Some(primary), None) if primary.window_duration_mins == Some(7 * 24 * 60) => {
+      (None, Some(primary))
+    }
+    windows => windows,
   }
 }
 
@@ -620,6 +633,28 @@ mod tests {
     assert_eq!(converted.window_duration_mins, Some(300));
     assert!(converted.resets_at.is_some());
     assert!(converted.window_start.is_some());
+  }
+
+  #[test]
+  fn convert_live_rate_limits_keeps_a_primary_only_seven_day_window_in_the_seven_day_slot() {
+    let converted = super::convert_live_rate_limits(super::AppServerRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: None,
+      plan_type: Some("pro".to_string()),
+      primary: Some(super::AppServerRateLimitWindow {
+        used_percent: 21,
+        window_duration_mins: Some(10_080),
+        resets_at: Some(1_774_589_128),
+      }),
+      secondary: None,
+    });
+
+    assert!(converted.primary.is_none());
+    assert_eq!(
+      converted.secondary.as_ref().and_then(|window| window.window_duration_mins),
+      Some(10_080)
+    );
+    assert_eq!(converted.secondary.map(|window| window.remaining_percent), Some(79));
   }
 
   #[test]

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -189,18 +189,16 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
     }
   }
 
-  if let Err(error) = send_app_server_request(
-    &mut child,
-    json!({
-      "id": READ_REQUEST_ID,
-      "method": "account/rateLimits/read",
-      "params": Value::Null,
-    }),
-    "Failed to request live rate limits after Codex app-server initialization",
-    "Failed to flush codex app-server rate-limit request",
-  ) {
-    stop_app_server(&mut child);
-    return Err(error);
+  for (message, write_context, flush_context) in post_initialize_messages() {
+    if let Err(error) = send_app_server_request(
+      &mut child,
+      message,
+      write_context,
+      flush_context,
+    ) {
+      stop_app_server(&mut child);
+      return Err(error);
+    }
   }
 
   let response = loop {
@@ -312,6 +310,27 @@ fn app_server_args() -> Vec<OsString> {
     OsString::from("app-server"),
     OsString::from("--listen"),
     OsString::from("stdio://"),
+  ]
+}
+
+fn post_initialize_messages() -> Vec<(Value, &'static str, &'static str)> {
+  vec![
+    (
+      json!({
+        "method": "initialized",
+        "params": {},
+      }),
+      "Failed to notify Codex app-server that initialization completed",
+      "Failed to flush Codex app-server initialized notification",
+    ),
+    (
+      json!({
+        "id": READ_REQUEST_ID,
+        "method": "account/rateLimits/read",
+      }),
+      "Failed to request live rate limits after Codex app-server initialization",
+      "Failed to flush Codex app-server rate-limit request",
+    ),
   ]
 }
 
@@ -500,6 +519,25 @@ mod tests {
     assert_eq!(converted.window_duration_mins, Some(300));
     assert!(converted.resets_at.is_some());
     assert!(converted.window_start.is_some());
+  }
+
+  #[test]
+  fn app_server_post_initialize_messages_follow_protocol_order() {
+    let messages = super::post_initialize_messages()
+      .into_iter()
+      .map(|(message, _, _)| message)
+      .collect::<Vec<_>>();
+
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].get("method").and_then(serde_json::Value::as_str), Some("initialized"));
+    assert!(messages[0].get("id").is_none());
+    assert_eq!(messages[0].get("params"), Some(&serde_json::json!({})));
+    assert_eq!(
+      messages[1].get("method").and_then(serde_json::Value::as_str),
+      Some("account/rateLimits/read")
+    );
+    assert_eq!(messages[1].get("id").and_then(serde_json::Value::as_str), Some(super::READ_REQUEST_ID));
+    assert!(messages[1].get("params").is_none());
   }
 
   #[test]

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::{Local, LocalResult, TimeZone, Timelike};
 use serde::Deserialize;
@@ -11,7 +11,6 @@ use serde_json::{json, Value};
 
 use crate::models::{LiveRateLimitSnapshot, RateLimitWindowSnapshot};
 
-const APP_SERVER_TIMEOUT: Duration = Duration::from_secs(5);
 const INIT_REQUEST_ID: &str = "codex-counter.init";
 const READ_REQUEST_ID: &str = "codex-counter.rate-limits";
 
@@ -51,7 +50,8 @@ struct AppServerCommandSpec {
   hide_window: bool,
 }
 
-pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
+pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+  let started_at = Instant::now();
   let codex_binary = resolve_codex_binary();
   let command_spec = app_server_command_spec(&codex_binary);
   let mut command = app_server_command(&command_spec);
@@ -158,7 +158,14 @@ pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
     return Err(error);
   }
 
-  let init_response = match receiver.recv_timeout(APP_SERVER_TIMEOUT) {
+  let init_timeout = match remaining_app_server_timeout(started_at, timeout) {
+    Some(timeout) => timeout,
+    None => {
+      stop_app_server(&mut child);
+      return Err("Timed out while initializing Codex app-server.".to_string());
+    }
+  };
+  let init_response = match receiver.recv_timeout(init_timeout) {
     Ok(message) => message,
     Err(_) => {
       stop_app_server(&mut child);
@@ -197,7 +204,14 @@ pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
   }
 
   let response = loop {
-    let message = match receiver.recv_timeout(APP_SERVER_TIMEOUT) {
+    let timeout = match remaining_app_server_timeout(started_at, timeout) {
+      Some(timeout) => timeout,
+      None => {
+        stop_app_server(&mut child);
+        return Err("Timed out while querying live rate limits from Codex.".to_string());
+      }
+    };
+    let message = match receiver.recv_timeout(timeout) {
       Ok(message) => message,
       Err(_) => {
         stop_app_server(&mut child);
@@ -217,6 +231,11 @@ pub fn query_live_rate_limits() -> Result<LiveRateLimitSnapshot, String> {
 
   stop_app_server(&mut child);
   response
+}
+
+fn remaining_app_server_timeout(started_at: Instant, timeout: Duration) -> Option<Duration> {
+  let remaining = timeout.checked_sub(started_at.elapsed())?;
+  (remaining > Duration::ZERO).then_some(remaining)
 }
 
 fn app_server_command(spec: &AppServerCommandSpec) -> Command {

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -2,7 +2,7 @@ use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
+use std::sync::{mpsc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -45,10 +45,151 @@ enum AppServerMessage {
   Closed,
 }
 
+#[derive(Clone)]
 struct AppServerCommandSpec {
   program: OsString,
   args: Vec<OsString>,
   hide_window: bool,
+}
+
+struct ReusableAppServerClient {
+  command_spec: AppServerCommandSpec,
+  command_path: PathBuf,
+  session: Option<AppServerSession>,
+  receiver: Option<mpsc::Receiver<AppServerMessage>>,
+}
+
+impl ReusableAppServerClient {
+  fn new(command_spec: AppServerCommandSpec, command_path: PathBuf) -> Self {
+    Self {
+      command_spec,
+      command_path,
+      session: None,
+      receiver: None,
+    }
+  }
+
+  fn query(&mut self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+    let started_at = Instant::now();
+    let reused_existing_session = self.session.is_some();
+    match self.query_once(started_at, timeout) {
+      Ok(snapshot) => Ok(snapshot),
+      Err(first_error) if reused_existing_session => {
+        self.disconnect();
+        if remaining_app_server_timeout(started_at, timeout).is_none() {
+          return Err(first_error);
+        }
+        self.query_once(started_at, timeout)
+      }
+      Err(error) => {
+        self.disconnect();
+        Err(error)
+      }
+    }
+  }
+
+  fn query_once(
+    &mut self,
+    started_at: Instant,
+    timeout: Duration,
+  ) -> Result<LiveRateLimitSnapshot, String> {
+    if self.session.is_none() {
+      self.connect(started_at, timeout)?;
+    }
+
+    let session = self
+      .session
+      .as_mut()
+      .ok_or_else(|| "Codex app-server session is unavailable.".to_string())?;
+    send_app_server_request(
+      &mut session.child,
+      rate_limit_request(),
+      "Failed to request live rate limits after Codex app-server initialization",
+      "Failed to flush Codex app-server rate-limit request",
+    )?;
+
+    loop {
+      let remaining = remaining_app_server_timeout(started_at, timeout)
+        .ok_or_else(|| "Timed out while querying live rate limits from Codex.".to_string())?;
+      let message = self
+        .receiver
+        .as_ref()
+        .ok_or_else(|| "Codex app-server response channel is unavailable.".to_string())?
+        .recv_timeout(remaining)
+        .map_err(|_| "Timed out while querying live rate limits from Codex.".to_string())?;
+      match message {
+        AppServerMessage::Initialized(Ok(())) => continue,
+        AppServerMessage::Initialized(Err(error)) => return Err(error),
+        AppServerMessage::RateLimits(result) => return result,
+        AppServerMessage::Closed => {
+          return Err("Codex app-server closed before returning live rate limits.".to_string())
+        }
+      }
+    }
+  }
+
+  fn connect(&mut self, started_at: Instant, timeout: Duration) -> Result<(), String> {
+    let (mut session, receiver) = start_app_server_session(&self.command_spec, &self.command_path)?;
+    send_app_server_request(
+      &mut session.child,
+      initialize_request(),
+      "Failed to initialize codex app-server",
+      "Failed to flush codex app-server init request",
+    )?;
+
+    let remaining = remaining_app_server_timeout(started_at, timeout)
+      .ok_or_else(|| "Timed out while initializing Codex app-server.".to_string())?;
+    match receiver
+      .recv_timeout(remaining)
+      .map_err(|_| "Timed out while initializing Codex app-server.".to_string())?
+    {
+      AppServerMessage::Initialized(Ok(())) => {}
+      AppServerMessage::Initialized(Err(error)) => return Err(error),
+      AppServerMessage::RateLimits(result) => return result.map(|_| ()),
+      AppServerMessage::Closed => {
+        return Err("Codex app-server closed before initialization completed.".to_string())
+      }
+    }
+
+    send_app_server_request(
+      &mut session.child,
+      initialized_notification(),
+      "Failed to notify Codex app-server that initialization completed",
+      "Failed to flush Codex app-server initialized notification",
+    )?;
+    self.session = Some(session);
+    self.receiver = Some(receiver);
+    Ok(())
+  }
+
+  fn disconnect(&mut self) {
+    self.receiver = None;
+    self.session = None;
+  }
+}
+
+pub struct LiveRateLimitClient {
+  inner: Mutex<ReusableAppServerClient>,
+}
+
+impl LiveRateLimitClient {
+  pub fn new() -> Self {
+    let codex_binary = resolve_codex_binary();
+    Self {
+      inner: Mutex::new(ReusableAppServerClient::new(
+        app_server_command_spec(&codex_binary),
+        codex_binary,
+      )),
+    }
+  }
+
+  pub fn query(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+    self
+      .inner
+      .lock()
+      .unwrap_or_else(|poisoned| poisoned.into_inner())
+      .query(timeout)
+  }
 }
 
 struct AppServerSession {
@@ -71,20 +212,22 @@ impl Drop for AppServerSession {
   }
 }
 
-pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
-  let started_at = Instant::now();
-  let codex_binary = resolve_codex_binary();
-  let command_spec = app_server_command_spec(&codex_binary);
-  query_live_rate_limits_with_command(started_at, timeout, command_spec, &codex_binary)
-}
-
+#[cfg(test)]
 fn query_live_rate_limits_with_command(
   started_at: Instant,
   timeout: Duration,
   command_spec: AppServerCommandSpec,
   command_path: &Path,
 ) -> Result<LiveRateLimitSnapshot, String> {
-  let mut command = app_server_command(&command_spec);
+  let mut client = ReusableAppServerClient::new(command_spec, command_path.to_path_buf());
+  client.query_once(started_at, timeout)
+}
+
+fn start_app_server_session(
+  command_spec: &AppServerCommandSpec,
+  command_path: &Path,
+) -> Result<(AppServerSession, mpsc::Receiver<AppServerMessage>), String> {
+  let mut command = app_server_command(command_spec);
   let child = command
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
@@ -128,7 +271,7 @@ fn query_live_rate_limits_with_command(
             "Codex app-server initialize failed: {}",
             json_error_message(error)
           ))));
-          return;
+          continue;
         }
         init_ok = true;
         let _ = sender.send(AppServerMessage::Initialized(Ok(())));
@@ -143,7 +286,7 @@ fn query_live_rate_limits_with_command(
         let _ = sender.send(AppServerMessage::RateLimits(Err(
           "Codex app-server returned rate limits before initialization completed.".to_string(),
         )));
-        return;
+        continue;
       }
 
       if let Some(error) = parsed.get("error") {
@@ -151,14 +294,14 @@ fn query_live_rate_limits_with_command(
           "Codex app-server rate-limit query failed: {}",
           json_error_message(error)
         ))));
-        return;
+        continue;
       }
 
       let Some(result) = parsed.get("result") else {
         let _ = sender.send(AppServerMessage::RateLimits(Err(
           "Codex app-server returned an empty rate-limit response.".to_string(),
         )));
-        return;
+        continue;
       };
 
       let response = serde_json::from_value::<AppServerRateLimitReadResponse>(result.clone())
@@ -166,80 +309,43 @@ fn query_live_rate_limits_with_command(
       let _ = sender.send(AppServerMessage::RateLimits(
         response.map(|value| convert_live_rate_limits(value.rate_limits)),
       ));
-      return;
+      continue;
     }
 
     let _ = sender.send(AppServerMessage::Closed);
   }));
 
-  if let Err(error) = send_app_server_request(
-    &mut session.child,
-    json!({
-      "id": INIT_REQUEST_ID,
-      "method": "initialize",
-      "params": {
-        "clientInfo": {
-          "name": "codex-counter",
-          "version": env!("CARGO_PKG_VERSION"),
-        },
-        "capabilities": {
-          "experimentalApi": true,
-        }
+  Ok((session, receiver))
+}
+
+fn initialize_request() -> Value {
+  json!({
+    "id": INIT_REQUEST_ID,
+    "method": "initialize",
+    "params": {
+      "clientInfo": {
+        "name": "codex-counter",
+        "version": env!("CARGO_PKG_VERSION"),
+      },
+      "capabilities": {
+        "experimentalApi": true,
       }
-    }),
-    "Failed to initialize codex app-server",
-    "Failed to flush codex app-server init request",
-  ) {
-    return Err(error);
-  }
-
-  let init_timeout = match remaining_app_server_timeout(started_at, timeout) {
-    Some(timeout) => timeout,
-    None => return Err("Timed out while initializing Codex app-server.".to_string()),
-  };
-  let init_response = match receiver.recv_timeout(init_timeout) {
-    Ok(message) => message,
-    Err(_) => return Err("Timed out while initializing Codex app-server.".to_string()),
-  };
-
-  match init_response {
-    AppServerMessage::Initialized(Ok(())) => {}
-    AppServerMessage::Initialized(Err(error)) => return Err(error),
-    AppServerMessage::RateLimits(result) => return result,
-    AppServerMessage::Closed => {
-      return Err("Codex app-server closed before initialization completed.".to_string())
     }
-  }
+  })
+}
 
-  for (message, write_context, flush_context) in post_initialize_messages() {
-    if let Err(error) =
-      send_app_server_request(&mut session.child, message, write_context, flush_context)
-    {
-      return Err(error);
-    }
-  }
+fn initialized_notification() -> Value {
+  json!({
+    "method": "initialized",
+    "params": {},
+  })
+}
 
-  let response = loop {
-    let timeout = match remaining_app_server_timeout(started_at, timeout) {
-      Some(timeout) => timeout,
-      None => return Err("Timed out while querying live rate limits from Codex.".to_string()),
-    };
-    let message = match receiver.recv_timeout(timeout) {
-      Ok(message) => message,
-      Err(_) => return Err("Timed out while querying live rate limits from Codex.".to_string()),
-    };
-
-    match message {
-      AppServerMessage::Initialized(Ok(())) => continue,
-      AppServerMessage::Initialized(Err(error)) => break Err(error),
-      AppServerMessage::RateLimits(result) => break result,
-      AppServerMessage::Closed => break Err(
-        "Codex app-server closed before returning live rate limits.".to_string(),
-      ),
-    }
-  };
-
-  response
+fn rate_limit_request() -> Value {
+  json!({
+    "id": READ_REQUEST_ID,
+    "method": "account/rateLimits/read",
+  })
 }
 
 fn remaining_app_server_timeout(started_at: Instant, timeout: Duration) -> Option<Duration> {
@@ -321,27 +427,6 @@ fn app_server_args() -> Vec<OsString> {
     OsString::from("app-server"),
     OsString::from("--listen"),
     OsString::from("stdio://"),
-  ]
-}
-
-fn post_initialize_messages() -> Vec<(Value, &'static str, &'static str)> {
-  vec![
-    (
-      json!({
-        "method": "initialized",
-        "params": {},
-      }),
-      "Failed to notify Codex app-server that initialization completed",
-      "Failed to flush Codex app-server initialized notification",
-    ),
-    (
-      json!({
-        "id": READ_REQUEST_ID,
-        "method": "account/rateLimits/read",
-      }),
-      "Failed to request live rate limits after Codex app-server initialization",
-      "Failed to flush Codex app-server rate-limit request",
-    ),
   ]
 }
 
@@ -621,6 +706,48 @@ mod tests {
   }
 
   #[test]
+  #[cfg(unix)]
+  fn repeated_live_queries_reuse_one_app_server_process() {
+    let temp_dir = tempfile::tempdir().expect("create fixture directory");
+    let launch_path = temp_dir.path().join("launches.txt");
+    let script = concat!(
+      "printf 'launch\\n' >> \"$1\"; ",
+      "while IFS= read -r line; do ",
+      "case \"$line\" in ",
+      "*codex-counter.init*) printf '%s\\n' '{\"id\":\"codex-counter.init\",\"result\":{}}' ;; ",
+      "*account/rateLimits/read*) printf '%s\\n' '{\"id\":\"codex-counter.rate-limits\",\"result\":{\"rateLimits\":{\"limitId\":\"codex\",\"limitName\":null,\"planType\":\"pro\",\"primary\":{\"usedPercent\":3,\"windowDurationMins\":10080,\"resetsAt\":1784498450},\"secondary\":null}}}' ;; ",
+      "esac; done"
+    );
+    let command_spec = super::AppServerCommandSpec {
+      program: "/bin/sh".into(),
+      args: vec![
+        "-c".into(),
+        script.into(),
+        "codex-pacer-reuse-fixture".into(),
+        launch_path.as_os_str().to_owned(),
+      ],
+      hide_window: false,
+    };
+    let mut client = super::ReusableAppServerClient::new(
+      command_spec,
+      PathBuf::from("local reusable fixture"),
+    );
+
+    let first = client.query(Duration::from_secs(1)).expect("first query");
+    let second = client.query(Duration::from_secs(1)).expect("second query");
+
+    assert_eq!(first.secondary.as_ref().map(|window| window.used_percent), Some(3));
+    assert_eq!(second.secondary.as_ref().map(|window| window.used_percent), Some(3));
+    assert_eq!(
+      std::fs::read_to_string(&launch_path)
+        .expect("read launches")
+        .lines()
+        .count(),
+      1
+    );
+  }
+
+  #[test]
   fn convert_window_calculates_remaining_and_start() {
     let converted = convert_window(super::AppServerRateLimitWindow {
       used_percent: 13,
@@ -658,11 +785,11 @@ mod tests {
   }
 
   #[test]
-  fn app_server_post_initialize_messages_follow_protocol_order() {
-    let messages = super::post_initialize_messages()
-      .into_iter()
-      .map(|(message, _, _)| message)
-      .collect::<Vec<_>>();
+  fn app_server_messages_follow_protocol_order() {
+    let messages = vec![
+      super::initialized_notification(),
+      super::rate_limit_request(),
+    ];
 
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[0].get("method").and_then(serde_json::Value::as_str), Some("initialized"));

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -3,6 +3,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use chrono::{Local, LocalResult, TimeZone, Timelike};
@@ -50,28 +51,63 @@ struct AppServerCommandSpec {
   hide_window: bool,
 }
 
+struct AppServerSession {
+  child: Child,
+  stdout_reader: Option<JoinHandle<()>>,
+}
+
+impl Drop for AppServerSession {
+  fn drop(&mut self) {
+    let _ = self.child.stdin.take();
+
+    if !matches!(self.child.try_wait(), Ok(Some(_))) {
+      let _ = self.child.kill();
+    }
+    let _ = self.child.wait();
+
+    if let Some(stdout_reader) = self.stdout_reader.take() {
+      let _ = stdout_reader.join();
+    }
+  }
+}
+
 pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
   let started_at = Instant::now();
   let codex_binary = resolve_codex_binary();
   let command_spec = app_server_command_spec(&codex_binary);
+  query_live_rate_limits_with_command(started_at, timeout, command_spec, &codex_binary)
+}
+
+fn query_live_rate_limits_with_command(
+  started_at: Instant,
+  timeout: Duration,
+  command_spec: AppServerCommandSpec,
+  command_path: &Path,
+) -> Result<LiveRateLimitSnapshot, String> {
   let mut command = app_server_command(&command_spec);
-  let mut child = command
+  let child = command
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
     .stderr(Stdio::null())
     .spawn()
-    .map_err(|error| format!("Failed to launch codex app-server from {}: {error}", codex_binary.display()))?;
+    .map_err(|error| {
+      format!(
+        "Failed to launch codex app-server from {}: {error}",
+        command_path.display()
+      )
+    })?;
+  let mut session = AppServerSession {
+    child,
+    stdout_reader: None,
+  };
 
-  let stdout = match child.stdout.take() {
+  let stdout = match session.child.stdout.take() {
     Some(stdout) => stdout,
-    None => {
-      stop_app_server(&mut child);
-      return Err("Failed to capture codex app-server stdout.".to_string());
-    }
+    None => return Err("Failed to capture codex app-server stdout.".to_string()),
   };
   let (sender, receiver) = mpsc::channel();
 
-  std::thread::spawn(move || {
+  session.stdout_reader = Some(std::thread::spawn(move || {
     let mut init_ok = false;
     for line in BufReader::new(stdout).lines().map_while(Result::ok) {
       let parsed: Value = match serde_json::from_str(&line) {
@@ -134,10 +170,10 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
     }
 
     let _ = sender.send(AppServerMessage::Closed);
-  });
+  }));
 
   if let Err(error) = send_app_server_request(
-    &mut child,
+    &mut session.child,
     json!({
       "id": INIT_REQUEST_ID,
       "method": "initialize",
@@ -154,49 +190,31 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
     "Failed to initialize codex app-server",
     "Failed to flush codex app-server init request",
   ) {
-    stop_app_server(&mut child);
     return Err(error);
   }
 
   let init_timeout = match remaining_app_server_timeout(started_at, timeout) {
     Some(timeout) => timeout,
-    None => {
-      stop_app_server(&mut child);
-      return Err("Timed out while initializing Codex app-server.".to_string());
-    }
+    None => return Err("Timed out while initializing Codex app-server.".to_string()),
   };
   let init_response = match receiver.recv_timeout(init_timeout) {
     Ok(message) => message,
-    Err(_) => {
-      stop_app_server(&mut child);
-      return Err("Timed out while initializing Codex app-server.".to_string());
-    }
+    Err(_) => return Err("Timed out while initializing Codex app-server.".to_string()),
   };
 
   match init_response {
     AppServerMessage::Initialized(Ok(())) => {}
-    AppServerMessage::Initialized(Err(error)) => {
-      stop_app_server(&mut child);
-      return Err(error);
-    }
-    AppServerMessage::RateLimits(result) => {
-      stop_app_server(&mut child);
-      return result;
-    }
+    AppServerMessage::Initialized(Err(error)) => return Err(error),
+    AppServerMessage::RateLimits(result) => return result,
     AppServerMessage::Closed => {
-      stop_app_server(&mut child);
-      return Err("Codex app-server closed before initialization completed.".to_string());
+      return Err("Codex app-server closed before initialization completed.".to_string())
     }
   }
 
   for (message, write_context, flush_context) in post_initialize_messages() {
-    if let Err(error) = send_app_server_request(
-      &mut child,
-      message,
-      write_context,
-      flush_context,
-    ) {
-      stop_app_server(&mut child);
+    if let Err(error) =
+      send_app_server_request(&mut session.child, message, write_context, flush_context)
+    {
       return Err(error);
     }
   }
@@ -204,17 +222,11 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
   let response = loop {
     let timeout = match remaining_app_server_timeout(started_at, timeout) {
       Some(timeout) => timeout,
-      None => {
-        stop_app_server(&mut child);
-        return Err("Timed out while querying live rate limits from Codex.".to_string());
-      }
+      None => return Err("Timed out while querying live rate limits from Codex.".to_string()),
     };
     let message = match receiver.recv_timeout(timeout) {
       Ok(message) => message,
-      Err(_) => {
-        stop_app_server(&mut child);
-        return Err("Timed out while querying live rate limits from Codex.".to_string());
-      }
+      Err(_) => return Err("Timed out while querying live rate limits from Codex.".to_string()),
     };
 
     match message {
@@ -227,7 +239,6 @@ pub fn query_live_rate_limits(timeout: Duration) -> Result<LiveRateLimitSnapshot
     }
   };
 
-  stop_app_server(&mut child);
   response
 }
 
@@ -348,12 +359,6 @@ fn send_app_server_request(
   stdin
     .flush()
     .map_err(|error| format!("{flush_context}: {error}"))
-}
-
-fn stop_app_server(child: &mut Child) {
-  let _ = child.stdin.take();
-  let _ = child.kill();
-  let _ = child.wait();
 }
 
 fn convert_live_rate_limits(snapshot: AppServerRateLimitSnapshot) -> LiveRateLimitSnapshot {
@@ -500,10 +505,106 @@ mod tests {
   #[cfg(windows)]
   use std::ffi::OsString;
   use std::path::{Path, PathBuf};
+  #[cfg(unix)]
+  use std::time::{Duration, Instant};
 
   fn existing_paths(paths: &[&str]) -> impl Fn(&Path) -> bool {
     let paths: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
     move |candidate| paths.iter().any(|path| path == candidate)
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn live_timeout_terminates_and_reaps_child() {
+    fn assert_not_running_or_waitable(pid: i32) {
+      const ESRCH: i32 = 3;
+      const ECHILD: i32 = 10;
+      const SIGKILL: i32 = 9;
+      const WNOHANG: i32 = 1;
+
+      extern "C" {
+        fn kill(pid: i32, signal: i32) -> i32;
+        fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
+      }
+
+      let kill_result = unsafe { kill(pid, 0) };
+      let kill_error = (kill_result == -1).then(std::io::Error::last_os_error);
+
+      let mut status = 0;
+      let wait_result = unsafe { waitpid(pid, &mut status, WNOHANG) };
+      let wait_error = (wait_result == -1).then(std::io::Error::last_os_error);
+
+      if wait_result == 0 {
+        let _ = unsafe { kill(pid, SIGKILL) };
+        let _ = unsafe { waitpid(pid, &mut status, 0) };
+      }
+
+      assert_eq!(
+        kill_result, -1,
+        "app-server fixture PID {pid} is still alive or a zombie"
+      );
+      assert_eq!(
+        kill_error.and_then(|error| error.raw_os_error()),
+        Some(ESRCH),
+        "unexpected kill probe result for PID {pid}"
+      );
+      assert_eq!(
+        wait_result, -1,
+        "app-server fixture PID {pid} was not reaped"
+      );
+      assert_eq!(
+        wait_error.and_then(|error| error.raw_os_error()),
+        Some(ECHILD),
+        "unexpected waitpid result for PID {pid}"
+      );
+    }
+
+    let fixtures = [
+      (
+        "echo $$ > \"$1\"; while IFS= read -r _line; do :; done",
+        "Timed out while initializing Codex app-server.",
+      ),
+      (
+        concat!(
+          "echo $$ > \"$1\"; ",
+          "IFS= read -r _line; ",
+          "printf '%s\\n' '{\"id\":\"codex-counter.init\",\"result\":{}}'; ",
+          "while IFS= read -r _line; do :; done"
+        ),
+        "Timed out while querying live rate limits from Codex.",
+      ),
+    ];
+
+    for (index, (script, expected_error)) in fixtures.into_iter().enumerate() {
+      let temp_dir = tempfile::tempdir().expect("create app-server fixture directory");
+      let pid_path = temp_dir.path().join(format!("fixture-{index}.pid"));
+      let command_spec = super::AppServerCommandSpec {
+        program: "/bin/sh".into(),
+        args: vec![
+          "-c".into(),
+          script.into(),
+          "codex-pacer-app-server-fixture".into(),
+          pid_path.as_os_str().to_owned(),
+        ],
+        hide_window: false,
+      };
+
+      let error = super::query_live_rate_limits_with_command(
+        Instant::now(),
+        Duration::from_millis(100),
+        command_spec,
+        Path::new("local app-server fixture"),
+      )
+      .expect_err("fixture should force a timeout");
+      assert_eq!(error, expected_error);
+
+      let pid = std::fs::read_to_string(&pid_path)
+        .expect("fixture should record its PID")
+        .trim()
+        .parse::<i32>()
+        .expect("fixture PID should be numeric");
+      assert_not_running_or_waitable(pid);
+    }
   }
 
   #[test]

--- a/src-tauri/src/refresh/live_cache.rs
+++ b/src-tauri/src/refresh/live_cache.rs
@@ -1,0 +1,550 @@
+use crate::models::{LiveQuotaState, LiveRateLimitSnapshot};
+use chrono::{DateTime, Utc};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+const PERSISTENCE_RETRY_SECONDS: [u64; 6] = [5, 15, 30, 60, 120, 300];
+const MAX_PERSISTENCE_RETRY: Duration = Duration::from_secs(300);
+const MIN_PERSISTENCE_RETRY: Duration = Duration::from_secs(1);
+
+#[derive(Clone)]
+pub(crate) struct LiveQuotaCache {
+  inner: Arc<Mutex<LiveQuotaCacheInner>>,
+}
+
+struct LiveQuotaCacheInner {
+  rate_limits: Option<Arc<LiveRateLimitSnapshot>>,
+  source_fetched_at: Option<String>,
+  cached_at: String,
+  is_fallback: bool,
+  last_live_success_at: Option<String>,
+  refreshing: bool,
+  fresh_at: Option<Instant>,
+}
+
+impl Default for LiveQuotaCache {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl LiveQuotaCache {
+  pub(crate) fn new() -> Self {
+    Self {
+      inner: Arc::new(Mutex::new(LiveQuotaCacheInner {
+        rate_limits: None,
+        source_fetched_at: None,
+        cached_at: "1970-01-01T00:00:00+00:00".to_string(),
+        is_fallback: false,
+        last_live_success_at: None,
+        refreshing: false,
+        fresh_at: None,
+      })),
+    }
+  }
+
+  pub(crate) fn state(&self) -> LiveQuotaState {
+    state_from_inner(&lock(&self.inner))
+  }
+
+  pub(crate) fn rate_limits(&self) -> Option<Arc<LiveRateLimitSnapshot>> {
+    lock(&self.inner).rate_limits.as_ref().map(Arc::clone)
+  }
+
+  pub(crate) fn publish_live(
+    &self,
+    snapshot: Arc<LiveRateLimitSnapshot>,
+    monotonic_now: Instant,
+    wall_now: DateTime<Utc>,
+  ) -> LiveQuotaState {
+    let mut inner = lock(&self.inner);
+    inner.source_fetched_at = Some(snapshot.fetched_at.clone());
+    inner.rate_limits = Some(snapshot);
+    inner.cached_at = wall_now.to_rfc3339();
+    inner.is_fallback = false;
+    inner.last_live_success_at = Some(wall_now.to_rfc3339());
+    inner.refreshing = false;
+    inner.fresh_at = Some(monotonic_now);
+    state_from_inner(&inner)
+  }
+
+  pub(crate) fn publish_fallback(
+    &self,
+    fallback: Arc<LiveRateLimitSnapshot>,
+    _monotonic_now: Instant,
+    wall_now: DateTime<Utc>,
+  ) -> LiveQuotaState {
+    let mut inner = lock(&self.inner);
+    let replace = inner.rate_limits.as_ref().map_or(true, |current| {
+      snapshot_is_strictly_newer(&fallback, current)
+    });
+    if replace {
+      inner.source_fetched_at = Some(fallback.fetched_at.clone());
+      inner.rate_limits = Some(fallback);
+      inner.cached_at = wall_now.to_rfc3339();
+    }
+    inner.is_fallback = true;
+    inner.refreshing = false;
+    inner.fresh_at = None;
+    state_from_inner(&inner)
+  }
+
+  pub(crate) fn set_refreshing(&self, refreshing: bool) -> LiveQuotaState {
+    let mut inner = lock(&self.inner);
+    inner.refreshing = refreshing;
+    state_from_inner(&inner)
+  }
+
+  pub(crate) fn mark_current_as_fallback(&self) -> LiveQuotaState {
+    let mut inner = lock(&self.inner);
+    inner.refreshing = false;
+    if inner.rate_limits.is_some() {
+      inner.is_fallback = true;
+      inner.fresh_at = None;
+    }
+    state_from_inner(&inner)
+  }
+
+  pub(crate) fn needs_live_refresh(&self, ttl: Duration, monotonic_now: Instant) -> bool {
+    let inner = lock(&self.inner);
+    inner.rate_limits.is_none()
+      || inner.is_fallback
+      || inner.fresh_at.map_or(true, |fresh_at| {
+        monotonic_now.saturating_duration_since(fresh_at) > ttl
+      })
+  }
+}
+
+fn state_from_inner(inner: &LiveQuotaCacheInner) -> LiveQuotaState {
+  LiveQuotaState {
+    rate_limits: inner
+      .rate_limits
+      .as_ref()
+      .map(|value| value.as_ref().clone()),
+    source_fetched_at: inner.source_fetched_at.clone(),
+    cached_at: inner.cached_at.clone(),
+    is_fallback: inner.is_fallback,
+    last_live_success_at: inner.last_live_success_at.clone(),
+    refreshing: inner.refreshing,
+  }
+}
+
+fn snapshot_is_strictly_newer(
+  candidate: &LiveRateLimitSnapshot,
+  current: &LiveRateLimitSnapshot,
+) -> bool {
+  match (
+    parse_source_instant(&candidate.fetched_at),
+    parse_source_instant(&current.fetched_at),
+  ) {
+    (Some(candidate), Some(current)) => candidate > current,
+    (Some(_), None) => true,
+    (None, Some(_)) => false,
+    (None, None) => candidate.fetched_at > current.fetched_at,
+  }
+}
+
+fn parse_source_instant(value: &str) -> Option<DateTime<Utc>> {
+  DateTime::parse_from_rfc3339(value)
+    .ok()
+    .map(|value| value.with_timezone(&Utc))
+}
+
+fn lock<T>(value: &Mutex<T>) -> MutexGuard<'_, T> {
+  value
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[derive(Clone)]
+struct PersistenceItem {
+  identity: u64,
+  source_generation: u64,
+  snapshot: Arc<LiveRateLimitSnapshot>,
+}
+
+#[derive(Clone)]
+pub(crate) struct LivePersistenceWork {
+  item: PersistenceItem,
+}
+
+impl LivePersistenceWork {
+  pub(crate) fn identity(&self) -> u64 {
+    self.item.identity
+  }
+
+  pub(crate) fn source_generation(&self) -> u64 {
+    self.item.source_generation
+  }
+
+  pub(crate) fn snapshot(&self) -> &Arc<LiveRateLimitSnapshot> {
+    &self.item.snapshot
+  }
+}
+
+pub(crate) struct LivePersistenceRetryState {
+  source_generation: Option<u64>,
+  in_flight: Option<PersistenceItem>,
+  latest_pending: Option<PersistenceItem>,
+  failure_streak: u32,
+  retry_at: Option<Instant>,
+  next_identity: u64,
+}
+
+impl Default for LivePersistenceRetryState {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl LivePersistenceRetryState {
+  pub(crate) fn new() -> Self {
+    Self {
+      source_generation: None,
+      in_flight: None,
+      latest_pending: None,
+      failure_streak: 0,
+      retry_at: None,
+      next_identity: 0,
+    }
+  }
+
+  pub(crate) fn publish(
+    &mut self,
+    snapshot: Arc<LiveRateLimitSnapshot>,
+    source_generation: u64,
+    _now: Instant,
+  ) {
+    if self.source_generation != Some(source_generation) {
+      self.reset_source(source_generation);
+    }
+    self.next_identity = self.next_identity.saturating_add(1);
+    self.latest_pending = Some(PersistenceItem {
+      identity: self.next_identity,
+      source_generation,
+      snapshot,
+    });
+    self.failure_streak = 0;
+    self.retry_at = None;
+  }
+
+  pub(crate) fn take_ready(
+    &mut self,
+    now: Instant,
+    live_fetch_running: bool,
+  ) -> Option<LivePersistenceWork> {
+    if live_fetch_running || self.in_flight.is_some() {
+      return None;
+    }
+    if self.retry_at.is_some_and(|deadline| deadline > now) {
+      return None;
+    }
+    let item = self.latest_pending.take()?;
+    self.retry_at = None;
+    self.in_flight = Some(item.clone());
+    Some(LivePersistenceWork { item })
+  }
+
+  pub(crate) fn finish(
+    &mut self,
+    work: &LivePersistenceWork,
+    result: Result<(), String>,
+    now: Instant,
+    interval: Duration,
+  ) -> bool {
+    let matches = self
+      .in_flight
+      .as_ref()
+      .is_some_and(|running| persistence_item_matches(running, &work.item));
+    if !matches {
+      return false;
+    }
+    self.in_flight = None;
+    if self.source_generation != Some(work.item.source_generation) {
+      if self.latest_pending.is_some() {
+        self.retry_at = None;
+      }
+      return true;
+    }
+    match result {
+      Ok(()) => {
+        self.failure_streak = 0;
+        self.retry_at = None;
+      }
+      Err(_) if self.latest_pending.is_some() => {
+        self.retry_at = None;
+      }
+      Err(_) => {
+        self.failure_streak = self.failure_streak.saturating_add(1);
+        self.latest_pending = Some(work.item.clone());
+        self.retry_at = Some(
+          now
+            .checked_add(persistence_retry_delay(self.failure_streak, interval))
+            .unwrap_or(now),
+        );
+      }
+    }
+    true
+  }
+
+  pub(crate) fn abandon(&mut self, work: &LivePersistenceWork) -> bool {
+    let matches = self
+      .in_flight
+      .as_ref()
+      .is_some_and(|running| persistence_item_matches(running, &work.item));
+    if !matches {
+      return false;
+    }
+    self.in_flight = None;
+    if self.latest_pending.is_some() {
+      self.retry_at = None;
+    }
+    true
+  }
+
+  pub(crate) fn reset_source(&mut self, source_generation: u64) {
+    if self.source_generation == Some(source_generation) {
+      return;
+    }
+    self.source_generation = Some(source_generation);
+    self.latest_pending = None;
+    self.failure_streak = 0;
+    self.retry_at = None;
+  }
+
+  pub(crate) fn cancel_pending(&mut self) {
+    self.latest_pending = None;
+    self.retry_at = None;
+  }
+
+  pub(crate) fn retry_deadline(&self) -> Option<Instant> {
+    self.retry_at
+  }
+
+  pub(crate) fn has_in_flight(&self) -> bool {
+    self.in_flight.is_some()
+  }
+
+  pub(crate) fn next_wait(&self, now: Instant, live_fetch_running: bool) -> Option<Duration> {
+    if live_fetch_running || self.in_flight.is_some() || self.latest_pending.is_none() {
+      return None;
+    }
+    Some(self.retry_at.map_or(Duration::ZERO, |deadline| {
+      deadline.saturating_duration_since(now)
+    }))
+  }
+
+  pub(crate) fn failure_streak(&self) -> u32 {
+    self.failure_streak
+  }
+}
+
+fn persistence_item_matches(left: &PersistenceItem, right: &PersistenceItem) -> bool {
+  left.identity == right.identity
+    && left.source_generation == right.source_generation
+    && Arc::ptr_eq(&left.snapshot, &right.snapshot)
+}
+
+fn persistence_retry_delay(failure_streak: u32, interval: Duration) -> Duration {
+  let index = failure_streak
+    .saturating_sub(1)
+    .min(PERSISTENCE_RETRY_SECONDS.len().saturating_sub(1) as u32) as usize;
+  let base = Duration::from_secs(PERSISTENCE_RETRY_SECONDS[index]);
+  let cap = interval
+    .min(MAX_PERSISTENCE_RETRY)
+    .max(MIN_PERSISTENCE_RETRY);
+  base.min(cap).max(MIN_PERSISTENCE_RETRY)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{LivePersistenceRetryState, LiveQuotaCache};
+  use crate::models::LiveRateLimitSnapshot;
+  use chrono::{DateTime, Utc};
+  use std::sync::Arc;
+  use std::time::{Duration, Instant};
+
+  fn utc(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+      .expect("valid test timestamp")
+      .with_timezone(&Utc)
+  }
+
+  fn snapshot(fetched_at: &str) -> Arc<LiveRateLimitSnapshot> {
+    Arc::new(LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: None,
+      fetched_at: fetched_at.to_string(),
+    })
+  }
+
+  #[test]
+  fn fallback_never_becomes_fresh_for_ttl() {
+    let cache = LiveQuotaCache::new();
+    let monotonic = Instant::now();
+    let state = cache.publish_fallback(
+      snapshot("2026-07-09T10:00:00+00:00"),
+      monotonic,
+      utc("2026-07-10T10:00:00Z"),
+    );
+
+    assert!(state.is_fallback);
+    assert_eq!(
+      state.source_fetched_at.as_deref(),
+      Some("2026-07-09T10:00:00+00:00")
+    );
+    assert_eq!(state.last_live_success_at, None);
+    assert!(cache.needs_live_refresh(Duration::from_secs(300), monotonic));
+    assert!(cache.needs_live_refresh(Duration::from_secs(300), monotonic + Duration::from_secs(1)));
+  }
+
+  #[test]
+  fn fallback_preserves_source_and_last_success() {
+    let cache = LiveQuotaCache::new();
+    let monotonic = Instant::now();
+    let live = snapshot("2026-07-10T10:05:00Z");
+    cache.publish_live(Arc::clone(&live), monotonic, utc("2026-07-10T10:06:00Z"));
+
+    let state = cache.publish_fallback(
+      snapshot("2026-07-10T10:00:00Z"),
+      monotonic + Duration::from_secs(1),
+      utc("2026-07-10T10:07:00Z"),
+    );
+
+    assert!(state.is_fallback);
+    assert_eq!(
+      state.source_fetched_at.as_deref(),
+      Some("2026-07-10T10:05:00Z")
+    );
+    assert_eq!(
+      state.last_live_success_at.as_deref(),
+      Some("2026-07-10T10:06:00+00:00")
+    );
+    assert_eq!(state.cached_at, "2026-07-10T10:06:00+00:00");
+    let cached = cache
+      .rate_limits()
+      .expect("newer in-memory snapshot remains");
+    assert!(Arc::ptr_eq(&cached, &live));
+    assert!(cache.needs_live_refresh(Duration::from_secs(300), monotonic));
+
+    let current_only = LiveQuotaCache::new();
+    current_only.publish_live(Arc::clone(&live), monotonic, utc("2026-07-10T10:06:00Z"));
+    let marked = current_only.mark_current_as_fallback();
+    assert!(marked.is_fallback);
+    assert_eq!(marked.cached_at, "2026-07-10T10:06:00+00:00");
+    assert_eq!(
+      marked.source_fetched_at.as_deref(),
+      Some("2026-07-10T10:05:00Z")
+    );
+    assert_eq!(
+      marked.last_live_success_at.as_deref(),
+      Some("2026-07-10T10:06:00+00:00")
+    );
+    assert!(current_only.needs_live_refresh(Duration::from_secs(300), monotonic));
+  }
+
+  #[test]
+  fn persistence_retry_is_capped() {
+    let mut retries = LivePersistenceRetryState::new();
+    let initial_snapshot = snapshot("2026-07-10T10:05:00Z");
+    let mut now = Instant::now();
+    retries.publish(Arc::clone(&initial_snapshot), 7, now);
+
+    for (index, expected) in [5, 15, 30, 60, 120, 300, 300].into_iter().enumerate() {
+      let work = retries
+        .take_ready(now, false)
+        .expect("published or retried snapshot is ready");
+      retries.finish(
+        &work,
+        Err("database busy".to_string()),
+        now,
+        Duration::from_secs(1_000),
+      );
+      let deadline = retries.retry_deadline().expect("failure schedules retry");
+      assert_eq!(
+        deadline.saturating_duration_since(now),
+        Duration::from_secs(expected)
+      );
+      assert_eq!(retries.failure_streak(), index as u32 + 1);
+      now = deadline;
+    }
+
+    let mut interval_capped = LivePersistenceRetryState::new();
+    interval_capped.publish(Arc::clone(&initial_snapshot), 7, now);
+    let first = interval_capped
+      .take_ready(now, false)
+      .expect("first capped work");
+    interval_capped.finish(
+      &first,
+      Err("database busy".to_string()),
+      now,
+      Duration::from_secs(12),
+    );
+    now = interval_capped
+      .retry_deadline()
+      .expect("first capped deadline");
+    let second = interval_capped
+      .take_ready(now, false)
+      .expect("second capped work");
+    interval_capped.finish(
+      &second,
+      Err("database busy".to_string()),
+      now,
+      Duration::from_secs(12),
+    );
+    assert_eq!(
+      interval_capped
+        .retry_deadline()
+        .expect("interval-capped deadline")
+        .saturating_duration_since(now),
+      Duration::from_secs(12)
+    );
+
+    let mut zero_interval = LivePersistenceRetryState::new();
+    zero_interval.publish(initial_snapshot, 7, now);
+    let work = zero_interval
+      .take_ready(now, false)
+      .expect("zero interval work");
+    zero_interval.finish(&work, Err("database busy".to_string()), now, Duration::ZERO);
+    assert_eq!(
+      zero_interval
+        .retry_deadline()
+        .expect("nonzero retry deadline")
+        .saturating_duration_since(now),
+      Duration::from_secs(1)
+    );
+
+    let mut superseded = LivePersistenceRetryState::new();
+    superseded.publish(snapshot("2026-07-10T10:05:00Z"), 7, now);
+    let old = superseded
+      .take_ready(now, false)
+      .expect("old persistence work");
+    superseded.publish(snapshot("2026-07-10T10:06:00Z"), 7, now);
+    superseded.finish(
+      &old,
+      Err("old write failed".to_string()),
+      now,
+      Duration::from_secs(300),
+    );
+    assert_eq!(superseded.failure_streak(), 0);
+    let latest = superseded
+      .take_ready(now, false)
+      .expect("newer work stays immediate");
+    superseded.finish(
+      &latest,
+      Err("new write failed".to_string()),
+      now,
+      Duration::from_secs(300),
+    );
+    assert_eq!(
+      superseded
+        .retry_deadline()
+        .expect("new value starts at first retry")
+        .saturating_duration_since(now),
+      Duration::from_secs(5)
+    );
+  }
+}

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use live_cache::{LivePersistenceRetryState, LivePersistenceWork, Live
 #[allow(unused_imports)]
 pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
 #[allow(unused_imports)]
-pub(crate) use power::{begin_scheduler_activity, ActivityFactory, SystemActivityFactory};
+pub(crate) use power::{ActivityFactory, SystemActivityFactory};
 #[allow(unused_imports)]
 pub(crate) use runtime::{
   LaneStatus, LiveQuotaFetcher, LiveQuotaPersister, ManualLiveTicket, ManualRefreshTicket,

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -1,10 +1,12 @@
 #![allow(dead_code)]
 
+mod live_cache;
 mod mutation;
 mod power;
 mod runtime;
 mod schedule;
 
+pub(crate) use live_cache::{LivePersistenceRetryState, LivePersistenceWork, LiveQuotaCache};
 #[allow(unused_imports)]
 pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
 #[allow(unused_imports)]

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -10,9 +10,13 @@ use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};
 
 #[allow(unused_imports)]
-pub(crate) use schedule::{CoordinatorAction, CoordinatorEvent, CoordinatorState};
+pub(crate) use schedule::{
+  CoordinatorAction, CoordinatorEvent, CoordinatorSnapshot, CoordinatorState, LaneScheduleSnapshot,
+};
 
 pub(crate) const LIVE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const REFRESH_WAITER_CAPACITY: usize = 32;
+pub(crate) const REFRESH_DETAIL_MAX_BYTES: usize = 256;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -24,12 +28,12 @@ pub(crate) enum RefreshLane {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub(crate) enum RefreshReason {
-  Startup,
-  Scheduled,
-  Manual,
-  SettingsChanged,
-  Wake,
-  Fallback,
+  Startup = 0,
+  Scheduled = 1,
+  Manual = 2,
+  SettingsChanged = 3,
+  Wake = 4,
+  Fallback = 5,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -39,6 +43,7 @@ pub(crate) enum TokenScanKind {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
 pub(crate) struct ReasonSet(u8);
 
 impl ReasonSet {
@@ -67,6 +72,10 @@ impl ReasonSet {
   pub(crate) fn is_empty(self) -> bool {
     self.0 == 0
   }
+
+  pub(crate) fn bits(self) -> u8 {
+    self.0
+  }
 }
 
 impl From<RefreshReason> for ReasonSet {
@@ -75,11 +84,54 @@ impl From<RefreshReason> for ReasonSet {
   }
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct TokenWaiterIds(Vec<TokenWaiterId>);
+
+impl TokenWaiterIds {
+  pub(crate) fn try_push(&mut self, waiter: TokenWaiterId) -> Result<(), RefreshRejectionCode> {
+    if self.0.contains(&waiter) {
+      return Ok(());
+    }
+    if self.0.len() >= REFRESH_WAITER_CAPACITY {
+      return Err(RefreshRejectionCode::Busy);
+    }
+    self.0.push(waiter);
+    Ok(())
+  }
+
+  pub(crate) fn as_slice(&self) -> &[TokenWaiterId] {
+    &self.0
+  }
+
+  pub(crate) fn len(&self) -> usize {
+    self.0.len()
+  }
+
+  pub(crate) fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+
+  pub(crate) fn contains(&self, waiter: &TokenWaiterId) -> bool {
+    self.0.contains(waiter)
+  }
+
+  pub(crate) fn clear(&mut self) {
+    self.0.clear();
+  }
+
+  fn into_vec(self) -> Vec<TokenWaiterId> {
+    self.0
+  }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct TokenRequest {
   pub reasons: ReasonSet,
   pub kind: TokenScanKind,
   pub codex_home: Option<String>,
+  pub waiter_ids: TokenWaiterIds,
+  pub planned_due_at: Option<Instant>,
+  source_generation: Option<u64>,
 }
 
 impl TokenRequest {
@@ -92,7 +144,16 @@ impl TokenRequest {
       reasons: reason.into(),
       kind: TokenScanKind::Incremental,
       codex_home: None,
+      waiter_ids: TokenWaiterIds::default(),
+      planned_due_at: None,
+      source_generation: None,
     }
+  }
+
+  pub(crate) fn for_reason_at(reason: RefreshReason, planned_due_at: Instant) -> Self {
+    let mut request = Self::for_reason(reason);
+    request.planned_due_at = Some(planned_due_at);
+    request
   }
 
   pub(crate) fn manual_full(codex_home: Option<String>) -> Self {
@@ -100,25 +161,147 @@ impl TokenRequest {
       reasons: RefreshReason::Manual.into(),
       kind: TokenScanKind::Full,
       codex_home,
+      waiter_ids: TokenWaiterIds::default(),
+      planned_due_at: None,
+      source_generation: None,
     }
   }
 
-  fn merge(&mut self, other: Self) {
+  pub(crate) fn manual_full_with_waiter(codex_home: Option<String>, waiter: TokenWaiterId) -> Self {
+    let mut request = Self::manual_full(codex_home);
+    request
+      .try_add_waiter(waiter)
+      .expect("an empty token request accepts one waiter");
+    request
+  }
+
+  pub(crate) fn try_add_waiter(
+    &mut self,
+    waiter: TokenWaiterId,
+  ) -> Result<(), RefreshRejectionCode> {
+    self.waiter_ids.try_push(waiter)
+  }
+
+  pub(crate) fn waiter_ids(&self) -> &[TokenWaiterId] {
+    self.waiter_ids.as_slice()
+  }
+
+  fn try_merge(&mut self, other: Self) -> Result<(), Self> {
+    if !self.same_source_identity(&other) {
+      return Err(other);
+    }
     self.reasons.merge(other.reasons);
     self.kind = self.kind.max(other.kind);
-    if other.codex_home.is_some() || self.codex_home.is_none() {
-      self.codex_home = other.codex_home;
+    for waiter in other.waiter_ids.into_vec() {
+      self
+        .waiter_ids
+        .try_push(waiter)
+        .expect("coordinator waiter capacity is enforced before request merges");
     }
+    self.planned_due_at = earliest_due(self.planned_due_at, other.planned_due_at);
+    Ok(())
+  }
+
+  fn same_source_identity(&self, other: &Self) -> bool {
+    self.codex_home == other.codex_home && self.source_generation == other.source_generation
+  }
+
+  fn bind_configured_source(&mut self, source_generation: u64, codex_home: Option<String>) {
+    self.codex_home = codex_home;
+    self.source_generation = Some(source_generation);
+  }
+
+  fn bind_source_if_needed(&mut self, source_generation: u64, codex_home: Option<String>) {
+    if self.source_generation.is_some() {
+      return;
+    }
+    if self.codex_home.is_none() || self.codex_home == codex_home {
+      self.bind_configured_source(source_generation, codex_home);
+    }
+  }
+
+  fn is_bound_to_source_generation(&self, source_generation: u64) -> bool {
+    self.source_generation == Some(source_generation)
+  }
+
+  fn drain_waiters(&mut self) -> Vec<TokenWaiterId> {
+    std::mem::take(&mut self.waiter_ids).into_vec()
+  }
+}
+
+fn earliest_due(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.min(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
   }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct TokenWaiterId(pub(crate) u64);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct LiveWaiterId(pub(crate) u64);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshFailureCode {
+  ExecutionFailed,
+  SourceChanged,
+  InvalidCompletion,
+  PreparedPayloadMissing,
+  WorkerPanicked,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshRejectionCode {
+  Busy,
+  InvalidRequest,
+  Superseded,
+  SourceChanged,
+  Shutdown,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(transparent)]
+pub(crate) struct RefreshDetail(String);
+
+impl RefreshDetail {
+  pub(crate) fn new(value: impl AsRef<str>) -> Self {
+    let value = value.as_ref();
+    if value.len() <= REFRESH_DETAIL_MAX_BYTES {
+      return Self(value.to_string());
+    }
+    let mut end = REFRESH_DETAIL_MAX_BYTES;
+    while !value.is_char_boundary(end) {
+      end -= 1;
+    }
+    Self(value[..end].to_string())
+  }
+
+  pub(crate) fn as_str(&self) -> &str {
+    &self.0
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshWaiterOutcome {
+  Completed {
+    generation: u64,
+    succeeded: bool,
+    failure_code: Option<RefreshFailureCode>,
+    detail: Option<RefreshDetail>,
+  },
+  Rejected {
+    code: RefreshRejectionCode,
+    detail: Option<RefreshDetail>,
+  },
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct LiveRequest {
   pub reasons: ReasonSet,
   pub waiter: Option<LiveWaiterId>,
+  pub planned_due_at: Option<Instant>,
 }
 
 impl LiveRequest {
@@ -130,13 +313,21 @@ impl LiveRequest {
     Self {
       reasons: reason.into(),
       waiter: None,
+      planned_due_at: None,
     }
+  }
+
+  pub(crate) fn for_reason_at(reason: RefreshReason, planned_due_at: Instant) -> Self {
+    let mut request = Self::for_reason(reason);
+    request.planned_due_at = Some(planned_due_at);
+    request
   }
 
   pub(crate) fn manual(waiter: LiveWaiterId) -> Self {
     Self {
       reasons: RefreshReason::Manual.into(),
       waiter: Some(waiter),
+      planned_due_at: None,
     }
   }
 }
@@ -153,6 +344,7 @@ pub(crate) struct LiveExecutionRequest {
   pub generation: u64,
   pub source_generation: u64,
   pub reasons: ReasonSet,
+  pub planned_due_at: Option<Instant>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -175,6 +367,7 @@ pub(crate) struct ExecutionCompletion {
   pub generation: u64,
   pub source_generation: u64,
   pub succeeded: bool,
+  pub failure_code: Option<RefreshFailureCode>,
   pub failure: Option<String>,
   pub completed_at: String,
   pub commit: Option<CommitMarker>,

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -13,10 +13,11 @@ pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordi
 pub(crate) use power::{ActivityFactory, SystemActivityFactory};
 #[allow(unused_imports)]
 pub(crate) use runtime::{
-  LaneStatus, LiveQuotaFetcher, LiveQuotaPersister, ManualLiveTicket, ManualRefreshTicket,
-  ManualTokenTicket, MutationPhase, PreparedTokenRefresh, RefreshCoordinatorHandle, RefreshError,
-  RefreshEventSink, RefreshLaneMetrics, RefreshMetricsSnapshot, RefreshRuntime,
-  RefreshRuntimeDependencies, RefreshStatus, ShutdownResult, TokenRefreshExecutor,
+  EpochMaintenanceBatch, EpochMaintenanceExecutor, LaneStatus, LiveQuotaFetcher,
+  LiveQuotaPersister, ManualLiveTicket, ManualRefreshTicket, ManualTokenTicket, MutationPhase,
+  PreparedTokenRefresh, RefreshCoordinatorHandle, RefreshError, RefreshEventSink,
+  RefreshLaneMetrics, RefreshMetricsSnapshot, RefreshRuntime, RefreshRuntimeDependencies,
+  RefreshStatus, ShutdownResult, TokenRefreshExecutor,
 };
 
 use chrono::{DateTime, Utc};

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -3,7 +3,7 @@
 mod schedule;
 
 use chrono::{DateTime, Utc};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[allow(unused_imports)]
 pub(crate) use schedule::{CoordinatorAction, CoordinatorEvent, CoordinatorState};
@@ -18,6 +18,7 @@ pub(crate) enum RefreshLane {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
 pub(crate) enum RefreshReason {
   Startup,
   Scheduled,
@@ -31,6 +32,163 @@ pub(crate) enum RefreshReason {
 pub(crate) enum TokenScanKind {
   Incremental,
   Full,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ReasonSet(u8);
+
+impl ReasonSet {
+  pub(crate) fn from_reason(reason: RefreshReason) -> Self {
+    let mut reasons = Self::default();
+    reasons.insert(reason);
+    reasons
+  }
+
+  pub(crate) fn insert(&mut self, reason: RefreshReason) {
+    self.0 |= 1 << reason as u8;
+  }
+
+  pub(crate) fn remove(&mut self, reason: RefreshReason) {
+    self.0 &= !(1 << reason as u8);
+  }
+
+  pub(crate) fn contains(self, reason: RefreshReason) -> bool {
+    self.0 & (1 << reason as u8) != 0
+  }
+
+  pub(crate) fn merge(&mut self, other: Self) {
+    self.0 |= other.0;
+  }
+
+  pub(crate) fn is_empty(self) -> bool {
+    self.0 == 0
+  }
+}
+
+impl From<RefreshReason> for ReasonSet {
+  fn from(reason: RefreshReason) -> Self {
+    Self::from_reason(reason)
+  }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TokenRequest {
+  pub reasons: ReasonSet,
+  pub kind: TokenScanKind,
+  pub codex_home: Option<String>,
+}
+
+impl TokenRequest {
+  pub(crate) fn scheduled() -> Self {
+    Self::for_reason(RefreshReason::Scheduled)
+  }
+
+  pub(crate) fn for_reason(reason: RefreshReason) -> Self {
+    Self {
+      reasons: reason.into(),
+      kind: TokenScanKind::Incremental,
+      codex_home: None,
+    }
+  }
+
+  pub(crate) fn manual_full(codex_home: Option<String>) -> Self {
+    Self {
+      reasons: RefreshReason::Manual.into(),
+      kind: TokenScanKind::Full,
+      codex_home,
+    }
+  }
+
+  fn merge(&mut self, other: Self) {
+    self.reasons.merge(other.reasons);
+    self.kind = self.kind.max(other.kind);
+    if other.codex_home.is_some() || self.codex_home.is_none() {
+      self.codex_home = other.codex_home;
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct LiveWaiterId(pub(crate) u64);
+
+#[derive(Clone, Debug)]
+pub(crate) struct LiveRequest {
+  pub reasons: ReasonSet,
+  pub waiter: Option<LiveWaiterId>,
+}
+
+impl LiveRequest {
+  pub(crate) fn scheduled() -> Self {
+    Self::for_reason(RefreshReason::Scheduled)
+  }
+
+  pub(crate) fn for_reason(reason: RefreshReason) -> Self {
+    Self {
+      reasons: reason.into(),
+      waiter: None,
+    }
+  }
+
+  pub(crate) fn manual(waiter: LiveWaiterId) -> Self {
+    Self {
+      reasons: RefreshReason::Manual.into(),
+      waiter: Some(waiter),
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TokenExecutionRequest {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub request: TokenRequest,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LiveExecutionRequest {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub reasons: ReasonSet,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CommitMarker {
+  pub sequence: u64,
+  pub committed_at: Instant,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DisplayInvalidation {
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub settings_revision: u64,
+  pub source_generation: u64,
+  pub commit: CommitMarker,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ExecutionCompletion {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub succeeded: bool,
+  pub failure: Option<String>,
+  pub completed_at: String,
+  pub commit: Option<CommitMarker>,
+  pub retry_jitter: Duration,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshCompletedEvent {
+  pub refresh_revision: u64,
+  pub lane: RefreshLane,
+  pub generation: u64,
+  pub usage_revision: u64,
+  pub quota_revision: u64,
+  pub source_generation: u64,
+  pub succeeded: bool,
+  pub failure: Option<String>,
+  pub completed_at: String,
 }
 
 #[derive(Clone, Debug)]

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -1,6 +1,10 @@
 #![allow(dead_code)]
 
+mod mutation;
 mod schedule;
+
+#[allow(unused_imports)]
+pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
 
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -181,24 +181,6 @@ impl TokenRequest {
     }
   }
 
-  pub(crate) fn manual_incremental_with_waiter(
-    codex_home: Option<String>,
-    waiter: TokenWaiterId,
-  ) -> Self {
-    let mut request = Self {
-      reasons: RefreshReason::Manual.into(),
-      kind: TokenScanKind::Incremental,
-      codex_home,
-      waiter_ids: TokenWaiterIds::default(),
-      planned_due_at: None,
-      source_generation: None,
-    };
-    request
-      .try_add_waiter(waiter)
-      .expect("an empty token request accepts one waiter");
-    request
-  }
-
   pub(crate) fn manual_full_with_waiter(codex_home: Option<String>, waiter: TokenWaiterId) -> Self {
     let mut request = Self::manual_full(codex_home);
     request

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -181,6 +181,24 @@ impl TokenRequest {
     }
   }
 
+  pub(crate) fn manual_incremental_with_waiter(
+    codex_home: Option<String>,
+    waiter: TokenWaiterId,
+  ) -> Self {
+    let mut request = Self {
+      reasons: RefreshReason::Manual.into(),
+      kind: TokenScanKind::Incremental,
+      codex_home,
+      waiter_ids: TokenWaiterIds::default(),
+      planned_due_at: None,
+      source_generation: None,
+    };
+    request
+      .try_add_waiter(waiter)
+      .expect("an empty token request accepts one waiter");
+    request
+  }
+
   pub(crate) fn manual_full_with_waiter(codex_home: Option<String>, waiter: TokenWaiterId) -> Self {
     let mut request = Self::manual_full(codex_home);
     request

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -1,10 +1,21 @@
 #![allow(dead_code)]
 
 mod mutation;
+mod power;
+mod runtime;
 mod schedule;
 
 #[allow(unused_imports)]
 pub(crate) use mutation::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
+#[allow(unused_imports)]
+pub(crate) use power::{begin_scheduler_activity, ActivityFactory, SystemActivityFactory};
+#[allow(unused_imports)]
+pub(crate) use runtime::{
+  LaneStatus, LiveQuotaFetcher, LiveQuotaPersister, ManualLiveTicket, ManualRefreshTicket,
+  ManualTokenTicket, MutationPhase, PreparedTokenRefresh, RefreshCoordinatorHandle, RefreshError,
+  RefreshEventSink, RefreshLaneMetrics, RefreshMetricsSnapshot, RefreshRuntime,
+  RefreshRuntimeDependencies, RefreshStatus, ShutdownResult, TokenRefreshExecutor,
+};
 
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};

--- a/src-tauri/src/refresh/mod.rs
+++ b/src-tauri/src/refresh/mod.rs
@@ -1,0 +1,49 @@
+#![allow(dead_code)]
+
+mod schedule;
+
+use chrono::{DateTime, Utc};
+use std::time::Duration;
+
+#[allow(unused_imports)]
+pub(crate) use schedule::{CoordinatorAction, CoordinatorEvent, CoordinatorState};
+
+pub(crate) const LIVE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RefreshLane {
+  Token,
+  Live,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshReason {
+  Startup,
+  Scheduled,
+  Manual,
+  SettingsChanged,
+  Wake,
+  Fallback,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum TokenScanKind {
+  Incremental,
+  Full,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RefreshConfig {
+  pub auto_scan_enabled: bool,
+  pub interval: Duration,
+  pub codex_home: Option<String>,
+  pub token_last_success_wall: Option<DateTime<Utc>>,
+  pub live_last_success_wall: Option<DateTime<Utc>>,
+}
+
+pub(crate) fn parse_persisted_success_wall(value: Option<&str>) -> Option<DateTime<Utc>> {
+  value
+    .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+    .map(|value| value.with_timezone(&Utc))
+}

--- a/src-tauri/src/refresh/mutation.rs
+++ b/src-tauri/src/refresh/mutation.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
@@ -46,6 +47,42 @@ impl UsageMutationCoordinator {
     MutationOutcome { value, queue_wait }
   }
 
+  pub(crate) fn run_cancellable<T>(
+    &self,
+    priority: MutationPriority,
+    cancelled: &AtomicBool,
+    mutation: impl FnOnce() -> T,
+  ) -> Option<MutationOutcome<T>> {
+    let queued_at = Instant::now();
+    let ticket = self.enqueue(priority);
+    let slot = self.wait_for_turn_cancellable(ticket, cancelled)?;
+    let queue_wait = queued_at.elapsed();
+
+    let value = mutation();
+    drop(slot);
+
+    Some(MutationOutcome { value, queue_wait })
+  }
+
+  pub(crate) fn cancel(&self, cancelled: &AtomicBool) {
+    cancelled.store(true, Ordering::Release);
+    let state = lock_state(&self.inner.state);
+    drop(state);
+    self.inner.changed.notify_all();
+  }
+
+  #[cfg(test)]
+  pub(crate) fn wait_for_queued_for_test(&self, expected: usize, timeout: Duration) {
+    let state = lock_state(&self.inner.state);
+    let (state, timed_out) = self
+      .inner
+      .changed
+      .wait_timeout_while(state, timeout, |state| state.queued.len() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(state.queued.len(), expected, "mutation queue length");
+    assert!(!timed_out.timed_out(), "timed out waiting for mutation queue");
+  }
+
   fn enqueue(&self, priority: MutationPriority) -> QueuedTicket {
     let mut state = lock_state(&self.inner.state);
     let ticket = QueuedTicket {
@@ -76,6 +113,43 @@ impl UsageMutationCoordinator {
         return ActiveMutationSlot {
           inner: Arc::clone(&self.inner),
         };
+      }
+
+      state = self
+        .inner
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+
+  fn wait_for_turn_cancellable(
+    &self,
+    ticket: QueuedTicket,
+    cancelled: &AtomicBool,
+  ) -> Option<ActiveMutationSlot> {
+    let mut state = lock_state(&self.inner.state);
+    loop {
+      if cancelled.load(Ordering::Acquire) {
+        if let Some(position) = state.queued.iter().position(|queued| *queued == ticket) {
+          state.queued.remove(position);
+        }
+        drop(state);
+        self.inner.changed.notify_all();
+        return None;
+      }
+
+      if !state.active && state.next_ticket() == Some(ticket) {
+        let position = state
+          .queued
+          .iter()
+          .position(|queued| *queued == ticket)
+          .expect("selected usage mutation ticket remains queued");
+        state.queued.remove(position);
+        state.active = true;
+        return Some(ActiveMutationSlot {
+          inner: Arc::clone(&self.inner),
+        });
       }
 
       state = self
@@ -143,9 +217,11 @@ fn lock_state(state: &Mutex<MutationState>) -> MutexGuard<'_, MutationState> {
 
 #[cfg(test)]
 mod tests {
-  use super::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
+  use super::{lock_state, MutationOutcome, MutationPriority, UsageMutationCoordinator};
   use std::panic::{self, AssertUnwindSafe};
+  use std::sync::atomic::{AtomicBool, Ordering};
   use std::sync::mpsc::{self, Receiver, Sender};
+  use std::sync::Arc;
   use std::thread::{self, JoinHandle};
   use std::time::Duration;
 
@@ -351,5 +427,139 @@ mod tests {
     assert!(panic_result.is_err());
     let outcome = coordinator.run(MutationPriority::Pricing, || 42);
     assert_eq!(outcome.value, 42);
+  }
+
+  #[test]
+  fn queued_cancellation_removes_maintenance_ticket_promptly() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Pricing);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_coordinator = coordinator.clone();
+    let worker_cancelled = Arc::clone(&cancelled);
+    let (finished_tx, finished_rx) = mpsc::sync_channel(1);
+    let maintenance = thread::spawn(move || {
+      let outcome = worker_coordinator.run_cancellable(
+        MutationPriority::Maintenance,
+        &worker_cancelled,
+        || "unexpected",
+      );
+      finished_tx.send(outcome).expect("report cancellation");
+    });
+    wait_for_queued(&coordinator, 1);
+
+    coordinator.cancel(&cancelled);
+
+    assert!(finished_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("queued waiter wakes")
+      .is_none());
+    assert!(lock_state(&coordinator.inner.state).queued.is_empty());
+    release_blocker.send(()).expect("release blocker");
+    blocker.join().expect("blocker exits");
+    maintenance.join().expect("maintenance exits");
+  }
+
+  #[test]
+  fn queued_cancellation_preserves_other_priority_and_fifo_order() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Pricing);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancelled_coordinator = coordinator.clone();
+    let cancelled_token = Arc::clone(&cancelled);
+    let cancelled_handle = thread::spawn(move || {
+      cancelled_coordinator.run_cancellable(
+        MutationPriority::Maintenance,
+        &cancelled_token,
+        || "cancelled",
+      )
+    });
+    wait_for_queued(&coordinator, 1);
+    let (order_tx, order_rx) = mpsc::channel();
+    let first_maintenance = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "maintenance-first",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 2);
+    let second_maintenance = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "maintenance-second",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 3);
+    let refresh = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Refresh,
+      "refresh",
+      order_tx,
+    );
+    wait_for_queued(&coordinator, 4);
+
+    coordinator.cancel(&cancelled);
+    assert!(cancelled.load(Ordering::Acquire));
+    release_blocker.send(()).expect("release blocker");
+
+    assert_eq!(recv_order(&order_rx), "refresh");
+    assert_eq!(recv_order(&order_rx), "maintenance-first");
+    assert_eq!(recv_order(&order_rx), "maintenance-second");
+    assert!(cancelled_handle
+      .join()
+      .expect("cancelled waiter exits")
+      .is_none());
+    blocker.join().expect("blocker exits");
+    first_maintenance.join().expect("first maintenance exits");
+    second_maintenance.join().expect("second maintenance exits");
+    refresh.join().expect("refresh exits");
+  }
+
+  #[test]
+  fn active_cancellation_releases_slot_only_after_closure_returns() {
+    let coordinator = UsageMutationCoordinator::new();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let active_coordinator = coordinator.clone();
+    let active_cancelled = Arc::clone(&cancelled);
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let active = thread::spawn(move || {
+      active_coordinator.run_cancellable(
+        MutationPriority::Maintenance,
+        &active_cancelled,
+        || {
+          entered_tx.send(()).expect("report active entry");
+          release_rx.recv().expect("release active mutation");
+          "finished"
+        },
+      )
+    });
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("maintenance owns slot");
+    coordinator.cancel(&cancelled);
+
+    let (follower_tx, follower_rx) = mpsc::sync_channel(1);
+    let follower_coordinator = coordinator.clone();
+    let follower = thread::spawn(move || {
+      follower_coordinator.run(MutationPriority::Refresh, || {
+        follower_tx.send(()).expect("report follower entry");
+      })
+    });
+    wait_for_queued(&coordinator, 1);
+    assert!(follower_rx.try_recv().is_err(), "active closure still owns slot");
+
+    release_tx.send(()).expect("release active closure");
+    follower_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("follower enters after active closure returns");
+    assert_eq!(
+      active
+        .join()
+        .expect("active thread exits")
+        .expect("active mutation had acquired slot")
+        .value,
+      "finished"
+    );
+    follower.join().expect("follower exits");
   }
 }

--- a/src-tauri/src/refresh/mutation.rs
+++ b/src-tauri/src/refresh/mutation.rs
@@ -1,0 +1,355 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum MutationPriority {
+  Pricing,
+  Maintenance,
+  Refresh,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct MutationOutcome<T> {
+  pub(crate) value: T,
+  pub(crate) queue_wait: Duration,
+}
+
+#[derive(Clone)]
+pub(crate) struct UsageMutationCoordinator {
+  inner: Arc<MutationCoordinatorInner>,
+}
+
+impl UsageMutationCoordinator {
+  pub(crate) fn new() -> Self {
+    Self {
+      inner: Arc::new(MutationCoordinatorInner {
+        state: Mutex::new(MutationState::default()),
+        changed: Condvar::new(),
+      }),
+    }
+  }
+
+  pub(crate) fn run<T>(
+    &self,
+    priority: MutationPriority,
+    mutation: impl FnOnce() -> T,
+  ) -> MutationOutcome<T> {
+    let queued_at = Instant::now();
+    let ticket = self.enqueue(priority);
+    let slot = self.wait_for_turn(ticket);
+    let queue_wait = queued_at.elapsed();
+
+    let value = mutation();
+    drop(slot);
+
+    MutationOutcome { value, queue_wait }
+  }
+
+  fn enqueue(&self, priority: MutationPriority) -> QueuedTicket {
+    let mut state = lock_state(&self.inner.state);
+    let ticket = QueuedTicket {
+      priority,
+      sequence: state.next_sequence,
+    };
+    state.next_sequence = state
+      .next_sequence
+      .checked_add(1)
+      .expect("usage mutation ticket sequence overflowed");
+    state.queued.push_back(ticket);
+    drop(state);
+    self.inner.changed.notify_all();
+    ticket
+  }
+
+  fn wait_for_turn(&self, ticket: QueuedTicket) -> ActiveMutationSlot {
+    let mut state = lock_state(&self.inner.state);
+    loop {
+      if !state.active && state.next_ticket() == Some(ticket) {
+        let position = state
+          .queued
+          .iter()
+          .position(|queued| *queued == ticket)
+          .expect("selected usage mutation ticket remains queued");
+        state.queued.remove(position);
+        state.active = true;
+        return ActiveMutationSlot {
+          inner: Arc::clone(&self.inner),
+        };
+      }
+
+      state = self
+        .inner
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+}
+
+impl Default for UsageMutationCoordinator {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+struct MutationCoordinatorInner {
+  state: Mutex<MutationState>,
+  changed: Condvar,
+}
+
+#[derive(Default)]
+struct MutationState {
+  active: bool,
+  next_sequence: u64,
+  queued: VecDeque<QueuedTicket>,
+}
+
+impl MutationState {
+  fn next_ticket(&self) -> Option<QueuedTicket> {
+    let priority = self.queued.iter().map(|ticket| ticket.priority).max()?;
+    self
+      .queued
+      .iter()
+      .find(|ticket| ticket.priority == priority)
+      .copied()
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct QueuedTicket {
+  priority: MutationPriority,
+  sequence: u64,
+}
+
+struct ActiveMutationSlot {
+  inner: Arc<MutationCoordinatorInner>,
+}
+
+impl Drop for ActiveMutationSlot {
+  fn drop(&mut self) {
+    let mut state = lock_state(&self.inner.state);
+    state.active = false;
+    drop(state);
+    self.inner.changed.notify_all();
+  }
+}
+
+fn lock_state(state: &Mutex<MutationState>) -> MutexGuard<'_, MutationState> {
+  state
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{MutationOutcome, MutationPriority, UsageMutationCoordinator};
+  use std::panic::{self, AssertUnwindSafe};
+  use std::sync::mpsc::{self, Receiver, Sender};
+  use std::thread::{self, JoinHandle};
+  use std::time::Duration;
+
+  const TEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+  fn wait_for_queued(coordinator: &UsageMutationCoordinator, expected: usize) {
+    let state = coordinator
+      .inner
+      .state
+      .lock()
+      .expect("mutation state locks");
+    let (state, timeout) = coordinator
+      .inner
+      .changed
+      .wait_timeout_while(state, TEST_TIMEOUT, |state| state.queued.len() < expected)
+      .expect("mutation state remains lockable");
+
+    assert_eq!(state.queued.len(), expected, "queued ticket count");
+    assert!(!timeout.timed_out(), "timed out waiting for queued ticket");
+  }
+
+  fn start_blocker(
+    coordinator: &UsageMutationCoordinator,
+    priority: MutationPriority,
+  ) -> (Sender<()>, JoinHandle<MutationOutcome<()>>) {
+    let coordinator = coordinator.clone();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+      coordinator.run(priority, || {
+        entered_tx.send(()).expect("report blocker entry");
+        release_rx.recv().expect("release blocker");
+      })
+    });
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("blocker enters mutation closure");
+    (release_tx, handle)
+  }
+
+  fn start_ordered_mutation(
+    coordinator: &UsageMutationCoordinator,
+    priority: MutationPriority,
+    label: &'static str,
+    order_tx: Sender<&'static str>,
+  ) -> JoinHandle<MutationOutcome<&'static str>> {
+    let coordinator = coordinator.clone();
+    thread::spawn(move || {
+      coordinator.run(priority, || {
+        order_tx.send(label).expect("record mutation order");
+        label
+      })
+    })
+  }
+
+  fn recv_order(order_rx: &Receiver<&'static str>) -> &'static str {
+    order_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("mutation reports execution order")
+  }
+
+  #[test]
+  fn mutation_priorities_order_refresh_before_maintenance_before_pricing() {
+    assert!(MutationPriority::Refresh > MutationPriority::Maintenance);
+    assert!(MutationPriority::Maintenance > MutationPriority::Pricing);
+  }
+
+  #[test]
+  fn mutations_are_serialized() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Maintenance);
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let follower_coordinator = coordinator.clone();
+    let follower = thread::spawn(move || {
+      follower_coordinator.run(MutationPriority::Refresh, || {
+        entered_tx.send(()).expect("report follower entry");
+      })
+    });
+
+    wait_for_queued(&coordinator, 1);
+    assert!(
+      entered_rx.try_recv().is_err(),
+      "follower entered concurrently"
+    );
+
+    release_blocker.send(()).expect("release active mutation");
+    blocker.join().expect("blocker exits normally");
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("follower enters after blocker");
+    follower.join().expect("follower exits normally");
+  }
+
+  #[test]
+  fn same_priority_is_fifo() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Refresh);
+    let (order_tx, order_rx) = mpsc::channel();
+
+    let first = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "first",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 1);
+    let second = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "second",
+      order_tx,
+    );
+    wait_for_queued(&coordinator, 2);
+
+    release_blocker.send(()).expect("release active mutation");
+
+    assert_eq!(recv_order(&order_rx), "first");
+    assert_eq!(recv_order(&order_rx), "second");
+    blocker.join().expect("blocker exits normally");
+    first.join().expect("first mutation exits normally");
+    second.join().expect("second mutation exits normally");
+  }
+
+  #[test]
+  fn pricing_waits_behind_refresh_mutation() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_refresh, refresh) = start_blocker(&coordinator, MutationPriority::Refresh);
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let pricing_coordinator = coordinator.clone();
+    let pricing = thread::spawn(move || {
+      pricing_coordinator.run(MutationPriority::Pricing, || {
+        entered_tx.send(()).expect("report pricing entry");
+        "priced"
+      })
+    });
+
+    wait_for_queued(&coordinator, 1);
+    assert!(
+      entered_rx.try_recv().is_err(),
+      "pricing entered during refresh"
+    );
+    thread::sleep(Duration::from_millis(25));
+    release_refresh.send(()).expect("release refresh mutation");
+
+    refresh.join().expect("refresh exits normally");
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("pricing enters after refresh");
+    let outcome = pricing.join().expect("pricing exits normally");
+    assert_eq!(outcome.value, "priced");
+    assert!(outcome.queue_wait >= Duration::from_millis(20));
+  }
+
+  #[test]
+  fn higher_priority_is_selected_after_active_blocker() {
+    let coordinator = UsageMutationCoordinator::new();
+    let (release_blocker, blocker) = start_blocker(&coordinator, MutationPriority::Maintenance);
+    let (order_tx, order_rx) = mpsc::channel();
+
+    let pricing = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Pricing,
+      "pricing",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 1);
+    let refresh = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Refresh,
+      "refresh",
+      order_tx.clone(),
+    );
+    wait_for_queued(&coordinator, 2);
+    let maintenance = start_ordered_mutation(
+      &coordinator,
+      MutationPriority::Maintenance,
+      "maintenance",
+      order_tx,
+    );
+    wait_for_queued(&coordinator, 3);
+
+    release_blocker.send(()).expect("release active mutation");
+
+    assert_eq!(recv_order(&order_rx), "refresh");
+    assert_eq!(recv_order(&order_rx), "maintenance");
+    assert_eq!(recv_order(&order_rx), "pricing");
+    blocker.join().expect("blocker exits normally");
+    pricing.join().expect("pricing exits normally");
+    refresh.join().expect("refresh exits normally");
+    maintenance.join().expect("maintenance exits normally");
+  }
+
+  #[test]
+  fn panic_releases_mutation_slot() {
+    let coordinator = UsageMutationCoordinator::new();
+
+    let panic_result = panic::catch_unwind(AssertUnwindSafe(|| {
+      coordinator.run(MutationPriority::Refresh, || {
+        panic!("intentional mutation panic");
+      });
+    }));
+
+    assert!(panic_result.is_err());
+    let outcome = coordinator.run(MutationPriority::Pricing, || 42);
+    assert_eq!(outcome.value, 42);
+  }
+}

--- a/src-tauri/src/refresh/power.rs
+++ b/src-tauri/src/refresh/power.rs
@@ -1,0 +1,193 @@
+#[cfg(test)]
+use std::sync::Arc;
+
+#[cfg(target_os = "macos")]
+use objc2::{
+  rc::Retained,
+  runtime::{NSObjectProtocol, ProtocolObject},
+};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
+
+pub(crate) trait ActivityGuard {}
+
+pub(crate) trait ActivityFactory: Send + Sync {
+  fn begin(&self) -> Box<dyn ActivityGuard>;
+}
+
+#[derive(Default)]
+pub(crate) struct SystemActivityFactory;
+
+impl ActivityFactory for SystemActivityFactory {
+  fn begin(&self) -> Box<dyn ActivityGuard> {
+    Box::new(SchedulerActivity::begin())
+  }
+}
+
+pub(crate) fn begin_scheduler_activity() -> Box<dyn ActivityGuard> {
+  SystemActivityFactory.begin()
+}
+
+#[cfg(target_os = "macos")]
+struct SchedulerActivity {
+  activity: Retained<ProtocolObject<dyn NSObjectProtocol>>,
+}
+
+#[cfg(target_os = "macos")]
+impl SchedulerActivity {
+  fn begin() -> Self {
+    let reason = NSString::from_str("Codex Pacer background refresh");
+    let activity = NSProcessInfo::processInfo()
+      .beginActivityWithOptions_reason(NSActivityOptions::Background, &reason);
+    Self { activity }
+  }
+}
+
+#[cfg(target_os = "macos")]
+impl ActivityGuard for SchedulerActivity {}
+
+#[cfg(target_os = "macos")]
+impl Drop for SchedulerActivity {
+  fn drop(&mut self) {
+    unsafe {
+      NSProcessInfo::processInfo().endActivity(&self.activity);
+    }
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+struct SchedulerActivity;
+
+#[cfg(not(target_os = "macos"))]
+impl SchedulerActivity {
+  fn begin() -> Self {
+    Self
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+impl ActivityGuard for SchedulerActivity {}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub(crate) struct CountingActivityFactory {
+  state: Arc<CountingActivityState>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct CountingActivityState {
+  active: std::sync::atomic::AtomicU64,
+  started: std::sync::atomic::AtomicU64,
+}
+
+#[cfg(test)]
+impl CountingActivityFactory {
+  pub(crate) fn begin(&self) -> Box<dyn ActivityGuard> {
+    <Self as ActivityFactory>::begin(self)
+  }
+
+  pub(crate) fn active(&self) -> u64 {
+    self.active_count()
+  }
+
+  pub(crate) fn started(&self) -> u64 {
+    self
+      .state
+      .started
+      .load(std::sync::atomic::Ordering::Acquire)
+  }
+
+  pub(crate) fn active_count(&self) -> u64 {
+    self.state.active.load(std::sync::atomic::Ordering::Acquire)
+  }
+}
+
+#[cfg(test)]
+impl ActivityFactory for CountingActivityFactory {
+  fn begin(&self) -> Box<dyn ActivityGuard> {
+    saturating_increment(&self.state.started);
+    saturating_increment(&self.state.active);
+    Box::new(CountingActivityGuard {
+      state: Arc::clone(&self.state),
+    })
+  }
+}
+
+#[cfg(test)]
+struct CountingActivityGuard {
+  state: Arc<CountingActivityState>,
+}
+
+#[cfg(test)]
+impl ActivityGuard for CountingActivityGuard {}
+
+#[cfg(test)]
+impl Drop for CountingActivityGuard {
+  fn drop(&mut self) {
+    let _ = self.state.active.fetch_update(
+      std::sync::atomic::Ordering::AcqRel,
+      std::sync::atomic::Ordering::Acquire,
+      |value| Some(value.saturating_sub(1)),
+    );
+  }
+}
+
+#[cfg(test)]
+fn saturating_increment(value: &std::sync::atomic::AtomicU64) {
+  let mut current = value.load(std::sync::atomic::Ordering::Acquire);
+  loop {
+    let next = current.saturating_add(1);
+    match value.compare_exchange_weak(
+      current,
+      next,
+      std::sync::atomic::Ordering::AcqRel,
+      std::sync::atomic::Ordering::Acquire,
+    ) {
+      Ok(_) => return,
+      Err(observed) => current = observed,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::CountingActivityFactory;
+
+  #[test]
+  fn injected_activity_factory_counts_only_live_guards() {
+    let factory = CountingActivityFactory::default();
+    assert_eq!(factory.active(), 0);
+
+    let first = factory.begin();
+    assert_eq!(factory.active(), 1);
+    {
+      let second = factory.begin();
+      assert_eq!(factory.active(), 2);
+      drop(second);
+    }
+    assert_eq!(factory.active(), 1);
+    drop(first);
+
+    assert_eq!(factory.active(), 0);
+    assert_eq!(factory.started(), 2);
+  }
+
+  #[test]
+  fn legacy_scheduler_activity_scope_is_narrow() {
+    let source = include_str!("../lib.rs");
+    assert!(
+      !source.contains("spawn(move || {\n      let _scheduler_activity"),
+      "the infinite scheduler loop must not own an activity"
+    );
+    assert!(
+      source.contains("let result = {\n    let _activity = begin_scheduler_activity();\n    scan(")
+    );
+    assert!(source.contains(
+      "let query_result = {\n    let _activity = begin_scheduler_activity();\n    query_live_rate_limits("
+    ));
+    assert!(source.contains(
+      "let _activity = begin_scheduler_activity();\n        let conn = open_connection("
+    ));
+  }
+}

--- a/src-tauri/src/refresh/power.rs
+++ b/src-tauri/src/refresh/power.rs
@@ -24,10 +24,6 @@ impl ActivityFactory for SystemActivityFactory {
   }
 }
 
-pub(crate) fn begin_scheduler_activity() -> Box<dyn ActivityGuard> {
-  SystemActivityFactory.begin()
-}
-
 #[cfg(target_os = "macos")]
 struct SchedulerActivity {
   activity: Retained<ProtocolObject<dyn NSObjectProtocol>>,
@@ -174,20 +170,19 @@ mod tests {
   }
 
   #[test]
-  fn legacy_scheduler_activity_scope_is_narrow() {
+  fn lib_removes_legacy_scheduler_activity_paths() {
     let source = include_str!("../lib.rs");
     assert!(
-      !source.contains("spawn(move || {\n      let _scheduler_activity"),
-      "the infinite scheduler loop must not own an activity"
+      !source.contains("spawn_scheduler"),
+      "the legacy scheduler entry point must stay removed"
     );
     assert!(
-      source.contains("let result = {\n    let _activity = begin_scheduler_activity();\n    scan(")
+      !source.contains("run_due_background_refresh"),
+      "commands and popup reads must not run legacy refresh work"
     );
-    assert!(source.contains(
-      "let query_result = {\n    let _activity = begin_scheduler_activity();\n    query_live_rate_limits("
-    ));
-    assert!(source.contains(
-      "let _activity = begin_scheduler_activity();\n        let conn = open_connection("
-    ));
+    assert!(
+      !source.contains("begin_scheduler_activity"),
+      "runtime executors own the only refresh activity scopes"
+    );
   }
 }

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -2203,7 +2203,7 @@ impl RefreshCoordinatorHandle {
       }
       waiters.token.insert(waiter, reply_tx);
     }
-    let request = TokenRequest::manual_incremental_with_waiter(codex_home, waiter);
+    let request = TokenRequest::manual_full_with_waiter(codex_home, waiter);
     if let Err(error) = try_send_public(&intake.sender, RuntimeMessage::RequestToken(request)) {
       lock(&self.inner.waiters).token.remove(&waiter);
       return Err(error);

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -2203,7 +2203,7 @@ impl RefreshCoordinatorHandle {
       }
       waiters.token.insert(waiter, reply_tx);
     }
-    let request = TokenRequest::manual_full_with_waiter(codex_home, waiter);
+    let request = TokenRequest::manual_incremental_with_waiter(codex_home, waiter);
     if let Err(error) = try_send_public(&intake.sender, RuntimeMessage::RequestToken(request)) {
       lock(&self.inner.waiters).token.remove(&waiter);
       return Err(error);

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
   use super::{
-    MetricsState, PanicPhase, RefreshClock, RefreshConfig, RefreshError, RefreshStatus,
-    RuntimeTestRig, SaturatingCounter, TestClock, TestLiveExecutor,
+    MetricsState, PanicPhase, PreparedTokenRefresh, RefreshClock, RefreshConfig, RefreshError,
+    RefreshStatus, RuntimeTestRig, SaturatingCounter, TestClock, TestLiveExecutor,
   };
   use crate::refresh::{RefreshFailureCode, RefreshRejectionCode, REFRESH_WAITER_CAPACITY};
   use chrono::{DateTime, Duration as ChronoDuration};
@@ -677,6 +677,66 @@ mod tests {
   }
 
   #[test]
+  fn settings_update_waits_for_saturated_queue_and_is_not_lost() {
+    let rig = RuntimeTestRig::disabled();
+    let pause = rig.pause_coordinator();
+    rig.fill_runtime_channel_until_busy();
+    let mut replacement = rig.config_with_source("replacement");
+    replacement.auto_scan_enabled = true;
+    let handle = rig.handle.clone();
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    let update = std::thread::spawn(move || {
+      let _ = result_tx.send(handle.update_settings(replacement));
+    });
+
+    rig.wait_for_reliable_in_flight(1, TEST_TIMEOUT);
+    assert_eq!(rig.handle.try_wake(), Err(RefreshError::Busy));
+    assert!(matches!(
+      rig.handle.request_manual_token(None),
+      Err(RefreshError::Busy)
+    ));
+    assert!(matches!(
+      rig.handle.request_manual_live(),
+      Err(RefreshError::Busy)
+    ));
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_intake_closed(TEST_TIMEOUT);
+    assert!(
+      !rig
+        .runtime
+        .lifecycle
+        .shutdown_requested
+        .load(std::sync::atomic::Ordering::Acquire),
+      "shutdown waits for the accepted settings update to finish"
+    );
+    assert!(matches!(
+      rig
+        .handle
+        .update_settings(rig.config_with_source("rejected-after-shutdown")),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    pause.release();
+    let result = result_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("settings update is acknowledged after capacity recovers");
+    update.join().expect("settings update thread exits");
+    let joined = shutdown.wait(TEST_TIMEOUT);
+
+    assert_eq!(result, Ok(()));
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+    assert_eq!(
+      super::lock(&rig.handle.inner.intake).reliable_in_flight,
+      0
+    );
+    let status = rig.handle.status();
+    assert_eq!(status.source_generation, 1);
+    assert!(status.auto_scan_enabled);
+  }
+
+  #[test]
   fn fixed_counters_saturate_without_wrap() {
     let counter = SaturatingCounter::new(u64::MAX - 1);
     counter.increment();
@@ -697,6 +757,23 @@ mod tests {
       metrics.start_lag_histogram[super::HISTOGRAM_BUCKETS - 2],
       u64::MAX
     );
+    rig.shutdown();
+  }
+
+  #[test]
+  fn prepared_token_refresh_constructor_initializes_test_defaults() {
+    let rig = RuntimeTestRig::disabled();
+    let (seed, _) = rig.token.make_prepared_for_test(1, 0, false);
+    let super::PreparedTokenRefresh { prepared_scan, .. } = seed;
+    let started_at = rig.clock.wall_now();
+
+    let prepared = PreparedTokenRefresh::new(7, 3, started_at, prepared_scan);
+
+    assert_eq!(prepared.generation, 7);
+    assert_eq!(prepared.source_generation, 3);
+    assert_eq!(prepared.started_at, started_at);
+    assert!(!prepared.omit_payload_for_test());
+    assert!(prepared.drop_probe.is_none());
     rig.shutdown();
   }
 
@@ -1252,6 +1329,26 @@ pub(crate) struct PreparedTokenRefresh {
   omit_payload: bool,
 }
 
+impl PreparedTokenRefresh {
+  pub(crate) fn new(
+    generation: u64,
+    source_generation: u64,
+    started_at: DateTime<Utc>,
+    prepared_scan: PreparedScan,
+  ) -> Self {
+    Self {
+      generation,
+      source_generation,
+      started_at,
+      prepared_scan,
+      #[cfg(test)]
+      drop_probe: None,
+      #[cfg(test)]
+      omit_payload: false,
+    }
+  }
+}
+
 pub(crate) trait LiveQuotaFetcher: Send + Sync {
   fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String>;
 
@@ -1637,6 +1734,7 @@ impl WaiterRegistries {
 
 struct IntakeState {
   accepting: bool,
+  reliable_in_flight: usize,
   sender: SyncSender<RuntimeMessage>,
   #[cfg(test)]
   pause_after_check: Option<Arc<TestGateState>>,
@@ -1644,12 +1742,31 @@ struct IntakeState {
 
 struct HandleInner {
   intake: Arc<Mutex<IntakeState>>,
+  reliable_changed: Arc<Condvar>,
   waiters: Arc<Mutex<WaiterRegistries>>,
   status: Arc<Mutex<RefreshStatus>>,
   metrics: Arc<MetricsState>,
   clock: Arc<dyn RefreshClock>,
   next_token_waiter: AtomicU64,
   next_live_waiter: AtomicU64,
+}
+
+struct ReliableInFlightGuard {
+  intake: Arc<Mutex<IntakeState>>,
+  changed: Arc<Condvar>,
+}
+
+impl Drop for ReliableInFlightGuard {
+  fn drop(&mut self) {
+    let mut intake = lock(&self.intake);
+    if intake.reliable_in_flight == 0 {
+      log::error!("Reliable refresh intake guard dropped without registration.");
+    } else {
+      intake.reliable_in_flight -= 1;
+    }
+    drop(intake);
+    self.changed.notify_all();
+  }
 }
 
 #[derive(Clone)]
@@ -1714,7 +1831,7 @@ impl RefreshCoordinatorHandle {
   }
 
   pub(crate) fn update_settings(&self, config: RefreshConfig) -> Result<(), RefreshError> {
-    self.send_acknowledged(|reply| RuntimeMessage::SettingsChanged(config, reply))
+    self.send_reliable_acknowledged(|reply| RuntimeMessage::SettingsChanged(config, reply))
   }
 
   pub(crate) fn wake(&self) -> Result<(), RefreshError> {
@@ -1747,6 +1864,39 @@ impl RefreshCoordinatorHandle {
     reply_rx
       .recv()
       .map_err(|_| RefreshError::CoordinatorUnavailable)
+  }
+
+  fn send_reliable_acknowledged(
+    &self,
+    build: impl FnOnce(SyncSender<()>) -> RuntimeMessage,
+  ) -> Result<(), RefreshError> {
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    let (sender, in_flight) = {
+      let mut intake = lock(&self.inner.intake);
+      if !intake.accepting {
+        return Err(shutdown_error());
+      }
+      intake.reliable_in_flight = intake
+        .reliable_in_flight
+        .checked_add(1)
+        .ok_or(RefreshError::Busy)?;
+      (
+        intake.sender.clone(),
+        ReliableInFlightGuard {
+          intake: Arc::clone(&self.inner.intake),
+          changed: Arc::clone(&self.inner.reliable_changed),
+        },
+      )
+    };
+    self.inner.reliable_changed.notify_all();
+    sender
+      .send(build(reply_tx))
+      .map_err(|_| RefreshError::CoordinatorUnavailable)?;
+    let result = reply_rx
+      .recv()
+      .map_err(|_| RefreshError::CoordinatorUnavailable);
+    drop(in_flight);
+    result
   }
 
   pub(crate) fn status(&self) -> RefreshStatus {
@@ -1815,6 +1965,7 @@ struct RuntimeLifecycle {
   changed: Condvar,
   coordinator: Mutex<Option<JoinHandle<()>>>,
   intake: Arc<Mutex<IntakeState>>,
+  reliable_changed: Arc<Condvar>,
   shutdown_requested: Arc<AtomicBool>,
   shutdown: Arc<AtomicBool>,
 }
@@ -1860,9 +2011,25 @@ impl RefreshRuntime {
     if owns_shutdown {
       let operation: Result<Arc<ShutdownResult>, RefreshError> = (|| {
         let (reply_tx, reply_rx) = mpsc::sync_channel(1);
-        {
+        let sender = {
           let mut intake = lock(&self.lifecycle.intake);
           intake.accepting = false;
+          intake.sender.clone()
+        };
+        self.lifecycle.reliable_changed.notify_all();
+        // Accepted settings updates finish before shutdown is published, while
+        // ordinary intake remains free to observe the closed state.
+        {
+          let mut intake = lock(&self.lifecycle.intake);
+          while intake.reliable_in_flight != 0 {
+            intake = self
+              .lifecycle
+              .reliable_changed
+              .wait(intake)
+              .unwrap_or_else(|poisoned| poisoned.into_inner());
+          }
+        }
+        {
           let shutdown_state = lock(&self.lifecycle.state);
           self
             .lifecycle
@@ -1870,11 +2037,10 @@ impl RefreshRuntime {
             .store(true, Ordering::Release);
           self.lifecycle.changed.notify_all();
           drop(shutdown_state);
-          intake
-            .sender
-            .send(RuntimeMessage::Shutdown(reply_tx))
-            .map_err(|_| RefreshError::CoordinatorUnavailable)?;
         }
+        sender
+          .send(RuntimeMessage::Shutdown(reply_tx))
+          .map_err(|_| RefreshError::CoordinatorUnavailable)?;
         let mut result = reply_rx
           .recv()
           .map_err(|_| RefreshError::CoordinatorUnavailable)?;
@@ -2139,8 +2305,10 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     hooks: Arc::clone(&hooks),
   })?;
 
+  let reliable_changed = Arc::new(Condvar::new());
   let shared_intake = Arc::new(Mutex::new(IntakeState {
     accepting: true,
+    reliable_in_flight: 0,
     sender: runtime_tx.clone(),
     #[cfg(test)]
     pause_after_check: None,
@@ -2148,6 +2316,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
   let handle = RefreshCoordinatorHandle {
     inner: Arc::new(HandleInner {
       intake: Arc::clone(&shared_intake),
+      reliable_changed: Arc::clone(&reliable_changed),
       waiters: Arc::clone(&waiters),
       status: Arc::clone(&status),
       metrics: Arc::clone(&metrics),
@@ -2198,6 +2367,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     changed: Condvar::new(),
     coordinator: Mutex::new(Some(coordinator)),
     intake: shared_intake,
+    reliable_changed,
     shutdown_requested,
     shutdown,
   });
@@ -5098,6 +5268,35 @@ impl RuntimeTestRig {
         Err(error) => panic!("unexpected command fill error: {error:?}"),
       }
     }
+  }
+
+  fn wait_for_reliable_in_flight(&self, expected: usize, timeout: Duration) {
+    let intake = lock(&self.handle.inner.intake);
+    let (intake, timed_out) = self
+      .handle
+      .inner
+      .reliable_changed
+      .wait_timeout_while(intake, timeout, |state| {
+        state.reliable_in_flight < expected
+      })
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(intake.reliable_in_flight, expected);
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for reliable refresh intake"
+    );
+  }
+
+  fn wait_for_intake_closed(&self, timeout: Duration) {
+    let intake = lock(&self.handle.inner.intake);
+    let (intake, timed_out) = self
+      .handle
+      .inner
+      .reliable_changed
+      .wait_timeout_while(intake, timeout, |state| state.accepting)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(!intake.accepting);
+    assert!(!timed_out.timed_out(), "timed out waiting for intake close");
   }
 
   fn start_intake_race_after_accept_check(&self) -> IntakeRace {

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -2,7 +2,7 @@
 mod tests {
   use super::{
     MetricsState, PanicPhase, RefreshClock, RefreshConfig, RefreshError, RefreshStatus,
-    RuntimeTestRig, SaturatingCounter, TestClock,
+    RuntimeTestRig, SaturatingCounter, TestClock, TestLiveExecutor,
   };
   use crate::refresh::{RefreshFailureCode, RefreshRejectionCode, REFRESH_WAITER_CAPACITY};
   use chrono::{DateTime, Duration as ChronoDuration};
@@ -10,6 +10,22 @@ mod tests {
   use std::time::Duration;
 
   const TEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+  fn assert_same_deadline(expected: &Option<String>, actual: &Option<String>) {
+    let expected = DateTime::parse_from_rfc3339(expected.as_deref().expect("expected deadline"))
+      .expect("expected RFC3339 deadline");
+    let actual = DateTime::parse_from_rfc3339(actual.as_deref().expect("actual deadline"))
+      .expect("actual RFC3339 deadline");
+    assert!(
+      actual
+        .signed_duration_since(expected)
+        .num_microseconds()
+        .unwrap_or(i64::MAX)
+        .unsigned_abs()
+        <= 1_000,
+      "normal live deadline moved: expected {expected}, actual {actual}"
+    );
+  }
 
   #[test]
   fn token_worker_does_not_delay_live_worker_start() {
@@ -325,6 +341,7 @@ mod tests {
       .expect("recovery live ticket")
       .wait_timeout(TEST_TIMEOUT)
       .is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
     assert_eq!(rig.live.fetch_calls(), 2);
     assert_eq!(rig.live.unique_fetch_worker_ids(), 1);
     assert_eq!(rig.live.worker_name(), "codex-pacer-refresh-live");
@@ -333,31 +350,28 @@ mod tests {
   }
 
   #[test]
-  fn persist_panic_becomes_failure_and_worker_recovers() {
+  fn persist_panic_does_not_fail_live_and_retry_recovers() {
     let rig = RuntimeTestRig::disabled();
     rig.live.panic_once(PanicPhase::Persist);
-    let failed = rig
+    let result = rig
       .handle
       .request_manual_live()
       .expect("failed live ticket")
       .wait_timeout(TEST_TIMEOUT);
-    assert!(matches!(
-      failed,
-      Err(RefreshError::Failed {
-        code: RefreshFailureCode::WorkerPanicked,
-        ..
-      })
-    ));
+    assert!(
+      result.is_ok(),
+      "persistence panic cannot fail fetched live quota"
+    );
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    assert_eq!(rig.live.fetch_calls(), 1);
+    assert_eq!(rig.live.persist_calls(), 1);
+    assert_eq!(rig.events.invalidation_count(), 1);
 
-    assert!(rig
-      .handle
-      .request_manual_live()
-      .expect("recovery live ticket")
-      .wait_timeout(TEST_TIMEOUT)
-      .is_ok());
+    rig.clock.advance(Duration::from_secs(5));
+    rig.handle.wake().expect("wake persistence retry");
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
     assert_eq!(rig.live.persist_calls(), 2);
-    assert_eq!(rig.live.unique_persist_worker_ids(), 1);
-    assert_eq!(rig.live.worker_name(), "codex-pacer-refresh-live");
+    assert_eq!(rig.live.fetch_calls(), 1, "retry cannot refetch");
     assert_eq!(rig.activities.active(), 0);
     rig.shutdown();
   }
@@ -371,6 +385,7 @@ mod tests {
     let live = rig.handle.request_manual_live().expect("live ticket");
     assert!(token.wait_timeout(TEST_TIMEOUT).is_ok());
     assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
     assert_eq!(rig.token.commit_calls(), 1);
     assert_eq!(rig.live.persist_calls(), 1);
     rig.shutdown();
@@ -814,6 +829,28 @@ mod tests {
   }
 
   #[test]
+  fn shutdown_drains_saturated_channel_and_joins_persistence_task() {
+    let rig = RuntimeTestRig::disabled();
+    let persist = rig.live.block_next_persist();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+    persist.wait_entered(TEST_TIMEOUT);
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+
+    let pause = rig.pause_coordinator();
+    rig.fill_runtime_channel_until_busy();
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    persist.release();
+    pause.release();
+
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.token_joined && joined.live_joined && joined.coordinator_joined);
+    assert_eq!(rig.activities.active(), 0);
+    assert!(!rig.live_cache.state().refreshing);
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+  }
+
+  #[test]
   fn shutdown_during_live_fetch_joins_after_bounded_completion() {
     let rig = RuntimeTestRig::disabled();
     let fetch = rig.live.block_next_fetch();
@@ -874,30 +911,38 @@ mod tests {
   }
 
   #[test]
-  fn source_change_during_live_persist_is_not_published_as_success() {
+  fn stale_persist_outcome_does_not_clear_newer_pending_snapshot() {
     let rig = RuntimeTestRig::disabled();
     let persist = rig.live.block_next_persist();
     let replacement = rig.token.block_parse_call(1);
-    let previous_success = rig.handle.status().live.last_success_at;
     let invalidations = rig.events.invalidation_count();
     let ticket = rig.handle.request_manual_live().expect("live ticket");
     persist.wait_entered(TEST_TIMEOUT);
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.events.invalidation_count(), invalidations + 1);
     rig
       .handle
       .update_settings(rig.config_with_source("replacement"))
       .expect("source update during persistence");
-    persist.release();
-
-    assert!(matches!(
-      ticket.wait_timeout(TEST_TIMEOUT),
-      Err(RefreshError::Failed {
-        code: RefreshFailureCode::SourceChanged,
-        ..
-      })
-    ));
     replacement.wait_worker_ready(TEST_TIMEOUT);
-    assert_eq!(rig.events.invalidation_count(), invalidations);
-    assert_eq!(rig.handle.status().live.last_success_at, previous_success);
+
+    let newer = TestLiveExecutor::snapshot_at("2026-07-11T00:02:00Z");
+    rig.live.queue_snapshot(Arc::clone(&newer));
+    let latest = rig
+      .handle
+      .request_manual_live()
+      .expect("new-source live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("new-source live result");
+    assert_eq!(latest.fetched_at, newer.fetched_at);
+    persist.release();
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
+    assert_eq!(rig.events.invalidation_count(), invalidations + 2);
+    assert_eq!(rig.live.persist_calls(), 2);
+    assert_eq!(
+      rig.live.persisted_fetched_at(),
+      ["2026-07-11T00:00:00Z", "2026-07-11T00:02:00Z"]
+    );
     let shutdown = rig.shutdown_in_background();
     rig.wait_for_shutdown_requested(TEST_TIMEOUT);
     replacement.release();
@@ -974,15 +1019,199 @@ mod tests {
     assert_eq!(rig.activities.active(), 1, "persist body owns one guard");
     persist.release();
     assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
     assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn fresh_value_is_visible_before_persistence_finishes() {
+    let rig = RuntimeTestRig::disabled();
+    let persist = rig.live.block_next_persist();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+    persist.wait_entered(TEST_TIMEOUT);
+
+    let result = ticket
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("waiter resolves before persistence finishes");
+    let produced = rig.live.fetched_arc(1, TEST_TIMEOUT);
+    let cached = rig.live_cache.rate_limits().expect("published live cache");
+    assert!(Arc::ptr_eq(&result, &produced));
+    assert!(Arc::ptr_eq(&result, &cached));
+    assert_eq!(
+      rig.events.trace_prefix(),
+      [
+        "live_cache_publish",
+        "live_invalidation",
+        "live_completion",
+        "live_waiter_reply",
+        "live_persist_start",
+      ]
+    );
+
+    persist.release();
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn fetch_receives_ten_second_timeout() {
+    let rig = RuntimeTestRig::disabled();
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(
+      rig.live.last_timeout(),
+      Some(crate::refresh::LIVE_QUERY_TIMEOUT)
+    );
+    assert_eq!(rig.live.last_timeout(), Some(Duration::from_secs(10)));
+    rig.shutdown();
+  }
+
+  #[test]
+  fn live_failure_does_not_run_token_inline() {
+    let rig = RuntimeTestRig::paused_clock();
+    let fallback = TestLiveExecutor::snapshot_at("2026-07-10T23:59:00Z");
+    rig
+      .live
+      .fail_next_fetch_with_fallback(Arc::clone(&fallback));
+    let parse = rig.token.block_next_parse();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::ExecutionFailed,
+        ..
+      })
+    ));
+    parse.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.live.fallback_calls(), 1);
+    assert!(rig.live_cache.state().is_fallback);
+    assert_eq!(
+      rig.events.trace_prefix(),
+      [
+        "live_cache_fallback",
+        "live_completion",
+        "live_waiter_reply",
+        "token_fallback_start",
+      ]
+    );
+
+    parse.release();
+    rig.token.wait_for_commit_calls(1, TEST_TIMEOUT);
+    rig.shutdown();
+
+    let no_fallback = RuntimeTestRig::paused_clock();
+    no_fallback.live.fail_next_fetch();
+    let parse = no_fallback.token.block_next_parse();
+    let ticket = no_fallback
+      .handle
+      .request_manual_live()
+      .expect("live ticket without fallback");
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_err());
+    parse.wait_entered(TEST_TIMEOUT);
+    assert_eq!(
+      no_fallback.events.trace_prefix(),
+      [
+        "live_completion",
+        "live_waiter_reply",
+        "token_fallback_start",
+      ]
+    );
+    parse.release();
+    no_fallback.token.wait_for_commit_calls(1, TEST_TIMEOUT);
+    no_fallback.shutdown();
+  }
+
+  #[test]
+  fn persistence_failure_retries_without_refetch() {
+    let rig = RuntimeTestRig::disabled();
+    rig.live.fail_next_persist();
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    assert_eq!(rig.live.fetch_calls(), 1);
+    assert_eq!(rig.live.persist_calls(), 1);
+
+    rig.clock.advance(Duration::from_secs(5));
+    rig.handle.wake().expect("wake persistence retry");
+    rig.live.wait_for_persist_calls(2, TEST_TIMEOUT);
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
+    assert_eq!(rig.live.fetch_calls(), 1, "retry must not refetch");
+    assert_eq!(rig.live.persist_calls(), 2);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn newer_live_snapshot_supersedes_pending_persistence_retry() {
+    let rig = RuntimeTestRig::disabled();
+    rig.live.fail_next_persist();
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("first live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+
+    let newer = TestLiveExecutor::snapshot_at("2026-07-11T00:01:00Z");
+    rig.live.queue_snapshot(Arc::clone(&newer));
+    let second = rig
+      .handle
+      .request_manual_live()
+      .expect("second live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("second live result");
+    assert_eq!(second.fetched_at, newer.fetched_at);
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
+    assert_eq!(
+      rig.live.persisted_fetched_at(),
+      ["2026-07-11T00:00:00Z", "2026-07-11T00:01:00Z"]
+    );
+
+    rig.clock.advance(Duration::from_secs(5));
+    rig.handle.wake().expect("wake past superseded retry");
+    rig.handle.barrier().expect("drain wake");
+    assert_eq!(rig.live.persist_calls(), 2, "old retry stays superseded");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn persistence_retry_does_not_move_live_deadline() {
+    let rig = RuntimeTestRig::disabled();
+    let initial_deadline = rig.handle.status().live.next_due_at;
+    rig.live.fail_next_persist();
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    assert_same_deadline(&initial_deadline, &rig.handle.status().live.next_due_at);
+
+    rig.clock.advance(Duration::from_secs(5));
+    rig.handle.wake().expect("wake persistence retry");
+    rig.wait_for_persist_outcomes(2, TEST_TIMEOUT);
+    assert_same_deadline(&initial_deadline, &rig.handle.status().live.next_due_at);
+    assert_eq!(rig.live.fetch_calls(), 1);
     rig.shutdown();
   }
 }
 use super::power::{ActivityFactory, SystemActivityFactory};
 use super::{
   CommitMarker, CoordinatorAction, CoordinatorEvent, CoordinatorState, DisplayInvalidation,
-  ExecutionCompletion, LiveExecutionRequest, LiveRequest, LiveWaiterId, MutationPriority,
-  RefreshCompletedEvent, RefreshConfig, RefreshDetail, RefreshFailureCode, RefreshRejectionCode,
+  ExecutionCompletion, LiveExecutionRequest, LivePersistenceRetryState, LivePersistenceWork,
+  LiveQuotaCache, LiveRequest, LiveWaiterId, MutationPriority, RefreshCompletedEvent,
+  RefreshConfig, RefreshDetail, RefreshFailureCode, RefreshReason, RefreshRejectionCode,
   RefreshWaiterOutcome, TokenExecutionRequest, TokenRequest, TokenWaiterId,
   UsageMutationCoordinator, LIVE_QUERY_TIMEOUT, REFRESH_WAITER_CAPACITY,
 };
@@ -991,6 +1220,8 @@ use crate::models::{LiveRateLimitSnapshot, ScanResult};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use std::array;
 use std::collections::HashMap;
+#[cfg(test)]
+use std::collections::VecDeque;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, SyncSender, TrySendError};
@@ -1536,6 +1767,7 @@ pub(crate) struct RefreshRuntimeDependencies {
   pub token_executor: Arc<dyn TokenRefreshExecutor>,
   pub live_fetcher: Arc<dyn LiveQuotaFetcher>,
   pub live_persister: Arc<dyn LiveQuotaPersister>,
+  pub live_cache: LiveQuotaCache,
   pub event_sink: Arc<dyn RefreshEventSink>,
   pub mutation: UsageMutationCoordinator,
   pub activity_factory: Arc<dyn ActivityFactory>,
@@ -1551,6 +1783,7 @@ impl RefreshRuntimeDependencies {
     token_executor: Arc<dyn TokenRefreshExecutor>,
     live_fetcher: Arc<dyn LiveQuotaFetcher>,
     live_persister: Arc<dyn LiveQuotaPersister>,
+    live_cache: LiveQuotaCache,
     event_sink: Arc<dyn RefreshEventSink>,
     mutation: UsageMutationCoordinator,
   ) -> Self {
@@ -1559,6 +1792,7 @@ impl RefreshRuntimeDependencies {
       token_executor,
       live_fetcher,
       live_persister,
+      live_cache,
       event_sink,
       mutation,
       activity_factory: Arc::new(SystemActivityFactory),
@@ -1715,6 +1949,7 @@ enum RuntimeMessage {
   WakeNoReply,
   Barrier(SyncSender<()>),
   Worker(WorkerOutcome),
+  Persistence(PersistenceWorkerOutcome),
   Shutdown(SyncSender<ShutdownResult>),
   #[cfg(test)]
   PauseCoordinator(Arc<TestGateState>, SyncSender<()>),
@@ -1789,11 +2024,22 @@ enum LiveWorkerOutcome {
     code: RefreshFailureCode,
     detail: RefreshDetail,
     fetch_duration: Duration,
+    fallback: Option<Arc<LiveRateLimitSnapshot>>,
   },
   Stale {
     generation: u64,
     source_generation: u64,
   },
+}
+
+enum PersistenceWorkerResult {
+  Completed(Result<(), String>),
+  Stale,
+}
+
+struct PersistenceWorkerOutcome {
+  work: LivePersistenceWork,
+  result: PersistenceWorkerResult,
 }
 
 struct PreparedSlot {
@@ -1810,10 +2056,16 @@ struct CoordinatorRuntime {
   current_live_result: Option<(u64, Arc<LiveRateLimitSnapshot>)>,
   token_sender: Option<SyncSender<TokenWorkerCommand>>,
   live_sender: Option<SyncSender<LiveWorkerCommand>>,
+  runtime_sender: SyncSender<RuntimeMessage>,
   waiters: Arc<Mutex<WaiterRegistries>>,
   status: Arc<Mutex<RefreshStatus>>,
   metrics: Arc<MetricsState>,
   event_sink: Arc<dyn RefreshEventSink>,
+  live_cache: LiveQuotaCache,
+  live_persister: Arc<dyn LiveQuotaPersister>,
+  activity_factory: Arc<dyn ActivityFactory>,
+  persistence: LivePersistenceRetryState,
+  persistence_handle: Option<JoinHandle<()>>,
   clock: Arc<dyn RefreshClock>,
   source_generation: Arc<AtomicU64>,
   shutdown: Arc<AtomicBool>,
@@ -1832,6 +2084,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     token_executor,
     live_fetcher,
     live_persister,
+    live_cache,
     event_sink,
     mutation,
     activity_factory,
@@ -1874,8 +2127,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     receiver: live_rx,
     runtime_sender: runtime_tx.clone(),
     fetcher: live_fetcher,
-    persister: live_persister,
-    activity_factory,
+    activity_factory: Arc::clone(&activity_factory),
     status: Arc::clone(&status),
     metrics: Arc::clone(&metrics),
     source_generation: Arc::clone(&source_generation),
@@ -1889,7 +2141,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
 
   let shared_intake = Arc::new(Mutex::new(IntakeState {
     accepting: true,
-    sender: runtime_tx,
+    sender: runtime_tx.clone(),
     #[cfg(test)]
     pause_after_check: None,
   }));
@@ -1914,10 +2166,16 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     current_live_result: None,
     token_sender: Some(token_tx),
     live_sender: Some(live_tx),
+    runtime_sender: runtime_tx.clone(),
     waiters,
     status,
     metrics,
     event_sink,
+    live_cache,
+    live_persister,
+    activity_factory,
+    persistence: LivePersistenceRetryState::new(),
+    persistence_handle: None,
     clock,
     source_generation,
     shutdown: Arc::clone(&shutdown),
@@ -2160,7 +2418,6 @@ struct LiveWorkerParameters {
   receiver: Receiver<LiveWorkerCommand>,
   runtime_sender: SyncSender<RuntimeMessage>,
   fetcher: Arc<dyn LiveQuotaFetcher>,
-  persister: Arc<dyn LiveQuotaPersister>,
   activity_factory: Arc<dyn ActivityFactory>,
   status: Arc<Mutex<RefreshStatus>>,
   metrics: Arc<MetricsState>,
@@ -2249,12 +2506,26 @@ fn run_live_refresh(
       if normalized.contains("timeout") || normalized.contains("timed out") {
         parameters.metrics.live_timeout_count.increment();
       }
+      if parameters.shutdown_requested.load(Ordering::Acquire)
+        || parameters.shutdown.load(Ordering::Acquire)
+        || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
+      {
+        return LiveWorkerOutcome::Stale {
+          generation: request.generation,
+          source_generation: request.source_generation,
+        };
+      }
+      let fallback = panic::catch_unwind(AssertUnwindSafe(|| parameters.fetcher.fallback()))
+        .ok()
+        .flatten()
+        .map(Arc::new);
       return LiveWorkerOutcome::Failed {
         generation: request.generation,
         source_generation: request.source_generation,
         code: RefreshFailureCode::ExecutionFailed,
         detail: RefreshDetail::new(detail),
         fetch_duration,
+        fallback,
       };
     }
     Err(_) => {
@@ -2264,6 +2535,7 @@ fn run_live_refresh(
         code: RefreshFailureCode::WorkerPanicked,
         detail: RefreshDetail::new("live fetch executor panicked"),
         fetch_duration,
+        fallback: None,
       };
     }
   };
@@ -2277,53 +2549,20 @@ fn run_live_refresh(
       source_generation: request.source_generation,
     };
   }
+  let snapshot = Arc::new(snapshot);
   #[cfg(test)]
-  parameters.hooks.before_live_persist();
-  let persisted = panic::catch_unwind(AssertUnwindSafe(|| {
-    let _activity = parameters.activity_factory.begin();
-    parameters.persister.persist(&snapshot)
-  }));
-  match persisted {
-    Ok(Ok(())) => {
-      if parameters.shutdown_requested.load(Ordering::Acquire)
-        || parameters.shutdown.load(Ordering::Acquire)
-        || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
-      {
-        return LiveWorkerOutcome::Stale {
-          generation: request.generation,
-          source_generation: request.source_generation,
-        };
-      }
-      let snapshot = Arc::new(snapshot);
-      #[cfg(test)]
-      parameters
-        .hooks
-        .record_live_arc(request.generation, Arc::clone(&snapshot));
-      LiveWorkerOutcome::Completed {
-        generation: request.generation,
-        source_generation: request.source_generation,
-        snapshot,
-        commit: CommitMarker {
-          sequence: parameters.commit_sequence.increment(),
-          committed_at: parameters.clock.monotonic_now(),
-        },
-        fetch_duration,
-      }
-    }
-    Ok(Err(detail)) => LiveWorkerOutcome::Failed {
-      generation: request.generation,
-      source_generation: request.source_generation,
-      code: RefreshFailureCode::ExecutionFailed,
-      detail: RefreshDetail::new(detail),
-      fetch_duration,
+  parameters
+    .hooks
+    .record_live_arc(request.generation, Arc::clone(&snapshot));
+  LiveWorkerOutcome::Completed {
+    generation: request.generation,
+    source_generation: request.source_generation,
+    snapshot,
+    commit: CommitMarker {
+      sequence: parameters.commit_sequence.increment(),
+      committed_at: parameters.clock.monotonic_now(),
     },
-    Err(_) => LiveWorkerOutcome::Failed {
-      generation: request.generation,
-      source_generation: request.source_generation,
-      code: RefreshFailureCode::WorkerPanicked,
-      detail: RefreshDetail::new("live persist executor panicked"),
-      fetch_duration,
-    },
+    fetch_duration,
   }
 }
 
@@ -2422,6 +2661,64 @@ impl Drop for ActiveLiveGuard<'_> {
   }
 }
 
+struct PersistenceTaskParameters {
+  work: LivePersistenceWork,
+  runtime_sender: SyncSender<RuntimeMessage>,
+  persister: Arc<dyn LiveQuotaPersister>,
+  activity_factory: Arc<dyn ActivityFactory>,
+  source_generation: Arc<AtomicU64>,
+  shutdown: Arc<AtomicBool>,
+  shutdown_requested: Arc<AtomicBool>,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn spawn_persistence_task(parameters: PersistenceTaskParameters) -> Result<JoinHandle<()>, String> {
+  thread::Builder::new()
+    .name("codex-pacer-live-persist".to_string())
+    .spawn(move || {
+      let result = run_persistence_task(&parameters);
+      let _ =
+        parameters
+          .runtime_sender
+          .send(RuntimeMessage::Persistence(PersistenceWorkerOutcome {
+            work: parameters.work.clone(),
+            result,
+          }));
+    })
+    .map_err(|error| error.to_string())
+}
+
+fn run_persistence_task(parameters: &PersistenceTaskParameters) -> PersistenceWorkerResult {
+  if persistence_task_is_stale(parameters) {
+    return PersistenceWorkerResult::Stale;
+  }
+  #[cfg(test)]
+  parameters.hooks.before_live_persist();
+  if persistence_task_is_stale(parameters) {
+    return PersistenceWorkerResult::Stale;
+  }
+  let result = panic::catch_unwind(AssertUnwindSafe(|| {
+    let _activity = parameters.activity_factory.begin();
+    parameters.persister.persist(parameters.work.snapshot())
+  }));
+  if persistence_task_is_stale(parameters) {
+    return PersistenceWorkerResult::Stale;
+  }
+  match result {
+    Ok(result) => PersistenceWorkerResult::Completed(result),
+    Err(_) => PersistenceWorkerResult::Completed(Err(
+      "live quota persistence executor panicked".to_string(),
+    )),
+  }
+}
+
+fn persistence_task_is_stale(parameters: &PersistenceTaskParameters) -> bool {
+  parameters.shutdown.load(Ordering::Acquire)
+    || parameters.shutdown_requested.load(Ordering::Acquire)
+    || parameters.source_generation.load(Ordering::Acquire) != parameters.work.source_generation()
+}
+
 fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: CoordinatorRuntime) {
   #[cfg(test)]
   runtime.hooks.record_thread_name();
@@ -2429,11 +2726,12 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
     let message = if runtime.shutdown_requested.load(Ordering::Acquire) {
       receiver.recv().map_err(|_| RecvError)
     } else {
-      match runtime.schedule.next_wait(runtime.clock.monotonic_now()) {
+      match runtime.next_wait() {
         Some(wait) => match receiver.recv_timeout(wait) {
           Ok(message) => Ok(message),
           Err(RecvTimeoutError::Timeout) => {
             runtime.process_schedule_event(CoordinatorEvent::Timer);
+            runtime.maybe_start_persistence();
             continue;
           }
           Err(RecvTimeoutError::Disconnected) => Err(RecvError),
@@ -2455,11 +2753,14 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
     match message {
       RuntimeMessage::RequestToken(request) => {
         runtime.process_schedule_event(CoordinatorEvent::RequestToken(request));
+        runtime.maybe_start_persistence();
       }
       RuntimeMessage::RequestLive(request) => {
         runtime.process_schedule_event(CoordinatorEvent::RequestLive(request));
+        runtime.maybe_start_persistence();
       }
       RuntimeMessage::SettingsChanged(config, reply) => {
+        let previous_source_generation = runtime.schedule.snapshot().source_generation;
         let actions = runtime.schedule.handle(
           runtime.clock.monotonic_now(),
           CoordinatorEvent::SettingsChanged(config),
@@ -2468,19 +2769,31 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
         runtime
           .source_generation
           .store(snapshot.source_generation, Ordering::Release);
+        if snapshot.source_generation != previous_source_generation {
+          runtime.persistence.reset_source(snapshot.source_generation);
+        }
         runtime.sync_schedule_snapshot();
         runtime.process_actions(actions);
+        runtime.maybe_start_persistence();
         let _ = reply.send(());
       }
       RuntimeMessage::Wake(reply) => {
         runtime.process_schedule_event(CoordinatorEvent::Wake);
+        runtime.maybe_start_persistence();
         let _ = reply.send(());
       }
-      RuntimeMessage::WakeNoReply => runtime.process_schedule_event(CoordinatorEvent::Wake),
+      RuntimeMessage::WakeNoReply => {
+        runtime.process_schedule_event(CoordinatorEvent::Wake);
+        runtime.maybe_start_persistence();
+      }
       RuntimeMessage::Barrier(reply) => {
         let _ = reply.send(());
       }
-      RuntimeMessage::Worker(outcome) => runtime.process_worker_outcome(outcome),
+      RuntimeMessage::Worker(outcome) => {
+        runtime.process_worker_outcome(outcome);
+        runtime.maybe_start_persistence();
+      }
+      RuntimeMessage::Persistence(outcome) => runtime.process_persistence_outcome(outcome),
       RuntimeMessage::Shutdown(reply) => {
         runtime.shutdown_and_join_workers(&receiver, reply);
         return;
@@ -2509,6 +2822,92 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
 }
 
 impl CoordinatorRuntime {
+  fn next_wait(&self) -> Option<Duration> {
+    let now = self.clock.monotonic_now();
+    let schedule = self.schedule.next_wait(now);
+    let live_running = self.schedule.snapshot().live.running_generation.is_some();
+    let persistence = self.persistence.next_wait(now, live_running);
+    match (schedule, persistence) {
+      (Some(schedule), Some(persistence)) => Some(schedule.min(persistence)),
+      (Some(wait), None) | (None, Some(wait)) => Some(wait),
+      (None, None) => None,
+    }
+  }
+
+  fn maybe_start_persistence(&mut self) {
+    if self.shutdown_requested.load(Ordering::Acquire)
+      || self.shutdown.load(Ordering::Acquire)
+      || self.persistence_handle.is_some()
+    {
+      return;
+    }
+    let live_running = self.schedule.snapshot().live.running_generation.is_some();
+    let Some(work) = self
+      .persistence
+      .take_ready(self.clock.monotonic_now(), live_running)
+    else {
+      return;
+    };
+    #[cfg(test)]
+    self.hooks.trace("live_persist_start");
+    let spawn = spawn_persistence_task(PersistenceTaskParameters {
+      work: work.clone(),
+      runtime_sender: self.runtime_sender.clone(),
+      persister: Arc::clone(&self.live_persister),
+      activity_factory: Arc::clone(&self.activity_factory),
+      source_generation: Arc::clone(&self.source_generation),
+      shutdown: Arc::clone(&self.shutdown),
+      shutdown_requested: Arc::clone(&self.shutdown_requested),
+      #[cfg(test)]
+      hooks: Arc::clone(&self.hooks),
+    });
+    match spawn {
+      Ok(handle) => self.persistence_handle = Some(handle),
+      Err(error) => {
+        log::warn!("Failed to start live quota persistence task: {error}");
+        self.persistence.finish(
+          &work,
+          Err(error),
+          self.clock.monotonic_now(),
+          self.schedule.snapshot().interval,
+        );
+        #[cfg(test)]
+        self.hooks.record_persistence_outcome();
+      }
+    }
+  }
+
+  fn process_persistence_outcome(&mut self, outcome: PersistenceWorkerOutcome) {
+    if let Some(handle) = self.persistence_handle.take() {
+      if handle.join().is_err() {
+        log::warn!("Live quota persistence task panicked after reporting its outcome.");
+      }
+    }
+    match outcome.result {
+      PersistenceWorkerResult::Completed(result) => {
+        if let Err(error) = &result {
+          log::warn!("Failed to persist live quota snapshot: {error}");
+        }
+        self.persistence.finish(
+          &outcome.work,
+          result,
+          self.clock.monotonic_now(),
+          self.schedule.snapshot().interval,
+        );
+      }
+      PersistenceWorkerResult::Stale => {
+        self.persistence.abandon(&outcome.work);
+      }
+    }
+    #[cfg(test)]
+    self.hooks.record_persistence_outcome();
+    if self.shutdown_requested.load(Ordering::Acquire) || self.shutdown.load(Ordering::Acquire) {
+      self.persistence.cancel_pending();
+    } else {
+      self.maybe_start_persistence();
+    }
+  }
+
   fn handle_message_while_shutdown_pending(&mut self, message: RuntimeMessage) {
     match message {
       RuntimeMessage::SettingsChanged(_, reply)
@@ -2521,6 +2920,10 @@ impl CoordinatorRuntime {
       }
       RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
         self.live_exited = true;
+      }
+      RuntimeMessage::Persistence(outcome) => {
+        self.process_persistence_outcome(outcome);
+        self.persistence.cancel_pending();
       }
       RuntimeMessage::Worker(_)
       | RuntimeMessage::RequestToken(_)
@@ -2712,17 +3115,25 @@ impl CoordinatorRuntime {
             generation,
             source_generation,
             RefreshFailureCode::SourceChanged,
-            RefreshDetail::new("refresh source changed during live persistence"),
+            RefreshDetail::new("refresh source changed before live publication"),
             self.clock.wall_now(),
           )));
           return;
         }
         lock(&self.metrics.mutable).live.app_server_duration_ms =
           nonzero_duration_millis(fetch_duration);
+        self.live_cache.publish_live(
+          Arc::clone(&snapshot),
+          self.clock.monotonic_now(),
+          self.clock.wall_now(),
+        );
+        lock(&self.metrics.mutable).live.fallback_age_ms = None;
+        #[cfg(test)]
+        self.hooks.trace("live_cache_publish");
         self.finish_live_timing(true);
         #[cfg(test)]
         self.hooks.set_completion_slots_empty(false);
-        self.current_live_result = Some((generation, snapshot));
+        self.current_live_result = Some((generation, Arc::clone(&snapshot)));
         self.process_schedule_event(CoordinatorEvent::LiveFinished(successful_completion(
           generation,
           source_generation,
@@ -2732,6 +3143,9 @@ impl CoordinatorRuntime {
         self.current_live_result = None;
         #[cfg(test)]
         self.hooks.set_completion_slots_empty(true);
+        self
+          .persistence
+          .publish(snapshot, source_generation, self.clock.monotonic_now());
       }
       LiveWorkerOutcome::Failed {
         generation,
@@ -2739,12 +3153,40 @@ impl CoordinatorRuntime {
         code,
         detail,
         fetch_duration,
+        fallback,
       } => {
-        if self.schedule.snapshot().live.running_generation != Some(generation) {
+        let coordinator_snapshot = self.schedule.snapshot();
+        if coordinator_snapshot.live.running_generation != Some(generation) {
+          return;
+        }
+        if coordinator_snapshot.source_generation != source_generation {
+          self.live_cache.set_refreshing(false);
+          self.finish_live_timing(false);
+          self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+            generation,
+            source_generation,
+            RefreshFailureCode::SourceChanged,
+            RefreshDetail::new("refresh source changed before live fallback publication"),
+            self.clock.wall_now(),
+          )));
           return;
         }
         lock(&self.metrics.mutable).live.app_server_duration_ms =
           nonzero_duration_millis(fetch_duration);
+        let submit_fallback_intent = code == RefreshFailureCode::ExecutionFailed;
+        if let Some(fallback) = fallback {
+          let state = self.live_cache.publish_fallback(
+            fallback,
+            self.clock.monotonic_now(),
+            self.clock.wall_now(),
+          );
+          self.record_fallback_age(state.source_fetched_at.as_deref());
+          #[cfg(test)]
+          self.hooks.trace("live_cache_fallback");
+        } else {
+          let state = self.live_cache.mark_current_as_fallback();
+          self.record_fallback_age(state.source_fetched_at.as_deref());
+        }
         self.finish_live_timing(false);
         self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
           generation,
@@ -2753,6 +3195,11 @@ impl CoordinatorRuntime {
           detail,
           self.clock.wall_now(),
         )));
+        if submit_fallback_intent {
+          self.process_schedule_event(CoordinatorEvent::RequestToken(TokenRequest::for_reason(
+            RefreshReason::Fallback,
+          )));
+        }
       }
       LiveWorkerOutcome::Stale {
         generation,
@@ -2761,6 +3208,7 @@ impl CoordinatorRuntime {
         if self.schedule.snapshot().live.running_generation != Some(generation) {
           return;
         }
+        self.live_cache.set_refreshing(false);
         self.finish_live_timing(false);
         self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
           generation,
@@ -2819,9 +3267,15 @@ impl CoordinatorRuntime {
           }
         }
         CoordinatorAction::PublishInvalidation(value) => {
+          #[cfg(test)]
+          let is_live = self.current_live_result.is_some();
           self.event_sink.publish_invalidation(value);
           #[cfg(test)]
-          self.hooks.trace("token_invalidation");
+          self.hooks.trace(if is_live {
+            "live_invalidation"
+          } else {
+            "token_invalidation"
+          });
         }
         CoordinatorAction::PublishCompletion(value) => {
           #[cfg(test)]
@@ -2847,7 +3301,9 @@ impl CoordinatorRuntime {
     self.record_lane_start(true, request.generation, request.request.planned_due_at);
     set_mutation_phase(&self.status, MutationPhase::Parsing);
     #[cfg(test)]
-    if request.generation > 1 {
+    if request.request.reasons.contains(RefreshReason::Fallback) {
+      self.hooks.trace("token_fallback_start");
+    } else if request.generation > 1 {
       self.hooks.trace("token_follow_up_start");
     }
     let result = self.token_sender.as_ref().ok_or(()).and_then(|sender| {
@@ -2867,12 +3323,14 @@ impl CoordinatorRuntime {
 
   fn start_live(&mut self, request: LiveExecutionRequest) {
     self.record_lane_start(false, request.generation, request.planned_due_at);
+    self.live_cache.set_refreshing(true);
     let result = self.live_sender.as_ref().ok_or(()).and_then(|sender| {
       sender
         .try_send(LiveWorkerCommand::Run(request.clone()))
         .map_err(|_| ())
     });
     if result.is_err() {
+      self.live_cache.set_refreshing(false);
       self.finish_live_timing(false);
       self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
         request.generation,
@@ -2950,6 +3408,24 @@ impl CoordinatorRuntime {
         let _ = reply.send(clone_result(&result));
       }
     }
+    drop(waiters);
+    #[cfg(test)]
+    self.hooks.trace("live_waiter_reply");
+  }
+
+  fn record_fallback_age(&self, source_fetched_at: Option<&str>) {
+    let age = source_fetched_at
+      .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+      .and_then(|fetched| {
+        self
+          .clock
+          .wall_now()
+          .signed_duration_since(fetched.with_timezone(&Utc))
+          .to_std()
+          .ok()
+      })
+      .map(duration_as_millis);
+    lock(&self.metrics.mutable).live.fallback_age_ms = age;
   }
 
   fn record_lane_start(&mut self, token: bool, generation: u64, due: Option<Instant>) {
@@ -3059,6 +3535,8 @@ impl CoordinatorRuntime {
   ) {
     // Required order: deny is linearized by the owner, then drain, drop, flag, close.
     drain_waiters_for_shutdown(&self.waiters);
+    self.live_cache.set_refreshing(false);
+    self.persistence.cancel_pending();
     self.prepared_slot = None;
     #[cfg(test)]
     self.hooks.set_prepared_slot_empty(true);
@@ -3074,7 +3552,7 @@ impl CoordinatorRuntime {
       status.mutation_phase = None;
     }
 
-    while !self.token_exited || !self.live_exited {
+    while !self.token_exited || !self.live_exited || self.persistence_handle.is_some() {
       let Ok(message) = receiver.recv() else {
         break;
       };
@@ -3084,6 +3562,10 @@ impl CoordinatorRuntime {
         }
         RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
           self.live_exited = true;
+        }
+        RuntimeMessage::Persistence(outcome) => {
+          self.process_persistence_outcome(outcome);
+          self.persistence.cancel_pending();
         }
         RuntimeMessage::Worker(_) => {}
         RuntimeMessage::SettingsChanged(_, ack)
@@ -3431,6 +3913,7 @@ struct TestHookData {
   token_waiting_count: u64,
   prepared_slot_empty: bool,
   completion_slots_empty: bool,
+  persistence_outcomes: u64,
 }
 
 #[cfg(test)]
@@ -3502,6 +3985,13 @@ impl RuntimeTestHooks {
 
   fn set_completion_slots_empty(&self, empty: bool) {
     lock(&self.data).completion_slots_empty = empty;
+    self.changed.notify_all();
+  }
+
+  fn record_persistence_outcome(&self) {
+    let mut data = lock(&self.data);
+    data.persistence_outcomes = data.persistence_outcomes.saturating_add(1);
+    drop(data);
     self.changed.notify_all();
   }
 
@@ -3955,6 +4445,11 @@ struct TestLiveBehavior {
   fetch_thread_ids: Vec<String>,
   persist_thread_ids: Vec<String>,
   last_timeout: Option<Duration>,
+  fail_next_fetch: bool,
+  fallback_snapshot: Option<Arc<LiveRateLimitSnapshot>>,
+  queued_snapshots: VecDeque<Arc<LiveRateLimitSnapshot>>,
+  fail_next_persist: bool,
+  persisted_fetched_at: Vec<String>,
 }
 
 #[cfg(test)]
@@ -3966,6 +4461,7 @@ struct TestLiveExecutor {
   persist_calls: AtomicU64,
   active: AtomicU64,
   maximum_active: AtomicU64,
+  fallback_calls: AtomicU64,
 }
 
 #[cfg(test)]
@@ -3979,6 +4475,7 @@ impl TestLiveExecutor {
       persist_calls: AtomicU64::new(0),
       active: AtomicU64::new(0),
       maximum_active: AtomicU64::new(0),
+      fallback_calls: AtomicU64::new(0),
     }
   }
 
@@ -4013,6 +4510,30 @@ impl TestLiveExecutor {
     lock(&self.behavior).panic_once.insert(phase, 1);
   }
 
+  fn fail_next_fetch_with_fallback(&self, fallback: Arc<LiveRateLimitSnapshot>) {
+    let mut behavior = lock(&self.behavior);
+    behavior.fail_next_fetch = true;
+    behavior.fallback_snapshot = Some(fallback);
+  }
+
+  fn fail_next_fetch(&self) {
+    let mut behavior = lock(&self.behavior);
+    behavior.fail_next_fetch = true;
+    behavior.fallback_snapshot = None;
+  }
+
+  fn fallback_calls(&self) -> u64 {
+    self.fallback_calls.load(Ordering::Acquire)
+  }
+
+  fn fail_next_persist(&self) {
+    lock(&self.behavior).fail_next_persist = true;
+  }
+
+  fn queue_snapshot(&self, snapshot: Arc<LiveRateLimitSnapshot>) {
+    lock(&self.behavior).queued_snapshots.push_back(snapshot);
+  }
+
   fn fetch_calls(&self) -> u64 {
     self.fetch_calls.load(Ordering::Acquire)
   }
@@ -4029,6 +4550,19 @@ impl TestLiveExecutor {
       .unwrap_or_else(|poisoned| poisoned.into_inner());
     assert!(self.fetch_calls() >= expected);
     assert!(!timed_out.timed_out(), "timed out waiting for live fetch");
+  }
+
+  fn wait_for_persist_calls(&self, expected: u64, timeout: Duration) {
+    let behavior = lock(&self.behavior);
+    let (_behavior, timed_out) = self
+      .changed
+      .wait_timeout_while(behavior, timeout, |_| self.persist_calls() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(self.persist_calls() >= expected);
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for live persistence"
+    );
   }
 
   fn maximum_active_fetches(&self) -> u64 {
@@ -4071,6 +4605,17 @@ impl TestLiveExecutor {
     lock(&self.behavior).last_timeout
   }
 
+  fn persisted_fetched_at(&self) -> Vec<String> {
+    lock(&self.behavior).persisted_fetched_at.clone()
+  }
+
+  fn snapshot_at(fetched_at: &str) -> Arc<LiveRateLimitSnapshot> {
+    Arc::new(LiveRateLimitSnapshot {
+      fetched_at: fetched_at.to_string(),
+      ..Self::snapshot()
+    })
+  }
+
   fn snapshot() -> LiveRateLimitSnapshot {
     LiveRateLimitSnapshot {
       limit_id: Some("runtime-test".to_string()),
@@ -4100,7 +4645,7 @@ impl LiveQuotaFetcher for TestLiveExecutor {
         Err(observed) => maximum = observed,
       }
     }
-    let (body_gate, pre_body, panic_now) = {
+    let (body_gate, pre_body, panic_now, fail_now, snapshot) = {
       let mut behavior = lock(&self.behavior);
       behavior
         .fetch_thread_ids
@@ -4111,6 +4656,8 @@ impl LiveQuotaFetcher for TestLiveExecutor {
         behavior.fetch_body_gates.remove(&call),
         behavior.pre_body_fetch_states.remove(&call),
         panic_now,
+        std::mem::take(&mut behavior.fail_next_fetch),
+        behavior.queued_snapshots.pop_front(),
       )
     };
     self.changed.notify_all();
@@ -4124,21 +4671,43 @@ impl LiveQuotaFetcher for TestLiveExecutor {
     if panic_now {
       panic!("intentional fetch panic");
     }
-    Ok(Self::snapshot())
+    if fail_now {
+      return Err("intentional live fetch failure".to_string());
+    }
+    Ok(
+      snapshot
+        .map(|snapshot| snapshot.as_ref().clone())
+        .unwrap_or_else(Self::snapshot),
+    )
+  }
+
+  fn fallback(&self) -> Option<LiveRateLimitSnapshot> {
+    self.fallback_calls.fetch_add(1, Ordering::AcqRel);
+    lock(&self.behavior)
+      .fallback_snapshot
+      .as_ref()
+      .map(|snapshot| snapshot.as_ref().clone())
   }
 }
 
 #[cfg(test)]
 impl LiveQuotaPersister for TestLiveExecutor {
-  fn persist(&self, _snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
+  fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
     let call = self.persist_calls.fetch_add(1, Ordering::AcqRel) + 1;
-    let (body_gate, panic_now) = {
+    let (body_gate, panic_now, fail_now) = {
       let mut behavior = lock(&self.behavior);
       behavior
         .persist_thread_ids
         .push(format!("{:?}", thread::current().id()));
       let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Persist);
-      (behavior.persist_body_gates.remove(&call), panic_now)
+      behavior
+        .persisted_fetched_at
+        .push(snapshot.fetched_at.clone());
+      (
+        behavior.persist_body_gates.remove(&call),
+        panic_now,
+        std::mem::take(&mut behavior.fail_next_persist),
+      )
     };
     self.changed.notify_all();
     if let Some(body_gate) = body_gate {
@@ -4146,6 +4715,9 @@ impl LiveQuotaPersister for TestLiveExecutor {
     }
     if panic_now {
       panic!("intentional persist panic");
+    }
+    if fail_now {
+      return Err("intentional persistence failure".to_string());
     }
     Ok(())
   }
@@ -4283,6 +4855,7 @@ struct RuntimeTestRig {
   handle: RefreshCoordinatorHandle,
   token: Arc<TestTokenExecutor>,
   live: Arc<TestLiveExecutor>,
+  live_cache: LiveQuotaCache,
   events: Arc<TestEvents>,
   mutation: UsageMutationCoordinator,
   activities: super::power::CountingActivityFactory,
@@ -4368,11 +4941,13 @@ impl RuntimeTestRig {
     let events = Arc::new(TestEvents::new(Arc::clone(&hooks)));
     let mutation = UsageMutationCoordinator::new();
     let activities = super::power::CountingActivityFactory::default();
+    let live_cache = LiveQuotaCache::new();
     let dependencies = RefreshRuntimeDependencies {
       config,
       token_executor: token.clone(),
       live_fetcher: live.clone(),
       live_persister: live.clone(),
+      live_cache: live_cache.clone(),
       event_sink: events.clone(),
       mutation: mutation.clone(),
       activity_factory: Arc::new(activities.clone()),
@@ -4387,6 +4962,7 @@ impl RuntimeTestRig {
       handle,
       token,
       live,
+      live_cache,
       events,
       mutation,
       activities,
@@ -4410,6 +4986,13 @@ impl RuntimeTestRig {
       let status = self.handle.status();
       !status.token.running && !status.live.running
     });
+  }
+
+  fn wait_for_persist_outcomes(&self, expected: u64, timeout: Duration) {
+    self
+      .runtime
+      .test_hooks
+      .wait_for(timeout, |data| data.persistence_outcomes >= expected);
   }
 
   fn shutdown(&self) {

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -751,6 +751,31 @@ mod tests {
   }
 
   #[test]
+  fn epoch_backfill_shutdown_publish_cancels_attempt_installed_across_race() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let (rig, before_install, shutdown_gap, between_install_and_send) =
+      RuntimeTestRig::build_with_maintenance_shutdown_install_gates(Arc::clone(&maintenance));
+    before_install.wait_worker_ready(TEST_TIMEOUT);
+
+    let shutdown = rig.shutdown_in_background();
+    shutdown_gap.wait_worker_ready(TEST_TIMEOUT);
+    before_install.release();
+    between_install_and_send.wait_worker_ready(TEST_TIMEOUT);
+    let was_cancelled_before_send = rig.maintenance_cancelled_between_install_and_send();
+    between_install_and_send.release();
+    shutdown_gap.release();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+    assert!(
+      was_cancelled_before_send,
+      "shutdown is visible and cancels the attempt before its command is sent"
+    );
+    assert_eq!(maintenance.calls(), 0, "shutdown enters no maintenance executor");
+  }
+
+  #[test]
   fn scheduled_start_lag_is_recorded() {
     let rig = RuntimeTestRig::scheduled_overdue(Duration::from_secs(2));
     rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
@@ -2456,13 +2481,15 @@ impl RefreshRuntime {
         }
         {
           let shutdown_state = lock(&self.lifecycle.state);
-          if let Some(control) = &self.lifecycle.maintenance_control {
-            control.cancel_current();
-          }
           self
             .lifecycle
             .shutdown_requested
             .store(true, Ordering::Release);
+          #[cfg(test)]
+          self.test_hooks.between_shutdown_publish_and_cancel();
+          if let Some(control) = &self.lifecycle.maintenance_control {
+            control.cancel_current();
+          }
           self.lifecycle.changed.notify_all();
           drop(shutdown_state);
         }
@@ -3681,6 +3708,8 @@ impl CoordinatorRuntime {
     if self.maintenance_wait(now) != Some(Duration::ZERO) {
       return;
     }
+    #[cfg(test)]
+    self.hooks.before_maintenance_install();
     let Some(sender) = self.maintenance_sender.clone() else {
       return;
     };
@@ -3691,6 +3720,16 @@ impl CoordinatorRuntime {
       return;
     };
     let cancellation = Arc::new(AtomicBool::new(false));
+    self
+      .maintenance_control
+      .install(attempt_id, Arc::clone(&cancellation));
+    if self.shutdown_requested.load(Ordering::Acquire) {
+      self.maintenance_control.cancel_current();
+    }
+    #[cfg(test)]
+    self
+      .hooks
+      .between_maintenance_install_and_send(&cancellation);
     let command = EpochMaintenanceWorkerCommand {
       attempt_id,
       cancellation: Arc::clone(&cancellation),
@@ -3699,19 +3738,18 @@ impl CoordinatorRuntime {
       Ok(()) => {
         self.maintenance.next_attempt_id = attempt_id;
         self.maintenance.next_eligible_at = None;
-        self
-          .maintenance_control
-          .install(attempt_id, Arc::clone(&cancellation));
         self.maintenance.running = Some(EpochMaintenanceAttempt { id: attempt_id });
         if self.shutdown_requested.load(Ordering::Acquire) {
           self.maintenance_control.cancel_current();
         }
       }
       Err(TrySendError::Full(_)) => {
+        self.maintenance_control.clear(attempt_id);
         log::warn!("Epoch maintenance command queue was unexpectedly full.");
         self.maintenance.next_eligible_at = now.checked_add(EPOCH_MAINTENANCE_PACE);
       }
       Err(TrySendError::Disconnected(_)) => {
+        self.maintenance_control.clear(attempt_id);
         log::warn!("Epoch maintenance worker became unavailable.");
         self.maintenance.pending = false;
         self.maintenance_sender = None;
@@ -4845,6 +4883,7 @@ struct TestHookData {
   persistence_outcomes: u64,
   maintenance_outcomes: u64,
   maintenance_exited: bool,
+  maintenance_cancelled_between_install_and_send: Option<bool>,
 }
 
 #[cfg(test)]
@@ -4854,6 +4893,9 @@ struct RuntimeTestHooks {
   token_commit_pre_body: IndexedPreBodyGates,
   live_fetch_pre_body: IndexedPreBodyGates,
   live_persist_pre_body: IndexedPreBodyGates,
+  maintenance_before_install: Mutex<Option<Arc<TestGateState>>>,
+  shutdown_between_publish_and_cancel: Mutex<Option<Arc<TestGateState>>>,
+  maintenance_between_install_and_send: Mutex<Option<Arc<TestGateState>>>,
   data: Mutex<TestHookData>,
   changed: Condvar,
 }
@@ -4874,6 +4916,45 @@ impl RuntimeTestHooks {
 
   fn before_live_persist(&self) {
     self.live_persist_pre_body.before_call();
+  }
+
+  fn block_maintenance_before_install(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    *lock(&self.maintenance_before_install) = Some(Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn before_maintenance_install(&self) {
+    if let Some(gate) = lock(&self.maintenance_before_install).take() {
+      gate.mark_worker_ready_and_wait();
+    }
+  }
+
+  fn block_shutdown_between_publish_and_cancel(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    *lock(&self.shutdown_between_publish_and_cancel) = Some(Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn between_shutdown_publish_and_cancel(&self) {
+    if let Some(gate) = lock(&self.shutdown_between_publish_and_cancel).take() {
+      gate.mark_worker_ready_and_wait();
+    }
+  }
+
+  fn block_between_maintenance_install_and_send(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    *lock(&self.maintenance_between_install_and_send) = Some(Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn between_maintenance_install_and_send(&self, cancellation: &AtomicBool) {
+    lock(&self.data).maintenance_cancelled_between_install_and_send =
+      Some(cancellation.load(Ordering::Acquire));
+    self.changed.notify_all();
+    if let Some(gate) = lock(&self.maintenance_between_install_and_send).take() {
+      gate.mark_worker_ready_and_wait();
+    }
   }
 
   fn notify_token_waiting_to_commit(&self) {
@@ -6019,6 +6100,36 @@ impl RuntimeTestRig {
     )
   }
 
+  fn build_with_maintenance_shutdown_install_gates(
+    maintenance: Arc<TestEpochMaintenanceExecutor>,
+  ) -> (
+    Self,
+    PhaseGateControl,
+    PhaseGateControl,
+    PhaseGateControl,
+  ) {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let before_install = hooks.block_maintenance_before_install();
+    let shutdown_gap = hooks.block_shutdown_between_publish_and_cancel();
+    let between_install_and_send = hooks.block_between_maintenance_install_and_send();
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    (
+      Self::build_with_components_and_options(
+        TestRigSchedule::Disabled,
+        hooks,
+        token,
+        live,
+        Some(maintenance),
+        None,
+      ),
+      before_install,
+      shutdown_gap,
+      between_install_and_send,
+    )
+  }
+
   fn build_with_maintenance_and_mutation(
     schedule: TestRigSchedule,
     maintenance: Arc<TestEpochMaintenanceExecutor>,
@@ -6154,6 +6265,12 @@ impl RuntimeTestRig {
       .runtime
       .test_hooks
       .wait_for(timeout, |data| data.maintenance_exited);
+  }
+
+  fn maintenance_cancelled_between_install_and_send(&self) -> bool {
+    lock(&self.runtime.test_hooks.data)
+      .maintenance_cancelled_between_install_and_send
+      .expect("recorded maintenance install/send cancellation state")
   }
 
   fn wait_for_mutation_queue(&self, expected: usize, timeout: Duration) {

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -1,0 +1,4742 @@
+#[cfg(test)]
+mod tests {
+  use super::{
+    MetricsState, PanicPhase, RefreshClock, RefreshConfig, RefreshError, RefreshStatus,
+    RuntimeTestRig, SaturatingCounter, TestClock,
+  };
+  use crate::refresh::{RefreshFailureCode, RefreshRejectionCode, REFRESH_WAITER_CAPACITY};
+  use chrono::{DateTime, Duration as ChronoDuration};
+  use std::sync::Arc;
+  use std::time::Duration;
+
+  const TEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+  #[test]
+  fn token_worker_does_not_delay_live_worker_start() {
+    let rig = RuntimeTestRig::disabled();
+    let parse = rig.token.block_next_parse();
+    let fetch = rig.live.block_next_fetch();
+    let token_ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+
+    let live_ticket = rig.handle.request_manual_live().expect("live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.token.parse_calls(), 1);
+    assert_eq!(rig.live.fetch_calls(), 1);
+
+    fetch.release();
+    parse.release();
+    assert!(token_ticket.wait().is_ok());
+    assert!(live_ticket.wait().is_ok());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn concurrent_live_callers_share_one_executor_generation() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let first = rig.handle.request_manual_live().expect("first live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    let second = rig
+      .handle
+      .request_manual_live()
+      .expect("second live ticket");
+
+    fetch.release();
+    let first = first.wait().expect("first live result");
+    let second = second.wait().expect("second live result");
+    assert!(Arc::ptr_eq(&first, &second));
+    assert_eq!(rig.live.fetch_calls(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn active_live_children_never_exceeds_one() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let first = rig.handle.request_manual_live().expect("first live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    let mut joined = Vec::new();
+    for _ in 1..REFRESH_WAITER_CAPACITY {
+      joined.push(
+        rig
+          .handle
+          .request_manual_live()
+          .expect("joined live ticket"),
+      );
+    }
+
+    assert_eq!(rig.metrics().live.active_executor_count, 1);
+    assert_eq!(rig.live.maximum_active_fetches(), 1);
+    fetch.release();
+    assert!(first.wait_timeout(TEST_TIMEOUT).is_ok());
+    for ticket in joined {
+      assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    }
+    assert_eq!(rig.metrics().live.active_executor_count, 0);
+    assert_eq!(rig.live.maximum_active_fetches(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn startup_status_is_busy_before_worker_body_runs() {
+    let (rig, parse, fetch) = RuntimeTestRig::startup_due_with_pre_body_gates();
+    parse.wait_worker_ready(TEST_TIMEOUT);
+    fetch.wait_worker_ready(TEST_TIMEOUT);
+
+    let status = rig.handle.status();
+    assert!(status.token.running);
+    assert!(status.live.running);
+    assert_eq!(status.token.generation, Some(1));
+    assert_eq!(status.live.generation, Some(1));
+    assert_eq!(status.mutation_phase, Some(super::MutationPhase::Parsing));
+    assert_eq!(rig.token.parse_calls(), 0, "executor body has not entered");
+    assert_eq!(rig.live.fetch_calls(), 0, "executor body has not entered");
+
+    rig.clock.advance(Duration::from_secs(7));
+    parse.release();
+    fetch.release();
+    parse.wait_entered(TEST_TIMEOUT);
+    fetch.wait_entered(TEST_TIMEOUT);
+    rig.wait_until_idle(TEST_TIMEOUT);
+    let metrics = rig.metrics();
+    assert!(metrics.token.lane.start_lag_ms > 5_000);
+    assert!(metrics.live.lane.start_lag_ms > 5_000);
+    assert_eq!(metrics.start_lag_warning_count, 2);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn completion_services_one_pending_follow_up() {
+    let rig = RuntimeTestRig::disabled();
+    let first_parse = rig.token.block_next_parse();
+    let follow_up_parse = rig.token.block_parse_call(2);
+    let first = rig
+      .handle
+      .request_manual_token(None)
+      .expect("first token ticket");
+    first_parse.wait_entered(TEST_TIMEOUT);
+    let follow_up = rig
+      .handle
+      .request_manual_token(None)
+      .expect("follow-up token ticket");
+    first_parse.release();
+
+    follow_up_parse.wait_worker_ready(TEST_TIMEOUT);
+    assert!(
+      first.wait_timeout(TEST_TIMEOUT).is_ok(),
+      "first waiter resolves before follow-up body"
+    );
+    assert_eq!(
+      rig.events.trace_prefix(),
+      [
+        "token_invalidation",
+        "token_completion",
+        "token_waiter_reply",
+        "token_follow_up_start"
+      ]
+    );
+    assert!(rig.current_completion_slots_are_empty());
+    follow_up_parse.release();
+    assert!(follow_up.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.token.wait_for_parse_calls(2, TEST_TIMEOUT);
+    assert_eq!(rig.token.parse_calls(), 2);
+    assert_eq!(rig.token.commit_calls(), 2);
+    assert!(!rig.handle.status().token.pending);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn successful_token_waiter_receives_exact_scan_result() {
+    let rig = RuntimeTestRig::disabled();
+    let first_parse = rig.token.block_next_parse();
+    let first = rig
+      .handle
+      .request_manual_token(None)
+      .expect("first token ticket");
+    first_parse.wait_entered(TEST_TIMEOUT);
+    let follow_up_one = rig
+      .handle
+      .request_manual_token(None)
+      .expect("first follow-up ticket");
+    let follow_up_two = rig
+      .handle
+      .request_manual_token(None)
+      .expect("second follow-up ticket");
+    first_parse.release();
+
+    let first = first
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("first generation result");
+    let follow_up_one = follow_up_one
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("first follow-up result");
+    let follow_up_two = follow_up_two
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("second follow-up result");
+    let produced = rig.token.committed_arc(2, TEST_TIMEOUT);
+    assert!(!Arc::ptr_eq(&first, &follow_up_one));
+    assert!(Arc::ptr_eq(&follow_up_one, &follow_up_two));
+    assert!(Arc::ptr_eq(&follow_up_one, &produced));
+    rig.token.assert_result_for_generation(&follow_up_one, 2);
+    assert_eq!(rig.token.commit_calls(), 2);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn successful_live_waiters_receive_exact_same_snapshot() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let first = rig.handle.request_manual_live().expect("first live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    let second = rig
+      .handle
+      .request_manual_live()
+      .expect("second live ticket");
+    fetch.release();
+
+    let first = first.wait().expect("first snapshot");
+    let second = second.wait().expect("second snapshot");
+    let produced = rig.live.fetched_arc(1, TEST_TIMEOUT);
+    assert!(Arc::ptr_eq(&first, &second));
+    assert!(Arc::ptr_eq(&first, &produced));
+    assert!(rig.current_completion_slots_are_empty());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn prepared_discard_drops_spool_before_follow_up() {
+    let rig = RuntimeTestRig::disabled();
+    let parse = rig.token.block_next_spooled_parse_with_drop_probe();
+    rig
+      .token
+      .assert_probe_dropped_before_next_parse(parse.probe());
+    let first = rig
+      .handle
+      .request_manual_token(None)
+      .expect("first token ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+    rig
+      .handle
+      .update_settings(rig.config_with_source("replacement"))
+      .expect("source update");
+    parse.release();
+
+    rig.token.wait_for_parse_calls(2, TEST_TIMEOUT);
+    parse.wait_dropped(TEST_TIMEOUT);
+    assert!(parse.used_spool());
+    assert!(rig.token.follow_up_observed_probe_dropped());
+    assert!(matches!(
+      first.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::SourceChanged,
+        ..
+      })
+    ));
+    rig.shutdown();
+  }
+
+  #[test]
+  fn parse_panic_becomes_failure_and_worker_recovers() {
+    let rig = RuntimeTestRig::disabled();
+    rig.token.panic_once(PanicPhase::Parse);
+    let failed = rig
+      .handle
+      .request_manual_token(None)
+      .expect("failed token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      failed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::WorkerPanicked,
+        ..
+      })
+    ));
+    assert_eq!(
+      rig.handle.status().mutation_phase,
+      Some(super::MutationPhase::Failed)
+    );
+    assert!(!rig.handle.status().token.running);
+
+    let recovered = rig
+      .handle
+      .request_manual_token(None)
+      .expect("recovery token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(recovered.is_ok());
+    assert_eq!(rig.token.parse_calls(), 2);
+    assert_eq!(rig.token.unique_parse_worker_ids(), 1);
+    assert_eq!(rig.token.worker_name(), "codex-pacer-refresh-token");
+    assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn commit_panic_becomes_failure_and_worker_recovers() {
+    let rig = RuntimeTestRig::disabled();
+    rig.token.panic_once(PanicPhase::Commit);
+    let failed = rig
+      .handle
+      .request_manual_token(None)
+      .expect("failed token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      failed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::WorkerPanicked,
+        ..
+      })
+    ));
+
+    assert!(rig
+      .handle
+      .request_manual_token(None)
+      .expect("recovery token ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(rig.token.commit_calls(), 2);
+    assert_eq!(rig.token.unique_commit_worker_ids(), 1);
+    assert_eq!(rig.token.worker_name(), "codex-pacer-refresh-token");
+    assert_eq!(rig.activities.active(), 0);
+    assert!(rig.mutation_slot_is_free());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn fetch_panic_becomes_failure_and_worker_recovers() {
+    let rig = RuntimeTestRig::disabled();
+    rig.live.panic_once(PanicPhase::Fetch);
+    let failed = rig
+      .handle
+      .request_manual_live()
+      .expect("failed live ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      failed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::WorkerPanicked,
+        ..
+      })
+    ));
+
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("recovery live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(rig.live.fetch_calls(), 2);
+    assert_eq!(rig.live.unique_fetch_worker_ids(), 1);
+    assert_eq!(rig.live.worker_name(), "codex-pacer-refresh-live");
+    assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn persist_panic_becomes_failure_and_worker_recovers() {
+    let rig = RuntimeTestRig::disabled();
+    rig.live.panic_once(PanicPhase::Persist);
+    let failed = rig
+      .handle
+      .request_manual_live()
+      .expect("failed live ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      failed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::WorkerPanicked,
+        ..
+      })
+    ));
+
+    assert!(rig
+      .handle
+      .request_manual_live()
+      .expect("recovery live ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(rig.live.persist_calls(), 2);
+    assert_eq!(rig.live.unique_persist_worker_ids(), 1);
+    assert_eq!(rig.live.worker_name(), "codex-pacer-refresh-live");
+    assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn disabled_scheduler_runs_manual_requests() {
+    let rig = RuntimeTestRig::disabled();
+    assert!(!rig.handle.status().auto_scan_enabled);
+
+    let token = rig.handle.request_manual_token(None).expect("token ticket");
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    assert!(token.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.token.commit_calls(), 1);
+    assert_eq!(rig.live.persist_calls(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn scheduled_start_lag_is_recorded() {
+    let rig = RuntimeTestRig::scheduled_overdue(Duration::from_secs(2));
+    rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
+    rig.live.wait_for_fetch_calls(1, TEST_TIMEOUT);
+    rig.wait_until_idle(TEST_TIMEOUT);
+
+    let metrics = rig.metrics();
+    assert!(metrics.token.lane.scheduled_due_at.is_some());
+    assert!(metrics.live.lane.scheduled_due_at.is_some());
+    assert!(metrics.token.lane.started_at.is_some());
+    assert!(metrics.live.lane.started_at.is_some());
+    assert!(metrics.token.lane.start_lag_ms >= 1_000);
+    assert!(metrics.live.lane.start_lag_ms >= 1_000);
+    assert_eq!(metrics.start_lag_histogram.iter().sum::<u64>(), 2);
+    assert!(metrics.token.lane.duration_ms > 0);
+    assert!(metrics.live.lane.duration_ms > 0);
+    assert!(metrics.token.lane.last_success_age_ms.is_some());
+    assert!(metrics.live.lane.last_success_age_ms.is_some());
+    assert_eq!(metrics.token.lane.failure_streak, 0);
+    assert_eq!(metrics.live.lane.failure_streak, 0);
+    assert!(metrics.token.lane.retry_at.is_none());
+    assert!(metrics.live.lane.retry_at.is_none());
+    assert_eq!(metrics.token.lane.running_generation, None);
+    assert_eq!(metrics.live.lane.running_generation, None);
+    assert_eq!(metrics.token.lane.pending_reasons, 0);
+    assert_eq!(metrics.live.lane.pending_reasons, 0);
+    assert_eq!(metrics.token.append_fast_path_count, 0);
+    assert!(metrics.token.files_visited > 0);
+    assert!(metrics.token.bytes_read > 0);
+    assert!(metrics.token.full_rebuild_count > 0);
+    assert!(metrics.token.commit_wait_ms <= metrics.token.lane.duration_ms);
+    assert_eq!(metrics.token.database_busy_count, 0);
+    assert_eq!(metrics.live.last_query_timeout_ms, 10_000);
+    assert!(metrics.live.app_server_duration_ms > 0);
+    assert_eq!(metrics.live.timeout_count, 0);
+    assert_eq!(metrics.live.active_executor_count, 0);
+    assert_eq!(metrics.live.waiter_count, 0);
+    assert!(metrics.live.fallback_age_ms.is_none());
+    assert!(rig.handle.status().token.next_due_at.is_some());
+    assert!(rig.handle.status().live.next_due_at.is_some());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn start_lag_above_five_seconds_warns() {
+    let rig = RuntimeTestRig::scheduled_overdue(Duration::from_secs(7));
+    rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
+    rig.live.wait_for_fetch_calls(1, TEST_TIMEOUT);
+    rig.wait_until_idle(TEST_TIMEOUT);
+
+    let metrics = rig.metrics();
+    assert!(metrics.token.lane.start_lag_ms > 5_000);
+    assert!(metrics.live.lane.start_lag_ms > 5_000);
+    assert_eq!(metrics.start_lag_warning_count, 2);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn resume_starts_overdue_lanes_within_five_seconds() {
+    let rig = RuntimeTestRig::paused_clock();
+    rig.clock.advance(Duration::from_secs(61));
+    rig.handle.wake().expect("wake command");
+    rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
+    rig.live.wait_for_fetch_calls(1, TEST_TIMEOUT);
+
+    let metrics = rig.metrics();
+    assert!(metrics.token.lane.start_lag_ms <= 5_000);
+    assert!(metrics.live.lane.start_lag_ms <= 5_000);
+    rig.wait_until_idle(TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn token_parse_runs_before_usage_commit_lock() {
+    let rig = RuntimeTestRig::disabled();
+    let mutation = rig.hold_mutation_slot();
+    let parse = rig.token.block_next_parse();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+
+    parse.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.token.parse_calls(), 1);
+    assert_eq!(rig.token.commit_calls(), 0);
+    parse.release();
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+    assert_eq!(rig.token.commit_calls(), 0);
+    mutation.release();
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn held_usage_commit_lock_does_not_delay_live_lane() {
+    let rig = RuntimeTestRig::disabled();
+    let mutation = rig.hold_mutation_slot();
+    let token = rig.handle.request_manual_token(None).expect("token ticket");
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+
+    let fetch = rig.live.block_next_fetch();
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.live.fetch_calls(), 1);
+    assert_eq!(rig.token.commit_calls(), 0);
+    fetch.release();
+    assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+
+    mutation.release();
+    assert!(token.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn source_change_while_waiting_skips_token_commit() {
+    let rig = RuntimeTestRig::disabled();
+    let mutation = rig.hold_mutation_slot();
+    let old = rig.token.use_spooled_prepared_for_next_parse();
+    let replacement = rig.token.block_parse_call(2);
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+    rig
+      .handle
+      .update_settings(rig.config_with_source("replacement"))
+      .expect("source update");
+
+    mutation.release();
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::SourceChanged,
+        ..
+      })
+    ));
+    assert_eq!(rig.token.commit_calls(), 0);
+    old.wait_dropped(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 0);
+    replacement.wait_worker_ready(TEST_TIMEOUT);
+    replacement.release();
+    rig.token.wait_for_commit_calls(1, TEST_TIMEOUT);
+    assert_eq!(rig.token.commit_calls_for_source("replacement"), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn missing_or_mismatched_prepared_slot_fails_without_hang() {
+    let rig = RuntimeTestRig::disabled();
+    rig.token.omit_prepared_payload_once();
+    let missing = rig
+      .handle
+      .request_manual_token(None)
+      .expect("missing token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      missing,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::PreparedPayloadMissing,
+        ..
+      })
+    ));
+    assert!(!rig.handle.status().token.running);
+
+    rig.token.return_mismatched_prepared_once();
+    let malformed = rig
+      .handle
+      .request_manual_token(None)
+      .expect("malformed token ticket")
+      .wait_timeout(TEST_TIMEOUT);
+    assert!(matches!(
+      malformed,
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::PreparedPayloadMissing,
+        ..
+      })
+    ));
+    assert!(!rig.handle.status().token.running);
+
+    assert!(rig
+      .handle
+      .request_manual_token(None)
+      .expect("recovery token ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .is_ok());
+    assert_eq!(rig.token.commit_calls(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn duplicate_worker_outcome_is_ignored() {
+    let rig = RuntimeTestRig::disabled();
+    let first = rig
+      .handle
+      .request_manual_token(None)
+      .expect("token ticket")
+      .wait_timeout(TEST_TIMEOUT)
+      .expect("token result");
+    let completions = rig.events.completion_count();
+    rig.inject_duplicate_prepared_after_take(1);
+    rig.inject_duplicate_token_completion(1, Arc::clone(&first));
+    let next_parse = rig.token.block_parse_call(2);
+    let next = rig
+      .handle
+      .request_manual_token(None)
+      .expect("next token ticket");
+    next_parse.wait_worker_ready(TEST_TIMEOUT);
+    rig.inject_duplicate_token_completion(1, Arc::clone(&first));
+    rig.handle.barrier().expect("coordinator barrier");
+
+    assert_eq!(rig.events.completion_count(), completions);
+    assert_eq!(rig.handle.status().token.generation, Some(2));
+    next_parse.release();
+    assert!(next.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.shutdown();
+  }
+
+  #[test]
+  fn waiter_and_command_capacity_are_bounded() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let mut tickets = Vec::new();
+    tickets.push(rig.handle.request_manual_live().expect("first live ticket"));
+    fetch.wait_entered(TEST_TIMEOUT);
+    for _ in 1..REFRESH_WAITER_CAPACITY {
+      tickets.push(
+        rig
+          .handle
+          .request_manual_live()
+          .expect("bounded live ticket"),
+      );
+    }
+    assert!(matches!(
+      rig.handle.request_manual_live(),
+      Err(RefreshError::Busy)
+    ));
+    assert_eq!(
+      rig.metrics().live.waiter_count,
+      REFRESH_WAITER_CAPACITY as u64
+    );
+
+    let parse = rig.token.block_next_parse();
+    let active_token = rig
+      .handle
+      .request_manual_token(None)
+      .expect("active token ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+    let mut token_tickets = Vec::new();
+    for _ in 1..REFRESH_WAITER_CAPACITY {
+      match rig.handle.request_manual_token(None) {
+        Ok(ticket) => token_tickets.push(ticket),
+        Err(RefreshError::Busy) => break,
+        Err(error) => panic!("unexpected token capacity error: {error:?}"),
+      }
+    }
+    assert_eq!(token_tickets.len(), REFRESH_WAITER_CAPACITY - 1);
+    assert!(matches!(
+      rig.handle.request_manual_token(None),
+      Err(RefreshError::Busy)
+    ));
+    assert_eq!(rig.token_schedule_waiter_count(), REFRESH_WAITER_CAPACITY);
+
+    let pause = rig.pause_coordinator();
+    for _ in 0..super::RUNTIME_COMMAND_CAPACITY {
+      rig.handle.try_wake().expect("bounded command slot");
+    }
+    assert!(matches!(rig.handle.try_wake(), Err(RefreshError::Busy)));
+    pause.release();
+
+    fetch.release();
+    for ticket in tickets {
+      assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    }
+    parse.release();
+    assert!(active_token.wait_timeout(TEST_TIMEOUT).is_ok());
+    for ticket in token_tickets {
+      assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    }
+    assert!(
+      rig.handle.request_manual_live().is_ok(),
+      "live capacity recovers"
+    );
+    assert!(
+      rig.handle.request_manual_token(None).is_ok(),
+      "token capacity recovers"
+    );
+    rig.shutdown();
+  }
+
+  #[test]
+  fn fixed_counters_saturate_without_wrap() {
+    let counter = SaturatingCounter::new(u64::MAX - 1);
+    counter.increment();
+    counter.increment();
+    assert_eq!(counter.load(), u64::MAX);
+
+    let rig = RuntimeTestRig::disabled();
+    rig.metrics_handle.set_warning_count_for_test(u64::MAX - 1);
+    rig
+      .metrics_handle
+      .set_start_lag_bucket_for_test(super::HISTOGRAM_BUCKETS - 2, u64::MAX - 1);
+    rig.metrics_handle.record_start_lag(Duration::from_secs(6));
+    rig.metrics_handle.record_start_lag(Duration::from_secs(6));
+    let metrics = rig.metrics();
+    assert_eq!(metrics.start_lag_warning_count, u64::MAX);
+    assert_eq!(metrics.start_lag_histogram.len(), super::HISTOGRAM_BUCKETS);
+    assert_eq!(
+      metrics.start_lag_histogram[super::HISTOGRAM_BUCKETS - 2],
+      u64::MAX
+    );
+    rig.shutdown();
+  }
+
+  #[test]
+  fn coordinator_shutdown_resolves_waiters() {
+    let rig = RuntimeTestRig::disabled();
+    let parse = rig.token.block_next_parse();
+    let fetch = rig.live.block_next_fetch();
+    let token = rig.handle.request_manual_token(None).expect("token ticket");
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+    fetch.wait_entered(TEST_TIMEOUT);
+
+    let pause = rig.pause_coordinator();
+    for _ in 0..(super::RUNTIME_COMMAND_CAPACITY - 1) {
+      rig.handle.try_wake().expect("reserve final command slot");
+    }
+    let race = rig.start_intake_race_after_accept_check();
+    race.wait_checked(TEST_TIMEOUT);
+    let shutdown = rig.shutdown_in_background();
+    race.release();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    parse.release();
+    fetch.release();
+    pause.release();
+    assert!(matches!(
+      token.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    assert!(matches!(
+      live.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    assert!(matches!(
+      rig.handle.request_manual_live(),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    assert!(matches!(
+      race.wait_result(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+  }
+
+  #[test]
+  fn shutdown_during_parse_wait_drops_prepared() {
+    let rig = RuntimeTestRig::disabled();
+    let parse = rig.token.block_next_spooled_parse_with_drop_probe();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    parse.wait_entered(TEST_TIMEOUT);
+    let shutdown = rig.shutdown_in_background();
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+
+    parse.release();
+    parse.wait_dropped(TEST_TIMEOUT);
+    assert!(parse.used_spool());
+    shutdown.wait(TEST_TIMEOUT);
+    assert_eq!(rig.token.commit_calls(), 0);
+  }
+
+  #[test]
+  fn shutdown_with_prepared_slot_drops_spool() {
+    let rig = RuntimeTestRig::disabled();
+    let prepared = rig.install_spooled_prepared_slot_via_coordinator();
+    assert!(prepared.used_spool());
+
+    let shutdown = rig.runtime.shutdown_and_join().expect("shutdown");
+    prepared.wait_dropped(TEST_TIMEOUT);
+    assert!(shutdown.token_joined && shutdown.live_joined && shutdown.coordinator_joined);
+    assert!(rig.prepared_slot_is_empty_via_coordinator());
+  }
+
+  #[test]
+  fn shutdown_during_commit_queue_skips_commit_and_joins() {
+    let rig = RuntimeTestRig::disabled();
+    let mutation = rig.hold_mutation_slot();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    rig.token.wait_for_parse_calls(1, TEST_TIMEOUT);
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+
+    let shutdown = rig.shutdown_in_background();
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    mutation.release();
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.token_joined && joined.live_joined && joined.coordinator_joined);
+    assert_eq!(rig.token.commit_calls(), 0);
+  }
+
+  #[test]
+  fn shutdown_is_idempotent_and_joins_all_threads() {
+    let rig = RuntimeTestRig::disabled();
+    let first = rig.runtime.shutdown_and_join().expect("first shutdown");
+    let second = rig.runtime.shutdown_and_join().expect("second shutdown");
+
+    assert!(Arc::ptr_eq(&first, &second));
+    assert!(first.token_joined && first.live_joined && first.coordinator_joined);
+    assert_eq!(
+      rig.thread_names(),
+      [
+        "codex-pacer-refresh-coordinator",
+        "codex-pacer-refresh-live",
+        "codex-pacer-refresh-token",
+      ]
+    );
+  }
+
+  #[test]
+  fn shutdown_during_live_fetch_joins_after_bounded_completion() {
+    let rig = RuntimeTestRig::disabled();
+    let fetch = rig.live.block_next_fetch();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    assert_eq!(
+      rig.live.last_timeout(),
+      Some(crate::refresh::LIVE_QUERY_TIMEOUT)
+    );
+
+    let shutdown = rig.shutdown_in_background();
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Rejected {
+        code: RefreshRejectionCode::Shutdown,
+        ..
+      })
+    ));
+    assert!(
+      !shutdown.is_finished(),
+      "join waits for bounded in-flight fetch"
+    );
+    fetch.release();
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.live_joined && joined.token_joined && joined.coordinator_joined);
+    assert_eq!(rig.live.persist_calls(), 0);
+  }
+
+  #[test]
+  fn source_change_during_commit_is_not_published_as_success() {
+    let rig = RuntimeTestRig::disabled();
+    let commit = rig.token.block_next_commit();
+    let replacement = rig.token.block_parse_call(2);
+    let previous_success = rig.handle.status().token.last_success_at;
+    let invalidations = rig.events.invalidation_count();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+    commit.wait_entered(TEST_TIMEOUT);
+    rig
+      .handle
+      .update_settings(rig.config_with_source("replacement"))
+      .expect("source update during commit");
+    commit.release();
+
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::SourceChanged,
+        ..
+      })
+    ));
+    replacement.wait_worker_ready(TEST_TIMEOUT);
+    assert_eq!(rig.events.invalidation_count(), invalidations);
+    assert_eq!(rig.handle.status().token.last_success_at, previous_success);
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    replacement.release();
+    shutdown.wait(TEST_TIMEOUT);
+  }
+
+  #[test]
+  fn source_change_during_live_persist_is_not_published_as_success() {
+    let rig = RuntimeTestRig::disabled();
+    let persist = rig.live.block_next_persist();
+    let replacement = rig.token.block_parse_call(1);
+    let previous_success = rig.handle.status().live.last_success_at;
+    let invalidations = rig.events.invalidation_count();
+    let ticket = rig.handle.request_manual_live().expect("live ticket");
+    persist.wait_entered(TEST_TIMEOUT);
+    rig
+      .handle
+      .update_settings(rig.config_with_source("replacement"))
+      .expect("source update during persistence");
+    persist.release();
+
+    assert!(matches!(
+      ticket.wait_timeout(TEST_TIMEOUT),
+      Err(RefreshError::Failed {
+        code: RefreshFailureCode::SourceChanged,
+        ..
+      })
+    ));
+    replacement.wait_worker_ready(TEST_TIMEOUT);
+    assert_eq!(rig.events.invalidation_count(), invalidations);
+    assert_eq!(rig.handle.status().live.last_success_at, previous_success);
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    replacement.release();
+    shutdown.wait(TEST_TIMEOUT);
+  }
+
+  #[test]
+  fn persisted_success_age_survives_short_monotonic_uptime() {
+    let clock = TestClock::new();
+    let success = clock.wall_now() - ChronoDuration::hours(24);
+    let config = RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(60),
+      codex_home: None,
+      token_last_success_wall: Some(success),
+      live_last_success_wall: Some(success),
+    };
+    let status = RefreshStatus::new(&config);
+    assert_eq!(status.token.last_success_at, Some(success.to_rfc3339()));
+    assert_eq!(status.live.last_success_at, Some(success.to_rfc3339()));
+    let metrics = MetricsState::new(&config, &clock);
+    let first = metrics.snapshot(0, clock.monotonic_now());
+    assert!(first.token.lane.last_success_age_ms.unwrap() >= 86_400_000);
+    clock.advance(Duration::from_secs(2));
+    let second = metrics.snapshot(0, clock.monotonic_now());
+    assert!(
+      second.token.lane.last_success_age_ms.unwrap()
+        >= first.token.lane.last_success_age_ms.unwrap() + 2_000
+    );
+  }
+
+  #[test]
+  fn extreme_interval_status_timestamp_is_clamped_without_panic() {
+    let rig = RuntimeTestRig::huge_interval();
+    let status = rig.handle.status();
+    assert!(status.token.next_due_at.is_some());
+    assert!(status.live.next_due_at.is_some());
+    DateTime::parse_from_rfc3339(status.token.next_due_at.as_deref().unwrap())
+      .expect("clamped token deadline is RFC3339");
+    DateTime::parse_from_rfc3339(status.live.next_due_at.as_deref().unwrap())
+      .expect("clamped live deadline is RFC3339");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn activity_guard_excludes_wait_and_queue_time() {
+    let rig = RuntimeTestRig::disabled();
+    assert_eq!(rig.activities.active(), 0, "idle coordinator owns no guard");
+    let mutation = rig.hold_mutation_slot();
+    let parse = rig.token.block_next_parse();
+    let commit = rig.token.block_next_commit();
+    let ticket = rig.handle.request_manual_token(None).expect("token ticket");
+
+    parse.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 1, "parse body owns one guard");
+    parse.release();
+    mutation.wait_until_refresh_queued(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 0, "mutation wait owns no guard");
+
+    mutation.release();
+    commit.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 1, "commit body owns one guard");
+    commit.release();
+    assert!(ticket.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.activities.active(), 0);
+
+    let fetch = rig.live.block_next_fetch();
+    let persist = rig.live.block_next_persist();
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    fetch.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 1, "fetch body owns one guard");
+    fetch.release();
+    persist.wait_entered(TEST_TIMEOUT);
+    assert_eq!(rig.activities.active(), 1, "persist body owns one guard");
+    persist.release();
+    assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.activities.active(), 0);
+    rig.shutdown();
+  }
+}
+use super::power::{ActivityFactory, SystemActivityFactory};
+use super::{
+  CommitMarker, CoordinatorAction, CoordinatorEvent, CoordinatorState, DisplayInvalidation,
+  ExecutionCompletion, LiveExecutionRequest, LiveRequest, LiveWaiterId, MutationPriority,
+  RefreshCompletedEvent, RefreshConfig, RefreshDetail, RefreshFailureCode, RefreshRejectionCode,
+  RefreshWaiterOutcome, TokenExecutionRequest, TokenRequest, TokenWaiterId,
+  UsageMutationCoordinator, LIVE_QUERY_TIMEOUT, REFRESH_WAITER_CAPACITY,
+};
+use crate::importer::{PreparedScan, PreparedScanStats};
+use crate::models::{LiveRateLimitSnapshot, ScanResult};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use std::array;
+use std::collections::HashMap;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, SyncSender, TrySendError};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+pub(crate) const RUNTIME_COMMAND_CAPACITY: usize = REFRESH_WAITER_CAPACITY;
+const WORKER_COMMAND_CAPACITY: usize = 1;
+pub(crate) const HISTOGRAM_BUCKETS: usize = 8;
+const START_LAG_WARNING: Duration = Duration::from_secs(5);
+const HISTOGRAM_UPPER_BOUNDS_MS: [u64; HISTOGRAM_BUCKETS] =
+  [0, 10, 100, 500, 1_000, 5_000, 30_000, u64::MAX];
+
+pub(crate) trait TokenRefreshExecutor: Send + Sync {
+  fn parse(&self, request: TokenExecutionRequest) -> Result<PreparedTokenRefresh, String>;
+  fn commit(&self, prepared: PreparedTokenRefresh) -> Result<ScanResult, String>;
+}
+
+pub(crate) struct PreparedTokenRefresh {
+  pub generation: u64,
+  pub source_generation: u64,
+  pub started_at: DateTime<Utc>,
+  pub prepared_scan: PreparedScan,
+  #[cfg(test)]
+  drop_probe: Option<TestPreparedDropProbe>,
+  #[cfg(test)]
+  omit_payload: bool,
+}
+
+pub(crate) trait LiveQuotaFetcher: Send + Sync {
+  fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String>;
+
+  fn fallback(&self) -> Option<LiveRateLimitSnapshot> {
+    None
+  }
+}
+
+pub(crate) trait LiveQuotaPersister: Send + Sync {
+  fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String>;
+}
+
+pub(crate) trait RefreshEventSink: Send + Sync {
+  fn publish_invalidation(&self, value: DisplayInvalidation);
+  fn publish_completion(&self, value: RefreshCompletedEvent);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MutationPhase {
+  Queued,
+  Parsing,
+  WaitingToCommit,
+  Committed,
+  Failed,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LaneStatus {
+  pub running: bool,
+  pub generation: Option<u64>,
+  pub pending: bool,
+  pub last_success_at: Option<String>,
+  pub next_due_at: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RefreshStatus {
+  pub token: LaneStatus,
+  pub live: LaneStatus,
+  pub mutation_phase: Option<MutationPhase>,
+  pub source_generation: u64,
+  pub auto_scan_enabled: bool,
+}
+
+impl RefreshStatus {
+  fn new(config: &RefreshConfig) -> Self {
+    let token = LaneStatus {
+      running: false,
+      generation: None,
+      pending: false,
+      last_success_at: config
+        .token_last_success_wall
+        .map(|value| value.to_rfc3339()),
+      next_due_at: None,
+    };
+    let live = LaneStatus {
+      last_success_at: config
+        .live_last_success_wall
+        .map(|value| value.to_rfc3339()),
+      ..token.clone()
+    };
+    Self {
+      token,
+      live,
+      mutation_phase: None,
+      source_generation: 0,
+      auto_scan_enabled: config.auto_scan_enabled,
+    }
+  }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RefreshLaneMetrics {
+  pub scheduled_due_at: Option<String>,
+  pub started_at: Option<String>,
+  pub start_lag_ms: u64,
+  pub duration_ms: u64,
+  pub last_success_age_ms: Option<u64>,
+  pub failure_streak: u32,
+  pub retry_at: Option<String>,
+  pub missed_deadline_count: u64,
+  pub coalesced_trigger_count: u64,
+  pub running_generation: Option<u64>,
+  pub pending_reasons: u8,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct TokenRefreshMetrics {
+  pub lane: RefreshLaneMetrics,
+  pub files_visited: u64,
+  pub bytes_read: u64,
+  pub append_fast_path_count: u64,
+  pub full_rebuild_count: u64,
+  pub commit_wait_ms: u64,
+  pub database_busy_count: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct LiveRefreshMetrics {
+  pub lane: RefreshLaneMetrics,
+  pub app_server_duration_ms: u64,
+  pub last_query_timeout_ms: u64,
+  pub timeout_count: u64,
+  pub active_executor_count: u64,
+  pub waiter_count: u64,
+  pub fallback_age_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RefreshMetricsSnapshot {
+  pub token: TokenRefreshMetrics,
+  pub live: LiveRefreshMetrics,
+  pub start_lag_warning_count: u64,
+  pub active_live_warning_count: u64,
+  pub start_lag_histogram: [u64; HISTOGRAM_BUCKETS],
+  pub duration_histogram: [u64; HISTOGRAM_BUCKETS],
+}
+
+#[derive(Debug)]
+pub(crate) struct SaturatingCounter(AtomicU64);
+
+impl SaturatingCounter {
+  pub(crate) const fn new(value: u64) -> Self {
+    Self(AtomicU64::new(value))
+  }
+
+  pub(crate) fn increment(&self) -> u64 {
+    self.add(1)
+  }
+
+  pub(crate) fn add(&self, amount: u64) -> u64 {
+    let mut current = self.0.load(Ordering::Acquire);
+    loop {
+      let next = current.saturating_add(amount);
+      match self
+        .0
+        .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+      {
+        Ok(_) => return next,
+        Err(observed) => current = observed,
+      }
+    }
+  }
+
+  pub(crate) fn load(&self) -> u64 {
+    self.0.load(Ordering::Acquire)
+  }
+
+  #[cfg(test)]
+  fn store(&self, value: u64) {
+    self.0.store(value, Ordering::Release);
+  }
+}
+
+struct FixedHistogram {
+  buckets: [SaturatingCounter; HISTOGRAM_BUCKETS],
+}
+
+impl FixedHistogram {
+  fn new() -> Self {
+    Self {
+      buckets: array::from_fn(|_| SaturatingCounter::new(0)),
+    }
+  }
+
+  fn record(&self, duration: Duration) {
+    let value = duration_as_millis(duration);
+    let index = HISTOGRAM_UPPER_BOUNDS_MS
+      .iter()
+      .position(|upper| value <= *upper)
+      .unwrap_or(HISTOGRAM_BUCKETS - 1);
+    self.buckets[index].increment();
+  }
+
+  fn snapshot(&self) -> [u64; HISTOGRAM_BUCKETS] {
+    array::from_fn(|index| self.buckets[index].load())
+  }
+}
+
+#[derive(Default)]
+struct MetricsMutable {
+  token: TokenRefreshMetrics,
+  live: LiveRefreshMetrics,
+  token_last_success: Option<SuccessAgeAnchor>,
+  live_last_success: Option<SuccessAgeAnchor>,
+  token_started: Option<Instant>,
+  live_started: Option<Instant>,
+}
+
+struct SuccessAgeAnchor {
+  baseline_age: Duration,
+  observed_at: Instant,
+}
+
+struct MetricsState {
+  mutable: Mutex<MetricsMutable>,
+  start_lag_warning_count: SaturatingCounter,
+  active_live_warning_count: SaturatingCounter,
+  live_timeout_count: SaturatingCounter,
+  database_busy_count: SaturatingCounter,
+  active_live: AtomicU64,
+  start_lag_histogram: FixedHistogram,
+  duration_histogram: FixedHistogram,
+}
+
+impl MetricsState {
+  fn new(config: &RefreshConfig, clock: &dyn RefreshClock) -> Self {
+    let now = clock.monotonic_now();
+    Self {
+      mutable: Mutex::new(MetricsMutable {
+        token_last_success: config
+          .token_last_success_wall
+          .map(|wall| success_age_anchor(now, clock.wall_now(), wall)),
+        live_last_success: config
+          .live_last_success_wall
+          .map(|wall| success_age_anchor(now, clock.wall_now(), wall)),
+        ..MetricsMutable::default()
+      }),
+      start_lag_warning_count: SaturatingCounter::new(0),
+      active_live_warning_count: SaturatingCounter::new(0),
+      live_timeout_count: SaturatingCounter::new(0),
+      database_busy_count: SaturatingCounter::new(0),
+      active_live: AtomicU64::new(0),
+      start_lag_histogram: FixedHistogram::new(),
+      duration_histogram: FixedHistogram::new(),
+    }
+  }
+
+  fn snapshot(&self, waiter_count: usize, now: Instant) -> RefreshMetricsSnapshot {
+    let mut mutable = lock(&self.mutable);
+    mutable.token.lane.last_success_age_ms = mutable.token_last_success.as_ref().map(|success| {
+      duration_as_millis(
+        success
+          .baseline_age
+          .saturating_add(now.saturating_duration_since(success.observed_at)),
+      )
+    });
+    mutable.live.lane.last_success_age_ms = mutable.live_last_success.as_ref().map(|success| {
+      duration_as_millis(
+        success
+          .baseline_age
+          .saturating_add(now.saturating_duration_since(success.observed_at)),
+      )
+    });
+    mutable.live.waiter_count = waiter_count as u64;
+    mutable.live.active_executor_count = self.active_live.load(Ordering::Acquire);
+    mutable.live.timeout_count = self.live_timeout_count.load();
+    mutable.token.database_busy_count = self.database_busy_count.load();
+    RefreshMetricsSnapshot {
+      token: mutable.token.clone(),
+      live: mutable.live.clone(),
+      start_lag_warning_count: self.start_lag_warning_count.load(),
+      active_live_warning_count: self.active_live_warning_count.load(),
+      start_lag_histogram: self.start_lag_histogram.snapshot(),
+      duration_histogram: self.duration_histogram.snapshot(),
+    }
+  }
+
+  fn record_start_lag(&self, lag: Duration) {
+    self.start_lag_histogram.record(lag);
+    if lag > START_LAG_WARNING {
+      self.start_lag_warning_count.increment();
+      log::warn!("Refresh worker start lag exceeded five seconds.");
+    }
+  }
+
+  fn record_worker_start(
+    &self,
+    token: bool,
+    generation: u64,
+    due: Option<Instant>,
+    clock: &dyn RefreshClock,
+  ) {
+    let now = clock.monotonic_now();
+    let wall = clock.wall_now();
+    let lag = due.map_or(Duration::ZERO, |due| now.saturating_duration_since(due));
+    self.record_start_lag(lag);
+    let mut metrics = lock(&self.mutable);
+    let lane = if token {
+      metrics.token_started = Some(now);
+      &mut metrics.token.lane
+    } else {
+      metrics.live_started = Some(now);
+      &mut metrics.live.lane
+    };
+    lane.scheduled_due_at = due.map(|due| wall_time_for_instant(clock, due).to_rfc3339());
+    lane.started_at = Some(wall.to_rfc3339());
+    lane.start_lag_ms = duration_as_millis(lag);
+    lane.running_generation = Some(generation);
+  }
+
+  #[cfg(test)]
+  fn set_warning_count_for_test(&self, value: u64) {
+    self.start_lag_warning_count.store(value);
+  }
+
+  #[cfg(test)]
+  fn set_start_lag_bucket_for_test(&self, index: usize, value: u64) {
+    self.start_lag_histogram.buckets[index].store(value);
+  }
+}
+
+pub(crate) trait RefreshClock: Send + Sync {
+  fn monotonic_now(&self) -> Instant;
+  fn wall_now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Default)]
+struct SystemRefreshClock;
+
+impl RefreshClock for SystemRefreshClock {
+  fn monotonic_now(&self) -> Instant {
+    Instant::now()
+  }
+
+  fn wall_now(&self) -> DateTime<Utc> {
+    Utc::now()
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RefreshError {
+  Busy,
+  Failed {
+    code: RefreshFailureCode,
+    detail: Option<RefreshDetail>,
+  },
+  Rejected {
+    code: RefreshRejectionCode,
+    detail: Option<RefreshDetail>,
+  },
+  CoordinatorUnavailable,
+}
+
+pub(crate) struct ManualRefreshTicket<T> {
+  reply: Receiver<Result<Arc<T>, RefreshError>>,
+}
+
+impl<T> ManualRefreshTicket<T> {
+  pub(crate) fn wait(self) -> Result<Arc<T>, RefreshError> {
+    self
+      .reply
+      .recv()
+      .unwrap_or(Err(RefreshError::CoordinatorUnavailable))
+  }
+
+  pub(crate) fn wait_timeout(self, timeout: Duration) -> Result<Arc<T>, RefreshError> {
+    match self.reply.recv_timeout(timeout) {
+      Ok(result) => result,
+      Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => {
+        Err(RefreshError::CoordinatorUnavailable)
+      }
+    }
+  }
+}
+
+pub(crate) type ManualTokenTicket = ManualRefreshTicket<ScanResult>;
+pub(crate) type ManualLiveTicket = ManualRefreshTicket<LiveRateLimitSnapshot>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ShutdownResult {
+  pub coordinator_joined: bool,
+  pub token_joined: bool,
+  pub live_joined: bool,
+}
+
+struct WaiterRegistries {
+  token: HashMap<TokenWaiterId, SyncSender<Result<Arc<ScanResult>, RefreshError>>>,
+  live: HashMap<LiveWaiterId, SyncSender<Result<Arc<LiveRateLimitSnapshot>, RefreshError>>>,
+}
+
+impl WaiterRegistries {
+  fn new() -> Self {
+    Self {
+      token: HashMap::with_capacity(REFRESH_WAITER_CAPACITY),
+      live: HashMap::with_capacity(REFRESH_WAITER_CAPACITY),
+    }
+  }
+}
+
+struct IntakeState {
+  accepting: bool,
+  sender: SyncSender<RuntimeMessage>,
+  #[cfg(test)]
+  pause_after_check: Option<Arc<TestGateState>>,
+}
+
+struct HandleInner {
+  intake: Arc<Mutex<IntakeState>>,
+  waiters: Arc<Mutex<WaiterRegistries>>,
+  status: Arc<Mutex<RefreshStatus>>,
+  metrics: Arc<MetricsState>,
+  clock: Arc<dyn RefreshClock>,
+  next_token_waiter: AtomicU64,
+  next_live_waiter: AtomicU64,
+}
+
+#[derive(Clone)]
+pub(crate) struct RefreshCoordinatorHandle {
+  inner: Arc<HandleInner>,
+}
+
+impl RefreshCoordinatorHandle {
+  pub(crate) fn request_manual_token(
+    &self,
+    codex_home: Option<String>,
+  ) -> Result<ManualTokenTicket, RefreshError> {
+    let waiter = TokenWaiterId(next_id(&self.inner.next_token_waiter)?);
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    #[allow(unused_mut)]
+    let mut intake = lock(&self.inner.intake);
+    if !intake.accepting {
+      return Err(shutdown_error());
+    }
+    #[cfg(test)]
+    wait_on_optional_gate(&mut intake.pause_after_check);
+    {
+      let mut waiters = lock(&self.inner.waiters);
+      if waiters.token.len() >= REFRESH_WAITER_CAPACITY {
+        return Err(RefreshError::Busy);
+      }
+      waiters.token.insert(waiter, reply_tx);
+    }
+    let request = TokenRequest::manual_full_with_waiter(codex_home, waiter);
+    if let Err(error) = try_send_public(&intake.sender, RuntimeMessage::RequestToken(request)) {
+      lock(&self.inner.waiters).token.remove(&waiter);
+      return Err(error);
+    }
+    Ok(ManualRefreshTicket { reply: reply_rx })
+  }
+
+  pub(crate) fn request_manual_live(&self) -> Result<ManualLiveTicket, RefreshError> {
+    let waiter = LiveWaiterId(next_id(&self.inner.next_live_waiter)?);
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    #[allow(unused_mut)]
+    let mut intake = lock(&self.inner.intake);
+    if !intake.accepting {
+      return Err(shutdown_error());
+    }
+    #[cfg(test)]
+    wait_on_optional_gate(&mut intake.pause_after_check);
+    {
+      let mut waiters = lock(&self.inner.waiters);
+      if waiters.live.len() >= REFRESH_WAITER_CAPACITY {
+        return Err(RefreshError::Busy);
+      }
+      waiters.live.insert(waiter, reply_tx);
+    }
+    if let Err(error) = try_send_public(
+      &intake.sender,
+      RuntimeMessage::RequestLive(LiveRequest::manual(waiter)),
+    ) {
+      lock(&self.inner.waiters).live.remove(&waiter);
+      return Err(error);
+    }
+    Ok(ManualRefreshTicket { reply: reply_rx })
+  }
+
+  pub(crate) fn update_settings(&self, config: RefreshConfig) -> Result<(), RefreshError> {
+    self.send_acknowledged(|reply| RuntimeMessage::SettingsChanged(config, reply))
+  }
+
+  pub(crate) fn wake(&self) -> Result<(), RefreshError> {
+    self.send_acknowledged(RuntimeMessage::Wake)
+  }
+
+  pub(crate) fn try_wake(&self) -> Result<(), RefreshError> {
+    let intake = lock(&self.inner.intake);
+    if !intake.accepting {
+      return Err(shutdown_error());
+    }
+    try_send_public(&intake.sender, RuntimeMessage::WakeNoReply)
+  }
+
+  pub(crate) fn barrier(&self) -> Result<(), RefreshError> {
+    self.send_acknowledged(RuntimeMessage::Barrier)
+  }
+
+  fn send_acknowledged(
+    &self,
+    build: impl FnOnce(SyncSender<()>) -> RuntimeMessage,
+  ) -> Result<(), RefreshError> {
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    let intake = lock(&self.inner.intake);
+    if !intake.accepting {
+      return Err(shutdown_error());
+    }
+    try_send_public(&intake.sender, build(reply_tx))?;
+    drop(intake);
+    reply_rx
+      .recv()
+      .map_err(|_| RefreshError::CoordinatorUnavailable)
+  }
+
+  pub(crate) fn status(&self) -> RefreshStatus {
+    lock(&self.inner.status).clone()
+  }
+
+  pub(crate) fn metrics(&self) -> RefreshMetricsSnapshot {
+    let live_waiters = lock(&self.inner.waiters).live.len();
+    self
+      .inner
+      .metrics
+      .snapshot(live_waiters, self.inner.clock.monotonic_now())
+  }
+}
+
+pub(crate) struct RefreshRuntimeDependencies {
+  pub config: RefreshConfig,
+  pub token_executor: Arc<dyn TokenRefreshExecutor>,
+  pub live_fetcher: Arc<dyn LiveQuotaFetcher>,
+  pub live_persister: Arc<dyn LiveQuotaPersister>,
+  pub event_sink: Arc<dyn RefreshEventSink>,
+  pub mutation: UsageMutationCoordinator,
+  pub activity_factory: Arc<dyn ActivityFactory>,
+  pub clock: Arc<dyn RefreshClock>,
+  #[cfg(test)]
+  test_hooks: Option<Arc<RuntimeTestHooks>>,
+}
+
+impl RefreshRuntimeDependencies {
+  #[allow(dead_code)]
+  pub(crate) fn with_system_defaults(
+    config: RefreshConfig,
+    token_executor: Arc<dyn TokenRefreshExecutor>,
+    live_fetcher: Arc<dyn LiveQuotaFetcher>,
+    live_persister: Arc<dyn LiveQuotaPersister>,
+    event_sink: Arc<dyn RefreshEventSink>,
+    mutation: UsageMutationCoordinator,
+  ) -> Self {
+    Self {
+      config,
+      token_executor,
+      live_fetcher,
+      live_persister,
+      event_sink,
+      mutation,
+      activity_factory: Arc::new(SystemActivityFactory),
+      clock: Arc::new(SystemRefreshClock),
+      #[cfg(test)]
+      test_hooks: None,
+    }
+  }
+}
+
+enum ShutdownLifecycle {
+  Running,
+  ShuttingDown,
+  Complete(Arc<ShutdownResult>),
+  Failed(RefreshError),
+}
+
+struct RuntimeLifecycle {
+  state: Mutex<ShutdownLifecycle>,
+  changed: Condvar,
+  coordinator: Mutex<Option<JoinHandle<()>>>,
+  intake: Arc<Mutex<IntakeState>>,
+  shutdown_requested: Arc<AtomicBool>,
+  shutdown: Arc<AtomicBool>,
+}
+
+pub(crate) struct RefreshRuntime {
+  handle: RefreshCoordinatorHandle,
+  lifecycle: Arc<RuntimeLifecycle>,
+  #[cfg(test)]
+  test_hooks: Arc<RuntimeTestHooks>,
+}
+
+impl RefreshRuntime {
+  pub(crate) fn start(dependencies: RefreshRuntimeDependencies) -> Result<Self, String> {
+    start_runtime(dependencies)
+  }
+
+  pub(crate) fn handle(&self) -> RefreshCoordinatorHandle {
+    self.handle.clone()
+  }
+
+  pub(crate) fn shutdown_and_join(&self) -> Result<Arc<ShutdownResult>, RefreshError> {
+    let owns_shutdown = {
+      let mut state = lock(&self.lifecycle.state);
+      loop {
+        match &*state {
+          ShutdownLifecycle::Complete(result) => return Ok(Arc::clone(result)),
+          ShutdownLifecycle::Failed(error) => return Err(error.clone()),
+          ShutdownLifecycle::Running => {
+            *state = ShutdownLifecycle::ShuttingDown;
+            break true;
+          }
+          ShutdownLifecycle::ShuttingDown => {
+            state = self
+              .lifecycle
+              .changed
+              .wait(state)
+              .unwrap_or_else(|poisoned| poisoned.into_inner());
+          }
+        }
+      }
+    };
+
+    if owns_shutdown {
+      let operation: Result<Arc<ShutdownResult>, RefreshError> = (|| {
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        {
+          let mut intake = lock(&self.lifecycle.intake);
+          intake.accepting = false;
+          let shutdown_state = lock(&self.lifecycle.state);
+          self
+            .lifecycle
+            .shutdown_requested
+            .store(true, Ordering::Release);
+          self.lifecycle.changed.notify_all();
+          drop(shutdown_state);
+          intake
+            .sender
+            .send(RuntimeMessage::Shutdown(reply_tx))
+            .map_err(|_| RefreshError::CoordinatorUnavailable)?;
+        }
+        let mut result = reply_rx
+          .recv()
+          .map_err(|_| RefreshError::CoordinatorUnavailable)?;
+        if let Some(coordinator) = lock(&self.lifecycle.coordinator).take() {
+          coordinator
+            .join()
+            .map_err(|_| RefreshError::CoordinatorUnavailable)?;
+          result.coordinator_joined = true;
+        }
+        Ok(Arc::new(result))
+      })();
+      let mut state = lock(&self.lifecycle.state);
+      match &operation {
+        Ok(result) => *state = ShutdownLifecycle::Complete(Arc::clone(result)),
+        Err(error) => *state = ShutdownLifecycle::Failed(error.clone()),
+      }
+      drop(state);
+      self.lifecycle.changed.notify_all();
+      return operation;
+    }
+    unreachable!("shutdown owner is selected in the lifecycle loop")
+  }
+}
+
+fn next_id(sequence: &AtomicU64) -> Result<u64, RefreshError> {
+  let mut current = sequence.load(Ordering::Acquire);
+  loop {
+    if current == u64::MAX {
+      return Err(RefreshError::Busy);
+    }
+    let next = current + 1;
+    match sequence.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+      Ok(_) => return Ok(next),
+      Err(observed) => current = observed,
+    }
+  }
+}
+
+fn try_send_public(
+  sender: &SyncSender<RuntimeMessage>,
+  message: RuntimeMessage,
+) -> Result<(), RefreshError> {
+  match sender.try_send(message) {
+    Ok(()) => Ok(()),
+    Err(TrySendError::Full(_)) => Err(RefreshError::Busy),
+    Err(TrySendError::Disconnected(_)) => Err(RefreshError::CoordinatorUnavailable),
+  }
+}
+
+fn shutdown_error() -> RefreshError {
+  RefreshError::Rejected {
+    code: RefreshRejectionCode::Shutdown,
+    detail: None,
+  }
+}
+
+fn duration_as_millis(value: Duration) -> u64 {
+  value.as_millis().min(u64::MAX as u128) as u64
+}
+
+fn lock<T>(value: &Mutex<T>) -> MutexGuard<'_, T> {
+  value
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+enum RuntimeMessage {
+  RequestToken(TokenRequest),
+  RequestLive(LiveRequest),
+  SettingsChanged(RefreshConfig, SyncSender<()>),
+  Wake(SyncSender<()>),
+  WakeNoReply,
+  Barrier(SyncSender<()>),
+  Worker(WorkerOutcome),
+  Shutdown(SyncSender<ShutdownResult>),
+  #[cfg(test)]
+  PauseCoordinator(Arc<TestGateState>, SyncSender<()>),
+  #[cfg(test)]
+  InstallPreparedSlot(PreparedTokenRefresh, SyncSender<()>),
+  #[cfg(test)]
+  PreparedSlotEmpty(SyncSender<bool>),
+}
+
+enum WorkerOutcome {
+  Token(TokenWorkerOutcome),
+  Live(LiveWorkerOutcome),
+  Exited(WorkerLane),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkerLane {
+  Token,
+  Live,
+}
+
+enum TokenWorkerCommand {
+  Parse(TokenExecutionRequest),
+  Commit(PreparedTokenRefresh),
+}
+
+enum LiveWorkerCommand {
+  Run(LiveExecutionRequest),
+}
+
+enum TokenWorkerOutcome {
+  Prepared {
+    expected_generation: u64,
+    expected_source_generation: u64,
+    prepared: PreparedTokenRefresh,
+  },
+  PreparedMissing {
+    generation: u64,
+    source_generation: u64,
+  },
+  Committed {
+    generation: u64,
+    source_generation: u64,
+    result: Arc<ScanResult>,
+    commit: CommitMarker,
+    queue_wait: Duration,
+  },
+  Failed {
+    generation: u64,
+    source_generation: u64,
+    code: RefreshFailureCode,
+    detail: RefreshDetail,
+    queue_wait: Option<Duration>,
+  },
+  Stale {
+    generation: u64,
+    source_generation: u64,
+  },
+}
+
+enum LiveWorkerOutcome {
+  Completed {
+    generation: u64,
+    source_generation: u64,
+    snapshot: Arc<LiveRateLimitSnapshot>,
+    commit: CommitMarker,
+    fetch_duration: Duration,
+  },
+  Failed {
+    generation: u64,
+    source_generation: u64,
+    code: RefreshFailureCode,
+    detail: RefreshDetail,
+    fetch_duration: Duration,
+  },
+  Stale {
+    generation: u64,
+    source_generation: u64,
+  },
+}
+
+struct PreparedSlot {
+  generation: u64,
+  source_generation: u64,
+  prepared: PreparedTokenRefresh,
+}
+
+struct CoordinatorRuntime {
+  schedule: CoordinatorState,
+  prepared_slot: Option<PreparedSlot>,
+  token_commit_dispatched: Option<(u64, u64)>,
+  current_token_result: Option<(u64, Arc<ScanResult>)>,
+  current_live_result: Option<(u64, Arc<LiveRateLimitSnapshot>)>,
+  token_sender: Option<SyncSender<TokenWorkerCommand>>,
+  live_sender: Option<SyncSender<LiveWorkerCommand>>,
+  waiters: Arc<Mutex<WaiterRegistries>>,
+  status: Arc<Mutex<RefreshStatus>>,
+  metrics: Arc<MetricsState>,
+  event_sink: Arc<dyn RefreshEventSink>,
+  clock: Arc<dyn RefreshClock>,
+  source_generation: Arc<AtomicU64>,
+  shutdown: Arc<AtomicBool>,
+  shutdown_requested: Arc<AtomicBool>,
+  token_handle: Option<JoinHandle<()>>,
+  live_handle: Option<JoinHandle<()>>,
+  token_exited: bool,
+  live_exited: bool,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRuntime, String> {
+  let RefreshRuntimeDependencies {
+    config,
+    token_executor,
+    live_fetcher,
+    live_persister,
+    event_sink,
+    mutation,
+    activity_factory,
+    clock,
+    #[cfg(test)]
+    test_hooks,
+  } = dependencies;
+  let (runtime_tx, runtime_rx) = mpsc::sync_channel(RUNTIME_COMMAND_CAPACITY);
+  let (token_tx, token_rx) = mpsc::sync_channel(WORKER_COMMAND_CAPACITY);
+  let (live_tx, live_rx) = mpsc::sync_channel(WORKER_COMMAND_CAPACITY);
+  let waiters = Arc::new(Mutex::new(WaiterRegistries::new()));
+  let status = Arc::new(Mutex::new(RefreshStatus::new(&config)));
+  let metrics = Arc::new(MetricsState::new(&config, &*clock));
+  let source_generation = Arc::new(AtomicU64::new(0));
+  let shutdown = Arc::new(AtomicBool::new(false));
+  let shutdown_requested = Arc::new(AtomicBool::new(false));
+  let commit_sequence = Arc::new(SaturatingCounter::new(0));
+  #[cfg(test)]
+  let hooks = test_hooks.unwrap_or_else(|| Arc::new(RuntimeTestHooks::default()));
+  #[cfg(test)]
+  let returned_hooks = Arc::clone(&hooks);
+
+  let token_handle = spawn_token_worker(TokenWorkerParameters {
+    receiver: token_rx,
+    runtime_sender: runtime_tx.clone(),
+    executor: token_executor,
+    mutation,
+    activity_factory: Arc::clone(&activity_factory),
+    status: Arc::clone(&status),
+    metrics: Arc::clone(&metrics),
+    source_generation: Arc::clone(&source_generation),
+    shutdown: Arc::clone(&shutdown),
+    shutdown_requested: Arc::clone(&shutdown_requested),
+    commit_sequence: Arc::clone(&commit_sequence),
+    clock: Arc::clone(&clock),
+    #[cfg(test)]
+    hooks: Arc::clone(&hooks),
+  })?;
+  let live_handle = spawn_live_worker(LiveWorkerParameters {
+    receiver: live_rx,
+    runtime_sender: runtime_tx.clone(),
+    fetcher: live_fetcher,
+    persister: live_persister,
+    activity_factory,
+    status: Arc::clone(&status),
+    metrics: Arc::clone(&metrics),
+    source_generation: Arc::clone(&source_generation),
+    shutdown: Arc::clone(&shutdown),
+    shutdown_requested: Arc::clone(&shutdown_requested),
+    commit_sequence,
+    clock: Arc::clone(&clock),
+    #[cfg(test)]
+    hooks: Arc::clone(&hooks),
+  })?;
+
+  let shared_intake = Arc::new(Mutex::new(IntakeState {
+    accepting: true,
+    sender: runtime_tx,
+    #[cfg(test)]
+    pause_after_check: None,
+  }));
+  let handle = RefreshCoordinatorHandle {
+    inner: Arc::new(HandleInner {
+      intake: Arc::clone(&shared_intake),
+      waiters: Arc::clone(&waiters),
+      status: Arc::clone(&status),
+      metrics: Arc::clone(&metrics),
+      clock: Arc::clone(&clock),
+      next_token_waiter: AtomicU64::new(0),
+      next_live_waiter: AtomicU64::new(0),
+    }),
+  };
+
+  let schedule = CoordinatorState::new(config, clock.monotonic_now(), clock.wall_now());
+  let coordinator_runtime = CoordinatorRuntime {
+    schedule,
+    prepared_slot: None,
+    token_commit_dispatched: None,
+    current_token_result: None,
+    current_live_result: None,
+    token_sender: Some(token_tx),
+    live_sender: Some(live_tx),
+    waiters,
+    status,
+    metrics,
+    event_sink,
+    clock,
+    source_generation,
+    shutdown: Arc::clone(&shutdown),
+    shutdown_requested: Arc::clone(&shutdown_requested),
+    token_handle: Some(token_handle),
+    live_handle: Some(live_handle),
+    token_exited: false,
+    live_exited: false,
+    #[cfg(test)]
+    hooks,
+  };
+  coordinator_runtime.sync_schedule_snapshot();
+  let coordinator = thread::Builder::new()
+    .name("codex-pacer-refresh-coordinator".to_string())
+    .spawn(move || coordinator_loop(runtime_rx, coordinator_runtime))
+    .map_err(|error| format!("Failed to start refresh coordinator: {error}"))?;
+
+  let lifecycle = Arc::new(RuntimeLifecycle {
+    state: Mutex::new(ShutdownLifecycle::Running),
+    changed: Condvar::new(),
+    coordinator: Mutex::new(Some(coordinator)),
+    intake: shared_intake,
+    shutdown_requested,
+    shutdown,
+  });
+  Ok(RefreshRuntime {
+    handle,
+    lifecycle,
+    #[cfg(test)]
+    test_hooks: returned_hooks,
+  })
+}
+
+struct TokenWorkerParameters {
+  receiver: Receiver<TokenWorkerCommand>,
+  runtime_sender: SyncSender<RuntimeMessage>,
+  executor: Arc<dyn TokenRefreshExecutor>,
+  mutation: UsageMutationCoordinator,
+  activity_factory: Arc<dyn ActivityFactory>,
+  status: Arc<Mutex<RefreshStatus>>,
+  metrics: Arc<MetricsState>,
+  source_generation: Arc<AtomicU64>,
+  shutdown: Arc<AtomicBool>,
+  shutdown_requested: Arc<AtomicBool>,
+  commit_sequence: Arc<SaturatingCounter>,
+  clock: Arc<dyn RefreshClock>,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn spawn_token_worker(parameters: TokenWorkerParameters) -> Result<JoinHandle<()>, String> {
+  thread::Builder::new()
+    .name("codex-pacer-refresh-token".to_string())
+    .spawn(move || {
+      let sender = parameters.runtime_sender.clone();
+      #[cfg(test)]
+      parameters.hooks.record_thread_name();
+      let _ = panic::catch_unwind(AssertUnwindSafe(|| token_worker_loop(parameters)));
+      let _ = sender.send(RuntimeMessage::Worker(WorkerOutcome::Exited(
+        WorkerLane::Token,
+      )));
+    })
+    .map_err(|error| format!("Failed to start token refresh worker: {error}"))
+}
+
+fn token_worker_loop(parameters: TokenWorkerParameters) {
+  while let Ok(command) = parameters.receiver.recv() {
+    let outcome = match command {
+      TokenWorkerCommand::Parse(request) => run_token_parse(&parameters, request),
+      TokenWorkerCommand::Commit(prepared) => run_token_commit(&parameters, prepared),
+    };
+    if parameters
+      .runtime_sender
+      .send(RuntimeMessage::Worker(WorkerOutcome::Token(outcome)))
+      .is_err()
+    {
+      return;
+    }
+  }
+}
+
+fn run_token_parse(
+  parameters: &TokenWorkerParameters,
+  request: TokenExecutionRequest,
+) -> TokenWorkerOutcome {
+  let generation = request.generation;
+  let source_generation = request.source_generation;
+  if parameters.shutdown.load(Ordering::Acquire)
+    || parameters.shutdown_requested.load(Ordering::Acquire)
+    || parameters.source_generation.load(Ordering::Acquire) != source_generation
+  {
+    return TokenWorkerOutcome::Stale {
+      generation,
+      source_generation,
+    };
+  }
+  set_mutation_phase(&parameters.status, MutationPhase::Parsing);
+  #[cfg(test)]
+  parameters.hooks.before_token_parse();
+  parameters.metrics.record_worker_start(
+    true,
+    generation,
+    request.request.planned_due_at,
+    &*parameters.clock,
+  );
+  let result = panic::catch_unwind(AssertUnwindSafe(|| {
+    let _activity = parameters.activity_factory.begin();
+    parameters.executor.parse(request)
+  }));
+  match result {
+    Ok(Ok(prepared)) => {
+      #[cfg(test)]
+      if prepared.omit_payload_for_test() {
+        return TokenWorkerOutcome::PreparedMissing {
+          generation,
+          source_generation,
+        };
+      }
+      TokenWorkerOutcome::Prepared {
+        expected_generation: generation,
+        expected_source_generation: source_generation,
+        prepared,
+      }
+    }
+    Ok(Err(detail)) => TokenWorkerOutcome::Failed {
+      generation,
+      source_generation,
+      code: RefreshFailureCode::ExecutionFailed,
+      detail: RefreshDetail::new(detail),
+      queue_wait: None,
+    },
+    Err(_) => TokenWorkerOutcome::Failed {
+      generation,
+      source_generation,
+      code: RefreshFailureCode::WorkerPanicked,
+      detail: RefreshDetail::new("token parse executor panicked"),
+      queue_wait: None,
+    },
+  }
+}
+
+enum CommitAttempt {
+  Committed(Result<ScanResult, String>),
+  Panicked,
+  Stale,
+}
+
+fn run_token_commit(
+  parameters: &TokenWorkerParameters,
+  prepared: PreparedTokenRefresh,
+) -> TokenWorkerOutcome {
+  let generation = prepared.generation;
+  let source_generation = prepared.source_generation;
+  set_mutation_phase(&parameters.status, MutationPhase::WaitingToCommit);
+  #[cfg(test)]
+  parameters.hooks.notify_token_waiting_to_commit();
+  let mutation = parameters.mutation.run(MutationPriority::Refresh, || {
+    if parameters.shutdown.load(Ordering::Acquire)
+      || parameters.shutdown_requested.load(Ordering::Acquire)
+      || parameters.source_generation.load(Ordering::Acquire) != source_generation
+    {
+      drop(prepared);
+      return CommitAttempt::Stale;
+    }
+    #[cfg(test)]
+    parameters.hooks.before_token_commit();
+    match panic::catch_unwind(AssertUnwindSafe(|| {
+      let _activity = parameters.activity_factory.begin();
+      parameters.executor.commit(prepared)
+    })) {
+      Ok(result) => CommitAttempt::Committed(result),
+      Err(_) => CommitAttempt::Panicked,
+    }
+  });
+  {
+    let mut metrics = lock(&parameters.metrics.mutable);
+    metrics.token.commit_wait_ms = duration_as_millis(mutation.queue_wait);
+  }
+  match mutation.value {
+    CommitAttempt::Committed(Ok(result)) => {
+      if parameters.shutdown_requested.load(Ordering::Acquire)
+        || parameters.shutdown.load(Ordering::Acquire)
+        || parameters.source_generation.load(Ordering::Acquire) != source_generation
+      {
+        drop(result);
+        set_mutation_phase(&parameters.status, MutationPhase::Failed);
+        return TokenWorkerOutcome::Stale {
+          generation,
+          source_generation,
+        };
+      }
+      set_mutation_phase(&parameters.status, MutationPhase::Committed);
+      let result = Arc::new(result);
+      #[cfg(test)]
+      parameters
+        .hooks
+        .record_token_arc(generation, Arc::clone(&result));
+      TokenWorkerOutcome::Committed {
+        generation,
+        source_generation,
+        result,
+        commit: CommitMarker {
+          sequence: parameters.commit_sequence.increment(),
+          committed_at: parameters.clock.monotonic_now(),
+        },
+        queue_wait: mutation.queue_wait,
+      }
+    }
+    CommitAttempt::Committed(Err(detail)) => {
+      set_mutation_phase(&parameters.status, MutationPhase::Failed);
+      if is_database_busy(&detail) {
+        parameters.metrics.database_busy_count.increment();
+      }
+      TokenWorkerOutcome::Failed {
+        generation,
+        source_generation,
+        code: RefreshFailureCode::ExecutionFailed,
+        detail: RefreshDetail::new(detail),
+        queue_wait: Some(mutation.queue_wait),
+      }
+    }
+    CommitAttempt::Panicked => {
+      set_mutation_phase(&parameters.status, MutationPhase::Failed);
+      TokenWorkerOutcome::Failed {
+        generation,
+        source_generation,
+        code: RefreshFailureCode::WorkerPanicked,
+        detail: RefreshDetail::new("token commit executor panicked"),
+        queue_wait: Some(mutation.queue_wait),
+      }
+    }
+    CommitAttempt::Stale => TokenWorkerOutcome::Stale {
+      generation,
+      source_generation,
+    },
+  }
+}
+
+struct LiveWorkerParameters {
+  receiver: Receiver<LiveWorkerCommand>,
+  runtime_sender: SyncSender<RuntimeMessage>,
+  fetcher: Arc<dyn LiveQuotaFetcher>,
+  persister: Arc<dyn LiveQuotaPersister>,
+  activity_factory: Arc<dyn ActivityFactory>,
+  status: Arc<Mutex<RefreshStatus>>,
+  metrics: Arc<MetricsState>,
+  source_generation: Arc<AtomicU64>,
+  shutdown: Arc<AtomicBool>,
+  shutdown_requested: Arc<AtomicBool>,
+  commit_sequence: Arc<SaturatingCounter>,
+  clock: Arc<dyn RefreshClock>,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn spawn_live_worker(parameters: LiveWorkerParameters) -> Result<JoinHandle<()>, String> {
+  thread::Builder::new()
+    .name("codex-pacer-refresh-live".to_string())
+    .spawn(move || {
+      let sender = parameters.runtime_sender.clone();
+      #[cfg(test)]
+      parameters.hooks.record_thread_name();
+      let _ = panic::catch_unwind(AssertUnwindSafe(|| live_worker_loop(parameters)));
+      let _ = sender.send(RuntimeMessage::Worker(WorkerOutcome::Exited(
+        WorkerLane::Live,
+      )));
+    })
+    .map_err(|error| format!("Failed to start live refresh worker: {error}"))
+}
+
+fn live_worker_loop(parameters: LiveWorkerParameters) {
+  while let Ok(LiveWorkerCommand::Run(request)) = parameters.receiver.recv() {
+    let outcome = run_live_refresh(&parameters, request);
+    if parameters
+      .runtime_sender
+      .send(RuntimeMessage::Worker(WorkerOutcome::Live(outcome)))
+      .is_err()
+    {
+      return;
+    }
+  }
+}
+
+fn run_live_refresh(
+  parameters: &LiveWorkerParameters,
+  request: LiveExecutionRequest,
+) -> LiveWorkerOutcome {
+  if parameters.shutdown.load(Ordering::Acquire)
+    || parameters.shutdown_requested.load(Ordering::Acquire)
+    || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
+  {
+    return LiveWorkerOutcome::Stale {
+      generation: request.generation,
+      source_generation: request.source_generation,
+    };
+  }
+  #[cfg(test)]
+  parameters.hooks.before_live_fetch();
+  parameters.metrics.record_worker_start(
+    false,
+    request.generation,
+    request.planned_due_at,
+    &*parameters.clock,
+  );
+  let previous = increment_saturating_atomic(&parameters.metrics.active_live).saturating_sub(1);
+  let active_guard = ActiveLiveGuard {
+    active: &parameters.metrics.active_live,
+  };
+  if previous >= 1 {
+    parameters.metrics.active_live_warning_count.increment();
+    log::warn!("More than one live quota executor became active.");
+  }
+  let fetch_started = Instant::now();
+  let fetched = panic::catch_unwind(AssertUnwindSafe(|| {
+    let _activity = parameters.activity_factory.begin();
+    parameters.fetcher.fetch(LIVE_QUERY_TIMEOUT)
+  }));
+  let fetch_duration = fetch_started.elapsed();
+  drop(active_guard);
+  {
+    let mut metrics = lock(&parameters.metrics.mutable);
+    metrics.live.app_server_duration_ms = nonzero_duration_millis(fetch_duration);
+    metrics.live.last_query_timeout_ms = duration_as_millis(LIVE_QUERY_TIMEOUT);
+  }
+  let snapshot = match fetched {
+    Ok(Ok(snapshot)) => snapshot,
+    Ok(Err(detail)) => {
+      let normalized = detail.to_ascii_lowercase();
+      if normalized.contains("timeout") || normalized.contains("timed out") {
+        parameters.metrics.live_timeout_count.increment();
+      }
+      return LiveWorkerOutcome::Failed {
+        generation: request.generation,
+        source_generation: request.source_generation,
+        code: RefreshFailureCode::ExecutionFailed,
+        detail: RefreshDetail::new(detail),
+        fetch_duration,
+      };
+    }
+    Err(_) => {
+      return LiveWorkerOutcome::Failed {
+        generation: request.generation,
+        source_generation: request.source_generation,
+        code: RefreshFailureCode::WorkerPanicked,
+        detail: RefreshDetail::new("live fetch executor panicked"),
+        fetch_duration,
+      };
+    }
+  };
+  if parameters.shutdown_requested.load(Ordering::Acquire)
+    || parameters.shutdown.load(Ordering::Acquire)
+    || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
+  {
+    drop(snapshot);
+    return LiveWorkerOutcome::Stale {
+      generation: request.generation,
+      source_generation: request.source_generation,
+    };
+  }
+  #[cfg(test)]
+  parameters.hooks.before_live_persist();
+  let persisted = panic::catch_unwind(AssertUnwindSafe(|| {
+    let _activity = parameters.activity_factory.begin();
+    parameters.persister.persist(&snapshot)
+  }));
+  match persisted {
+    Ok(Ok(())) => {
+      if parameters.shutdown_requested.load(Ordering::Acquire)
+        || parameters.shutdown.load(Ordering::Acquire)
+        || parameters.source_generation.load(Ordering::Acquire) != request.source_generation
+      {
+        return LiveWorkerOutcome::Stale {
+          generation: request.generation,
+          source_generation: request.source_generation,
+        };
+      }
+      let snapshot = Arc::new(snapshot);
+      #[cfg(test)]
+      parameters
+        .hooks
+        .record_live_arc(request.generation, Arc::clone(&snapshot));
+      LiveWorkerOutcome::Completed {
+        generation: request.generation,
+        source_generation: request.source_generation,
+        snapshot,
+        commit: CommitMarker {
+          sequence: parameters.commit_sequence.increment(),
+          committed_at: parameters.clock.monotonic_now(),
+        },
+        fetch_duration,
+      }
+    }
+    Ok(Err(detail)) => LiveWorkerOutcome::Failed {
+      generation: request.generation,
+      source_generation: request.source_generation,
+      code: RefreshFailureCode::ExecutionFailed,
+      detail: RefreshDetail::new(detail),
+      fetch_duration,
+    },
+    Err(_) => LiveWorkerOutcome::Failed {
+      generation: request.generation,
+      source_generation: request.source_generation,
+      code: RefreshFailureCode::WorkerPanicked,
+      detail: RefreshDetail::new("live persist executor panicked"),
+      fetch_duration,
+    },
+  }
+}
+
+fn set_mutation_phase(status: &Mutex<RefreshStatus>, phase: MutationPhase) {
+  lock(status).mutation_phase = Some(phase);
+}
+
+fn is_database_busy(detail: &str) -> bool {
+  let detail = detail.to_ascii_lowercase();
+  detail.contains("database is locked") || detail.contains("database busy")
+}
+
+fn nonzero_duration_millis(value: Duration) -> u64 {
+  if value.is_zero() {
+    0
+  } else {
+    duration_as_millis(value).max(1)
+  }
+}
+
+fn wall_time_for_instant(clock: &dyn RefreshClock, target: Instant) -> DateTime<Utc> {
+  let monotonic_now = clock.monotonic_now();
+  let wall_now = clock.wall_now();
+  if target >= monotonic_now {
+    wall_now
+      .checked_add_signed(
+        ChronoDuration::from_std(target.duration_since(monotonic_now))
+          .unwrap_or(ChronoDuration::MAX),
+      )
+      .unwrap_or_else(rfc3339_max_utc)
+  } else {
+    wall_now
+      .checked_sub_signed(
+        ChronoDuration::from_std(monotonic_now.duration_since(target))
+          .unwrap_or(ChronoDuration::MAX),
+      )
+      .unwrap_or_else(rfc3339_min_utc)
+  }
+}
+
+fn rfc3339_max_utc() -> DateTime<Utc> {
+  DateTime::parse_from_rfc3339("9999-12-31T23:59:59.999999999Z")
+    .expect("RFC3339 maximum timestamp is valid")
+    .with_timezone(&Utc)
+}
+
+fn rfc3339_min_utc() -> DateTime<Utc> {
+  DateTime::parse_from_rfc3339("0001-01-01T00:00:00Z")
+    .expect("RFC3339 minimum timestamp is valid")
+    .with_timezone(&Utc)
+}
+
+fn success_age_anchor(
+  monotonic_now: Instant,
+  wall_now: DateTime<Utc>,
+  success_wall: DateTime<Utc>,
+) -> SuccessAgeAnchor {
+  let baseline_age = wall_now
+    .signed_duration_since(success_wall)
+    .to_std()
+    .unwrap_or(Duration::ZERO);
+  SuccessAgeAnchor {
+    baseline_age,
+    observed_at: monotonic_now,
+  }
+}
+
+fn increment_saturating_atomic(value: &AtomicU64) -> u64 {
+  let mut current = value.load(Ordering::Acquire);
+  loop {
+    let next = current.saturating_add(1);
+    match value.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+      Ok(_) => return next,
+      Err(observed) => current = observed,
+    }
+  }
+}
+
+struct ActiveLiveGuard<'a> {
+  active: &'a AtomicU64,
+}
+
+impl Drop for ActiveLiveGuard<'_> {
+  fn drop(&mut self) {
+    let mut current = self.active.load(Ordering::Acquire);
+    loop {
+      let next = current.saturating_sub(1);
+      match self
+        .active
+        .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+      {
+        Ok(_) => return,
+        Err(observed) => current = observed,
+      }
+    }
+  }
+}
+
+fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: CoordinatorRuntime) {
+  #[cfg(test)]
+  runtime.hooks.record_thread_name();
+  loop {
+    let message = if runtime.shutdown_requested.load(Ordering::Acquire) {
+      receiver.recv().map_err(|_| RecvError)
+    } else {
+      match runtime.schedule.next_wait(runtime.clock.monotonic_now()) {
+        Some(wait) => match receiver.recv_timeout(wait) {
+          Ok(message) => Ok(message),
+          Err(RecvTimeoutError::Timeout) => {
+            runtime.process_schedule_event(CoordinatorEvent::Timer);
+            continue;
+          }
+          Err(RecvTimeoutError::Disconnected) => Err(RecvError),
+        },
+        None => receiver.recv(),
+      }
+    };
+    let Ok(message) = message else {
+      return;
+    };
+
+    if runtime.shutdown_requested.load(Ordering::Acquire)
+      && !matches!(message, RuntimeMessage::Shutdown(_))
+    {
+      runtime.handle_message_while_shutdown_pending(message);
+      continue;
+    }
+
+    match message {
+      RuntimeMessage::RequestToken(request) => {
+        runtime.process_schedule_event(CoordinatorEvent::RequestToken(request));
+      }
+      RuntimeMessage::RequestLive(request) => {
+        runtime.process_schedule_event(CoordinatorEvent::RequestLive(request));
+      }
+      RuntimeMessage::SettingsChanged(config, reply) => {
+        let actions = runtime.schedule.handle(
+          runtime.clock.monotonic_now(),
+          CoordinatorEvent::SettingsChanged(config),
+        );
+        let snapshot = runtime.schedule.snapshot();
+        runtime
+          .source_generation
+          .store(snapshot.source_generation, Ordering::Release);
+        runtime.sync_schedule_snapshot();
+        runtime.process_actions(actions);
+        let _ = reply.send(());
+      }
+      RuntimeMessage::Wake(reply) => {
+        runtime.process_schedule_event(CoordinatorEvent::Wake);
+        let _ = reply.send(());
+      }
+      RuntimeMessage::WakeNoReply => runtime.process_schedule_event(CoordinatorEvent::Wake),
+      RuntimeMessage::Barrier(reply) => {
+        let _ = reply.send(());
+      }
+      RuntimeMessage::Worker(outcome) => runtime.process_worker_outcome(outcome),
+      RuntimeMessage::Shutdown(reply) => {
+        runtime.shutdown_and_join_workers(&receiver, reply);
+        return;
+      }
+      #[cfg(test)]
+      RuntimeMessage::PauseCoordinator(gate, ready) => {
+        let _ = ready.send(());
+        gate.wait_for_release();
+      }
+      #[cfg(test)]
+      RuntimeMessage::InstallPreparedSlot(prepared, reply) => {
+        runtime.prepared_slot = Some(PreparedSlot {
+          generation: prepared.generation,
+          source_generation: prepared.source_generation,
+          prepared,
+        });
+        runtime.hooks.set_prepared_slot_empty(false);
+        let _ = reply.send(());
+      }
+      #[cfg(test)]
+      RuntimeMessage::PreparedSlotEmpty(reply) => {
+        let _ = reply.send(runtime.prepared_slot.is_none());
+      }
+    }
+  }
+}
+
+impl CoordinatorRuntime {
+  fn handle_message_while_shutdown_pending(&mut self, message: RuntimeMessage) {
+    match message {
+      RuntimeMessage::SettingsChanged(_, reply)
+      | RuntimeMessage::Wake(reply)
+      | RuntimeMessage::Barrier(reply) => {
+        let _ = reply.send(());
+      }
+      RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Token)) => {
+        self.token_exited = true;
+      }
+      RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
+        self.live_exited = true;
+      }
+      RuntimeMessage::Worker(_)
+      | RuntimeMessage::RequestToken(_)
+      | RuntimeMessage::RequestLive(_) => {}
+      RuntimeMessage::WakeNoReply => {}
+      RuntimeMessage::Shutdown(_) => unreachable!("shutdown message handled by the main loop"),
+      #[cfg(test)]
+      RuntimeMessage::PauseCoordinator(gate, ready) => {
+        let _ = ready.send(());
+        gate.wait_for_release();
+      }
+      #[cfg(test)]
+      RuntimeMessage::InstallPreparedSlot(prepared, reply) => {
+        drop(prepared);
+        let _ = reply.send(());
+      }
+      #[cfg(test)]
+      RuntimeMessage::PreparedSlotEmpty(reply) => {
+        let _ = reply.send(true);
+      }
+    }
+  }
+
+  fn process_schedule_event(&mut self, event: CoordinatorEvent) {
+    let actions = self.schedule.handle(self.clock.monotonic_now(), event);
+    self.sync_schedule_snapshot();
+    self.process_actions(actions);
+  }
+
+  fn process_worker_outcome(&mut self, outcome: WorkerOutcome) {
+    match outcome {
+      WorkerOutcome::Token(outcome) => self.process_token_outcome(outcome),
+      WorkerOutcome::Live(outcome) => self.process_live_outcome(outcome),
+      WorkerOutcome::Exited(WorkerLane::Token) => self.token_exited = true,
+      WorkerOutcome::Exited(WorkerLane::Live) => self.live_exited = true,
+    }
+  }
+
+  fn process_token_outcome(&mut self, outcome: TokenWorkerOutcome) {
+    match outcome {
+      TokenWorkerOutcome::Prepared {
+        expected_generation,
+        expected_source_generation,
+        prepared,
+      } => {
+        if self.schedule.snapshot().token.running_generation != Some(expected_generation) {
+          drop(prepared);
+          return;
+        }
+        if self.token_commit_dispatched == Some((expected_generation, expected_source_generation)) {
+          drop(prepared);
+          return;
+        }
+        if prepared.generation != expected_generation
+          || prepared.source_generation != expected_source_generation
+          || self.prepared_slot.is_some()
+        {
+          drop(prepared);
+          self.fail_running_token(
+            expected_generation,
+            expected_source_generation,
+            RefreshFailureCode::PreparedPayloadMissing,
+            "prepared token payload did not match the running generation",
+          );
+          return;
+        }
+        self.record_prepared_stats(prepared.prepared_scan.stats());
+        self.prepared_slot = Some(PreparedSlot {
+          generation: expected_generation,
+          source_generation: expected_source_generation,
+          prepared,
+        });
+        #[cfg(test)]
+        self.hooks.set_prepared_slot_empty(false);
+        self.process_schedule_event(CoordinatorEvent::TokenPrepared {
+          generation: expected_generation,
+          source_generation: expected_source_generation,
+        });
+      }
+      TokenWorkerOutcome::PreparedMissing {
+        generation,
+        source_generation,
+      } => self.fail_running_token(
+        generation,
+        source_generation,
+        RefreshFailureCode::PreparedPayloadMissing,
+        "prepared token payload was missing",
+      ),
+      TokenWorkerOutcome::Committed {
+        generation,
+        source_generation,
+        result,
+        commit,
+        queue_wait,
+      } => {
+        let snapshot = self.schedule.snapshot();
+        if snapshot.token.running_generation != Some(generation) {
+          return;
+        }
+        if snapshot.source_generation != source_generation {
+          drop(result);
+          self.token_commit_dispatched = None;
+          set_mutation_phase(&self.status, MutationPhase::Failed);
+          self.finish_token_timing(false);
+          self.process_schedule_event(CoordinatorEvent::TokenFinished(failed_completion(
+            generation,
+            source_generation,
+            RefreshFailureCode::SourceChanged,
+            RefreshDetail::new("refresh source changed during token commit"),
+            self.clock.wall_now(),
+          )));
+          return;
+        }
+        self.token_commit_dispatched = None;
+        lock(&self.metrics.mutable).token.commit_wait_ms = duration_as_millis(queue_wait);
+        self.finish_token_timing(true);
+        #[cfg(test)]
+        self.hooks.set_completion_slots_empty(false);
+        self.current_token_result = Some((generation, result));
+        let completion =
+          successful_completion(generation, source_generation, commit, self.clock.wall_now());
+        self.process_schedule_event(CoordinatorEvent::TokenFinished(completion));
+        self.current_token_result = None;
+        #[cfg(test)]
+        self.hooks.set_completion_slots_empty(true);
+      }
+      TokenWorkerOutcome::Failed {
+        generation,
+        source_generation,
+        code,
+        detail,
+        queue_wait,
+      } => {
+        if self.schedule.snapshot().token.running_generation != Some(generation) {
+          return;
+        }
+        self.token_commit_dispatched = None;
+        set_mutation_phase(&self.status, MutationPhase::Failed);
+        if let Some(queue_wait) = queue_wait {
+          lock(&self.metrics.mutable).token.commit_wait_ms = duration_as_millis(queue_wait);
+        }
+        self.finish_token_timing(false);
+        self.process_schedule_event(CoordinatorEvent::TokenFinished(failed_completion(
+          generation,
+          source_generation,
+          code,
+          detail,
+          self.clock.wall_now(),
+        )));
+      }
+      TokenWorkerOutcome::Stale {
+        generation,
+        source_generation,
+      } => {
+        if self.schedule.snapshot().token.running_generation != Some(generation) {
+          return;
+        }
+        self.token_commit_dispatched = None;
+        set_mutation_phase(&self.status, MutationPhase::Failed);
+        self.finish_token_timing(false);
+        self.process_schedule_event(CoordinatorEvent::TokenFinished(failed_completion(
+          generation,
+          source_generation,
+          RefreshFailureCode::SourceChanged,
+          RefreshDetail::new("refresh source changed before token commit"),
+          self.clock.wall_now(),
+        )));
+      }
+    }
+  }
+
+  fn process_live_outcome(&mut self, outcome: LiveWorkerOutcome) {
+    match outcome {
+      LiveWorkerOutcome::Completed {
+        generation,
+        source_generation,
+        snapshot,
+        commit,
+        fetch_duration,
+      } => {
+        let coordinator_snapshot = self.schedule.snapshot();
+        if coordinator_snapshot.live.running_generation != Some(generation) {
+          return;
+        }
+        if coordinator_snapshot.source_generation != source_generation {
+          drop(snapshot);
+          self.finish_live_timing(false);
+          self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+            generation,
+            source_generation,
+            RefreshFailureCode::SourceChanged,
+            RefreshDetail::new("refresh source changed during live persistence"),
+            self.clock.wall_now(),
+          )));
+          return;
+        }
+        lock(&self.metrics.mutable).live.app_server_duration_ms =
+          nonzero_duration_millis(fetch_duration);
+        self.finish_live_timing(true);
+        #[cfg(test)]
+        self.hooks.set_completion_slots_empty(false);
+        self.current_live_result = Some((generation, snapshot));
+        self.process_schedule_event(CoordinatorEvent::LiveFinished(successful_completion(
+          generation,
+          source_generation,
+          commit,
+          self.clock.wall_now(),
+        )));
+        self.current_live_result = None;
+        #[cfg(test)]
+        self.hooks.set_completion_slots_empty(true);
+      }
+      LiveWorkerOutcome::Failed {
+        generation,
+        source_generation,
+        code,
+        detail,
+        fetch_duration,
+      } => {
+        if self.schedule.snapshot().live.running_generation != Some(generation) {
+          return;
+        }
+        lock(&self.metrics.mutable).live.app_server_duration_ms =
+          nonzero_duration_millis(fetch_duration);
+        self.finish_live_timing(false);
+        self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+          generation,
+          source_generation,
+          code,
+          detail,
+          self.clock.wall_now(),
+        )));
+      }
+      LiveWorkerOutcome::Stale {
+        generation,
+        source_generation,
+      } => {
+        if self.schedule.snapshot().live.running_generation != Some(generation) {
+          return;
+        }
+        self.finish_live_timing(false);
+        self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+          generation,
+          source_generation,
+          RefreshFailureCode::SourceChanged,
+          RefreshDetail::new("refresh source changed before live fetch"),
+          self.clock.wall_now(),
+        )));
+      }
+    }
+  }
+
+  fn fail_running_token(
+    &mut self,
+    generation: u64,
+    source_generation: u64,
+    code: RefreshFailureCode,
+    detail: &str,
+  ) {
+    if self.schedule.snapshot().token.running_generation != Some(generation) {
+      return;
+    }
+    self.prepared_slot = None;
+    #[cfg(test)]
+    self.hooks.set_prepared_slot_empty(true);
+    self.token_commit_dispatched = None;
+    set_mutation_phase(&self.status, MutationPhase::Failed);
+    self.finish_token_timing(false);
+    self.process_schedule_event(CoordinatorEvent::TokenFinished(failed_completion(
+      generation,
+      source_generation,
+      code,
+      RefreshDetail::new(detail),
+      self.clock.wall_now(),
+    )));
+  }
+
+  fn process_actions(&mut self, actions: Vec<CoordinatorAction>) {
+    for action in actions {
+      match action {
+        CoordinatorAction::StartToken(request) => self.start_token(request),
+        CoordinatorAction::StartLive(request) => self.start_live(request),
+        CoordinatorAction::CommitToken {
+          generation,
+          source_generation,
+        } => self.commit_token(generation, source_generation),
+        CoordinatorAction::DiscardToken {
+          generation,
+          source_generation,
+        } => {
+          let should_drop = self.prepared_slot.as_ref().is_some_and(|slot| {
+            slot.generation == generation && slot.source_generation == source_generation
+          });
+          if should_drop {
+            self.prepared_slot = None;
+          }
+        }
+        CoordinatorAction::PublishInvalidation(value) => {
+          self.event_sink.publish_invalidation(value);
+          #[cfg(test)]
+          self.hooks.trace("token_invalidation");
+        }
+        CoordinatorAction::PublishCompletion(value) => {
+          #[cfg(test)]
+          self.hooks.trace(match value.lane {
+            super::RefreshLane::Token => "token_completion",
+            super::RefreshLane::Live => "live_completion",
+          });
+          self.event_sink.publish_completion(value);
+        }
+        CoordinatorAction::ResolveLiveWaiters {
+          waiter_ids,
+          outcome,
+        } => self.resolve_live_waiters(waiter_ids, outcome),
+        CoordinatorAction::ResolveTokenWaiters {
+          waiter_ids,
+          outcome,
+        } => self.resolve_token_waiters(waiter_ids, outcome),
+      }
+    }
+  }
+
+  fn start_token(&mut self, request: TokenExecutionRequest) {
+    self.record_lane_start(true, request.generation, request.request.planned_due_at);
+    set_mutation_phase(&self.status, MutationPhase::Parsing);
+    #[cfg(test)]
+    if request.generation > 1 {
+      self.hooks.trace("token_follow_up_start");
+    }
+    let result = self.token_sender.as_ref().ok_or(()).and_then(|sender| {
+      sender
+        .try_send(TokenWorkerCommand::Parse(request.clone()))
+        .map_err(|_| ())
+    });
+    if result.is_err() {
+      self.fail_running_token(
+        request.generation,
+        request.source_generation,
+        RefreshFailureCode::ExecutionFailed,
+        "token worker command queue was busy",
+      );
+    }
+  }
+
+  fn start_live(&mut self, request: LiveExecutionRequest) {
+    self.record_lane_start(false, request.generation, request.planned_due_at);
+    let result = self.live_sender.as_ref().ok_or(()).and_then(|sender| {
+      sender
+        .try_send(LiveWorkerCommand::Run(request.clone()))
+        .map_err(|_| ())
+    });
+    if result.is_err() {
+      self.finish_live_timing(false);
+      self.process_schedule_event(CoordinatorEvent::LiveFinished(failed_completion(
+        request.generation,
+        request.source_generation,
+        RefreshFailureCode::ExecutionFailed,
+        RefreshDetail::new("live worker command queue was busy"),
+        self.clock.wall_now(),
+      )));
+    }
+  }
+
+  fn commit_token(&mut self, generation: u64, source_generation: u64) {
+    let matching = self.prepared_slot.as_ref().is_some_and(|slot| {
+      slot.generation == generation && slot.source_generation == source_generation
+    });
+    if !matching {
+      self.prepared_slot = None;
+      self.fail_running_token(
+        generation,
+        source_generation,
+        RefreshFailureCode::PreparedPayloadMissing,
+        "prepared token payload was missing at commit dispatch",
+      );
+      return;
+    }
+    let prepared = self
+      .prepared_slot
+      .take()
+      .expect("matching prepared slot was checked")
+      .prepared;
+    #[cfg(test)]
+    self.hooks.set_prepared_slot_empty(true);
+    self.token_commit_dispatched = Some((generation, source_generation));
+    let result = self.token_sender.as_ref().ok_or(()).and_then(|sender| {
+      sender
+        .try_send(TokenWorkerCommand::Commit(prepared))
+        .map_err(|_| ())
+    });
+    if result.is_err() {
+      self.fail_running_token(
+        generation,
+        source_generation,
+        RefreshFailureCode::ExecutionFailed,
+        "token worker commit queue was busy",
+      );
+    }
+  }
+
+  fn resolve_token_waiters(
+    &mut self,
+    waiter_ids: Vec<TokenWaiterId>,
+    outcome: RefreshWaiterOutcome,
+  ) {
+    let result = waiter_result_for_token(&outcome, self.current_token_result.take());
+    #[cfg(test)]
+    self.hooks.set_completion_slots_empty(true);
+    let mut waiters = lock(&self.waiters);
+    for waiter in waiter_ids {
+      if let Some(reply) = waiters.token.remove(&waiter) {
+        let _ = reply.send(clone_result(&result));
+      }
+    }
+    drop(waiters);
+    #[cfg(test)]
+    self.hooks.trace("token_waiter_reply");
+  }
+
+  fn resolve_live_waiters(&mut self, waiter_ids: Vec<LiveWaiterId>, outcome: RefreshWaiterOutcome) {
+    let result = waiter_result_for_live(&outcome, self.current_live_result.take());
+    #[cfg(test)]
+    self.hooks.set_completion_slots_empty(true);
+    let mut waiters = lock(&self.waiters);
+    for waiter in waiter_ids {
+      if let Some(reply) = waiters.live.remove(&waiter) {
+        let _ = reply.send(clone_result(&result));
+      }
+    }
+  }
+
+  fn record_lane_start(&mut self, token: bool, generation: u64, due: Option<Instant>) {
+    let mut metrics = lock(&self.metrics.mutable);
+    let lane = if token {
+      &mut metrics.token.lane
+    } else {
+      &mut metrics.live.lane
+    };
+    lane.scheduled_due_at = due.map(|due| wall_time_for_instant(&*self.clock, due).to_rfc3339());
+    lane.started_at = None;
+    lane.start_lag_ms = 0;
+    lane.running_generation = Some(generation);
+    drop(metrics);
+    self.sync_schedule_snapshot();
+  }
+
+  fn finish_token_timing(&mut self, succeeded: bool) {
+    let started = lock(&self.metrics.mutable).token_started.take();
+    if let Some(started) = started {
+      let duration = self
+        .clock
+        .monotonic_now()
+        .saturating_duration_since(started);
+      self.metrics.duration_histogram.record(duration);
+      let mut metrics = lock(&self.metrics.mutable);
+      metrics.token.lane.duration_ms = nonzero_duration_millis(duration);
+      metrics.token.lane.running_generation = None;
+      if succeeded {
+        metrics.token_last_success = Some(SuccessAgeAnchor {
+          baseline_age: Duration::ZERO,
+          observed_at: self.clock.monotonic_now(),
+        });
+        lock(&self.status).token.last_success_at = Some(self.clock.wall_now().to_rfc3339());
+      }
+    }
+  }
+
+  fn finish_live_timing(&mut self, succeeded: bool) {
+    let started = lock(&self.metrics.mutable).live_started.take();
+    if let Some(started) = started {
+      let duration = self
+        .clock
+        .monotonic_now()
+        .saturating_duration_since(started);
+      self.metrics.duration_histogram.record(duration);
+      let mut metrics = lock(&self.metrics.mutable);
+      metrics.live.lane.duration_ms = nonzero_duration_millis(duration);
+      metrics.live.lane.running_generation = None;
+      if succeeded {
+        metrics.live_last_success = Some(SuccessAgeAnchor {
+          baseline_age: Duration::ZERO,
+          observed_at: self.clock.monotonic_now(),
+        });
+        lock(&self.status).live.last_success_at = Some(self.clock.wall_now().to_rfc3339());
+      }
+    }
+  }
+
+  fn record_prepared_stats(&self, stats: PreparedScanStats) {
+    let mut metrics = lock(&self.metrics.mutable);
+    metrics.token.files_visited = stats.files_visited as u64;
+    metrics.token.bytes_read = stats.source_bytes_read;
+    if stats.full_rebuild {
+      metrics.token.full_rebuild_count = metrics.token.full_rebuild_count.saturating_add(1);
+    }
+  }
+
+  fn sync_schedule_snapshot(&self) {
+    let snapshot = self.schedule.snapshot();
+    let token_deadline = snapshot
+      .token
+      .retry_deadline
+      .map_or(snapshot.token.next_normal_deadline, |retry| {
+        retry.min(snapshot.token.next_normal_deadline)
+      });
+    let live_deadline = snapshot
+      .live
+      .retry_deadline
+      .map_or(snapshot.live.next_normal_deadline, |retry| {
+        retry.min(snapshot.live.next_normal_deadline)
+      });
+    let token_next_due = wall_time_for_instant(&*self.clock, token_deadline).to_rfc3339();
+    let live_next_due = wall_time_for_instant(&*self.clock, live_deadline).to_rfc3339();
+    {
+      let mut status = lock(&self.status);
+      status.token.running = snapshot.token.running_generation.is_some();
+      status.token.generation = snapshot.token.running_generation;
+      status.token.pending = snapshot.token.pending;
+      status.token.next_due_at = Some(token_next_due);
+      status.live.running = snapshot.live.running_generation.is_some();
+      status.live.generation = snapshot.live.running_generation;
+      status.live.pending = snapshot.live.pending;
+      status.live.next_due_at = Some(live_next_due);
+      status.source_generation = snapshot.source_generation;
+      status.auto_scan_enabled = snapshot.auto_scan_enabled;
+    }
+    let mut metrics = lock(&self.metrics.mutable);
+    sync_lane_metrics(&mut metrics.token.lane, snapshot.token, &*self.clock);
+    sync_lane_metrics(&mut metrics.live.lane, snapshot.live, &*self.clock);
+  }
+
+  fn shutdown_and_join_workers(
+    &mut self,
+    receiver: &Receiver<RuntimeMessage>,
+    reply: SyncSender<ShutdownResult>,
+  ) {
+    // Required order: deny is linearized by the owner, then drain, drop, flag, close.
+    drain_waiters_for_shutdown(&self.waiters);
+    self.prepared_slot = None;
+    #[cfg(test)]
+    self.hooks.set_prepared_slot_empty(true);
+    self.shutdown.store(true, Ordering::Release);
+    self.token_sender = None;
+    self.live_sender = None;
+    {
+      let mut status = lock(&self.status);
+      status.token.running = false;
+      status.token.pending = false;
+      status.live.running = false;
+      status.live.pending = false;
+      status.mutation_phase = None;
+    }
+
+    while !self.token_exited || !self.live_exited {
+      let Ok(message) = receiver.recv() else {
+        break;
+      };
+      match message {
+        RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Token)) => {
+          self.token_exited = true;
+        }
+        RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
+          self.live_exited = true;
+        }
+        RuntimeMessage::Worker(_) => {}
+        RuntimeMessage::SettingsChanged(_, ack)
+        | RuntimeMessage::Wake(ack)
+        | RuntimeMessage::Barrier(ack) => {
+          let _ = ack.send(());
+        }
+        RuntimeMessage::RequestToken(_)
+        | RuntimeMessage::RequestLive(_)
+        | RuntimeMessage::WakeNoReply => {}
+        RuntimeMessage::Shutdown(other) => {
+          let _ = other.send(ShutdownResult {
+            coordinator_joined: false,
+            token_joined: false,
+            live_joined: false,
+          });
+        }
+        #[cfg(test)]
+        RuntimeMessage::PauseCoordinator(gate, ready) => {
+          let _ = ready.send(());
+          gate.wait_for_release();
+        }
+        #[cfg(test)]
+        RuntimeMessage::InstallPreparedSlot(prepared, ack) => {
+          drop(prepared);
+          let _ = ack.send(());
+        }
+        #[cfg(test)]
+        RuntimeMessage::PreparedSlotEmpty(value) => {
+          let _ = value.send(true);
+        }
+      }
+    }
+
+    let token_joined = self
+      .token_handle
+      .take()
+      .map(|handle| handle.join().is_ok())
+      .unwrap_or(true);
+    let live_joined = self
+      .live_handle
+      .take()
+      .map(|handle| handle.join().is_ok())
+      .unwrap_or(true);
+    let _ = reply.send(ShutdownResult {
+      coordinator_joined: false,
+      token_joined,
+      live_joined,
+    });
+  }
+}
+
+fn sync_lane_metrics(
+  target: &mut RefreshLaneMetrics,
+  source: super::LaneScheduleSnapshot,
+  clock: &dyn RefreshClock,
+) {
+  target.failure_streak = source.failure_streak;
+  target.retry_at = source
+    .retry_deadline
+    .map(|retry| wall_time_for_instant(clock, retry).to_rfc3339());
+  target.missed_deadline_count = source.missed_deadline_count;
+  target.coalesced_trigger_count = source.coalesced_trigger_count;
+  target.running_generation = source.running_generation;
+  target.pending_reasons = source.pending_reasons.bits();
+}
+
+fn successful_completion(
+  generation: u64,
+  source_generation: u64,
+  commit: CommitMarker,
+  completed_at: DateTime<Utc>,
+) -> ExecutionCompletion {
+  ExecutionCompletion {
+    generation,
+    source_generation,
+    succeeded: true,
+    failure_code: None,
+    failure: None,
+    completed_at: completed_at.to_rfc3339(),
+    commit: Some(commit),
+    retry_jitter: Duration::ZERO,
+  }
+}
+
+fn failed_completion(
+  generation: u64,
+  source_generation: u64,
+  code: RefreshFailureCode,
+  detail: RefreshDetail,
+  completed_at: DateTime<Utc>,
+) -> ExecutionCompletion {
+  ExecutionCompletion {
+    generation,
+    source_generation,
+    succeeded: false,
+    failure_code: Some(code),
+    failure: Some(detail.as_str().to_string()),
+    completed_at: completed_at.to_rfc3339(),
+    commit: None,
+    retry_jitter: Duration::ZERO,
+  }
+}
+
+fn waiter_error(outcome: &RefreshWaiterOutcome) -> RefreshError {
+  match outcome {
+    RefreshWaiterOutcome::Completed {
+      failure_code,
+      detail,
+      ..
+    } => RefreshError::Failed {
+      code: failure_code.unwrap_or(RefreshFailureCode::ExecutionFailed),
+      detail: detail.clone(),
+    },
+    RefreshWaiterOutcome::Rejected { code, detail } => RefreshError::Rejected {
+      code: *code,
+      detail: detail.clone(),
+    },
+  }
+}
+
+fn waiter_result_for_token(
+  outcome: &RefreshWaiterOutcome,
+  current: Option<(u64, Arc<ScanResult>)>,
+) -> Result<Arc<ScanResult>, RefreshError> {
+  match outcome {
+    RefreshWaiterOutcome::Completed {
+      generation,
+      succeeded: true,
+      ..
+    } => current
+      .filter(|(result_generation, _)| result_generation == generation)
+      .map(|(_, result)| result)
+      .ok_or_else(|| RefreshError::Failed {
+        code: RefreshFailureCode::PreparedPayloadMissing,
+        detail: Some(RefreshDetail::new(
+          "successful token completion had no exact result",
+        )),
+      }),
+    _ => Err(waiter_error(outcome)),
+  }
+}
+
+fn waiter_result_for_live(
+  outcome: &RefreshWaiterOutcome,
+  current: Option<(u64, Arc<LiveRateLimitSnapshot>)>,
+) -> Result<Arc<LiveRateLimitSnapshot>, RefreshError> {
+  match outcome {
+    RefreshWaiterOutcome::Completed {
+      generation,
+      succeeded: true,
+      ..
+    } => current
+      .filter(|(result_generation, _)| result_generation == generation)
+      .map(|(_, result)| result)
+      .ok_or_else(|| RefreshError::Failed {
+        code: RefreshFailureCode::PreparedPayloadMissing,
+        detail: Some(RefreshDetail::new(
+          "successful live completion had no exact snapshot",
+        )),
+      }),
+    _ => Err(waiter_error(outcome)),
+  }
+}
+
+fn clone_result<T>(result: &Result<Arc<T>, RefreshError>) -> Result<Arc<T>, RefreshError> {
+  match result {
+    Ok(value) => Ok(Arc::clone(value)),
+    Err(error) => Err(error.clone()),
+  }
+}
+
+fn drain_waiters_for_shutdown(waiters: &Mutex<WaiterRegistries>) {
+  let mut waiters = lock(waiters);
+  for (_, reply) in waiters.token.drain() {
+    let _ = reply.send(Err(shutdown_error()));
+  }
+  for (_, reply) in waiters.live.drain() {
+    let _ = reply.send(Err(shutdown_error()));
+  }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestGateSnapshot {
+  worker_ready: bool,
+  entered: bool,
+  released: bool,
+  dropped: bool,
+  used_spool: bool,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestGateState {
+  state: Mutex<TestGateSnapshot>,
+  changed: Condvar,
+}
+
+#[cfg(test)]
+impl TestGateState {
+  fn mark_worker_ready_and_wait(&self) {
+    let mut state = lock(&self.state);
+    state.worker_ready = true;
+    self.changed.notify_all();
+    while !state.released {
+      state = self
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+
+  fn mark_entered_and_wait(&self) {
+    let mut state = lock(&self.state);
+    state.entered = true;
+    self.changed.notify_all();
+    while !state.released {
+      state = self
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+
+  fn mark_entered(&self) {
+    lock(&self.state).entered = true;
+    self.changed.notify_all();
+  }
+
+  fn wait_for_release(&self) {
+    let mut state = lock(&self.state);
+    while !state.released {
+      state = self
+        .changed
+        .wait(state)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+  }
+
+  fn release(&self) {
+    lock(&self.state).released = true;
+    self.changed.notify_all();
+  }
+
+  fn wait_for(&self, timeout: Duration, predicate: impl Fn(&TestGateSnapshot) -> bool) {
+    let state = lock(&self.state);
+    let (state, timed_out) = self
+      .changed
+      .wait_timeout_while(state, timeout, |state| !predicate(state))
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(predicate(&state), "gate condition was not reached");
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for gate condition"
+    );
+  }
+
+  fn mark_dropped(&self) {
+    lock(&self.state).dropped = true;
+    self.changed.notify_all();
+  }
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct PhaseGateControl {
+  state: Arc<TestGateState>,
+}
+
+#[cfg(test)]
+impl PhaseGateControl {
+  fn wait_worker_ready(&self, timeout: Duration) {
+    self.state.wait_for(timeout, |state| state.worker_ready);
+  }
+
+  fn wait_entered(&self, timeout: Duration) {
+    self.state.wait_for(timeout, |state| state.entered);
+  }
+
+  fn release(&self) {
+    self.state.release();
+  }
+
+  fn wait_dropped(&self, timeout: Duration) {
+    self.state.wait_for(timeout, |state| state.dropped);
+  }
+
+  fn used_spool(&self) -> bool {
+    lock(&self.state.state).used_spool
+  }
+
+  fn probe(&self) -> Arc<TestGateState> {
+    Arc::clone(&self.state)
+  }
+}
+
+#[cfg(test)]
+struct TestPreparedDropProbe {
+  state: Arc<TestGateState>,
+}
+
+#[cfg(test)]
+impl Drop for TestPreparedDropProbe {
+  fn drop(&mut self) {
+    self.state.mark_dropped();
+  }
+}
+
+#[cfg(test)]
+impl PreparedTokenRefresh {
+  fn omit_payload_for_test(&self) -> bool {
+    self.omit_payload
+  }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct IndexedPreBodyGates {
+  next_call: AtomicU64,
+  gates: Mutex<HashMap<u64, Arc<TestGateState>>>,
+}
+
+#[cfg(test)]
+impl IndexedPreBodyGates {
+  fn arm(&self, call: u64, gate: Arc<TestGateState>) {
+    lock(&self.gates).insert(call, gate);
+  }
+
+  fn before_call(&self) {
+    let call = self.next_call.fetch_add(1, Ordering::AcqRel) + 1;
+    if let Some(gate) = lock(&self.gates).remove(&call) {
+      gate.mark_worker_ready_and_wait();
+    }
+  }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestHookData {
+  token_arcs: HashMap<u64, Arc<ScanResult>>,
+  live_arcs: HashMap<u64, Arc<LiveRateLimitSnapshot>>,
+  trace: Vec<&'static str>,
+  thread_names: Vec<String>,
+  token_waiting_count: u64,
+  prepared_slot_empty: bool,
+  completion_slots_empty: bool,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct RuntimeTestHooks {
+  token_parse_pre_body: IndexedPreBodyGates,
+  token_commit_pre_body: IndexedPreBodyGates,
+  live_fetch_pre_body: IndexedPreBodyGates,
+  live_persist_pre_body: IndexedPreBodyGates,
+  data: Mutex<TestHookData>,
+  changed: Condvar,
+}
+
+#[cfg(test)]
+impl RuntimeTestHooks {
+  fn before_token_parse(&self) {
+    self.token_parse_pre_body.before_call();
+  }
+
+  fn before_token_commit(&self) {
+    self.token_commit_pre_body.before_call();
+  }
+
+  fn before_live_fetch(&self) {
+    self.live_fetch_pre_body.before_call();
+  }
+
+  fn before_live_persist(&self) {
+    self.live_persist_pre_body.before_call();
+  }
+
+  fn notify_token_waiting_to_commit(&self) {
+    let mut data = lock(&self.data);
+    data.token_waiting_count = data.token_waiting_count.saturating_add(1);
+    drop(data);
+    self.changed.notify_all();
+  }
+
+  fn record_token_arc(&self, generation: u64, result: Arc<ScanResult>) {
+    lock(&self.data).token_arcs.insert(generation, result);
+    self.changed.notify_all();
+  }
+
+  fn record_live_arc(&self, generation: u64, result: Arc<LiveRateLimitSnapshot>) {
+    lock(&self.data).live_arcs.insert(generation, result);
+    self.changed.notify_all();
+  }
+
+  fn trace(&self, value: &'static str) {
+    lock(&self.data).trace.push(value);
+    self.changed.notify_all();
+  }
+
+  fn record_thread_name(&self) {
+    if let Some(name) = thread::current().name() {
+      let mut data = lock(&self.data);
+      if !data.thread_names.iter().any(|existing| existing == name) {
+        data.thread_names.push(name.to_string());
+      }
+      drop(data);
+      self.changed.notify_all();
+    }
+  }
+
+  fn set_prepared_slot_empty(&self, empty: bool) {
+    lock(&self.data).prepared_slot_empty = empty;
+    self.changed.notify_all();
+  }
+
+  fn set_completion_slots_empty(&self, empty: bool) {
+    lock(&self.data).completion_slots_empty = empty;
+    self.changed.notify_all();
+  }
+
+  fn wait_for(&self, timeout: Duration, predicate: impl Fn(&TestHookData) -> bool) {
+    let data = lock(&self.data);
+    let (data, timed_out) = self
+      .changed
+      .wait_timeout_while(data, timeout, |data| !predicate(data))
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(predicate(&data), "runtime hook condition was not reached");
+    assert!(!timed_out.timed_out(), "timed out waiting for runtime hook");
+  }
+}
+
+#[cfg(test)]
+fn wait_on_optional_gate(gate: &mut Option<Arc<TestGateState>>) {
+  if let Some(gate) = gate.take() {
+    gate.mark_worker_ready_and_wait();
+  }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum PanicPhase {
+  Parse,
+  Commit,
+  Fetch,
+  Persist,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestTokenBehavior {
+  parse_body_gates: HashMap<u64, Arc<TestGateState>>,
+  commit_body_gates: HashMap<u64, Arc<TestGateState>>,
+  pre_body_parse_states: HashMap<u64, Arc<TestGateState>>,
+  panic_once: HashMap<PanicPhase, u64>,
+  spool_calls: HashMap<u64, Arc<TestGateState>>,
+  omit_prepared_once: bool,
+  mismatch_prepared_once: bool,
+  assert_drop_before_next: Option<(u64, Arc<TestGateState>)>,
+  follow_up_observed_drop: bool,
+  commit_sources: Vec<String>,
+  parse_thread_ids: Vec<String>,
+  commit_thread_ids: Vec<String>,
+}
+
+#[cfg(test)]
+struct TestScanEnvironment {
+  _root: tempfile::TempDir,
+  db_path: std::path::PathBuf,
+  primary: std::path::PathBuf,
+  replacement: std::path::PathBuf,
+}
+
+#[cfg(test)]
+impl TestScanEnvironment {
+  fn new() -> Self {
+    let root = tempfile::tempdir().expect("test scan root");
+    let db_path = root.path().join("runtime.sqlite");
+    let conn = crate::database::open_connection(&db_path).expect("open runtime test database");
+    crate::database::init_db(&conn).expect("initialize runtime test database");
+    drop(conn);
+    let primary = root.path().join("primary");
+    let replacement = root.path().join("replacement");
+    write_runtime_session(&primary, "11111111-1111-1111-1111-111111111111", false);
+    write_runtime_session(&replacement, "22222222-2222-2222-2222-222222222222", false);
+    Self {
+      _root: root,
+      db_path,
+      primary,
+      replacement,
+    }
+  }
+
+  fn prepare(&self, request: &TokenExecutionRequest, spool: bool) -> PreparedScan {
+    let source = request
+      .request
+      .codex_home
+      .as_ref()
+      .map(std::path::PathBuf::from)
+      .unwrap_or_else(|| self.primary.clone());
+    if spool {
+      write_runtime_session(&source, "33333333-3333-3333-3333-333333333333", true);
+      write_runtime_session(&source, "44444444-4444-4444-4444-444444444444", true);
+    }
+    crate::importer::prepare_scan(
+      &self.db_path,
+      Some(source.to_string_lossy().to_string()),
+      crate::importer::ScanKind::Full,
+    )
+    .expect("prepare runtime test scan")
+  }
+}
+
+#[cfg(test)]
+fn write_runtime_session(home: &std::path::Path, id: &str, large: bool) {
+  let sessions = home.join("sessions");
+  std::fs::create_dir_all(&sessions).expect("create runtime sessions directory");
+  let path = sessions.join(format!("rollout-2026-07-10T00-00-00-{id}.jsonl"));
+  if path.exists() {
+    return;
+  }
+  let mut body = format!(
+    concat!(
+      "{{\"timestamp\":\"2026-07-10T00:00:00Z\",\"type\":\"session_meta\",",
+      "\"payload\":{{\"id\":\"{}\"}}}}\n",
+      "{{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"turn_context\",",
+      "\"payload\":{{\"model\":\"gpt-5.4\"}}}}\n"
+    ),
+    id
+  );
+  let line = concat!(
+    "{\"timestamp\":\"2026-07-10T00:00:02Z\",\"type\":\"event_msg\",",
+    "\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{",
+    "\"input_tokens\":10,\"cached_input_tokens\":0,\"output_tokens\":0,",
+    "\"reasoning_output_tokens\":0,\"total_tokens\":10}},",
+    "\"rate_limits\":{\"plan_type\":\"pro\"}}}\n"
+  );
+  body.push_str(line);
+  if large {
+    while body.len() < 160 * 1024 {
+      body.push_str(line);
+    }
+  }
+  std::fs::write(path, body).expect("write runtime session");
+}
+
+#[cfg(test)]
+struct TestTokenExecutor {
+  environment: TestScanEnvironment,
+  hooks: Arc<RuntimeTestHooks>,
+  behavior: Mutex<TestTokenBehavior>,
+  changed: Condvar,
+  parse_calls: AtomicU64,
+  commit_calls: AtomicU64,
+}
+
+#[cfg(test)]
+impl TestTokenExecutor {
+  fn new(hooks: Arc<RuntimeTestHooks>) -> Self {
+    Self {
+      environment: TestScanEnvironment::new(),
+      hooks,
+      behavior: Mutex::new(TestTokenBehavior::default()),
+      changed: Condvar::new(),
+      parse_calls: AtomicU64::new(0),
+      commit_calls: AtomicU64::new(0),
+    }
+  }
+
+  fn primary_source(&self) -> String {
+    self.environment.primary.to_string_lossy().to_string()
+  }
+
+  fn replacement_source(&self) -> String {
+    self.environment.replacement.to_string_lossy().to_string()
+  }
+
+  fn next_parse_call(&self) -> u64 {
+    self.parse_calls.load(Ordering::Acquire) + 1
+  }
+
+  fn next_commit_call(&self) -> u64 {
+    self.commit_calls.load(Ordering::Acquire) + 1
+  }
+
+  fn block_next_parse(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    lock(&self.behavior)
+      .parse_body_gates
+      .insert(self.next_parse_call(), Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_parse_call(&self, call: u64) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    self
+      .hooks
+      .token_parse_pre_body
+      .arm(call, Arc::clone(&state));
+    lock(&self.behavior)
+      .pre_body_parse_states
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_next_commit(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    lock(&self.behavior)
+      .commit_body_gates
+      .insert(self.next_commit_call(), Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_next_spooled_parse_with_drop_probe(&self) -> PhaseGateControl {
+    let control = self.block_next_parse();
+    lock(&self.behavior)
+      .spool_calls
+      .insert(self.next_parse_call(), control.probe());
+    control
+  }
+
+  fn use_spooled_prepared_for_next_parse(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    state.release();
+    lock(&self.behavior)
+      .spool_calls
+      .insert(self.next_parse_call(), Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn assert_probe_dropped_before_next_parse(&self, probe: Arc<TestGateState>) {
+    lock(&self.behavior).assert_drop_before_next = Some((self.next_parse_call() + 1, probe));
+  }
+
+  fn follow_up_observed_probe_dropped(&self) -> bool {
+    lock(&self.behavior).follow_up_observed_drop
+  }
+
+  fn panic_once(&self, phase: PanicPhase) {
+    lock(&self.behavior).panic_once.insert(phase, 1);
+  }
+
+  fn omit_prepared_payload_once(&self) {
+    lock(&self.behavior).omit_prepared_once = true;
+  }
+
+  fn return_mismatched_prepared_once(&self) {
+    lock(&self.behavior).mismatch_prepared_once = true;
+  }
+
+  fn parse_calls(&self) -> u64 {
+    self.parse_calls.load(Ordering::Acquire)
+  }
+
+  fn commit_calls(&self) -> u64 {
+    self.commit_calls.load(Ordering::Acquire)
+  }
+
+  fn wait_for_parse_calls(&self, expected: u64, timeout: Duration) {
+    self.wait_for_counter(&self.parse_calls, expected, timeout);
+  }
+
+  fn wait_for_commit_calls(&self, expected: u64, timeout: Duration) {
+    self.wait_for_counter(&self.commit_calls, expected, timeout);
+  }
+
+  fn wait_for_counter(&self, counter: &AtomicU64, expected: u64, timeout: Duration) {
+    let state = lock(&self.behavior);
+    let (_state, timed_out) = self
+      .changed
+      .wait_timeout_while(state, timeout, |_| {
+        counter.load(Ordering::Acquire) < expected
+      })
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(counter.load(Ordering::Acquire) >= expected);
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for executor calls"
+    );
+  }
+
+  fn committed_arc(&self, generation: u64, timeout: Duration) -> Arc<ScanResult> {
+    self
+      .hooks
+      .wait_for(timeout, |data| data.token_arcs.contains_key(&generation));
+    Arc::clone(
+      lock(&self.hooks.data)
+        .token_arcs
+        .get(&generation)
+        .expect("recorded token arc"),
+    )
+  }
+
+  fn assert_result_for_generation(&self, result: &ScanResult, generation: u64) {
+    assert_eq!(result.imported_sessions, generation as usize);
+    assert_eq!(result.updated_sessions, generation as usize);
+  }
+
+  fn unique_parse_worker_ids(&self) -> usize {
+    let ids = &lock(&self.behavior).parse_thread_ids;
+    ids.iter().collect::<std::collections::HashSet<_>>().len()
+  }
+
+  fn unique_commit_worker_ids(&self) -> usize {
+    let ids = &lock(&self.behavior).commit_thread_ids;
+    ids.iter().collect::<std::collections::HashSet<_>>().len()
+  }
+
+  fn worker_name(&self) -> String {
+    "codex-pacer-refresh-token".to_string()
+  }
+
+  fn commit_calls_for_source(&self, label: &str) -> usize {
+    lock(&self.behavior)
+      .commit_sources
+      .iter()
+      .filter(|source| source.contains(label))
+      .count()
+  }
+
+  fn make_prepared_for_test(
+    &self,
+    generation: u64,
+    source_generation: u64,
+    spool: bool,
+  ) -> (PreparedTokenRefresh, PhaseGateControl) {
+    let state = Arc::new(TestGateState::default());
+    state.release();
+    let mut request = TokenRequest::manual_full(Some(self.primary_source()));
+    request.planned_due_at = None;
+    let execution = TokenExecutionRequest {
+      generation,
+      source_generation,
+      request,
+    };
+    let prepared_scan = self.environment.prepare(&execution, spool);
+    lock(&state.state).used_spool = prepared_scan.stats().used_spool;
+    (
+      PreparedTokenRefresh {
+        generation,
+        source_generation,
+        started_at: Utc::now(),
+        prepared_scan,
+        drop_probe: Some(TestPreparedDropProbe {
+          state: Arc::clone(&state),
+        }),
+        omit_payload: false,
+      },
+      PhaseGateControl { state },
+    )
+  }
+}
+
+#[cfg(test)]
+impl TokenRefreshExecutor for TestTokenExecutor {
+  fn parse(&self, request: TokenExecutionRequest) -> Result<PreparedTokenRefresh, String> {
+    let call = self.parse_calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let thread_id = format!("{:?}", thread::current().id());
+    let (body_gate, pre_body, spool_state, panic_now, omit, mismatch, observed_drop) = {
+      let mut behavior = lock(&self.behavior);
+      behavior.parse_thread_ids.push(thread_id);
+      let observed_drop = behavior
+        .assert_drop_before_next
+        .as_ref()
+        .filter(|(target, _)| *target == call)
+        .map(|(_, probe)| lock(&probe.state).dropped);
+      if let Some(dropped) = observed_drop {
+        behavior.follow_up_observed_drop = dropped;
+        behavior.assert_drop_before_next = None;
+      }
+      let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Parse);
+      (
+        behavior.parse_body_gates.remove(&call),
+        behavior.pre_body_parse_states.remove(&call),
+        behavior.spool_calls.remove(&call),
+        panic_now,
+        std::mem::take(&mut behavior.omit_prepared_once),
+        std::mem::take(&mut behavior.mismatch_prepared_once),
+        observed_drop,
+      )
+    };
+    self.changed.notify_all();
+    if let Some(pre_body) = pre_body {
+      pre_body.mark_entered();
+    }
+    if let Some(body_gate) = body_gate {
+      body_gate.mark_entered_and_wait();
+    }
+    if observed_drop == Some(false) {
+      panic!("follow-up parse entered before prepared spool dropped");
+    }
+    if panic_now {
+      panic!("intentional parse panic");
+    }
+    let mut generation = request.generation;
+    if mismatch {
+      generation = generation.saturating_add(1);
+    }
+    let prepared_scan = self.environment.prepare(&request, spool_state.is_some());
+    if let Some(state) = &spool_state {
+      lock(&state.state).used_spool = prepared_scan.stats().used_spool;
+    }
+    Ok(PreparedTokenRefresh {
+      generation,
+      source_generation: request.source_generation,
+      started_at: Utc::now(),
+      prepared_scan,
+      drop_probe: spool_state.map(|state| TestPreparedDropProbe { state }),
+      omit_payload: omit,
+    })
+  }
+
+  fn commit(&self, prepared: PreparedTokenRefresh) -> Result<ScanResult, String> {
+    let call = self.commit_calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let thread_id = format!("{:?}", thread::current().id());
+    let (body_gate, panic_now) = {
+      let mut behavior = lock(&self.behavior);
+      behavior.commit_thread_ids.push(thread_id);
+      behavior.commit_sources.push(
+        prepared
+          .prepared_scan
+          .source_key()
+          .resolved_home()
+          .to_string_lossy()
+          .to_string(),
+      );
+      let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Commit);
+      (behavior.commit_body_gates.remove(&call), panic_now)
+    };
+    self.changed.notify_all();
+    if let Some(body_gate) = body_gate {
+      body_gate.mark_entered_and_wait();
+    }
+    if panic_now {
+      panic!("intentional commit panic");
+    }
+    let generation = prepared.generation;
+    drop(prepared);
+    Ok(ScanResult {
+      codex_home: format!("generation-{generation}"),
+      scanned_files: generation as usize,
+      imported_sessions: generation as usize,
+      updated_sessions: generation as usize,
+      missing_sessions: 0,
+      last_completed_at: "2026-07-11T00:00:00Z".to_string(),
+    })
+  }
+}
+
+#[cfg(test)]
+fn take_panic(panics: &mut HashMap<PanicPhase, u64>, phase: PanicPhase) -> bool {
+  let Some(remaining) = panics.get_mut(&phase) else {
+    return false;
+  };
+  if *remaining == 0 {
+    return false;
+  }
+  *remaining -= 1;
+  true
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestLiveBehavior {
+  fetch_body_gates: HashMap<u64, Arc<TestGateState>>,
+  persist_body_gates: HashMap<u64, Arc<TestGateState>>,
+  pre_body_fetch_states: HashMap<u64, Arc<TestGateState>>,
+  panic_once: HashMap<PanicPhase, u64>,
+  fetch_thread_ids: Vec<String>,
+  persist_thread_ids: Vec<String>,
+  last_timeout: Option<Duration>,
+}
+
+#[cfg(test)]
+struct TestLiveExecutor {
+  hooks: Arc<RuntimeTestHooks>,
+  behavior: Mutex<TestLiveBehavior>,
+  changed: Condvar,
+  fetch_calls: AtomicU64,
+  persist_calls: AtomicU64,
+  active: AtomicU64,
+  maximum_active: AtomicU64,
+}
+
+#[cfg(test)]
+impl TestLiveExecutor {
+  fn new(hooks: Arc<RuntimeTestHooks>) -> Self {
+    Self {
+      hooks,
+      behavior: Mutex::new(TestLiveBehavior::default()),
+      changed: Condvar::new(),
+      fetch_calls: AtomicU64::new(0),
+      persist_calls: AtomicU64::new(0),
+      active: AtomicU64::new(0),
+      maximum_active: AtomicU64::new(0),
+    }
+  }
+
+  fn block_next_fetch(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    let call = self.fetch_calls.load(Ordering::Acquire) + 1;
+    lock(&self.behavior)
+      .fetch_body_gates
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_fetch_call_before_body(&self, call: u64) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    self.hooks.live_fetch_pre_body.arm(call, Arc::clone(&state));
+    lock(&self.behavior)
+      .pre_body_fetch_states
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn block_next_persist(&self) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    let call = self.persist_calls.load(Ordering::Acquire) + 1;
+    lock(&self.behavior)
+      .persist_body_gates
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn panic_once(&self, phase: PanicPhase) {
+    lock(&self.behavior).panic_once.insert(phase, 1);
+  }
+
+  fn fetch_calls(&self) -> u64 {
+    self.fetch_calls.load(Ordering::Acquire)
+  }
+
+  fn persist_calls(&self) -> u64 {
+    self.persist_calls.load(Ordering::Acquire)
+  }
+
+  fn wait_for_fetch_calls(&self, expected: u64, timeout: Duration) {
+    let behavior = lock(&self.behavior);
+    let (_behavior, timed_out) = self
+      .changed
+      .wait_timeout_while(behavior, timeout, |_| self.fetch_calls() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(self.fetch_calls() >= expected);
+    assert!(!timed_out.timed_out(), "timed out waiting for live fetch");
+  }
+
+  fn maximum_active_fetches(&self) -> u64 {
+    self.maximum_active.load(Ordering::Acquire)
+  }
+
+  fn fetched_arc(&self, generation: u64, timeout: Duration) -> Arc<LiveRateLimitSnapshot> {
+    self
+      .hooks
+      .wait_for(timeout, |data| data.live_arcs.contains_key(&generation));
+    Arc::clone(
+      lock(&self.hooks.data)
+        .live_arcs
+        .get(&generation)
+        .expect("recorded live arc"),
+    )
+  }
+
+  fn unique_fetch_worker_ids(&self) -> usize {
+    lock(&self.behavior)
+      .fetch_thread_ids
+      .iter()
+      .collect::<std::collections::HashSet<_>>()
+      .len()
+  }
+
+  fn unique_persist_worker_ids(&self) -> usize {
+    lock(&self.behavior)
+      .persist_thread_ids
+      .iter()
+      .collect::<std::collections::HashSet<_>>()
+      .len()
+  }
+
+  fn worker_name(&self) -> String {
+    "codex-pacer-refresh-live".to_string()
+  }
+
+  fn last_timeout(&self) -> Option<Duration> {
+    lock(&self.behavior).last_timeout
+  }
+
+  fn snapshot() -> LiveRateLimitSnapshot {
+    LiveRateLimitSnapshot {
+      limit_id: Some("runtime-test".to_string()),
+      limit_name: Some("Runtime Test".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: None,
+      fetched_at: "2026-07-11T00:00:00Z".to_string(),
+    }
+  }
+}
+
+#[cfg(test)]
+impl LiveQuotaFetcher for TestLiveExecutor {
+  fn fetch(&self, timeout: Duration) -> Result<LiveRateLimitSnapshot, String> {
+    let call = self.fetch_calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let active = increment_saturating_atomic(&self.active);
+    let mut maximum = self.maximum_active.load(Ordering::Acquire);
+    while active > maximum {
+      match self.maximum_active.compare_exchange_weak(
+        maximum,
+        active,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+      ) {
+        Ok(_) => break,
+        Err(observed) => maximum = observed,
+      }
+    }
+    let (body_gate, pre_body, panic_now) = {
+      let mut behavior = lock(&self.behavior);
+      behavior
+        .fetch_thread_ids
+        .push(format!("{:?}", thread::current().id()));
+      behavior.last_timeout = Some(timeout);
+      let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Fetch);
+      (
+        behavior.fetch_body_gates.remove(&call),
+        behavior.pre_body_fetch_states.remove(&call),
+        panic_now,
+      )
+    };
+    self.changed.notify_all();
+    if let Some(pre_body) = pre_body {
+      pre_body.mark_entered();
+    }
+    if let Some(body_gate) = body_gate {
+      body_gate.mark_entered_and_wait();
+    }
+    decrement_saturating_atomic(&self.active);
+    if panic_now {
+      panic!("intentional fetch panic");
+    }
+    Ok(Self::snapshot())
+  }
+}
+
+#[cfg(test)]
+impl LiveQuotaPersister for TestLiveExecutor {
+  fn persist(&self, _snapshot: &LiveRateLimitSnapshot) -> Result<(), String> {
+    let call = self.persist_calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let (body_gate, panic_now) = {
+      let mut behavior = lock(&self.behavior);
+      behavior
+        .persist_thread_ids
+        .push(format!("{:?}", thread::current().id()));
+      let panic_now = take_panic(&mut behavior.panic_once, PanicPhase::Persist);
+      (behavior.persist_body_gates.remove(&call), panic_now)
+    };
+    self.changed.notify_all();
+    if let Some(body_gate) = body_gate {
+      body_gate.mark_entered_and_wait();
+    }
+    if panic_now {
+      panic!("intentional persist panic");
+    }
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+fn decrement_saturating_atomic(value: &AtomicU64) {
+  let mut current = value.load(Ordering::Acquire);
+  loop {
+    match value.compare_exchange_weak(
+      current,
+      current.saturating_sub(1),
+      Ordering::AcqRel,
+      Ordering::Acquire,
+    ) {
+      Ok(_) => return,
+      Err(observed) => current = observed,
+    }
+  }
+}
+
+#[cfg(test)]
+struct TestClock {
+  base_monotonic: Instant,
+  base_wall: DateTime<Utc>,
+  offset: Mutex<Duration>,
+}
+
+#[cfg(test)]
+impl TestClock {
+  fn new() -> Self {
+    Self {
+      base_monotonic: Instant::now(),
+      base_wall: Utc::now(),
+      offset: Mutex::new(Duration::ZERO),
+    }
+  }
+
+  fn advance(&self, duration: Duration) {
+    let mut offset = lock(&self.offset);
+    *offset = offset.saturating_add(duration);
+  }
+}
+
+#[cfg(test)]
+impl RefreshClock for TestClock {
+  fn monotonic_now(&self) -> Instant {
+    let elapsed = self.base_monotonic.elapsed();
+    self
+      .base_monotonic
+      .checked_add(elapsed.saturating_add(*lock(&self.offset)))
+      .unwrap_or(self.base_monotonic)
+  }
+
+  fn wall_now(&self) -> DateTime<Utc> {
+    let elapsed = self.base_monotonic.elapsed();
+    self
+      .base_wall
+      .checked_add_signed(
+        ChronoDuration::from_std(elapsed.saturating_add(*lock(&self.offset)))
+          .unwrap_or(ChronoDuration::MAX),
+      )
+      .unwrap_or(DateTime::<Utc>::MAX_UTC)
+  }
+}
+
+#[cfg(test)]
+struct TestEvents {
+  invalidations: SaturatingCounter,
+  completions: SaturatingCounter,
+  hooks: Arc<RuntimeTestHooks>,
+  changed: Condvar,
+  gate: Mutex<()>,
+}
+
+#[cfg(test)]
+impl TestEvents {
+  fn new(hooks: Arc<RuntimeTestHooks>) -> Self {
+    Self {
+      invalidations: SaturatingCounter::new(0),
+      completions: SaturatingCounter::new(0),
+      hooks,
+      changed: Condvar::new(),
+      gate: Mutex::new(()),
+    }
+  }
+
+  fn completion_count(&self) -> u64 {
+    self.completions.load()
+  }
+
+  fn invalidation_count(&self) -> u64 {
+    self.invalidations.load()
+  }
+
+  fn trace_prefix(&self) -> Vec<&'static str> {
+    lock(&self.hooks.data).trace.clone()
+  }
+
+  fn wait_for_completions(&self, expected: u64, timeout: Duration) {
+    let gate = lock(&self.gate);
+    let (_gate, timed_out) = self
+      .changed
+      .wait_timeout_while(gate, timeout, |_| self.completion_count() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(self.completion_count() >= expected);
+    assert!(!timed_out.timed_out(), "timed out waiting for completions");
+  }
+}
+
+#[cfg(test)]
+impl RefreshEventSink for TestEvents {
+  fn publish_invalidation(&self, _value: DisplayInvalidation) {
+    self.invalidations.increment();
+  }
+
+  fn publish_completion(&self, _value: RefreshCompletedEvent) {
+    self.completions.increment();
+    self.changed.notify_all();
+  }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+enum TestRigSchedule {
+  Disabled,
+  StartupDue,
+  Paused,
+  HugeInterval,
+}
+
+#[cfg(test)]
+struct RuntimeTestRig {
+  runtime: Arc<RefreshRuntime>,
+  handle: RefreshCoordinatorHandle,
+  token: Arc<TestTokenExecutor>,
+  live: Arc<TestLiveExecutor>,
+  events: Arc<TestEvents>,
+  mutation: UsageMutationCoordinator,
+  activities: super::power::CountingActivityFactory,
+  clock: Arc<TestClock>,
+  metrics_handle: Arc<MetricsState>,
+}
+
+#[cfg(test)]
+impl RuntimeTestRig {
+  fn disabled() -> Self {
+    Self::build(TestRigSchedule::Disabled).0
+  }
+
+  fn startup_due_with_pre_body_gates() -> (Self, PhaseGateControl, PhaseGateControl) {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    let parse = token.block_parse_call(1);
+    let fetch = live.block_fetch_call_before_body(1);
+    (
+      Self::build_with_components(TestRigSchedule::StartupDue, hooks, token, live),
+      parse,
+      fetch,
+    )
+  }
+
+  fn scheduled_overdue(overdue: Duration) -> Self {
+    let rig = Self::build(TestRigSchedule::Paused).0;
+    rig
+      .clock
+      .advance(Duration::from_secs(60).saturating_add(overdue));
+    rig.handle.wake().expect("wake overdue test runtime");
+    rig
+  }
+
+  fn paused_clock() -> Self {
+    Self::build(TestRigSchedule::Paused).0
+  }
+
+  fn huge_interval() -> Self {
+    Self::build(TestRigSchedule::HugeInterval).0
+  }
+
+  fn build(schedule: TestRigSchedule) -> (Self, Arc<RuntimeTestHooks>) {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    let rig = Self::build_with_components(schedule, Arc::clone(&hooks), token, live);
+    (rig, hooks)
+  }
+
+  fn build_with_components(
+    schedule: TestRigSchedule,
+    hooks: Arc<RuntimeTestHooks>,
+    token: Arc<TestTokenExecutor>,
+    live: Arc<TestLiveExecutor>,
+  ) -> Self {
+    let clock = Arc::new(TestClock::new());
+    let interval = if matches!(schedule, TestRigSchedule::HugeInterval) {
+      Duration::MAX
+    } else {
+      Duration::from_secs(60)
+    };
+    let wall_now = clock.wall_now();
+    let (auto_scan_enabled, success_wall) = match schedule {
+      TestRigSchedule::Disabled => (false, Some(wall_now)),
+      TestRigSchedule::StartupDue => (
+        true,
+        Some(wall_now - ChronoDuration::from_std(interval + Duration::from_secs(1)).unwrap()),
+      ),
+      TestRigSchedule::Paused => (true, Some(wall_now)),
+      TestRigSchedule::HugeInterval => (false, Some(wall_now)),
+    };
+    let config = RefreshConfig {
+      auto_scan_enabled,
+      interval,
+      codex_home: Some(token.primary_source()),
+      token_last_success_wall: success_wall,
+      live_last_success_wall: success_wall,
+    };
+    let events = Arc::new(TestEvents::new(Arc::clone(&hooks)));
+    let mutation = UsageMutationCoordinator::new();
+    let activities = super::power::CountingActivityFactory::default();
+    let dependencies = RefreshRuntimeDependencies {
+      config,
+      token_executor: token.clone(),
+      live_fetcher: live.clone(),
+      live_persister: live.clone(),
+      event_sink: events.clone(),
+      mutation: mutation.clone(),
+      activity_factory: Arc::new(activities.clone()),
+      clock: clock.clone(),
+      test_hooks: Some(Arc::clone(&hooks)),
+    };
+    let runtime = Arc::new(RefreshRuntime::start(dependencies).expect("start test runtime"));
+    let handle = runtime.handle();
+    let metrics_handle = Arc::clone(&handle.inner.metrics);
+    Self {
+      runtime,
+      handle,
+      token,
+      live,
+      events,
+      mutation,
+      activities,
+      clock,
+      metrics_handle,
+    }
+  }
+
+  fn metrics(&self) -> RefreshMetricsSnapshot {
+    self.handle.metrics()
+  }
+
+  fn wait_until_idle(&self, timeout: Duration) {
+    let initial = self.events.completion_count();
+    if self.handle.status().token.running || self.handle.status().live.running {
+      self
+        .events
+        .wait_for_completions(initial.saturating_add(1), timeout);
+    }
+    self.runtime.test_hooks.wait_for(timeout, |_| {
+      let status = self.handle.status();
+      !status.token.running && !status.live.running
+    });
+  }
+
+  fn shutdown(&self) {
+    self
+      .runtime
+      .shutdown_and_join()
+      .expect("shutdown test runtime");
+  }
+
+  fn config_with_source(&self, _label: &str) -> RefreshConfig {
+    RefreshConfig {
+      auto_scan_enabled: false,
+      interval: Duration::from_secs(60),
+      codex_home: Some(self.token.replacement_source()),
+      token_last_success_wall: Some(self.clock.wall_now()),
+      live_last_success_wall: Some(self.clock.wall_now()),
+    }
+  }
+
+  fn thread_names(&self) -> [String; 3] {
+    self
+      .runtime
+      .test_hooks
+      .wait_for(Duration::from_secs(2), |data| data.thread_names.len() == 3);
+    let mut names = lock(&self.runtime.test_hooks.data).thread_names.clone();
+    names.sort();
+    names.try_into().expect("three runtime thread names")
+  }
+
+  fn current_completion_slots_are_empty(&self) -> bool {
+    lock(&self.runtime.test_hooks.data).completion_slots_empty
+  }
+
+  fn hold_mutation_slot(&self) -> MutationHold {
+    MutationHold::start(self.mutation.clone(), Arc::clone(&self.runtime.test_hooks))
+  }
+
+  fn mutation_slot_is_free(&self) -> bool {
+    self.mutation.run(MutationPriority::Pricing, || true).value
+  }
+
+  fn token_schedule_waiter_count(&self) -> usize {
+    lock(&self.handle.inner.waiters).token.len()
+  }
+
+  fn runtime_sender(&self) -> SyncSender<RuntimeMessage> {
+    lock(&self.handle.inner.intake).sender.clone()
+  }
+
+  fn inject_duplicate_prepared_after_take(&self, generation: u64) {
+    let (prepared, _) = self.token.make_prepared_for_test(generation, 0, false);
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::Worker(WorkerOutcome::Token(
+        TokenWorkerOutcome::Prepared {
+          expected_generation: generation,
+          expected_source_generation: 0,
+          prepared,
+        },
+      )))
+      .expect("inject duplicate prepared outcome");
+  }
+
+  fn inject_duplicate_token_completion(&self, generation: u64, result: Arc<ScanResult>) {
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::Worker(WorkerOutcome::Token(
+        TokenWorkerOutcome::Committed {
+          generation,
+          source_generation: 0,
+          result,
+          commit: CommitMarker {
+            sequence: generation,
+            committed_at: self.clock.monotonic_now(),
+          },
+          queue_wait: Duration::ZERO,
+        },
+      )))
+      .expect("inject duplicate token completion");
+  }
+
+  fn pause_coordinator(&self) -> CoordinatorPause {
+    let gate = Arc::new(TestGateState::default());
+    let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::PauseCoordinator(
+        Arc::clone(&gate),
+        ready_tx,
+      ))
+      .expect("pause coordinator command");
+    ready_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("coordinator pauses");
+    CoordinatorPause { gate }
+  }
+
+  fn fill_runtime_channel_until_busy(&self) {
+    loop {
+      match self.handle.try_wake() {
+        Ok(()) => {}
+        Err(RefreshError::Busy) => return,
+        Err(error) => panic!("unexpected command fill error: {error:?}"),
+      }
+    }
+  }
+
+  fn start_intake_race_after_accept_check(&self) -> IntakeRace {
+    let gate = Arc::new(TestGateState::default());
+    lock(&self.handle.inner.intake).pause_after_check = Some(Arc::clone(&gate));
+    let handle = self.handle.clone();
+    let (result_tx, result_rx) = mpsc::sync_channel(1);
+    let join = thread::spawn(move || {
+      let result = handle
+        .request_manual_live()
+        .and_then(|ticket| ticket.wait_timeout(Duration::from_secs(2)));
+      let _ = result_tx.send(result);
+    });
+    IntakeRace {
+      gate,
+      result: Mutex::new(Some(result_rx)),
+      join: Mutex::new(Some(join)),
+    }
+  }
+
+  fn shutdown_in_background(&self) -> BackgroundShutdown {
+    BackgroundShutdown::start(Arc::clone(&self.runtime))
+  }
+
+  fn wait_for_shutdown_requested(&self, timeout: Duration) {
+    let state = lock(&self.runtime.lifecycle.state);
+    let (_state, timed_out) = self
+      .runtime
+      .lifecycle
+      .changed
+      .wait_timeout_while(state, timeout, |_| {
+        !self
+          .runtime
+          .lifecycle
+          .shutdown_requested
+          .load(Ordering::Acquire)
+      })
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(
+      self
+        .runtime
+        .lifecycle
+        .shutdown_requested
+        .load(Ordering::Acquire),
+      "shutdown request was not linearized"
+    );
+    assert!(
+      !timed_out.timed_out(),
+      "timed out waiting for shutdown request"
+    );
+  }
+
+  fn install_spooled_prepared_slot_via_coordinator(&self) -> PhaseGateControl {
+    let (prepared, control) = self.token.make_prepared_for_test(999, 0, true);
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::InstallPreparedSlot(prepared, reply_tx))
+      .expect("install coordinator prepared slot");
+    reply_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("coordinator owns prepared slot");
+    control
+  }
+
+  fn prepared_slot_is_empty_via_coordinator(&self) -> bool {
+    lock(&self.runtime.test_hooks.data).prepared_slot_empty
+  }
+}
+
+#[cfg(test)]
+fn initialize_test_hooks(hooks: &RuntimeTestHooks) {
+  let mut data = lock(&hooks.data);
+  data.prepared_slot_empty = true;
+  data.completion_slots_empty = true;
+}
+
+#[cfg(test)]
+struct MutationHold {
+  release: Mutex<Option<mpsc::Sender<()>>>,
+  join: Mutex<Option<JoinHandle<()>>>,
+  hooks: Arc<RuntimeTestHooks>,
+  waiting_baseline: u64,
+}
+
+#[cfg(test)]
+impl MutationHold {
+  fn start(mutation: UsageMutationCoordinator, hooks: Arc<RuntimeTestHooks>) -> Self {
+    let waiting_baseline = lock(&hooks.data).token_waiting_count;
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::channel();
+    let join = thread::spawn(move || {
+      mutation.run(MutationPriority::Maintenance, || {
+        let _ = entered_tx.send(());
+        let _ = release_rx.recv();
+      });
+    });
+    entered_rx
+      .recv_timeout(Duration::from_secs(2))
+      .expect("mutation blocker enters");
+    Self {
+      release: Mutex::new(Some(release_tx)),
+      join: Mutex::new(Some(join)),
+      hooks,
+      waiting_baseline,
+    }
+  }
+
+  fn wait_until_refresh_queued(&self, timeout: Duration) {
+    self.hooks.wait_for(timeout, |data| {
+      data.token_waiting_count > self.waiting_baseline
+    });
+  }
+
+  fn release(&self) {
+    if let Some(release) = lock(&self.release).take() {
+      let _ = release.send(());
+    }
+    if let Some(join) = lock(&self.join).take() {
+      join.join().expect("mutation blocker exits");
+    }
+  }
+}
+
+#[cfg(test)]
+struct CoordinatorPause {
+  gate: Arc<TestGateState>,
+}
+
+#[cfg(test)]
+impl CoordinatorPause {
+  fn release(&self) {
+    self.gate.release();
+  }
+}
+
+#[cfg(test)]
+struct IntakeRace {
+  gate: Arc<TestGateState>,
+  result: Mutex<Option<Receiver<Result<Arc<LiveRateLimitSnapshot>, RefreshError>>>>,
+  join: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[cfg(test)]
+impl IntakeRace {
+  fn wait_checked(&self, timeout: Duration) {
+    self.gate.wait_for(timeout, |state| state.worker_ready);
+  }
+
+  fn release(&self) {
+    self.gate.release();
+  }
+
+  fn wait_result(&self, timeout: Duration) -> Result<Arc<LiveRateLimitSnapshot>, RefreshError> {
+    let result = lock(&self.result)
+      .take()
+      .expect("intake race result receiver")
+      .recv_timeout(timeout)
+      .expect("intake race reports result");
+    if let Some(join) = lock(&self.join).take() {
+      join.join().expect("intake race thread exits");
+    }
+    result
+  }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct BackgroundShutdownState {
+  result: Option<Result<Arc<ShutdownResult>, RefreshError>>,
+  finished: bool,
+}
+
+#[cfg(test)]
+struct BackgroundShutdown {
+  state: Arc<(Mutex<BackgroundShutdownState>, Condvar)>,
+  join: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[cfg(test)]
+impl BackgroundShutdown {
+  fn start(runtime: Arc<RefreshRuntime>) -> Self {
+    let state = Arc::new((
+      Mutex::new(BackgroundShutdownState::default()),
+      Condvar::new(),
+    ));
+    let thread_state = Arc::clone(&state);
+    let join = thread::spawn(move || {
+      let result = runtime.shutdown_and_join();
+      let (lock_state, changed) = &*thread_state;
+      let mut state = lock(lock_state);
+      state.result = Some(result);
+      state.finished = true;
+      drop(state);
+      changed.notify_all();
+    });
+    Self {
+      state,
+      join: Mutex::new(Some(join)),
+    }
+  }
+
+  fn is_finished(&self) -> bool {
+    lock(&self.state.0).finished
+  }
+
+  fn wait(&self, timeout: Duration) -> Arc<ShutdownResult> {
+    let (state, changed) = &*self.state;
+    let state = lock(state);
+    let (mut state, timed_out) = changed
+      .wait_timeout_while(state, timeout, |state| !state.finished)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(!timed_out.timed_out(), "timed out waiting for shutdown");
+    let result = state
+      .result
+      .take()
+      .expect("shutdown result")
+      .expect("shutdown succeeds");
+    drop(state);
+    if let Some(join) = lock(&self.join).take() {
+      join.join().expect("shutdown thread exits");
+    }
+    result
+  }
+}

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -5448,6 +5448,10 @@ impl TokenRefreshExecutor for TestTokenExecutor {
       imported_sessions: generation as usize,
       updated_sessions: generation as usize,
       missing_sessions: 0,
+      scan_kind: "incremental".to_string(),
+      source_bytes_read: 0,
+      tail_parsed_files: 0,
+      fully_parsed_files: 0,
       last_completed_at: "2026-07-11T00:00:00Z".to_string(),
     })
   }

--- a/src-tauri/src/refresh/runtime.rs
+++ b/src-tauri/src/refresh/runtime.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod tests {
   use super::{
-    MetricsState, PanicPhase, PreparedTokenRefresh, RefreshClock, RefreshConfig, RefreshError,
-    RefreshStatus, RuntimeTestRig, SaturatingCounter, TestClock, TestLiveExecutor,
+    EpochMaintenanceBatch, MetricsState, PanicPhase, PreparedTokenRefresh, RefreshClock,
+    RefreshConfig, RefreshError, RefreshStatus, RuntimeTestRig, SaturatingCounter, TestClock,
+    TestEpochMaintenanceExecutor, TestLiveExecutor, TestRigSchedule,
   };
   use crate::refresh::{RefreshFailureCode, RefreshRejectionCode, REFRESH_WAITER_CAPACITY};
   use chrono::{DateTime, Duration as ChronoDuration};
-  use std::sync::Arc;
+  use std::sync::atomic::Ordering;
+  use std::sync::{mpsc, Arc};
+  use std::thread;
   use std::time::Duration;
 
   const TEST_TIMEOUT: Duration = Duration::from_secs(2);
@@ -389,6 +392,362 @@ mod tests {
     assert_eq!(rig.token.commit_calls(), 1);
     assert_eq!(rig.live.persist_calls(), 1);
     rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_runs_one_batch_per_maintenance_dispatch() {
+    assert_eq!(super::EPOCH_MAINTENANCE_COMMAND_CAPACITY, 1);
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 1_000,
+      complete: false,
+    }));
+    let first = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+
+    first.wait_entered(TEST_TIMEOUT);
+    assert_eq!(maintenance.limits(), [1_000]);
+    for _ in 0..4 {
+      rig.handle.wake().expect("wake gated maintenance");
+      rig.handle.barrier().expect("drain wake");
+    }
+    assert_eq!(maintenance.calls(), 1, "only one bounded batch is active");
+
+    first.release();
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.handle.wake().expect("wake before pacing deadline");
+    rig.handle.barrier().expect("drain early wake");
+    assert_eq!(maintenance.calls(), 1, "outcome alone cannot chain a batch");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_progresses_when_auto_scan_is_disabled() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+
+    maintenance.wait_for_calls(1, TEST_TIMEOUT);
+    assert!(!rig.handle.status().auto_scan_enabled);
+    rig.wait_for_maintenance_exit(TEST_TIMEOUT);
+    assert_eq!(maintenance.calls(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_waits_while_token_or_live_lane_is_busy() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let (rig, parse, fetch) =
+      RuntimeTestRig::startup_due_with_pre_body_gates_and_maintenance(Arc::clone(&maintenance));
+    parse.wait_worker_ready(TEST_TIMEOUT);
+    fetch.wait_worker_ready(TEST_TIMEOUT);
+    rig.handle.barrier().expect("observe both busy lanes");
+    assert_eq!(maintenance.calls(), 0);
+
+    parse.release();
+    rig.token.wait_for_commit_calls(1, TEST_TIMEOUT);
+    rig.handle.barrier().expect("observe live lane still busy");
+    assert_eq!(maintenance.calls(), 0);
+
+    fetch.release();
+    maintenance.wait_for_calls(1, TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_respects_thirty_second_refresh_deadline_guard() {
+    let exact = Arc::new(TestEpochMaintenanceExecutor::new());
+    let exact_rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::ThirtySecondDeadline,
+      Arc::clone(&exact),
+    );
+    exact_rig.handle.barrier().expect("observe exact deadline");
+    assert_eq!(exact.calls(), 0, "exactly thirty seconds is guarded");
+    exact_rig.shutdown();
+
+    let beyond = Arc::new(TestEpochMaintenanceExecutor::new());
+    beyond.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let beyond_rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::ThirtyOneSecondDeadline,
+      Arc::clone(&beyond),
+    );
+    beyond.wait_for_calls(1, TEST_TIMEOUT);
+    beyond_rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_incomplete_batches_are_paced_without_busy_loop() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 1_000,
+      complete: false,
+    }));
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 7,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.handle.wake().expect("wake before two-second pace");
+    rig.handle.barrier().expect("drain early wake");
+    assert_eq!(maintenance.calls(), 1);
+
+    rig.clock.advance(Duration::from_secs(2));
+    rig.handle.wake().expect("wake at pacing deadline");
+    maintenance.wait_for_calls(2, TEST_TIMEOUT);
+    rig.wait_for_maintenance_exit(TEST_TIMEOUT);
+    assert_eq!(maintenance.unique_worker_ids(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn stale_or_duplicate_epoch_backfill_outcomes_are_ignored() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 1_000,
+      complete: false,
+    }));
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+
+    rig.inject_maintenance_outcome(
+      1,
+      Ok(EpochMaintenanceBatch::Progress {
+        processed_rows: 0,
+        complete: true,
+      }),
+    );
+    rig.handle.barrier().expect("drain duplicate outcome");
+    rig.clock.advance(Duration::from_secs(2));
+    rig.handle.wake().expect("wake next real attempt");
+
+    maintenance.wait_for_calls(2, TEST_TIMEOUT);
+    rig.wait_for_maintenance_exit(TEST_TIMEOUT);
+    assert_eq!(maintenance.calls(), 2, "duplicate did not complete the repair");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_failure_uses_backoff_without_hot_loop() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.queue_result(Err("injected maintenance failure".to_string()));
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+
+    rig.clock.advance(Duration::from_secs(29));
+    rig.handle.wake().expect("wake before retry backoff");
+    rig.handle.barrier().expect("drain early retry wake");
+    assert_eq!(maintenance.calls(), 1);
+    rig.clock.advance(Duration::from_secs(1));
+    rig.handle.wake().expect("wake at retry backoff");
+    maintenance.wait_for_calls(2, TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_failure_backoff_is_bounded_to_five_minutes() {
+    assert_eq!(
+      super::epoch_maintenance_retry_delay(1),
+      Duration::from_secs(30)
+    );
+    assert_eq!(
+      super::epoch_maintenance_retry_delay(2),
+      Duration::from_secs(60)
+    );
+    assert_eq!(
+      super::epoch_maintenance_retry_delay(5),
+      Duration::from_secs(5 * 60)
+    );
+    assert_eq!(
+      super::epoch_maintenance_retry_delay(u32::MAX),
+      Duration::from_secs(5 * 60)
+    );
+  }
+
+  #[test]
+  fn epoch_backfill_panic_uses_backoff_and_worker_recovers() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    maintenance.panic_batch(1);
+    maintenance.queue_result(Ok(EpochMaintenanceBatch::Progress {
+      processed_rows: 0,
+      complete: true,
+    }));
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    assert_eq!(maintenance.calls(), 1);
+
+    rig.clock.advance(Duration::from_secs(30));
+    rig.handle.wake().expect("wake after panic backoff");
+    maintenance.wait_for_calls(2, TEST_TIMEOUT);
+    rig.wait_for_maintenance_exit(TEST_TIMEOUT);
+    assert_eq!(maintenance.unique_worker_ids(), 1);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn snapshot_getter_remains_available_while_epoch_backfill_waits() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let gate = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    gate.wait_entered(TEST_TIMEOUT);
+
+    let status = rig.handle.status();
+    let metrics = rig.handle.metrics();
+    assert!(!status.token.running && !status.live.running);
+    assert_eq!(metrics.token.lane.running_generation, None);
+
+    gate.release();
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.shutdown();
+  }
+
+  #[test]
+  fn refresh_priority_overtakes_queued_epoch_maintenance() {
+    let mutation = crate::refresh::UsageMutationCoordinator::new();
+    let blocker_mutation = mutation.clone();
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let blocker = thread::spawn(move || {
+      blocker_mutation.run(crate::refresh::MutationPriority::Pricing, || {
+        entered_tx.send(()).expect("report blocker entry");
+        release_rx.recv().expect("release blocker");
+      });
+    });
+    entered_rx
+      .recv_timeout(TEST_TIMEOUT)
+      .expect("pricing blocker owns mutation slot");
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let retry_gate = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance_and_mutation(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+      mutation,
+    );
+    rig.wait_for_mutation_queue(1, TEST_TIMEOUT);
+    let token = rig.handle.request_manual_token(None).expect("token ticket");
+    rig.token.wait_until_waiting_to_commit(TEST_TIMEOUT);
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.wait_for_mutation_queue(1, TEST_TIMEOUT);
+    assert_eq!(maintenance.calls(), 0, "queued maintenance never enters executor");
+
+    release_tx.send(()).expect("release blocker");
+    assert!(token.wait_timeout(TEST_TIMEOUT).is_ok());
+    assert_eq!(rig.token.commit_calls(), 1);
+
+    rig.clock.advance(Duration::from_secs(2));
+    rig.handle.wake().expect("wake paced maintenance retry");
+    retry_gate.wait_entered(TEST_TIMEOUT);
+    retry_gate.release();
+    blocker.join().expect("blocker exits");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn ready_live_persistence_cancels_epoch_maintenance_then_persists_first() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let first = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    first.wait_entered(TEST_TIMEOUT);
+
+    let live = rig.handle.request_manual_live().expect("live ticket");
+    assert!(live.wait_timeout(TEST_TIMEOUT).is_ok());
+    rig.handle.barrier().expect("process ready persistence");
+    assert!(maintenance.cancellation(1).load(Ordering::Acquire));
+    assert_eq!(rig.live.persist_calls(), 0, "persistence waits for batch outcome");
+
+    first.release();
+    rig.wait_for_maintenance_outcomes(1, TEST_TIMEOUT);
+    rig.wait_for_persist_outcomes(1, TEST_TIMEOUT);
+    assert_eq!(rig.live.persist_calls(), 1);
+    assert_eq!(maintenance.calls(), 1, "maintenance retry remains paced");
+    rig.shutdown();
+  }
+
+  #[test]
+  fn epoch_backfill_shutdown_joins_worker_without_followup() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let first = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    first.wait_entered(TEST_TIMEOUT);
+
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    assert!(maintenance.cancellation(1).load(Ordering::Acquire));
+    assert!(!shutdown.is_finished());
+    first.release();
+
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+    assert_eq!(maintenance.calls(), 1);
+    assert_eq!(maintenance.unique_worker_ids(), 1);
+  }
+
+  #[test]
+  fn epoch_backfill_shutdown_drains_saturated_outcome_without_deadlock() {
+    let maintenance = Arc::new(TestEpochMaintenanceExecutor::new());
+    let first = maintenance.block_batch(1);
+    let rig = RuntimeTestRig::build_with_maintenance(
+      TestRigSchedule::Disabled,
+      Arc::clone(&maintenance),
+    );
+    first.wait_entered(TEST_TIMEOUT);
+    let pause = rig.pause_coordinator();
+    rig.fill_runtime_channel_until_busy();
+
+    let shutdown = rig.shutdown_in_background();
+    rig.wait_for_shutdown_requested(TEST_TIMEOUT);
+    first.release();
+    pause.release();
+
+    let joined = shutdown.wait(TEST_TIMEOUT);
+    assert!(joined.coordinator_joined && joined.token_joined && joined.live_joined);
+    assert_eq!(maintenance.calls(), 1);
+    assert_eq!(maintenance.unique_worker_ids(), 1);
   }
 
   #[test]
@@ -1308,6 +1667,13 @@ use std::time::{Duration, Instant};
 
 pub(crate) const RUNTIME_COMMAND_CAPACITY: usize = REFRESH_WAITER_CAPACITY;
 const WORKER_COMMAND_CAPACITY: usize = 1;
+pub(crate) const EPOCH_MAINTENANCE_COMMAND_CAPACITY: usize = 1;
+const EPOCH_MAINTENANCE_STACK_SIZE: usize = 512 * 1024;
+const EPOCH_MAINTENANCE_BATCH_SIZE: usize = 1_000;
+const EPOCH_MAINTENANCE_PACE: Duration = Duration::from_secs(2);
+const EPOCH_MAINTENANCE_DEADLINE_GUARD: Duration = Duration::from_secs(30);
+const EPOCH_MAINTENANCE_RETRY_BASE: Duration = Duration::from_secs(30);
+const EPOCH_MAINTENANCE_RETRY_MAX: Duration = Duration::from_secs(5 * 60);
 pub(crate) const HISTOGRAM_BUCKETS: usize = 8;
 const START_LAG_WARNING: Duration = Duration::from_secs(5);
 const HISTOGRAM_UPPER_BOUNDS_MS: [u64; HISTOGRAM_BUCKETS] =
@@ -1359,6 +1725,23 @@ pub(crate) trait LiveQuotaFetcher: Send + Sync {
 
 pub(crate) trait LiveQuotaPersister: Send + Sync {
   fn persist(&self, snapshot: &LiveRateLimitSnapshot) -> Result<(), String>;
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EpochMaintenanceBatch {
+  Progress {
+    processed_rows: usize,
+    complete: bool,
+  },
+  Cancelled,
+}
+
+pub(crate) trait EpochMaintenanceExecutor: Send + Sync {
+  fn run_batch(
+    &self,
+    limit: usize,
+    cancellation: Arc<AtomicBool>,
+  ) -> Result<EpochMaintenanceBatch, String>;
 }
 
 pub(crate) trait RefreshEventSink: Send + Sync {
@@ -1922,6 +2305,7 @@ pub(crate) struct RefreshRuntimeDependencies {
   pub mutation: UsageMutationCoordinator,
   pub activity_factory: Arc<dyn ActivityFactory>,
   pub clock: Arc<dyn RefreshClock>,
+  pub epoch_maintenance_executor: Option<Arc<dyn EpochMaintenanceExecutor>>,
   #[cfg(test)]
   test_hooks: Option<Arc<RuntimeTestHooks>>,
 }
@@ -1947,9 +2331,18 @@ impl RefreshRuntimeDependencies {
       mutation,
       activity_factory: Arc::new(SystemActivityFactory),
       clock: Arc::new(SystemRefreshClock),
+      epoch_maintenance_executor: None,
       #[cfg(test)]
       test_hooks: None,
     }
+  }
+
+  pub(crate) fn with_epoch_maintenance(
+    mut self,
+    executor: Arc<dyn EpochMaintenanceExecutor>,
+  ) -> Self {
+    self.epoch_maintenance_executor = Some(executor);
+    self
   }
 }
 
@@ -1968,6 +2361,38 @@ struct RuntimeLifecycle {
   reliable_changed: Arc<Condvar>,
   shutdown_requested: Arc<AtomicBool>,
   shutdown: Arc<AtomicBool>,
+  maintenance_control: Option<Arc<EpochMaintenanceControl>>,
+}
+
+struct EpochMaintenanceControl {
+  current: Mutex<Option<(u64, Arc<AtomicBool>)>>,
+  mutation: UsageMutationCoordinator,
+}
+
+impl EpochMaintenanceControl {
+  fn new(mutation: UsageMutationCoordinator) -> Self {
+    Self {
+      current: Mutex::new(None),
+      mutation,
+    }
+  }
+
+  fn install(&self, attempt_id: u64, cancellation: Arc<AtomicBool>) {
+    *lock(&self.current) = Some((attempt_id, cancellation));
+  }
+
+  fn clear(&self, attempt_id: u64) {
+    let mut current = lock(&self.current);
+    if current.as_ref().is_some_and(|(id, _)| *id == attempt_id) {
+      *current = None;
+    }
+  }
+
+  fn cancel_current(&self) {
+    if let Some((_, cancellation)) = lock(&self.current).as_ref() {
+      self.mutation.cancel(cancellation.as_ref());
+    }
+  }
 }
 
 pub(crate) struct RefreshRuntime {
@@ -2031,6 +2456,9 @@ impl RefreshRuntime {
         }
         {
           let shutdown_state = lock(&self.lifecycle.state);
+          if let Some(control) = &self.lifecycle.maintenance_control {
+            control.cancel_current();
+          }
           self
             .lifecycle
             .shutdown_requested
@@ -2128,6 +2556,7 @@ enum RuntimeMessage {
 enum WorkerOutcome {
   Token(TokenWorkerOutcome),
   Live(LiveWorkerOutcome),
+  Maintenance(EpochMaintenanceWorkerOutcome),
   Exited(WorkerLane),
 }
 
@@ -2135,6 +2564,7 @@ enum WorkerOutcome {
 enum WorkerLane {
   Token,
   Live,
+  Maintenance,
 }
 
 enum TokenWorkerCommand {
@@ -2144,6 +2574,16 @@ enum TokenWorkerCommand {
 
 enum LiveWorkerCommand {
   Run(LiveExecutionRequest),
+}
+
+struct EpochMaintenanceWorkerCommand {
+  attempt_id: u64,
+  cancellation: Arc<AtomicBool>,
+}
+
+struct EpochMaintenanceWorkerOutcome {
+  attempt_id: u64,
+  result: Result<EpochMaintenanceBatch, String>,
 }
 
 enum TokenWorkerOutcome {
@@ -2214,6 +2654,30 @@ struct PreparedSlot {
   prepared: PreparedTokenRefresh,
 }
 
+struct EpochMaintenanceAttempt {
+  id: u64,
+}
+
+struct EpochMaintenanceState {
+  pending: bool,
+  running: Option<EpochMaintenanceAttempt>,
+  next_attempt_id: u64,
+  next_eligible_at: Option<Instant>,
+  failure_streak: u32,
+}
+
+impl EpochMaintenanceState {
+  fn new(pending: bool) -> Self {
+    Self {
+      pending,
+      running: None,
+      next_attempt_id: 0,
+      next_eligible_at: None,
+      failure_streak: 0,
+    }
+  }
+}
+
 struct CoordinatorRuntime {
   schedule: CoordinatorState,
   prepared_slot: Option<PreparedSlot>,
@@ -2222,6 +2686,8 @@ struct CoordinatorRuntime {
   current_live_result: Option<(u64, Arc<LiveRateLimitSnapshot>)>,
   token_sender: Option<SyncSender<TokenWorkerCommand>>,
   live_sender: Option<SyncSender<LiveWorkerCommand>>,
+  maintenance_sender: Option<SyncSender<EpochMaintenanceWorkerCommand>>,
+  maintenance_control: Arc<EpochMaintenanceControl>,
   runtime_sender: SyncSender<RuntimeMessage>,
   waiters: Arc<Mutex<WaiterRegistries>>,
   status: Arc<Mutex<RefreshStatus>>,
@@ -2238,8 +2704,11 @@ struct CoordinatorRuntime {
   shutdown_requested: Arc<AtomicBool>,
   token_handle: Option<JoinHandle<()>>,
   live_handle: Option<JoinHandle<()>>,
+  maintenance_handle: Option<JoinHandle<()>>,
+  maintenance: EpochMaintenanceState,
   token_exited: bool,
   live_exited: bool,
+  maintenance_exited: bool,
   #[cfg(test)]
   hooks: Arc<RuntimeTestHooks>,
 }
@@ -2255,6 +2724,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     mutation,
     activity_factory,
     clock,
+    epoch_maintenance_executor,
     #[cfg(test)]
     test_hooks,
   } = dependencies;
@@ -2272,12 +2742,14 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
   let hooks = test_hooks.unwrap_or_else(|| Arc::new(RuntimeTestHooks::default()));
   #[cfg(test)]
   let returned_hooks = Arc::clone(&hooks);
+  let maintenance_pending = epoch_maintenance_executor.is_some();
+  let maintenance_control = Arc::new(EpochMaintenanceControl::new(mutation.clone()));
 
   let token_handle = spawn_token_worker(TokenWorkerParameters {
     receiver: token_rx,
     runtime_sender: runtime_tx.clone(),
     executor: token_executor,
-    mutation,
+    mutation: mutation.clone(),
     activity_factory: Arc::clone(&activity_factory),
     status: Arc::clone(&status),
     metrics: Arc::clone(&metrics),
@@ -2289,6 +2761,22 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     #[cfg(test)]
     hooks: Arc::clone(&hooks),
   })?;
+  let (maintenance_sender, maintenance_handle) = match epoch_maintenance_executor {
+    Some(executor) => {
+      let (sender, receiver) =
+        mpsc::sync_channel(EPOCH_MAINTENANCE_COMMAND_CAPACITY);
+      let handle = spawn_epoch_maintenance_worker(EpochMaintenanceWorkerParameters {
+        receiver,
+        runtime_sender: runtime_tx.clone(),
+        executor,
+        mutation: mutation.clone(),
+        #[cfg(test)]
+        hooks: Arc::clone(&hooks),
+      })?;
+      (Some(sender), Some(handle))
+    }
+    None => (None, None),
+  };
   let live_handle = spawn_live_worker(LiveWorkerParameters {
     receiver: live_rx,
     runtime_sender: runtime_tx.clone(),
@@ -2335,6 +2823,8 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     current_live_result: None,
     token_sender: Some(token_tx),
     live_sender: Some(live_tx),
+    maintenance_sender,
+    maintenance_control: Arc::clone(&maintenance_control),
     runtime_sender: runtime_tx.clone(),
     waiters,
     status,
@@ -2351,8 +2841,11 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     shutdown_requested: Arc::clone(&shutdown_requested),
     token_handle: Some(token_handle),
     live_handle: Some(live_handle),
+    maintenance_handle,
+    maintenance: EpochMaintenanceState::new(maintenance_pending),
     token_exited: false,
     live_exited: false,
+    maintenance_exited: !maintenance_pending,
     #[cfg(test)]
     hooks,
   };
@@ -2370,6 +2863,7 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     reliable_changed,
     shutdown_requested,
     shutdown,
+    maintenance_control: maintenance_pending.then_some(maintenance_control),
   });
   Ok(RefreshRuntime {
     handle,
@@ -2377,6 +2871,72 @@ fn start_runtime(dependencies: RefreshRuntimeDependencies) -> Result<RefreshRunt
     #[cfg(test)]
     test_hooks: returned_hooks,
   })
+}
+
+struct EpochMaintenanceWorkerParameters {
+  receiver: Receiver<EpochMaintenanceWorkerCommand>,
+  runtime_sender: SyncSender<RuntimeMessage>,
+  executor: Arc<dyn EpochMaintenanceExecutor>,
+  mutation: UsageMutationCoordinator,
+  #[cfg(test)]
+  hooks: Arc<RuntimeTestHooks>,
+}
+
+fn spawn_epoch_maintenance_worker(
+  parameters: EpochMaintenanceWorkerParameters,
+) -> Result<JoinHandle<()>, String> {
+  thread::Builder::new()
+    .name("codex-pacer-epoch-maintenance".to_string())
+    .stack_size(EPOCH_MAINTENANCE_STACK_SIZE)
+    .spawn(move || {
+      let sender = parameters.runtime_sender.clone();
+      #[cfg(test)]
+      parameters.hooks.record_thread_name();
+      let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+        while let Ok(command) = parameters.receiver.recv() {
+          let attempt_id = command.attempt_id;
+          let result = run_epoch_maintenance_batch(&parameters, command.cancellation);
+          if sender
+            .send(RuntimeMessage::Worker(WorkerOutcome::Maintenance(
+              EpochMaintenanceWorkerOutcome { attempt_id, result },
+            )))
+            .is_err()
+          {
+            return;
+          }
+        }
+      }));
+      let _ = sender.send(RuntimeMessage::Worker(WorkerOutcome::Exited(
+        WorkerLane::Maintenance,
+      )));
+    })
+    .map_err(|error| format!("Failed to start epoch maintenance worker: {error}"))
+}
+
+fn run_epoch_maintenance_batch(
+  parameters: &EpochMaintenanceWorkerParameters,
+  cancellation: Arc<AtomicBool>,
+) -> Result<EpochMaintenanceBatch, String> {
+  let mutation = parameters.mutation.run_cancellable(
+    MutationPriority::Maintenance,
+    &cancellation,
+    || {
+      if cancellation.load(Ordering::Acquire) {
+        return Ok(EpochMaintenanceBatch::Cancelled);
+      }
+      match panic::catch_unwind(AssertUnwindSafe(|| {
+        parameters
+          .executor
+          .run_batch(EPOCH_MAINTENANCE_BATCH_SIZE, Arc::clone(&cancellation))
+      })) {
+        Ok(result) => result,
+        Err(_) => Err("epoch maintenance executor panicked".to_string()),
+      }
+    },
+  );
+  mutation
+    .map(|outcome| outcome.value)
+    .unwrap_or(Ok(EpochMaintenanceBatch::Cancelled))
 }
 
 struct TokenWorkerParameters {
@@ -2753,6 +3313,17 @@ fn nonzero_duration_millis(value: Duration) -> u64 {
   }
 }
 
+fn epoch_maintenance_retry_delay(failure_streak: u32) -> Duration {
+  let shift = failure_streak.saturating_sub(1).min(4);
+  let multiplier = 1_u64 << shift;
+  Duration::from_secs(
+    EPOCH_MAINTENANCE_RETRY_BASE
+      .as_secs()
+      .saturating_mul(multiplier)
+      .min(EPOCH_MAINTENANCE_RETRY_MAX.as_secs()),
+  )
+}
+
 fn wall_time_for_instant(clock: &dyn RefreshClock, target: Instant) -> DateTime<Utc> {
   let monotonic_now = clock.monotonic_now();
   let wall_now = clock.wall_now();
@@ -2892,6 +3463,7 @@ fn persistence_task_is_stale(parameters: &PersistenceTaskParameters) -> bool {
 fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: CoordinatorRuntime) {
   #[cfg(test)]
   runtime.hooks.record_thread_name();
+  runtime.drive_background_work();
   loop {
     let message = if runtime.shutdown_requested.load(Ordering::Acquire) {
       receiver.recv().map_err(|_| RecvError)
@@ -2901,7 +3473,7 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
           Ok(message) => Ok(message),
           Err(RecvTimeoutError::Timeout) => {
             runtime.process_schedule_event(CoordinatorEvent::Timer);
-            runtime.maybe_start_persistence();
+            runtime.drive_background_work();
             continue;
           }
           Err(RecvTimeoutError::Disconnected) => Err(RecvError),
@@ -2923,11 +3495,11 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
     match message {
       RuntimeMessage::RequestToken(request) => {
         runtime.process_schedule_event(CoordinatorEvent::RequestToken(request));
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
       }
       RuntimeMessage::RequestLive(request) => {
         runtime.process_schedule_event(CoordinatorEvent::RequestLive(request));
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
       }
       RuntimeMessage::SettingsChanged(config, reply) => {
         let previous_source_generation = runtime.schedule.snapshot().source_generation;
@@ -2944,26 +3516,30 @@ fn coordinator_loop(receiver: Receiver<RuntimeMessage>, mut runtime: Coordinator
         }
         runtime.sync_schedule_snapshot();
         runtime.process_actions(actions);
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
         let _ = reply.send(());
       }
       RuntimeMessage::Wake(reply) => {
         runtime.process_schedule_event(CoordinatorEvent::Wake);
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
         let _ = reply.send(());
       }
       RuntimeMessage::WakeNoReply => {
         runtime.process_schedule_event(CoordinatorEvent::Wake);
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
       }
       RuntimeMessage::Barrier(reply) => {
+        runtime.drive_background_work();
         let _ = reply.send(());
       }
       RuntimeMessage::Worker(outcome) => {
         runtime.process_worker_outcome(outcome);
-        runtime.maybe_start_persistence();
+        runtime.drive_background_work();
       }
-      RuntimeMessage::Persistence(outcome) => runtime.process_persistence_outcome(outcome),
+      RuntimeMessage::Persistence(outcome) => {
+        runtime.process_persistence_outcome(outcome);
+        runtime.drive_background_work();
+      }
       RuntimeMessage::Shutdown(reply) => {
         runtime.shutdown_and_join_workers(&receiver, reply);
         return;
@@ -2997,11 +3573,16 @@ impl CoordinatorRuntime {
     let schedule = self.schedule.next_wait(now);
     let live_running = self.schedule.snapshot().live.running_generation.is_some();
     let persistence = self.persistence.next_wait(now, live_running);
-    match (schedule, persistence) {
-      (Some(schedule), Some(persistence)) => Some(schedule.min(persistence)),
-      (Some(wait), None) | (None, Some(wait)) => Some(wait),
-      (None, None) => None,
-    }
+    let maintenance = self.maintenance_wait(now);
+    [schedule, persistence, maintenance]
+      .into_iter()
+      .flatten()
+      .min()
+  }
+
+  fn drive_background_work(&mut self) {
+    self.maybe_start_persistence();
+    self.maybe_start_maintenance();
   }
 
   fn maybe_start_persistence(&mut self) {
@@ -3011,10 +3592,17 @@ impl CoordinatorRuntime {
     {
       return;
     }
+    let now = self.clock.monotonic_now();
     let live_running = self.schedule.snapshot().live.running_generation.is_some();
+    if self.persistence.next_wait(now, live_running) == Some(Duration::ZERO)
+      && self.maintenance.running.is_some()
+    {
+      self.cancel_epoch_maintenance();
+      return;
+    }
     let Some(work) = self
       .persistence
-      .take_ready(self.clock.monotonic_now(), live_running)
+      .take_ready(now, live_running)
     else {
       return;
     };
@@ -3047,6 +3635,139 @@ impl CoordinatorRuntime {
     }
   }
 
+  fn maintenance_wait(&self, now: Instant) -> Option<Duration> {
+    if !self.maintenance_dispatch_gates_open(now) {
+      return None;
+    }
+    Some(
+      self
+        .maintenance
+        .next_eligible_at
+        .map(|deadline| deadline.saturating_duration_since(now))
+        .unwrap_or(Duration::ZERO),
+    )
+  }
+
+  fn maintenance_dispatch_gates_open(&self, now: Instant) -> bool {
+    if !self.maintenance.pending
+      || self.maintenance.running.is_some()
+      || self.maintenance_sender.is_none()
+      || self.shutdown_requested.load(Ordering::Acquire)
+      || self.shutdown.load(Ordering::Acquire)
+      || self.persistence_handle.is_some()
+    {
+      return false;
+    }
+    let snapshot = self.schedule.snapshot();
+    if snapshot.token.running_generation.is_some()
+      || snapshot.live.running_generation.is_some()
+      || snapshot.token.pending
+      || snapshot.live.pending
+    {
+      return false;
+    }
+    if self
+      .schedule
+      .next_wait(now)
+      .is_some_and(|wait| wait <= EPOCH_MAINTENANCE_DEADLINE_GUARD)
+    {
+      return false;
+    }
+    self.persistence.next_wait(now, false) != Some(Duration::ZERO)
+  }
+
+  fn maybe_start_maintenance(&mut self) {
+    let now = self.clock.monotonic_now();
+    if self.maintenance_wait(now) != Some(Duration::ZERO) {
+      return;
+    }
+    let Some(sender) = self.maintenance_sender.clone() else {
+      return;
+    };
+    let Some(attempt_id) = self.maintenance.next_attempt_id.checked_add(1) else {
+      log::error!("Epoch maintenance attempt ID overflowed; disabling the repair worker.");
+      self.maintenance.pending = false;
+      self.maintenance_sender = None;
+      return;
+    };
+    let cancellation = Arc::new(AtomicBool::new(false));
+    let command = EpochMaintenanceWorkerCommand {
+      attempt_id,
+      cancellation: Arc::clone(&cancellation),
+    };
+    match sender.try_send(command) {
+      Ok(()) => {
+        self.maintenance.next_attempt_id = attempt_id;
+        self.maintenance.next_eligible_at = None;
+        self
+          .maintenance_control
+          .install(attempt_id, Arc::clone(&cancellation));
+        self.maintenance.running = Some(EpochMaintenanceAttempt { id: attempt_id });
+        if self.shutdown_requested.load(Ordering::Acquire) {
+          self.maintenance_control.cancel_current();
+        }
+      }
+      Err(TrySendError::Full(_)) => {
+        log::warn!("Epoch maintenance command queue was unexpectedly full.");
+        self.maintenance.next_eligible_at = now.checked_add(EPOCH_MAINTENANCE_PACE);
+      }
+      Err(TrySendError::Disconnected(_)) => {
+        log::warn!("Epoch maintenance worker became unavailable.");
+        self.maintenance.pending = false;
+        self.maintenance_sender = None;
+      }
+    }
+  }
+
+  fn cancel_epoch_maintenance(&self) {
+    if self.maintenance.running.is_some() {
+      self.maintenance_control.cancel_current();
+    }
+  }
+
+  fn process_maintenance_outcome(&mut self, outcome: EpochMaintenanceWorkerOutcome) {
+    let Some(attempt) = self.maintenance.running.as_ref() else {
+      return;
+    };
+    if attempt.id != outcome.attempt_id {
+      return;
+    }
+    self.maintenance_control.clear(outcome.attempt_id);
+    self.maintenance.running = None;
+    #[cfg(test)]
+    self.hooks.record_maintenance_outcome();
+    if self.shutdown_requested.load(Ordering::Acquire) || self.shutdown.load(Ordering::Acquire) {
+      return;
+    }
+    let now = self.clock.monotonic_now();
+    match outcome.result {
+      Ok(EpochMaintenanceBatch::Progress {
+        processed_rows,
+        complete,
+      }) => {
+        self.maintenance.failure_streak = 0;
+        if complete {
+          log::debug!("Epoch maintenance completed after a {processed_rows}-row slice.");
+          self.maintenance.pending = false;
+          self.maintenance.next_eligible_at = None;
+          self.maintenance_sender = None;
+        } else {
+          self.maintenance.next_eligible_at = now.checked_add(EPOCH_MAINTENANCE_PACE);
+        }
+      }
+      Ok(EpochMaintenanceBatch::Cancelled) => {
+        self.maintenance.failure_streak = 0;
+        self.maintenance.next_eligible_at = now.checked_add(EPOCH_MAINTENANCE_PACE);
+      }
+      Err(error) => {
+        self.maintenance.failure_streak = self.maintenance.failure_streak.saturating_add(1);
+        self.maintenance.next_eligible_at =
+          now.checked_add(epoch_maintenance_retry_delay(self.maintenance.failure_streak));
+        log::warn!("Epoch maintenance slice failed; retrying later: {error}");
+      }
+    }
+  }
+
   fn process_persistence_outcome(&mut self, outcome: PersistenceWorkerOutcome) {
     if let Some(handle) = self.persistence_handle.take() {
       if handle.join().is_err() {
@@ -3073,8 +3794,6 @@ impl CoordinatorRuntime {
     self.hooks.record_persistence_outcome();
     if self.shutdown_requested.load(Ordering::Acquire) || self.shutdown.load(Ordering::Acquire) {
       self.persistence.cancel_pending();
-    } else {
-      self.maybe_start_persistence();
     }
   }
 
@@ -3090,6 +3809,12 @@ impl CoordinatorRuntime {
       }
       RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
         self.live_exited = true;
+      }
+      RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Maintenance)) => {
+        self.finish_maintenance_worker_exit();
+      }
+      RuntimeMessage::Worker(WorkerOutcome::Maintenance(outcome)) => {
+        self.process_maintenance_outcome(outcome);
       }
       RuntimeMessage::Persistence(outcome) => {
         self.process_persistence_outcome(outcome);
@@ -3127,9 +3852,28 @@ impl CoordinatorRuntime {
     match outcome {
       WorkerOutcome::Token(outcome) => self.process_token_outcome(outcome),
       WorkerOutcome::Live(outcome) => self.process_live_outcome(outcome),
+      WorkerOutcome::Maintenance(outcome) => self.process_maintenance_outcome(outcome),
       WorkerOutcome::Exited(WorkerLane::Token) => self.token_exited = true,
       WorkerOutcome::Exited(WorkerLane::Live) => self.live_exited = true,
+      WorkerOutcome::Exited(WorkerLane::Maintenance) => self.finish_maintenance_worker_exit(),
     }
+  }
+
+  fn finish_maintenance_worker_exit(&mut self) {
+    self.maintenance_exited = true;
+    if let Some(handle) = self.maintenance_handle.take() {
+      if handle.join().is_err() {
+        log::warn!("Epoch maintenance worker panicked while exiting.");
+      }
+    }
+    if let Some(attempt) = self.maintenance.running.take() {
+      self.maintenance_control.clear(attempt.id);
+      log::warn!("Epoch maintenance worker exited before reporting its active attempt.");
+    }
+    self.maintenance.pending = false;
+    self.maintenance_sender = None;
+    #[cfg(test)]
+    self.hooks.record_maintenance_exit();
   }
 
   fn process_token_outcome(&mut self, outcome: TokenWorkerOutcome) {
@@ -3468,6 +4212,7 @@ impl CoordinatorRuntime {
   }
 
   fn start_token(&mut self, request: TokenExecutionRequest) {
+    self.cancel_epoch_maintenance();
     self.record_lane_start(true, request.generation, request.request.planned_due_at);
     set_mutation_phase(&self.status, MutationPhase::Parsing);
     #[cfg(test)]
@@ -3492,6 +4237,7 @@ impl CoordinatorRuntime {
   }
 
   fn start_live(&mut self, request: LiveExecutionRequest) {
+    self.cancel_epoch_maintenance();
     self.record_lane_start(false, request.generation, request.planned_due_at);
     self.live_cache.set_refreshing(true);
     let result = self.live_sender.as_ref().ok_or(()).and_then(|sender| {
@@ -3707,6 +4453,9 @@ impl CoordinatorRuntime {
     drain_waiters_for_shutdown(&self.waiters);
     self.live_cache.set_refreshing(false);
     self.persistence.cancel_pending();
+    self.cancel_epoch_maintenance();
+    self.maintenance.pending = false;
+    self.maintenance_sender = None;
     self.prepared_slot = None;
     #[cfg(test)]
     self.hooks.set_prepared_slot_empty(true);
@@ -3722,7 +4471,11 @@ impl CoordinatorRuntime {
       status.mutation_phase = None;
     }
 
-    while !self.token_exited || !self.live_exited || self.persistence_handle.is_some() {
+    while !self.token_exited
+      || !self.live_exited
+      || !self.maintenance_exited
+      || self.persistence_handle.is_some()
+    {
       let Ok(message) = receiver.recv() else {
         break;
       };
@@ -3732,6 +4485,12 @@ impl CoordinatorRuntime {
         }
         RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Live)) => {
           self.live_exited = true;
+        }
+        RuntimeMessage::Worker(WorkerOutcome::Exited(WorkerLane::Maintenance)) => {
+          self.finish_maintenance_worker_exit();
+        }
+        RuntimeMessage::Worker(WorkerOutcome::Maintenance(outcome)) => {
+          self.process_maintenance_outcome(outcome);
         }
         RuntimeMessage::Persistence(outcome) => {
           self.process_persistence_outcome(outcome);
@@ -4084,6 +4843,8 @@ struct TestHookData {
   prepared_slot_empty: bool,
   completion_slots_empty: bool,
   persistence_outcomes: u64,
+  maintenance_outcomes: u64,
+  maintenance_exited: bool,
 }
 
 #[cfg(test)]
@@ -4162,6 +4923,18 @@ impl RuntimeTestHooks {
     let mut data = lock(&self.data);
     data.persistence_outcomes = data.persistence_outcomes.saturating_add(1);
     drop(data);
+    self.changed.notify_all();
+  }
+
+  fn record_maintenance_outcome(&self) {
+    let mut data = lock(&self.data);
+    data.maintenance_outcomes = data.maintenance_outcomes.saturating_add(1);
+    drop(data);
+    self.changed.notify_all();
+  }
+
+  fn record_maintenance_exit(&self) {
+    lock(&self.data).maintenance_exited = true;
     self.changed.notify_all();
   }
 
@@ -4408,6 +5181,12 @@ impl TestTokenExecutor {
 
   fn wait_for_commit_calls(&self, expected: u64, timeout: Duration) {
     self.wait_for_counter(&self.commit_calls, expected, timeout);
+  }
+
+  fn wait_until_waiting_to_commit(&self, timeout: Duration) {
+    self
+      .hooks
+      .wait_for(timeout, |data| data.token_waiting_count > 0);
   }
 
   fn wait_for_counter(&self, counter: &AtomicU64, expected: u64, timeout: Duration) {
@@ -4894,6 +5673,124 @@ impl LiveQuotaPersister for TestLiveExecutor {
 }
 
 #[cfg(test)]
+#[derive(Default)]
+struct TestEpochMaintenanceBehavior {
+  body_gates: HashMap<u64, Arc<TestGateState>>,
+  results: VecDeque<Result<EpochMaintenanceBatch, String>>,
+  limits: Vec<usize>,
+  cancellations: Vec<Arc<AtomicBool>>,
+  worker_ids: Vec<String>,
+  panic_calls: std::collections::HashSet<u64>,
+}
+
+#[cfg(test)]
+struct TestEpochMaintenanceExecutor {
+  behavior: Mutex<TestEpochMaintenanceBehavior>,
+  changed: Condvar,
+  calls: AtomicU64,
+}
+
+#[cfg(test)]
+impl TestEpochMaintenanceExecutor {
+  fn new() -> Self {
+    Self {
+      behavior: Mutex::new(TestEpochMaintenanceBehavior::default()),
+      changed: Condvar::new(),
+      calls: AtomicU64::new(0),
+    }
+  }
+
+  fn queue_result(&self, result: Result<EpochMaintenanceBatch, String>) {
+    lock(&self.behavior).results.push_back(result);
+  }
+
+  fn block_batch(&self, call: u64) -> PhaseGateControl {
+    let state = Arc::new(TestGateState::default());
+    lock(&self.behavior)
+      .body_gates
+      .insert(call, Arc::clone(&state));
+    PhaseGateControl { state }
+  }
+
+  fn panic_batch(&self, call: u64) {
+    lock(&self.behavior).panic_calls.insert(call);
+  }
+
+  fn wait_for_calls(&self, expected: u64, timeout: Duration) {
+    let behavior = lock(&self.behavior);
+    let (_behavior, timed_out) = self
+      .changed
+      .wait_timeout_while(behavior, timeout, |_| self.calls() < expected)
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(self.calls() >= expected, "maintenance call count");
+    assert!(!timed_out.timed_out(), "timed out waiting for maintenance call");
+  }
+
+  fn calls(&self) -> u64 {
+    self.calls.load(Ordering::Acquire)
+  }
+
+  fn limits(&self) -> Vec<usize> {
+    lock(&self.behavior).limits.clone()
+  }
+
+  fn cancellation(&self, call: usize) -> Arc<AtomicBool> {
+    Arc::clone(
+      lock(&self.behavior)
+        .cancellations
+        .get(call.saturating_sub(1))
+        .expect("recorded maintenance cancellation token"),
+    )
+  }
+
+  fn unique_worker_ids(&self) -> usize {
+    lock(&self.behavior)
+      .worker_ids
+      .iter()
+      .collect::<std::collections::HashSet<_>>()
+      .len()
+  }
+}
+
+#[cfg(test)]
+impl EpochMaintenanceExecutor for TestEpochMaintenanceExecutor {
+  fn run_batch(
+    &self,
+    limit: usize,
+    cancellation: Arc<AtomicBool>,
+  ) -> Result<EpochMaintenanceBatch, String> {
+    let call = self.calls.fetch_add(1, Ordering::AcqRel) + 1;
+    let (gate, result, panic_now) = {
+      let mut behavior = lock(&self.behavior);
+      behavior.limits.push(limit);
+      behavior.cancellations.push(Arc::clone(&cancellation));
+      behavior
+        .worker_ids
+        .push(format!("{:?}", thread::current().id()));
+      let panic_now = behavior.panic_calls.remove(&call);
+      let result = (!panic_now).then(|| {
+        behavior.results.pop_front().unwrap_or(Ok(EpochMaintenanceBatch::Progress {
+          processed_rows: 1_000,
+          complete: false,
+        }))
+      });
+      (behavior.body_gates.remove(&call), result, panic_now)
+    };
+    self.changed.notify_all();
+    if let Some(gate) = gate {
+      gate.mark_entered_and_wait();
+    }
+    if panic_now {
+      panic!("intentional epoch maintenance panic");
+    }
+    if cancellation.load(Ordering::Acquire) {
+      return Ok(EpochMaintenanceBatch::Cancelled);
+    }
+    result.expect("non-panicking maintenance call has a result")
+  }
+}
+
+#[cfg(test)]
 fn decrement_saturating_atomic(value: &AtomicU64) {
   let mut current = value.load(Ordering::Acquire);
   loop {
@@ -5017,6 +5914,8 @@ enum TestRigSchedule {
   StartupDue,
   Paused,
   HugeInterval,
+  ThirtySecondDeadline,
+  ThirtyOneSecondDeadline,
 }
 
 #[cfg(test)]
@@ -5053,6 +5952,29 @@ impl RuntimeTestRig {
     )
   }
 
+  fn startup_due_with_pre_body_gates_and_maintenance(
+    maintenance: Arc<TestEpochMaintenanceExecutor>,
+  ) -> (Self, PhaseGateControl, PhaseGateControl) {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    let parse = token.block_parse_call(1);
+    let fetch = live.block_fetch_call_before_body(1);
+    (
+      Self::build_with_components_and_options(
+        TestRigSchedule::StartupDue,
+        hooks,
+        token,
+        live,
+        Some(maintenance),
+        None,
+      ),
+      parse,
+      fetch,
+    )
+  }
+
   fn scheduled_overdue(overdue: Duration) -> Self {
     let rig = Self::build(TestRigSchedule::Paused).0;
     rig
@@ -5079,17 +6001,66 @@ impl RuntimeTestRig {
     (rig, hooks)
   }
 
+  fn build_with_maintenance(
+    schedule: TestRigSchedule,
+    maintenance: Arc<TestEpochMaintenanceExecutor>,
+  ) -> Self {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    Self::build_with_components_and_options(
+      schedule,
+      hooks,
+      token,
+      live,
+      Some(maintenance),
+      None,
+    )
+  }
+
+  fn build_with_maintenance_and_mutation(
+    schedule: TestRigSchedule,
+    maintenance: Arc<TestEpochMaintenanceExecutor>,
+    mutation: UsageMutationCoordinator,
+  ) -> Self {
+    let hooks = Arc::new(RuntimeTestHooks::default());
+    initialize_test_hooks(&hooks);
+    let token = Arc::new(TestTokenExecutor::new(Arc::clone(&hooks)));
+    let live = Arc::new(TestLiveExecutor::new(Arc::clone(&hooks)));
+    Self::build_with_components_and_options(
+      schedule,
+      hooks,
+      token,
+      live,
+      Some(maintenance),
+      Some(mutation),
+    )
+  }
+
   fn build_with_components(
     schedule: TestRigSchedule,
     hooks: Arc<RuntimeTestHooks>,
     token: Arc<TestTokenExecutor>,
     live: Arc<TestLiveExecutor>,
   ) -> Self {
+    Self::build_with_components_and_options(schedule, hooks, token, live, None, None)
+  }
+
+  fn build_with_components_and_options(
+    schedule: TestRigSchedule,
+    hooks: Arc<RuntimeTestHooks>,
+    token: Arc<TestTokenExecutor>,
+    live: Arc<TestLiveExecutor>,
+    maintenance: Option<Arc<TestEpochMaintenanceExecutor>>,
+    mutation: Option<UsageMutationCoordinator>,
+  ) -> Self {
     let clock = Arc::new(TestClock::new());
-    let interval = if matches!(schedule, TestRigSchedule::HugeInterval) {
-      Duration::MAX
-    } else {
-      Duration::from_secs(60)
+    let interval = match schedule {
+      TestRigSchedule::HugeInterval => Duration::MAX,
+      TestRigSchedule::ThirtySecondDeadline => Duration::from_secs(30),
+      TestRigSchedule::ThirtyOneSecondDeadline => Duration::from_secs(31),
+      _ => Duration::from_secs(60),
     };
     let wall_now = clock.wall_now();
     let (auto_scan_enabled, success_wall) = match schedule {
@@ -5100,6 +6071,9 @@ impl RuntimeTestRig {
       ),
       TestRigSchedule::Paused => (true, Some(wall_now)),
       TestRigSchedule::HugeInterval => (false, Some(wall_now)),
+      TestRigSchedule::ThirtySecondDeadline | TestRigSchedule::ThirtyOneSecondDeadline => {
+        (true, Some(wall_now))
+      }
     };
     let config = RefreshConfig {
       auto_scan_enabled,
@@ -5109,7 +6083,7 @@ impl RuntimeTestRig {
       live_last_success_wall: success_wall,
     };
     let events = Arc::new(TestEvents::new(Arc::clone(&hooks)));
-    let mutation = UsageMutationCoordinator::new();
+    let mutation = mutation.unwrap_or_default();
     let activities = super::power::CountingActivityFactory::default();
     let live_cache = LiveQuotaCache::new();
     let dependencies = RefreshRuntimeDependencies {
@@ -5122,6 +6096,9 @@ impl RuntimeTestRig {
       mutation: mutation.clone(),
       activity_factory: Arc::new(activities.clone()),
       clock: clock.clone(),
+      epoch_maintenance_executor: maintenance
+        .as_ref()
+        .map(|executor| executor.clone() as Arc<dyn EpochMaintenanceExecutor>),
       test_hooks: Some(Arc::clone(&hooks)),
     };
     let runtime = Arc::new(RefreshRuntime::start(dependencies).expect("start test runtime"));
@@ -5163,6 +6140,24 @@ impl RuntimeTestRig {
       .runtime
       .test_hooks
       .wait_for(timeout, |data| data.persistence_outcomes >= expected);
+  }
+
+  fn wait_for_maintenance_outcomes(&self, expected: u64, timeout: Duration) {
+    self
+      .runtime
+      .test_hooks
+      .wait_for(timeout, |data| data.maintenance_outcomes >= expected);
+  }
+
+  fn wait_for_maintenance_exit(&self, timeout: Duration) {
+    self
+      .runtime
+      .test_hooks
+      .wait_for(timeout, |data| data.maintenance_exited);
+  }
+
+  fn wait_for_mutation_queue(&self, expected: usize, timeout: Duration) {
+    self.mutation.wait_for_queued_for_test(expected, timeout);
   }
 
   fn shutdown(&self) {
@@ -5242,6 +6237,19 @@ impl RuntimeTestRig {
         },
       )))
       .expect("inject duplicate token completion");
+  }
+
+  fn inject_maintenance_outcome(
+    &self,
+    attempt_id: u64,
+    result: Result<EpochMaintenanceBatch, String>,
+  ) {
+    self
+      .runtime_sender()
+      .send(RuntimeMessage::Worker(WorkerOutcome::Maintenance(
+        EpochMaintenanceWorkerOutcome { attempt_id, result },
+      )))
+      .expect("inject maintenance outcome");
   }
 
   fn pause_coordinator(&self) -> CoordinatorPause {

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -24,6 +24,7 @@ struct LaneState {
   next_deadline: Instant,
   running: bool,
   startup_due: bool,
+  immediate_due: bool,
 }
 
 impl LaneState {
@@ -32,6 +33,7 @@ impl LaneState {
       next_deadline,
       running: false,
       startup_due: next_deadline <= monotonic_now,
+      immediate_due: false,
     }
   }
 
@@ -45,7 +47,23 @@ impl LaneState {
     } else {
       old_interval.saturating_add(now.duration_since(self.next_deadline))
     };
-    self.next_deadline = now + new_interval.saturating_sub(elapsed);
+    let remaining = if self.next_deadline.checked_sub(old_interval).is_some() {
+      let phase = duration_remainder(elapsed, new_interval);
+      if phase.is_zero() {
+        new_interval
+      } else {
+        new_interval - phase
+      }
+    } else {
+      let remaining = new_interval.saturating_sub(elapsed);
+      if remaining.is_zero() {
+        new_interval
+      } else {
+        remaining
+      }
+    };
+    self.next_deadline = now + remaining;
+    self.immediate_due |= elapsed >= new_interval;
   }
 
   fn take_due(
@@ -54,12 +72,15 @@ impl LaneState {
     interval: Duration,
     trigger_reason: RefreshReason,
   ) -> Option<RefreshReason> {
-    if self.next_deadline > now {
+    if !self.immediate_due && self.next_deadline > now {
       return None;
     }
 
-    let (next_deadline, _) = advance_fixed_deadline(self.next_deadline, interval, now);
-    self.next_deadline = next_deadline;
+    self.immediate_due = false;
+    if self.next_deadline <= now {
+      let (next_deadline, _) = advance_fixed_deadline(self.next_deadline, interval, now);
+      self.next_deadline = next_deadline;
+    }
     let reason = if self.startup_due {
       RefreshReason::Startup
     } else {
@@ -176,6 +197,14 @@ fn advance_fixed_deadline(
     elapsed_intervals += 1;
   }
   (deadline, elapsed_intervals.saturating_sub(1))
+}
+
+fn duration_remainder(value: Duration, modulus: Duration) -> Duration {
+  let remainder_nanos = value.as_nanos() % modulus.as_nanos();
+  Duration::new(
+    (remainder_nanos / 1_000_000_000) as u64,
+    (remainder_nanos % 1_000_000_000) as u32,
+  )
 }
 
 fn initial_deadline(
@@ -424,6 +453,33 @@ mod tests {
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(90));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(90));
+  }
+
+  #[test]
+  fn shorter_interval_preserves_unaligned_fixed_deadline() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(45),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(30), Some(wall))),
+    );
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert_eq!(
+      state.token_next_deadline().duration_since(base),
+      Duration::from_secs(60)
+    );
+    assert_eq!(
+      state.live_next_deadline().duration_since(base),
+      Duration::from_secs(60)
+    );
   }
 
   #[test]

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -35,18 +35,17 @@ impl LaneState {
     }
   }
 
-  fn recalculate_interval(&mut self, old_interval: Duration, new_interval: Duration) {
+  fn recalculate_interval(&mut self, now: Instant, old_interval: Duration, new_interval: Duration) {
     if self.startup_due || old_interval == new_interval {
       return;
     }
 
-    let Some(previous_planned_deadline) = self.next_deadline.checked_sub(old_interval) else {
-      return;
+    let elapsed = if self.next_deadline > now {
+      old_interval.saturating_sub(self.next_deadline.duration_since(now))
+    } else {
+      old_interval.saturating_add(now.duration_since(self.next_deadline))
     };
-    let Some(next_deadline) = previous_planned_deadline.checked_add(new_interval) else {
-      return;
-    };
-    self.next_deadline = next_deadline;
+    self.next_deadline = now + new_interval.saturating_sub(elapsed);
   }
 
   fn take_due(
@@ -125,10 +124,10 @@ impl CoordinatorState {
         let old_interval = self.config.interval;
         self
           .token
-          .recalculate_interval(old_interval, config.interval);
+          .recalculate_interval(now, old_interval, config.interval);
         self
           .live
-          .recalculate_interval(old_interval, config.interval);
+          .recalculate_interval(now, old_interval, config.interval);
         self.config = config;
         RefreshReason::SettingsChanged
       }
@@ -425,6 +424,41 @@ mod tests {
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(90));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(90));
+  }
+
+  #[test]
+  fn shorter_interval_recalculates_when_prior_anchor_predates_monotonic_epoch() {
+    let base = Instant::now();
+    let old_interval = Duration::MAX;
+    let old_next_deadline = base + Duration::from_secs(60);
+    assert!(old_next_deadline.checked_sub(old_interval).is_none());
+    let mut state = CoordinatorState {
+      config: test_config(old_interval, None),
+      token: LaneState::new(old_next_deadline, base),
+      live: LaneState::new(old_next_deadline, base),
+    };
+
+    let actions = state.handle(
+      base + Duration::from_secs(30),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(10), None)),
+    );
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert!(matches!(
+      actions.as_slice(),
+      [
+        CoordinatorAction::StartToken {
+          reason: RefreshReason::SettingsChanged,
+          ..
+        },
+        CoordinatorAction::StartLive {
+          reason: RefreshReason::SettingsChanged,
+        },
+      ]
+    ));
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(40));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(40));
   }
 
   #[test]

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -140,7 +140,8 @@ pub(crate) struct CoordinatorState {
   live: LaneState,
   token_running: Option<TokenExecutionRequest>,
   token_running_source_refresh: bool,
-  token_pending: Option<TokenRequest>,
+  token_pending_manual: Option<TokenRequest>,
+  token_pending_automatic: Option<TokenRequest>,
   token_source_refresh_pending: Option<TokenRequest>,
   token_retry_request: Option<TokenRequest>,
   token_retry_source_refresh: bool,
@@ -184,7 +185,8 @@ impl CoordinatorState {
       live: LaneState::new(live_next_deadline, monotonic_now),
       token_running: None,
       token_running_source_refresh: false,
-      token_pending: None,
+      token_pending_manual: None,
+      token_pending_automatic: None,
       token_source_refresh_pending: None,
       token_retry_request: None,
       token_retry_source_refresh: false,
@@ -315,7 +317,10 @@ impl CoordinatorState {
       if let Some(previous_source_refresh) = self.token_source_refresh_pending.take() {
         request.reasons.merge(previous_source_refresh.reasons);
       }
-      if let Some(mut pending) = self.token_pending.take() {
+      if let Some(pending) = self.token_pending_automatic.take() {
+        request.reasons.merge(pending.reasons);
+      }
+      if let Some(mut pending) = self.token_pending_manual.take() {
         let manual_for_another_home = pending.reasons.contains(RefreshReason::Manual)
           && pending.codex_home != self.config.codex_home;
         if manual_for_another_home {
@@ -323,7 +328,7 @@ impl CoordinatorState {
           automatic_reasons.remove(RefreshReason::Manual);
           request.reasons.merge(automatic_reasons);
           pending.reasons = RefreshReason::Manual.into();
-          self.token_pending = Some(pending);
+          self.token_pending_manual = Some(pending);
         } else {
           request.reasons.merge(pending.reasons);
         }
@@ -454,7 +459,7 @@ impl CoordinatorState {
           }
         }
       }
-      merge_token_request(&mut self.token_pending, request);
+      self.queue_token_pending_request(request);
       return;
     }
 
@@ -463,7 +468,7 @@ impl CoordinatorState {
         if source_retry.codex_home == request.codex_home {
           source_retry.merge(request);
         } else {
-          merge_token_request(&mut self.token_pending, request);
+          self.queue_token_pending_request(request);
         }
         return;
       }
@@ -471,11 +476,53 @@ impl CoordinatorState {
     }
 
     if let Some(mut retry) = self.token_retry_request.take() {
-      retry.merge(request);
-      request = retry;
+      if retry.codex_home == request.codex_home {
+        retry.merge(request);
+        request = retry;
+      }
     }
     self.token.retry_at = None;
     self.start_token_request(request, false, actions);
+  }
+
+  fn queue_token_pending_request(&mut self, mut request: TokenRequest) {
+    if request.reasons.contains(RefreshReason::Manual) {
+      let automatic_matches = self
+        .token_pending_automatic
+        .as_ref()
+        .is_some_and(|pending| pending.codex_home == request.codex_home);
+      if automatic_matches {
+        if let Some(automatic) = self.token_pending_automatic.take() {
+          request.merge(automatic);
+        }
+      }
+      if let Some(manual) = self.token_pending_manual.as_mut() {
+        if manual.codex_home == request.codex_home {
+          manual.merge(request);
+        } else {
+          *manual = request;
+        }
+      } else {
+        self.token_pending_manual = Some(request);
+      }
+      return;
+    }
+
+    if let Some(manual) = self.token_pending_manual.as_mut() {
+      if manual.codex_home == request.codex_home {
+        manual.merge(request);
+        return;
+      }
+    }
+    if let Some(automatic) = self.token_pending_automatic.as_mut() {
+      if automatic.codex_home == request.codex_home {
+        automatic.merge(request);
+      } else {
+        *automatic = request;
+      }
+    } else {
+      self.token_pending_automatic = Some(request);
+    }
   }
 
   fn start_token_request(
@@ -741,21 +788,22 @@ impl CoordinatorState {
       self.submit_source_refresh_request(request, actions);
       return;
     }
-    if let Some(request) = self.token_pending.take() {
-      if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
-        return;
-      }
+    if let Some(request) = self.token_pending_manual.take() {
       self.submit_token_request(request, actions);
+      return;
+    }
+    if let Some(request) = self.token_pending_automatic.take() {
+      if self.config.auto_scan_enabled {
+        self.submit_token_request(request, actions);
+      }
     }
   }
 
   fn prune_automatic_pending_work(&mut self) {
-    if let Some(mut pending) = self.token_pending.take() {
-      if pending.reasons.contains(RefreshReason::Manual) {
-        pending.reasons = RefreshReason::Manual.into();
-        self.token_pending = Some(pending);
-      }
+    if let Some(pending) = self.token_pending_manual.as_mut() {
+      pending.reasons = RefreshReason::Manual.into();
     }
+    self.token_pending_automatic = None;
     self.live_pending = ReasonSet::default();
   }
 
@@ -2108,5 +2156,88 @@ mod tests {
     assert!(completion_actions
       .iter()
       .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+  }
+
+  #[test]
+  fn later_automatic_trigger_does_not_retarget_pending_manual_home() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/configured-home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("configured-source Full refresh starts");
+
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home-c".to_string(),
+      ))),
+    );
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+
+    let protected_success = state.handle(
+      base + Duration::from_secs(5),
+      CoordinatorEvent::TokenFinished(execution_success(
+        protected.generation,
+        protected.source_generation,
+        2,
+        base + Duration::from_secs(5),
+      )),
+    );
+    let manual = protected_success
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual follow-up starts first");
+    assert_eq!(manual.request.kind, TokenScanKind::Full);
+    assert!(manual.request.reasons.contains(RefreshReason::Manual));
+    assert_eq!(
+      manual.request.codex_home.as_deref(),
+      Some("/normalized/manual-home-c")
+    );
+
+    let manual_success = state.handle(
+      base + Duration::from_secs(6),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual.generation,
+        manual.source_generation,
+        3,
+        base + Duration::from_secs(6),
+      )),
+    );
+    assert!(matches!(
+      manual_success.last(),
+      Some(CoordinatorAction::StartToken(request))
+        if request.request.reasons.contains(RefreshReason::Scheduled)
+          && !request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref()
+            == Some("/normalized/configured-home-b")
+    ));
   }
 }

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -1,0 +1,456 @@
+use super::{RefreshConfig, RefreshReason, TokenScanKind};
+use chrono::{DateTime, Utc};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug)]
+pub(crate) enum CoordinatorEvent {
+  Timer,
+  Wake,
+  SettingsChanged(RefreshConfig),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CoordinatorAction {
+  StartToken {
+    kind: TokenScanKind,
+    reason: RefreshReason,
+  },
+  StartLive {
+    reason: RefreshReason,
+  },
+}
+
+struct LaneState {
+  next_deadline: Instant,
+  running: bool,
+  startup_due: bool,
+}
+
+impl LaneState {
+  fn new(next_deadline: Instant, monotonic_now: Instant) -> Self {
+    Self {
+      next_deadline,
+      running: false,
+      startup_due: next_deadline <= monotonic_now,
+    }
+  }
+
+  fn recalculate_interval(&mut self, old_interval: Duration, new_interval: Duration) {
+    if self.startup_due || old_interval == new_interval {
+      return;
+    }
+
+    let Some(previous_planned_deadline) = self.next_deadline.checked_sub(old_interval) else {
+      return;
+    };
+    let Some(next_deadline) = previous_planned_deadline.checked_add(new_interval) else {
+      return;
+    };
+    self.next_deadline = next_deadline;
+  }
+
+  fn take_due(
+    &mut self,
+    now: Instant,
+    interval: Duration,
+    trigger_reason: RefreshReason,
+  ) -> Option<RefreshReason> {
+    if self.next_deadline > now {
+      return None;
+    }
+
+    let (next_deadline, _) = advance_fixed_deadline(self.next_deadline, interval, now);
+    self.next_deadline = next_deadline;
+    let reason = if self.startup_due {
+      RefreshReason::Startup
+    } else {
+      trigger_reason
+    };
+    self.startup_due = false;
+
+    if self.running {
+      return None;
+    }
+
+    self.running = true;
+    Some(reason)
+  }
+}
+
+pub(crate) struct CoordinatorState {
+  config: RefreshConfig,
+  token: LaneState,
+  live: LaneState,
+}
+
+impl CoordinatorState {
+  pub(crate) fn new(
+    config: RefreshConfig,
+    monotonic_now: Instant,
+    wall_now: DateTime<Utc>,
+  ) -> Self {
+    assert!(
+      !config.interval.is_zero(),
+      "refresh interval must be positive"
+    );
+    let token_next_deadline = initial_deadline(
+      monotonic_now,
+      wall_now,
+      config.token_last_success_wall,
+      config.interval,
+    );
+    let live_next_deadline = initial_deadline(
+      monotonic_now,
+      wall_now,
+      config.live_last_success_wall,
+      config.interval,
+    );
+
+    Self {
+      config,
+      token: LaneState::new(token_next_deadline, monotonic_now),
+      live: LaneState::new(live_next_deadline, monotonic_now),
+    }
+  }
+
+  pub(crate) fn handle(&mut self, now: Instant, event: CoordinatorEvent) -> Vec<CoordinatorAction> {
+    let trigger_reason = match event {
+      CoordinatorEvent::Timer => RefreshReason::Scheduled,
+      CoordinatorEvent::Wake => RefreshReason::Wake,
+      CoordinatorEvent::SettingsChanged(config) => {
+        assert!(
+          !config.interval.is_zero(),
+          "refresh interval must be positive"
+        );
+        let old_interval = self.config.interval;
+        self
+          .token
+          .recalculate_interval(old_interval, config.interval);
+        self
+          .live
+          .recalculate_interval(old_interval, config.interval);
+        self.config = config;
+        RefreshReason::SettingsChanged
+      }
+    };
+
+    if !self.config.auto_scan_enabled {
+      return Vec::new();
+    }
+
+    let mut actions = Vec::with_capacity(2);
+    if let Some(reason) = self
+      .token
+      .take_due(now, self.config.interval, trigger_reason)
+    {
+      actions.push(CoordinatorAction::StartToken {
+        kind: TokenScanKind::Incremental,
+        reason,
+      });
+    }
+    if let Some(reason) = self
+      .live
+      .take_due(now, self.config.interval, trigger_reason)
+    {
+      actions.push(CoordinatorAction::StartLive { reason });
+    }
+    actions
+  }
+
+  pub(crate) fn token_next_deadline(&self) -> Instant {
+    self.token.next_deadline
+  }
+
+  pub(crate) fn live_next_deadline(&self) -> Instant {
+    self.live.next_deadline
+  }
+}
+
+fn advance_fixed_deadline(
+  mut deadline: Instant,
+  interval: Duration,
+  now: Instant,
+) -> (Instant, u64) {
+  let mut elapsed_intervals = 0_u64;
+  while deadline <= now {
+    deadline += interval;
+    elapsed_intervals += 1;
+  }
+  (deadline, elapsed_intervals.saturating_sub(1))
+}
+
+fn initial_deadline(
+  monotonic_now: Instant,
+  wall_now: DateTime<Utc>,
+  last_success: Option<DateTime<Utc>>,
+  interval: Duration,
+) -> Instant {
+  let Some(age) =
+    last_success.and_then(|value| wall_now.signed_duration_since(value).to_std().ok())
+  else {
+    return monotonic_now;
+  };
+  monotonic_now + interval.saturating_sub(age)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use chrono::{DateTime, Duration as ChronoDuration, Utc};
+  use std::time::{Duration, Instant};
+
+  fn utc(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+      .expect("valid test timestamp")
+      .with_timezone(&Utc)
+  }
+
+  fn test_config(interval: Duration, last_success_wall: Option<DateTime<Utc>>) -> RefreshConfig {
+    RefreshConfig {
+      auto_scan_enabled: true,
+      interval,
+      codex_home: None,
+      token_last_success_wall: last_success_wall,
+      live_last_success_wall: last_success_wall,
+    }
+  }
+
+  fn token_starts(actions: &[CoordinatorAction]) -> usize {
+    actions
+      .iter()
+      .filter(|value| matches!(value, CoordinatorAction::StartToken { .. }))
+      .count()
+  }
+
+  fn live_starts(actions: &[CoordinatorAction]) -> usize {
+    actions
+      .iter()
+      .filter(|value| matches!(value, CoordinatorAction::StartLive { .. }))
+      .count()
+  }
+
+  #[test]
+  fn persisted_success_maps_remaining_wall_time_to_monotonic_deadline() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let last_success = wall - ChronoDuration::seconds(120);
+    let state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(last_success)),
+      base,
+      wall,
+    );
+
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(180));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(180));
+  }
+
+  #[test]
+  fn missing_persisted_success_starts_one_immediate_catch_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(test_config(Duration::from_secs(300), None), base, wall);
+
+    let first = state.handle(base, CoordinatorEvent::Timer);
+    let duplicate = state.handle(base + Duration::from_secs(1), CoordinatorEvent::Timer);
+
+    assert_eq!(token_starts(&first), 1);
+    assert_eq!(live_starts(&first), 1);
+    assert!(matches!(
+      first.as_slice(),
+      [
+        CoordinatorAction::StartToken {
+          kind: TokenScanKind::Incremental,
+          reason: RefreshReason::Startup,
+        },
+        CoordinatorAction::StartLive {
+          reason: RefreshReason::Startup,
+        },
+      ]
+    ));
+    assert!(duplicate.is_empty());
+  }
+
+  #[test]
+  fn invalid_persisted_success_starts_one_immediate_catch_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let malformed_success = crate::refresh::parse_persisted_success_wall(Some("not-a-timestamp"));
+    let future_success = wall + ChronoDuration::seconds(1);
+
+    assert_eq!(malformed_success, None);
+    for last_success in [malformed_success, Some(future_success)] {
+      let mut state = CoordinatorState::new(
+        test_config(Duration::from_secs(300), last_success),
+        base,
+        wall,
+      );
+
+      let first = state.handle(base, CoordinatorEvent::Timer);
+      let duplicate = state.handle(base, CoordinatorEvent::Timer);
+
+      assert_eq!(token_starts(&first), 1);
+      assert_eq!(live_starts(&first), 1);
+      assert!(duplicate.is_empty());
+    }
+  }
+
+  #[test]
+  fn overdue_persisted_success_starts_one_immediate_catch_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let overdue_success = wall - ChronoDuration::seconds(301);
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(overdue_success)),
+      base,
+      wall,
+    );
+
+    let first = state.handle(base, CoordinatorEvent::Timer);
+    let duplicate = state.handle(base + Duration::from_secs(1), CoordinatorEvent::Timer);
+
+    assert_eq!(token_starts(&first), 1);
+    assert_eq!(live_starts(&first), 1);
+    assert!(duplicate.is_empty());
+  }
+
+  #[test]
+  fn due_lanes_start_together_and_advance_from_planned_deadlines() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let config = test_config(Duration::from_secs(300), Some(wall));
+    let mut state = CoordinatorState::new(config, base, wall);
+
+    let actions = state.handle(base + Duration::from_secs(300), CoordinatorEvent::Timer);
+
+    assert!(actions
+      .iter()
+      .any(|value| matches!(value, CoordinatorAction::StartToken { .. })));
+    assert!(actions
+      .iter()
+      .any(|value| matches!(value, CoordinatorAction::StartLive { .. })));
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
+  }
+
+  #[test]
+  fn token_running_does_not_block_due_live_lane() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let config = RefreshConfig {
+      auto_scan_enabled: true,
+      interval: Duration::from_secs(300),
+      codex_home: None,
+      token_last_success_wall: None,
+      live_last_success_wall: Some(wall),
+    };
+    let mut state = CoordinatorState::new(config, base, wall);
+
+    let startup = state.handle(base, CoordinatorEvent::Timer);
+    let live_due = state.handle(base + Duration::from_secs(300), CoordinatorEvent::Timer);
+
+    assert_eq!(token_starts(&startup), 1);
+    assert_eq!(live_starts(&startup), 0);
+    assert_eq!(token_starts(&live_due), 0);
+    assert_eq!(live_starts(&live_due), 1);
+    assert!(matches!(
+      live_due.as_slice(),
+      [CoordinatorAction::StartLive {
+        reason: RefreshReason::Scheduled,
+      }]
+    ));
+  }
+
+  #[test]
+  fn missed_intervals_coalesce_into_one_catch_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let config = test_config(Duration::from_secs(300), Some(wall));
+    let mut state = CoordinatorState::new(config, base, wall);
+
+    let actions = state.handle(base + Duration::from_secs(950), CoordinatorEvent::Wake);
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert!(matches!(
+      actions.as_slice(),
+      [
+        CoordinatorAction::StartToken {
+          reason: RefreshReason::Wake,
+          ..
+        },
+        CoordinatorAction::StartLive {
+          reason: RefreshReason::Wake,
+        },
+      ]
+    ));
+    assert_eq!(
+      state.token_next_deadline(),
+      base + Duration::from_secs(1_200)
+    );
+    assert_eq!(
+      state.live_next_deadline(),
+      base + Duration::from_secs(1_200)
+    );
+  }
+
+  #[test]
+  fn shorter_interval_recalculates_deadline_immediately() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let shorter = test_config(Duration::from_secs(30), Some(wall));
+
+    let actions = state.handle(
+      base + Duration::from_secs(60),
+      CoordinatorEvent::SettingsChanged(shorter),
+    );
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert!(matches!(
+      actions.as_slice(),
+      [
+        CoordinatorAction::StartToken {
+          reason: RefreshReason::SettingsChanged,
+          ..
+        },
+        CoordinatorAction::StartLive {
+          reason: RefreshReason::SettingsChanged,
+        },
+      ]
+    ));
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(90));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(90));
+  }
+
+  #[test]
+  fn backward_wall_clock_does_not_move_runtime_deadline() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let future_wall_success = wall + ChronoDuration::hours(1);
+
+    let early = state.handle(
+      base + Duration::from_secs(299),
+      CoordinatorEvent::SettingsChanged(test_config(
+        Duration::from_secs(300),
+        Some(future_wall_success),
+      )),
+    );
+    let due = state.handle(base + Duration::from_secs(300), CoordinatorEvent::Timer);
+
+    assert!(early.is_empty());
+    assert_eq!(token_starts(&due), 1);
+    assert_eq!(live_starts(&due), 1);
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
+  }
+}

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -398,14 +398,19 @@ impl CoordinatorState {
           .token
           .take_normal_due(now, self.config.interval, trigger_reason)
       {
-        merge_token_request(
-          &mut request,
-          TokenRequest {
-            reasons: reason.into(),
-            kind: TokenScanKind::Incremental,
-            codex_home: self.config.codex_home.clone(),
-          },
-        );
+        let automatic = TokenRequest {
+          reasons: reason.into(),
+          kind: TokenScanKind::Incremental,
+          codex_home: self.config.codex_home.clone(),
+        };
+        let retry_has_different_home = request
+          .as_ref()
+          .is_some_and(|retry| retry.codex_home != automatic.codex_home);
+        if retry_has_different_home {
+          self.queue_token_pending_request(automatic);
+        } else {
+          merge_token_request(&mut request, automatic);
+        }
       }
     }
     request.map(|request| (request, source_refresh))
@@ -473,6 +478,16 @@ impl CoordinatorState {
         return;
       }
       self.token_retry_source_refresh = false;
+    }
+
+    let preserves_manual_retry = self.token_retry_request.as_ref().is_some_and(|retry| {
+      retry.reasons.contains(RefreshReason::Manual)
+        && !request.reasons.contains(RefreshReason::Manual)
+        && retry.codex_home != request.codex_home
+    });
+    if preserves_manual_retry {
+      self.queue_token_pending_request(request);
+      return;
     }
 
     if let Some(mut retry) = self.token_retry_request.take() {
@@ -2229,6 +2244,179 @@ mod tests {
         manual.source_generation,
         3,
         base + Duration::from_secs(6),
+      )),
+    );
+    assert!(matches!(
+      manual_success.last(),
+      Some(CoordinatorAction::StartToken(request))
+        if request.request.reasons.contains(RefreshReason::Scheduled)
+          && !request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref()
+            == Some("/normalized/configured-home-b")
+    ));
+  }
+
+  #[test]
+  fn failed_manual_retry_survives_different_home_automatic_pending() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/configured-home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("configured-source Full refresh starts");
+
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home-c".to_string(),
+      ))),
+    );
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    let protected_success = state.handle(
+      base + Duration::from_secs(5),
+      CoordinatorEvent::TokenFinished(execution_success(
+        protected.generation,
+        protected.source_generation,
+        2,
+        base + Duration::from_secs(5),
+      )),
+    );
+    let manual = protected_success
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual follow-up starts first");
+
+    let manual_failure = state.handle(
+      base + Duration::from_secs(6),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual.generation,
+        manual.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(token_starts(&manual_failure), 0);
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(11)));
+
+    let early = state.handle(base + Duration::from_secs(10), CoordinatorEvent::Timer);
+    assert_eq!(token_starts(&early), 0);
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(11)));
+
+    let retry_actions = state.handle(base + Duration::from_secs(11), CoordinatorEvent::Timer);
+    let manual_retry = retry_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual Full retry starts at its deadline");
+    assert_eq!(manual_retry.request.kind, TokenScanKind::Full);
+    assert!(manual_retry.request.reasons.contains(RefreshReason::Manual));
+    assert_eq!(
+      manual_retry.request.codex_home.as_deref(),
+      Some("/normalized/manual-home-c")
+    );
+
+    let manual_success = state.handle(
+      base + Duration::from_secs(12),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual_retry.generation,
+        manual_retry.source_generation,
+        3,
+        base + Duration::from_secs(12),
+      )),
+    );
+    assert!(matches!(
+      manual_success.last(),
+      Some(CoordinatorAction::StartToken(request))
+        if request.request.reasons.contains(RefreshReason::Scheduled)
+          && !request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref()
+            == Some("/normalized/configured-home-b")
+    ));
+  }
+
+  #[test]
+  fn due_automatic_trigger_does_not_retarget_manual_retry() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(5);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/configured-home-b".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let manual = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+          "/normalized/manual-home-c".to_string(),
+        ))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual Full refresh starts");
+
+    let failure_actions = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual.generation,
+        manual.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(token_starts(&failure_actions), 0);
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(6)));
+
+    let retry_actions = state.handle(base + Duration::from_secs(6), CoordinatorEvent::Timer);
+    let manual_retry = retry_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual Full retry starts at its deadline");
+    assert_eq!(manual_retry.request.kind, TokenScanKind::Full);
+    assert!(manual_retry.request.reasons.contains(RefreshReason::Manual));
+    assert_eq!(
+      manual_retry.request.codex_home.as_deref(),
+      Some("/normalized/manual-home-c")
+    );
+
+    let manual_success = state.handle(
+      base + Duration::from_secs(7),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual_retry.generation,
+        manual_retry.source_generation,
+        1,
+        base + Duration::from_secs(7),
       )),
     );
     assert!(matches!(

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -1,7 +1,8 @@
 use super::{
   CommitMarker, DisplayInvalidation, ExecutionCompletion, LiveExecutionRequest, LiveRequest,
-  LiveWaiterId, ReasonSet, RefreshCompletedEvent, RefreshConfig, RefreshLane, RefreshReason,
-  TokenExecutionRequest, TokenRequest, TokenScanKind,
+  LiveWaiterId, ReasonSet, RefreshCompletedEvent, RefreshConfig, RefreshDetail, RefreshFailureCode,
+  RefreshLane, RefreshReason, RefreshRejectionCode, RefreshWaiterOutcome, TokenExecutionRequest,
+  TokenRequest, TokenScanKind, TokenWaiterId, REFRESH_WAITER_CAPACITY,
 };
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};
@@ -37,20 +38,27 @@ pub(crate) enum CoordinatorAction {
   PublishCompletion(RefreshCompletedEvent),
   ResolveLiveWaiters {
     waiter_ids: Vec<LiveWaiterId>,
-    generation: u64,
-    succeeded: bool,
-    failure: Option<String>,
+    outcome: RefreshWaiterOutcome,
+  },
+  ResolveTokenWaiters {
+    waiter_ids: Vec<TokenWaiterId>,
+    outcome: RefreshWaiterOutcome,
   },
 }
 
 struct LaneState {
   next_deadline: Instant,
   startup_due: bool,
-  immediate_due: bool,
+  immediate_due_at: Option<Instant>,
   last_generation: u64,
   running_generation: Option<u64>,
   failure_streak: u32,
   retry_at: Option<Instant>,
+  missed_deadline_count: u64,
+  coalesced_trigger_count: u64,
+  suppress_next_missed_count: bool,
+  disabled_normal_overdue_lag: Option<Duration>,
+  disabled_retry_overdue_lag: Option<Duration>,
 }
 
 impl LaneState {
@@ -58,15 +66,26 @@ impl LaneState {
     Self {
       next_deadline,
       startup_due: next_deadline <= monotonic_now,
-      immediate_due: false,
+      immediate_due_at: None,
       last_generation: 0,
       running_generation: None,
       failure_streak: 0,
       retry_at: None,
+      missed_deadline_count: 0,
+      coalesced_trigger_count: 0,
+      suppress_next_missed_count: false,
+      disabled_normal_overdue_lag: None,
+      disabled_retry_overdue_lag: None,
     }
   }
 
-  fn recalculate_interval(&mut self, now: Instant, old_interval: Duration, new_interval: Duration) {
+  fn recalculate_interval(
+    &mut self,
+    now: Instant,
+    old_interval: Duration,
+    new_interval: Duration,
+    count_missed: bool,
+  ) {
     if self.startup_due || old_interval == new_interval {
       return;
     }
@@ -76,7 +95,8 @@ impl LaneState {
     } else {
       old_interval.saturating_add(now.duration_since(self.next_deadline))
     };
-    let remaining = if self.next_deadline.checked_sub(old_interval).is_some() {
+    let anchor = self.next_deadline.checked_sub(old_interval);
+    let remaining = if anchor.is_some() {
       let phase = duration_remainder(elapsed, new_interval);
       if phase.is_zero() {
         new_interval
@@ -91,8 +111,82 @@ impl LaneState {
         remaining
       }
     };
-    self.next_deadline = now + remaining;
-    self.immediate_due = elapsed >= new_interval;
+    self.next_deadline = saturating_instant_add(now, remaining);
+    self.immediate_due_at = if elapsed >= new_interval {
+      if count_missed {
+        let due_count = elapsed.as_nanos() / new_interval.as_nanos();
+        let missed = due_count.saturating_sub(1).min(u64::MAX as u128) as u64;
+        self.missed_deadline_count = self.missed_deadline_count.saturating_add(missed);
+      }
+      anchor
+        .and_then(|anchor| anchor.checked_add(new_interval))
+        .or_else(|| now.checked_sub(elapsed.saturating_sub(new_interval)))
+        .or(Some(now))
+    } else {
+      None
+    };
+  }
+
+  fn pause_normal_schedule(&mut self, now: Instant) {
+    self.disabled_normal_overdue_lag = self
+      .immediate_due_at
+      .map(|planned_due_at| now.saturating_duration_since(planned_due_at));
+  }
+
+  fn resume_normal_schedule(&mut self, now: Instant) {
+    if self.immediate_due_at.is_some() || self.next_deadline <= now {
+      self.immediate_due_at = Some(
+        self
+          .disabled_normal_overdue_lag
+          .and_then(|lag| now.checked_sub(lag))
+          .unwrap_or(now),
+      );
+    }
+    self.disabled_normal_overdue_lag = None;
+    self.suppress_next_missed_count = self.next_deadline <= now;
+  }
+
+  fn pause_automatic_retry(&mut self, now: Instant) {
+    self.disabled_retry_overdue_lag = self
+      .retry_at
+      .filter(|retry_at| *retry_at <= now)
+      .map(|retry_at| now.saturating_duration_since(retry_at));
+  }
+
+  fn resume_automatic_retry(&mut self, now: Instant) -> Option<Instant> {
+    let Some(retry_at) = self.retry_at else {
+      self.disabled_retry_overdue_lag = None;
+      return None;
+    };
+    if retry_at > now {
+      self.disabled_retry_overdue_lag = None;
+      return None;
+    }
+    let planned_due_at = self
+      .disabled_retry_overdue_lag
+      .take()
+      .and_then(|lag| now.checked_sub(lag))
+      .unwrap_or(now);
+    self.retry_at = Some(planned_due_at);
+    Some(planned_due_at)
+  }
+
+  fn capture_enabled_overdue(&mut self, now: Instant, interval: Duration) -> Option<Instant> {
+    if self.next_deadline > now {
+      return self.immediate_due_at;
+    }
+    let planned_due_at = self.immediate_due_at.unwrap_or(self.next_deadline);
+    let had_immediate_due = self.immediate_due_at.is_some();
+    let (next_deadline, missed) = advance_fixed_deadline(self.next_deadline, interval, now);
+    self.next_deadline = next_deadline;
+    let missed = if had_immediate_due {
+      missed.saturating_add(1)
+    } else {
+      missed
+    };
+    self.missed_deadline_count = self.missed_deadline_count.saturating_add(missed);
+    self.immediate_due_at = Some(planned_due_at);
+    self.immediate_due_at
   }
 
   fn take_normal_due(
@@ -100,23 +194,34 @@ impl LaneState {
     now: Instant,
     interval: Duration,
     trigger_reason: RefreshReason,
-  ) -> Option<RefreshReason> {
-    if !self.immediate_due && self.next_deadline > now {
+  ) -> Option<(RefreshReason, Instant)> {
+    if self.immediate_due_at.is_none() && self.next_deadline > now {
       return None;
     }
 
-    self.immediate_due = false;
+    let had_immediate_due = self.immediate_due_at.is_some();
+    let planned_due_at = self.immediate_due_at.unwrap_or(self.next_deadline);
+    self.immediate_due_at = None;
     if self.next_deadline <= now {
-      let (next_deadline, _) = advance_fixed_deadline(self.next_deadline, interval, now);
+      let (next_deadline, missed) = advance_fixed_deadline(self.next_deadline, interval, now);
       self.next_deadline = next_deadline;
+      if !self.suppress_next_missed_count {
+        let missed = if had_immediate_due {
+          missed.saturating_add(1)
+        } else {
+          missed
+        };
+        self.missed_deadline_count = self.missed_deadline_count.saturating_add(missed);
+      }
     }
+    self.suppress_next_missed_count = false;
     let reason = if self.startup_due {
       RefreshReason::Startup
     } else {
       trigger_reason
     };
     self.startup_due = false;
-    Some(reason)
+    Some((reason, planned_due_at))
   }
 
   fn start_generation(&mut self) -> u64 {
@@ -134,6 +239,27 @@ impl LaneState {
   }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct LaneScheduleSnapshot {
+  pub running_generation: Option<u64>,
+  pub next_normal_deadline: Instant,
+  pub retry_deadline: Option<Instant>,
+  pub failure_streak: u32,
+  pub pending: bool,
+  pub pending_reasons: ReasonSet,
+  pub missed_deadline_count: u64,
+  pub coalesced_trigger_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CoordinatorSnapshot {
+  pub token: LaneScheduleSnapshot,
+  pub live: LaneScheduleSnapshot,
+  pub source_generation: u64,
+  pub interval: Duration,
+  pub auto_scan_enabled: bool,
+}
+
 pub(crate) struct CoordinatorState {
   config: RefreshConfig,
   token: LaneState,
@@ -147,7 +273,9 @@ pub(crate) struct CoordinatorState {
   token_retry_source_refresh: bool,
   live_running: Option<LiveExecutionRequest>,
   live_pending: ReasonSet,
+  live_pending_due_at: Option<Instant>,
   live_retry_reasons: ReasonSet,
+  live_retry_planned_due_at: Option<Instant>,
   live_waiters: Vec<LiveWaiterId>,
   source_generation: u64,
   refresh_revision: u64,
@@ -158,7 +286,7 @@ pub(crate) struct CoordinatorState {
 
 impl CoordinatorState {
   pub(crate) fn new(
-    config: RefreshConfig,
+    mut config: RefreshConfig,
     monotonic_now: Instant,
     wall_now: DateTime<Utc>,
   ) -> Self {
@@ -166,6 +294,7 @@ impl CoordinatorState {
       !config.interval.is_zero(),
       "refresh interval must be positive"
     );
+    config.interval = effective_interval(monotonic_now, config.interval);
     let token_next_deadline = initial_deadline(
       monotonic_now,
       wall_now,
@@ -192,7 +321,9 @@ impl CoordinatorState {
       token_retry_source_refresh: false,
       live_running: None,
       live_pending: ReasonSet::default(),
+      live_pending_due_at: None,
       live_retry_reasons: ReasonSet::default(),
+      live_retry_planned_due_at: None,
       live_waiters: Vec::new(),
       source_generation: 0,
       refresh_revision: 0,
@@ -207,83 +338,243 @@ impl CoordinatorState {
       CoordinatorEvent::Timer => self.handle_due(now, RefreshReason::Scheduled),
       CoordinatorEvent::Wake => self.handle_due(now, RefreshReason::Wake),
       CoordinatorEvent::SettingsChanged(config) => self.handle_settings_changed(now, config),
-      CoordinatorEvent::RequestToken(request) => {
-        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
-          return Vec::new();
+      CoordinatorEvent::RequestToken(mut request) => {
+        let mut actions = Vec::with_capacity(2);
+        if !self.prepare_token_intake(&mut request, &mut actions) {
+          return actions;
         }
-        let mut actions = Vec::with_capacity(1);
-        self.submit_token_request(request, &mut actions);
+        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+          return actions;
+        }
+        self.submit_token_request_with_due(now, request, &mut actions);
         actions
       }
       CoordinatorEvent::RequestLive(request) => {
-        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
-          return Vec::new();
+        let mut actions = Vec::with_capacity(2);
+        if let Some(waiter) = request.waiter {
+          if !request.reasons.contains(RefreshReason::Manual) {
+            actions.push(CoordinatorAction::ResolveLiveWaiters {
+              waiter_ids: vec![waiter],
+              outcome: rejected_outcome(RefreshRejectionCode::InvalidRequest, None),
+            });
+            return actions;
+          }
         }
-        let mut actions = Vec::with_capacity(1);
-        self.submit_live_request(request, &mut actions);
+        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+          return actions;
+        }
+        if let Some(waiter) = request.waiter {
+          if !self.live_waiters.contains(&waiter)
+            && self.live_waiters.len() >= REFRESH_WAITER_CAPACITY
+          {
+            actions.push(CoordinatorAction::ResolveLiveWaiters {
+              waiter_ids: vec![waiter],
+              outcome: rejected_outcome(RefreshRejectionCode::Busy, None),
+            });
+            return actions;
+          }
+        }
+        self.submit_live_request_with_due(now, request, &mut actions);
         actions
       }
       CoordinatorEvent::TokenPrepared {
         generation,
         source_generation,
-      } => self.handle_token_prepared(generation, source_generation),
-      CoordinatorEvent::TokenFinished(completion) => {
-        self.handle_token_finished(now, completion)
-      }
-      CoordinatorEvent::LiveFinished(completion) => {
-        self.handle_live_finished(now, completion)
-      }
+      } => self.handle_token_prepared(now, generation, source_generation),
+      CoordinatorEvent::TokenFinished(completion) => self.handle_token_finished(now, completion),
+      CoordinatorEvent::LiveFinished(completion) => self.handle_live_finished(now, completion),
     }
   }
 
   fn handle_due(&mut self, now: Instant, trigger_reason: RefreshReason) -> Vec<CoordinatorAction> {
     let mut token_request = self.take_due_token_request(now, trigger_reason);
-    let mut live_reasons = self.take_due_live_reasons(now, trigger_reason);
+    let live_request = self.take_due_live_request(now, trigger_reason);
     let mut actions = Vec::with_capacity(2);
 
     if let Some((request, source_refresh)) = token_request.take() {
       if source_refresh {
         self.submit_source_refresh_request(request, &mut actions);
       } else {
-        self.submit_token_request(request, &mut actions);
+        self.submit_token_request(now, request, &mut actions);
       }
     }
-    if !live_reasons.is_empty() {
-      self.submit_live_request(
-        LiveRequest {
-          reasons: std::mem::take(&mut live_reasons),
-          waiter: None,
-        },
-        &mut actions,
-      );
+    if let Some(request) = live_request {
+      self.submit_live_request(now, request, &mut actions);
     }
 
     actions
   }
 
+  fn submit_token_request_with_due(
+    &mut self,
+    now: Instant,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    let Some((due, due_is_source_refresh)) =
+      self.take_due_token_request(now, RefreshReason::Scheduled)
+    else {
+      self.submit_token_request(now, request, actions);
+      return;
+    };
+
+    if request.same_source_identity(&due) {
+      request
+        .try_merge(due)
+        .expect("same source identity was checked before request-time due merge");
+      self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+      if due_is_source_refresh {
+        self.submit_source_refresh_request(request, actions);
+      } else {
+        self.submit_token_request(now, request, actions);
+      }
+      return;
+    }
+
+    let due_matches_protected = !due_is_source_refresh
+      && self
+        .token_source_refresh_pending
+        .as_ref()
+        .is_some_and(|protected| protected.same_source_identity(&due));
+    let due_matches_protected_retry = !due_is_source_refresh
+      && self.token_retry_source_refresh
+      && self
+        .token_retry_request
+        .as_ref()
+        .is_some_and(|protected| protected.same_source_identity(&due));
+    if due_matches_protected {
+      self
+        .token_source_refresh_pending
+        .as_mut()
+        .expect("matching protected source refresh remains pending")
+        .try_merge(due)
+        .expect("same source identity was checked before protected due merge");
+      self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+    } else if due_matches_protected_retry {
+      self
+        .token_retry_request
+        .as_mut()
+        .expect("matching protected retry remains pending")
+        .try_merge(due)
+        .expect("same source identity was checked before protected retry due merge");
+      self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+    } else if due_is_source_refresh {
+      self.submit_source_refresh_request(due, actions);
+    } else {
+      self.queue_token_pending_request(due, actions);
+    }
+    self.submit_token_request(now, request, actions);
+  }
+
+  fn submit_live_request_with_due(
+    &mut self,
+    now: Instant,
+    mut request: LiveRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if let Some(due) = self.take_due_live_request(now, RefreshReason::Scheduled) {
+      request.reasons.merge(due.reasons);
+      request.planned_due_at = earliest_planned_due(request.planned_due_at, due.planned_due_at);
+      self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
+    }
+    self.submit_live_request(now, request, actions);
+  }
+
   fn handle_settings_changed(
     &mut self,
     now: Instant,
-    config: RefreshConfig,
+    mut config: RefreshConfig,
   ) -> Vec<CoordinatorAction> {
     assert!(
       !config.interval.is_zero(),
       "refresh interval must be positive"
     );
+    config.interval = effective_interval(now, config.interval);
     let old_interval = self.config.interval;
     let source_changed = self.config.codex_home != config.codex_home;
     let disabling_auto_scan = self.config.auto_scan_enabled && !config.auto_scan_enabled;
+    let enabling_auto_scan = !self.config.auto_scan_enabled && config.auto_scan_enabled;
+    let auto_scan_remains_enabled = self.config.auto_scan_enabled && config.auto_scan_enabled;
     let settings_changed = self.config.auto_scan_enabled != config.auto_scan_enabled
       || old_interval != config.interval
       || source_changed;
 
-    self
-      .token
-      .recalculate_interval(now, old_interval, config.interval);
-    self
-      .live
-      .recalculate_interval(now, old_interval, config.interval);
+    let token_enabled_due = disabling_auto_scan
+      .then(|| self.token.capture_enabled_overdue(now, old_interval))
+      .flatten();
+    let live_enabled_due = disabling_auto_scan
+      .then(|| self.live.capture_enabled_overdue(now, old_interval))
+      .flatten();
+    if !self.config.auto_scan_enabled && old_interval != config.interval {
+      self.token.disabled_normal_overdue_lag = None;
+      self.live.disabled_normal_overdue_lag = None;
+    }
+
+    self.token.recalculate_interval(
+      now,
+      old_interval,
+      config.interval,
+      auto_scan_remains_enabled,
+    );
+    self.live.recalculate_interval(
+      now,
+      old_interval,
+      config.interval,
+      auto_scan_remains_enabled,
+    );
+    self.token.immediate_due_at =
+      earliest_planned_due(self.token.immediate_due_at, token_enabled_due);
+    self.live.immediate_due_at = earliest_planned_due(self.live.immediate_due_at, live_enabled_due);
+    if disabling_auto_scan {
+      self.token.pause_normal_schedule(now);
+      self.live.pause_normal_schedule(now);
+      let token_retry_is_automatic_only = !self.token_retry_source_refresh
+        && self
+          .token_retry_request
+          .as_ref()
+          .is_some_and(|request| !request.reasons.contains(RefreshReason::Manual));
+      if token_retry_is_automatic_only {
+        self.token.pause_automatic_retry(now);
+      } else {
+        self.token.disabled_retry_overdue_lag = None;
+      }
+      let live_retry_is_automatic_only = !self.live_retry_reasons.is_empty()
+        && !self.live_retry_reasons.contains(RefreshReason::Manual);
+      if live_retry_is_automatic_only {
+        self.live.pause_automatic_retry(now);
+      } else {
+        self.live.disabled_retry_overdue_lag = None;
+      }
+    }
     self.config = config;
+
+    if enabling_auto_scan {
+      self.token.resume_normal_schedule(now);
+      self.live.resume_normal_schedule(now);
+      let token_retry_is_automatic_only = !self.token_retry_source_refresh
+        && self
+          .token_retry_request
+          .as_ref()
+          .is_some_and(|request| !request.reasons.contains(RefreshReason::Manual));
+      if token_retry_is_automatic_only {
+        if let Some(planned_due_at) = self.token.resume_automatic_retry(now) {
+          if let Some(request) = self.token_retry_request.as_mut() {
+            request.planned_due_at = Some(planned_due_at);
+          }
+        }
+      } else {
+        self.token.disabled_retry_overdue_lag = None;
+      }
+      let live_retry_is_automatic_only = !self.live_retry_reasons.is_empty()
+        && !self.live_retry_reasons.contains(RefreshReason::Manual);
+      if live_retry_is_automatic_only {
+        if let Some(planned_due_at) = self.live.resume_automatic_retry(now) {
+          self.live_retry_planned_due_at = Some(planned_due_at);
+        }
+      } else {
+        self.live.disabled_retry_overdue_lag = None;
+      }
+    }
 
     if disabling_auto_scan {
       self.prune_automatic_pending_work();
@@ -295,7 +586,8 @@ impl CoordinatorState {
 
     let mut token_request = None;
     let mut token_request_is_source_refresh = false;
-    let mut live_reasons = ReasonSet::default();
+    let mut live_request = None;
+    let mut actions = Vec::with_capacity(4);
     if source_changed {
       self.source_generation = self
         .source_generation
@@ -303,67 +595,101 @@ impl CoordinatorState {
         .expect("refresh source generation overflowed");
       self.token.failure_streak = 0;
       self.token.retry_at = None;
-      self.token_retry_request = None;
+      self.token.disabled_retry_overdue_lag = None;
+      if let Some(mut retry) = self.token_retry_request.take() {
+        self.reject_token_waiters(
+          retry.drain_waiters(),
+          RefreshRejectionCode::SourceChanged,
+          Some("refresh source changed"),
+          &mut actions,
+        );
+      }
       self.token_retry_source_refresh = false;
       self.live.failure_streak = 0;
       self.live.retry_at = None;
+      self.live.disabled_retry_overdue_lag = None;
       self.live_retry_reasons = ReasonSet::default();
+      self.live_retry_planned_due_at = None;
 
-      let mut request = TokenRequest {
-        reasons: RefreshReason::SettingsChanged.into(),
-        kind: TokenScanKind::Full,
-        codex_home: self.config.codex_home.clone(),
-      };
+      let mut request = TokenRequest::for_reason(RefreshReason::SettingsChanged);
+      request.kind = TokenScanKind::Full;
+      request.bind_configured_source(self.source_generation, self.config.codex_home.clone());
       if let Some(previous_source_refresh) = self.token_source_refresh_pending.take() {
-        request.reasons.merge(previous_source_refresh.reasons);
+        self.retarget_automatic_reasons(
+          &mut request,
+          previous_source_refresh,
+          RefreshRejectionCode::SourceChanged,
+          &mut actions,
+        );
       }
       if let Some(pending) = self.token_pending_automatic.take() {
-        request.reasons.merge(pending.reasons);
+        self.retarget_automatic_reasons(
+          &mut request,
+          pending,
+          RefreshRejectionCode::SourceChanged,
+          &mut actions,
+        );
       }
-      if let Some(mut pending) = self.token_pending_manual.take() {
-        let manual_for_another_home = pending.reasons.contains(RefreshReason::Manual)
-          && pending.codex_home != self.config.codex_home;
-        if manual_for_another_home {
-          let mut automatic_reasons = pending.reasons;
+      if let Some(pending) = self.token_pending_manual.take() {
+        if pending.same_source_identity(&request) {
+          request
+            .try_merge(pending)
+            .expect("same source identity was checked before settings merge");
+        } else if pending.source_generation.is_none() {
+          let mut manual = pending;
+          let mut automatic_reasons = manual.reasons;
           automatic_reasons.remove(RefreshReason::Manual);
           request.reasons.merge(automatic_reasons);
-          pending.reasons = RefreshReason::Manual.into();
-          self.token_pending_manual = Some(pending);
+          request.planned_due_at =
+            earliest_planned_due(request.planned_due_at, manual.planned_due_at);
+          manual.reasons = RefreshReason::Manual.into();
+          manual.planned_due_at = None;
+          self.token_pending_manual = Some(manual);
         } else {
-          request.reasons.merge(pending.reasons);
+          self.retarget_automatic_reasons(
+            &mut request,
+            pending,
+            RefreshRejectionCode::SourceChanged,
+            &mut actions,
+          );
         }
       }
       token_request = Some(request);
       token_request_is_source_refresh = true;
       if self.config.auto_scan_enabled {
-        live_reasons.insert(RefreshReason::SettingsChanged);
+        live_request = Some(LiveRequest::for_reason(RefreshReason::SettingsChanged));
       }
     }
 
     if let Some((due, due_is_source_refresh)) =
       self.take_due_token_request(now, RefreshReason::SettingsChanged)
     {
-      merge_token_request(&mut token_request, due);
-      token_request_is_source_refresh |= due_is_source_refresh;
+      let merged_existing = token_request.is_some();
+      if let Err(due) = merge_token_request(&mut token_request, due) {
+        self.queue_token_pending_request(due, &mut actions);
+      } else {
+        if merged_existing {
+          self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+        }
+        token_request_is_source_refresh |= due_is_source_refresh;
+      }
     }
-    live_reasons.merge(self.take_due_live_reasons(now, RefreshReason::SettingsChanged));
+    if let Some(due) = self.take_due_live_request(now, RefreshReason::SettingsChanged) {
+      if live_request.is_some() {
+        self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
+      }
+      merge_live_request(&mut live_request, due);
+    }
 
-    let mut actions = Vec::with_capacity(2);
     if let Some(request) = token_request {
       if token_request_is_source_refresh {
         self.submit_source_refresh_request(request, &mut actions);
       } else {
-        self.submit_token_request(request, &mut actions);
+        self.submit_token_request(now, request, &mut actions);
       }
     }
-    if !live_reasons.is_empty() {
-      self.submit_live_request(
-        LiveRequest {
-          reasons: live_reasons,
-          waiter: None,
-        },
-        &mut actions,
-      );
+    if let Some(request) = live_request {
+      self.submit_live_request(now, request, &mut actions);
     }
     actions
   }
@@ -384,8 +710,10 @@ impl CoordinatorState {
           .is_some_and(|value| value.reasons.contains(RefreshReason::Manual));
       if retry_allowed {
         self.token.retry_at = None;
+        self.token.disabled_retry_overdue_lag = None;
         if let Some(retry) = self.token_retry_request.take() {
-          merge_token_request(&mut request, retry);
+          merge_token_request(&mut request, retry)
+            .expect("an empty due request accepts the retry source");
           source_refresh = self.token_retry_source_refresh;
           self.token_retry_source_refresh = false;
         }
@@ -393,87 +721,103 @@ impl CoordinatorState {
     }
 
     if self.config.auto_scan_enabled {
-      if let Some(reason) =
+      if let Some((reason, planned_due_at)) =
         self
           .token
           .take_normal_due(now, self.config.interval, trigger_reason)
       {
-        let automatic = TokenRequest {
-          reasons: reason.into(),
-          kind: TokenScanKind::Incremental,
-          codex_home: self.config.codex_home.clone(),
-        };
-        let retry_has_different_home = request
+        let mut automatic = TokenRequest::for_reason_at(reason, planned_due_at);
+        automatic.bind_configured_source(self.source_generation, self.config.codex_home.clone());
+        let retry_has_different_source = request
           .as_ref()
-          .is_some_and(|retry| retry.codex_home != automatic.codex_home);
-        if retry_has_different_home {
-          self.queue_token_pending_request(automatic);
+          .is_some_and(|retry| !retry.same_source_identity(&automatic));
+        if retry_has_different_source {
+          self.queue_token_pending_request(automatic, &mut Vec::new());
         } else {
-          merge_token_request(&mut request, automatic);
+          if request.is_some() {
+            self.token.coalesced_trigger_count =
+              self.token.coalesced_trigger_count.saturating_add(1);
+          }
+          merge_token_request(&mut request, automatic)
+            .expect("same configured source was checked before deadline merge");
         }
       }
     }
     request.map(|request| (request, source_refresh))
   }
 
-  fn take_due_live_reasons(
+  fn take_due_live_request(
     &mut self,
     now: Instant,
     trigger_reason: RefreshReason,
-  ) -> ReasonSet {
+  ) -> Option<LiveRequest> {
     let mut reasons = ReasonSet::default();
+    let mut planned_due_at = None;
     if self.live.retry_at.is_some_and(|retry_at| retry_at <= now) {
-      let retry_allowed = self.config.auto_scan_enabled
-        || self.live_retry_reasons.contains(RefreshReason::Manual);
+      let retry_allowed =
+        self.config.auto_scan_enabled || self.live_retry_reasons.contains(RefreshReason::Manual);
       if retry_allowed {
         self.live.retry_at = None;
+        self.live.disabled_retry_overdue_lag = None;
         reasons.merge(std::mem::take(&mut self.live_retry_reasons));
+        planned_due_at = self.live_retry_planned_due_at.take();
       }
     }
 
     if self.config.auto_scan_enabled {
-      if let Some(reason) =
+      if let Some((reason, normal_due_at)) =
         self
           .live
           .take_normal_due(now, self.config.interval, trigger_reason)
       {
+        if !reasons.is_empty() {
+          self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
+        }
         reasons.insert(reason);
+        planned_due_at = earliest_planned_due(planned_due_at, Some(normal_due_at));
       }
     }
-    reasons
+    (!reasons.is_empty()).then_some(LiveRequest {
+      reasons,
+      waiter: None,
+      planned_due_at,
+    })
   }
 
   fn submit_token_request(
     &mut self,
+    now: Instant,
     mut request: TokenRequest,
     actions: &mut Vec<CoordinatorAction>,
   ) {
     if request.reasons.is_empty() {
       return;
     }
-    if request.codex_home.is_none() {
-      request.codex_home = self.config.codex_home.clone();
-    }
+    request.bind_source_if_needed(self.source_generation, self.config.codex_home.clone());
 
     if self.token.running_generation.is_some() {
-      if !self.token_running_source_refresh {
-        if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
-          if source_refresh.codex_home == request.codex_home {
-            source_refresh.merge(request);
-            return;
-          }
+      if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
+        if source_refresh.same_source_identity(&request) {
+          source_refresh
+            .try_merge(request)
+            .expect("same source identity was checked before protected merge");
+          self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+          return;
         }
       }
-      self.queue_token_pending_request(request);
+      self.queue_token_pending_request(request, actions);
       return;
     }
 
     if self.token_retry_source_refresh {
       if let Some(source_retry) = self.token_retry_request.as_mut() {
-        if source_retry.codex_home == request.codex_home {
-          source_retry.merge(request);
+        if source_retry.same_source_identity(&request) {
+          source_retry
+            .try_merge(request)
+            .expect("same source identity was checked before protected retry merge");
+          self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
         } else {
-          self.queue_token_pending_request(request);
+          self.queue_token_pending_request(request, actions);
         }
         return;
       }
@@ -483,39 +827,80 @@ impl CoordinatorState {
     let preserves_manual_retry = self.token_retry_request.as_ref().is_some_and(|retry| {
       retry.reasons.contains(RefreshReason::Manual)
         && !request.reasons.contains(RefreshReason::Manual)
-        && retry.codex_home != request.codex_home
+        && !retry.same_source_identity(&request)
     });
     if preserves_manual_retry {
-      self.queue_token_pending_request(request);
+      self.queue_token_pending_request(request, actions);
       return;
     }
 
     if let Some(mut retry) = self.token_retry_request.take() {
-      if retry.codex_home == request.codex_home {
-        retry.merge(request);
+      if retry.same_source_identity(&request) {
+        let retry_was_manual = retry.reasons.contains(RefreshReason::Manual);
+        let retry_due_was_eligible = self.token.retry_at.is_some_and(|retry_at| retry_at <= now)
+          && (self.config.auto_scan_enabled || self.token_retry_source_refresh || retry_was_manual);
+        if !retry_due_was_eligible {
+          retry.planned_due_at = if !self.config.auto_scan_enabled && !retry_was_manual {
+            self
+              .token
+              .disabled_retry_overdue_lag
+              .and_then(|lag| now.checked_sub(lag))
+          } else {
+            None
+          };
+        }
+        retry
+          .try_merge(request)
+          .expect("same source identity was checked before retry merge");
         request = retry;
+        self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
+      } else {
+        self.reject_token_waiters(
+          retry.drain_waiters(),
+          RefreshRejectionCode::Superseded,
+          Some("refresh request was superseded"),
+          actions,
+        );
       }
     }
     self.token.retry_at = None;
+    self.token.disabled_retry_overdue_lag = None;
     self.start_token_request(request, false, actions);
   }
 
-  fn queue_token_pending_request(&mut self, mut request: TokenRequest) {
+  fn queue_token_pending_request(
+    &mut self,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
     if request.reasons.contains(RefreshReason::Manual) {
       let automatic_matches = self
         .token_pending_automatic
         .as_ref()
-        .is_some_and(|pending| pending.codex_home == request.codex_home);
+        .is_some_and(|pending| pending.same_source_identity(&request));
       if automatic_matches {
         if let Some(automatic) = self.token_pending_automatic.take() {
-          request.merge(automatic);
+          request
+            .try_merge(automatic)
+            .expect("same source identity was checked before pending merge");
         }
       }
-      if let Some(manual) = self.token_pending_manual.as_mut() {
-        if manual.codex_home == request.codex_home {
-          manual.merge(request);
+      if let Some(mut manual) = self.token_pending_manual.take() {
+        if manual.same_source_identity(&request) {
+          manual
+            .try_merge(request)
+            .expect("same source identity was checked before manual merge");
+          self.token_pending_manual = Some(manual);
         } else {
-          *manual = request;
+          self.reject_token_waiters(
+            manual.drain_waiters(),
+            RefreshRejectionCode::Superseded,
+            Some("refresh request was superseded"),
+            actions,
+          );
+          self.retain_automatic_request(manual, actions);
+          self.token_pending_manual = Some(request);
         }
       } else {
         self.token_pending_manual = Some(request);
@@ -524,16 +909,27 @@ impl CoordinatorState {
     }
 
     if let Some(manual) = self.token_pending_manual.as_mut() {
-      if manual.codex_home == request.codex_home {
-        manual.merge(request);
+      if manual.same_source_identity(&request) {
+        manual
+          .try_merge(request)
+          .expect("same source identity was checked before automatic merge");
         return;
       }
     }
-    if let Some(automatic) = self.token_pending_automatic.as_mut() {
-      if automatic.codex_home == request.codex_home {
-        automatic.merge(request);
+    if let Some(mut automatic) = self.token_pending_automatic.take() {
+      if automatic.same_source_identity(&request) {
+        automatic
+          .try_merge(request)
+          .expect("same source identity was checked before automatic merge");
+        self.token_pending_automatic = Some(automatic);
       } else {
-        *automatic = request;
+        self.reject_token_waiters(
+          automatic.drain_waiters(),
+          RefreshRejectionCode::Superseded,
+          Some("refresh request was superseded"),
+          actions,
+        );
+        self.token_pending_automatic = Some(request);
       }
     } else {
       self.token_pending_automatic = Some(request);
@@ -542,10 +938,28 @@ impl CoordinatorState {
 
   fn start_token_request(
     &mut self,
-    request: TokenRequest,
+    mut request: TokenRequest,
     source_refresh: bool,
     actions: &mut Vec<CoordinatorAction>,
   ) {
+    if request
+      .source_generation
+      .is_some_and(|generation| generation != self.source_generation)
+    {
+      self.reject_token_waiters(
+        request.drain_waiters(),
+        RefreshRejectionCode::SourceChanged,
+        Some("refresh source changed"),
+        actions,
+      );
+      request.reasons.remove(RefreshReason::Manual);
+      if request.reasons.is_empty() {
+        return;
+      }
+      request.bind_configured_source(self.source_generation, self.config.codex_home.clone());
+      request.kind = TokenScanKind::Full;
+      request.reasons.insert(RefreshReason::SettingsChanged);
+    }
     let generation = self.token.start_generation();
     let execution = TokenExecutionRequest {
       generation,
@@ -567,25 +981,48 @@ impl CoordinatorState {
         && self
           .token_running
           .as_ref()
-          .is_some_and(|running| running.request.codex_home == request.codex_home);
+          .is_some_and(|running| running.request.same_source_identity(&request));
       if matches_running_source_refresh {
-        merge_token_request(&mut self.token_source_refresh_pending, request);
+        if let Err(request) = merge_token_request(&mut self.token_source_refresh_pending, request) {
+          self.token_source_refresh_pending = Some(request);
+        }
+        self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
         return;
       }
       if let Some(previous) = self.token_source_refresh_pending.take() {
-        request.reasons.merge(previous.reasons);
+        if request.same_source_identity(&previous) {
+          request
+            .try_merge(previous)
+            .expect("same source identity was checked before source-refresh merge");
+        } else {
+          self.retarget_automatic_reasons(
+            &mut request,
+            previous,
+            RefreshRejectionCode::SourceChanged,
+            actions,
+          );
+        }
       }
       self.token_source_refresh_pending = Some(request);
+      self.token.coalesced_trigger_count = self.token.coalesced_trigger_count.saturating_add(1);
       return;
     }
     self.token.retry_at = None;
-    self.token_retry_request = None;
+    if let Some(mut retry) = self.token_retry_request.take() {
+      self.reject_token_waiters(
+        retry.drain_waiters(),
+        RefreshRejectionCode::SourceChanged,
+        Some("refresh source changed"),
+        actions,
+      );
+    }
     self.token_retry_source_refresh = false;
     self.start_token_request(request, true, actions);
   }
 
   fn submit_live_request(
     &mut self,
+    now: Instant,
     mut request: LiveRequest,
     actions: &mut Vec<CoordinatorAction>,
   ) {
@@ -595,14 +1032,39 @@ impl CoordinatorState {
       }
       request.reasons.remove(RefreshReason::Manual);
       self.live_pending.merge(request.reasons);
+      self.live_pending_due_at =
+        earliest_planned_due(self.live_pending_due_at, request.planned_due_at);
+      self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
       return;
     }
 
     if let Some(waiter) = request.waiter {
       push_unique_waiter(&mut self.live_waiters, waiter);
     }
-    request.reasons.merge(std::mem::take(&mut self.live_retry_reasons));
+    let had_retry = !self.live_retry_reasons.is_empty();
+    let retry_was_manual = self.live_retry_reasons.contains(RefreshReason::Manual);
+    let retry_due_was_eligible = self.live.retry_at.is_some_and(|retry_at| retry_at <= now)
+      && (self.config.auto_scan_enabled || retry_was_manual);
+    request
+      .reasons
+      .merge(std::mem::take(&mut self.live_retry_reasons));
+    let retry_planned_due_at = self.live_retry_planned_due_at.take();
+    let retry_planned_due_at = if retry_due_was_eligible {
+      retry_planned_due_at
+    } else if !self.config.auto_scan_enabled && !retry_was_manual {
+      self
+        .live
+        .disabled_retry_overdue_lag
+        .and_then(|lag| now.checked_sub(lag))
+    } else {
+      None
+    };
+    request.planned_due_at = earliest_planned_due(request.planned_due_at, retry_planned_due_at);
     self.live.retry_at = None;
+    self.live.disabled_retry_overdue_lag = None;
+    if had_retry {
+      self.live.coalesced_trigger_count = self.live.coalesced_trigger_count.saturating_add(1);
+    }
     if request.reasons.is_empty() {
       return;
     }
@@ -612,6 +1074,7 @@ impl CoordinatorState {
       generation,
       source_generation: self.source_generation,
       reasons: request.reasons,
+      planned_due_at: request.planned_due_at,
     };
     self.live_running = Some(execution.clone());
     actions.push(CoordinatorAction::StartLive(execution));
@@ -619,6 +1082,7 @@ impl CoordinatorState {
 
   fn handle_token_prepared(
     &mut self,
+    now: Instant,
     generation: u64,
     source_generation: u64,
   ) -> Vec<CoordinatorAction> {
@@ -639,8 +1103,7 @@ impl CoordinatorState {
       return actions;
     }
 
-    if running.source_generation == source_generation
-      && source_generation == self.source_generation
+    if running.source_generation == source_generation && source_generation == self.source_generation
     {
       actions.push(CoordinatorAction::CommitToken {
         generation,
@@ -659,14 +1122,30 @@ impl CoordinatorState {
       generation,
       source_generation,
     });
-    if self.token_source_refresh_pending.is_none() {
-      let mut request = stale.request;
+    let mut stale_request = stale.request;
+    let stale_waiters = stale_request.drain_waiters();
+    self.complete_token_waiters(
+      stale_waiters,
+      generation,
+      false,
+      Some(RefreshFailureCode::SourceChanged),
+      Some("refresh source changed"),
+      &mut actions,
+    );
+    let mut replacement = self.token_source_refresh_pending.take().unwrap_or_else(|| {
+      let mut request = TokenRequest::for_reason(RefreshReason::SettingsChanged);
       request.kind = TokenScanKind::Full;
-      request.codex_home = self.config.codex_home.clone();
-      request.reasons.insert(RefreshReason::SettingsChanged);
-      self.token_source_refresh_pending = Some(request);
-    }
-    self.start_pending_token(&mut actions);
+      request.bind_configured_source(self.source_generation, self.config.codex_home.clone());
+      request
+    });
+    self.retarget_automatic_reasons(
+      &mut replacement,
+      stale_request,
+      RefreshRejectionCode::SourceChanged,
+      &mut actions,
+    );
+    self.token_source_refresh_pending = Some(replacement);
+    self.start_pending_token(now, &mut actions);
     actions
   }
 
@@ -682,7 +1161,7 @@ impl CoordinatorState {
       return Vec::new();
     }
 
-    let running = self
+    let mut running = self
       .token_running
       .take()
       .expect("matching token generation remains present");
@@ -692,31 +1171,88 @@ impl CoordinatorState {
     if running.source_generation != completion.source_generation
       || completion.source_generation != self.source_generation
     {
-      let mut actions = Vec::with_capacity(1);
-      self.start_pending_token(&mut actions);
+      let mut actions = Vec::with_capacity(3);
+      let waiters = running.request.drain_waiters();
+      self.complete_token_waiters(
+        waiters,
+        completion.generation,
+        false,
+        Some(RefreshFailureCode::SourceChanged),
+        Some("refresh source changed"),
+        &mut actions,
+      );
+      self.start_pending_token(now, &mut actions);
       return actions;
     }
 
     let completion = normalize_completion(completion);
-    let mut actions = Vec::with_capacity(3);
+    let waiters = running.request.drain_waiters();
+    let mut actions = Vec::with_capacity(4);
     if completion.succeeded {
       self.token.failure_streak = 0;
       self.token.retry_at = None;
+      self.token.disabled_retry_overdue_lag = None;
       self.token_retry_request = None;
       self.token_retry_source_refresh = false;
       self.usage_revision = self.usage_revision.saturating_add(1);
       actions.push(CoordinatorAction::PublishInvalidation(
-        self.invalidation(completion.commit.expect("normalized success has commit marker")),
+        self.invalidation(
+          completion
+            .commit
+            .expect("normalized success has commit marker"),
+        ),
       ));
     } else {
       self.token.failure_streak = self.token.failure_streak.saturating_add(1);
       let jitter = completion.retry_jitter.min(Duration::from_secs(1));
       let delay = retry_delay(self.token.failure_streak, self.config.interval, jitter);
-      self.token.retry_at = Some(now.checked_add(delay).unwrap_or(now));
+      let retry_at = now.checked_add(delay).unwrap_or(now);
+      self.token.retry_at = Some(retry_at);
+      self.token.disabled_retry_overdue_lag = None;
       let mut retry_request = running.request;
+      retry_request.planned_due_at = Some(retry_at);
       if running_source_refresh {
         if let Some(pending) = self.token_source_refresh_pending.take() {
-          retry_request.merge(pending);
+          if retry_request.same_source_identity(&pending) {
+            retry_request
+              .try_merge(pending)
+              .expect("same source identity was checked before protected retry merge");
+          } else {
+            self.retarget_automatic_reasons(
+              &mut retry_request,
+              pending,
+              RefreshRejectionCode::SourceChanged,
+              &mut actions,
+            );
+          }
+        }
+        let pending_manual_matches = self
+          .token_pending_manual
+          .as_ref()
+          .is_some_and(|pending| retry_request.same_source_identity(pending));
+        if pending_manual_matches {
+          retry_request
+            .try_merge(
+              self
+                .token_pending_manual
+                .take()
+                .expect("matching protected follow-up remains pending"),
+            )
+            .expect("same source identity was checked before protected follow-up merge");
+        }
+        let pending_automatic_matches = self
+          .token_pending_automatic
+          .as_ref()
+          .is_some_and(|pending| retry_request.same_source_identity(pending));
+        if pending_automatic_matches {
+          retry_request
+            .try_merge(
+              self
+                .token_pending_automatic
+                .take()
+                .expect("matching protected automatic follow-up remains pending"),
+            )
+            .expect("same source identity was checked before protected automatic merge");
         }
       }
       self.token_retry_request = Some(retry_request);
@@ -725,7 +1261,15 @@ impl CoordinatorState {
     actions.push(CoordinatorAction::PublishCompletion(
       self.completed_event(RefreshLane::Token, &completion),
     ));
-    self.start_pending_token(&mut actions);
+    self.complete_token_waiters(
+      waiters,
+      completion.generation,
+      completion.succeeded,
+      completion.failure_code,
+      completion.failure.as_deref(),
+      &mut actions,
+    );
+    self.start_pending_token(now, &mut actions);
     actions
   }
 
@@ -751,15 +1295,15 @@ impl CoordinatorState {
       || completion.source_generation != self.source_generation
     {
       let mut actions = Vec::with_capacity(2);
-      if !waiters.is_empty() {
-        actions.push(CoordinatorAction::ResolveLiveWaiters {
-          waiter_ids: waiters,
-          generation: completion.generation,
-          succeeded: false,
-          failure: Some("refresh source changed".to_string()),
-        });
-      }
-      self.start_pending_live(&mut actions);
+      self.complete_live_waiters(
+        waiters,
+        completion.generation,
+        false,
+        Some(RefreshFailureCode::SourceChanged),
+        Some("refresh source changed"),
+        &mut actions,
+      );
+      self.start_pending_live(now, &mut actions);
       return actions;
     }
 
@@ -768,34 +1312,42 @@ impl CoordinatorState {
     if completion.succeeded {
       self.live.failure_streak = 0;
       self.live.retry_at = None;
+      self.live.disabled_retry_overdue_lag = None;
       self.live_retry_reasons = ReasonSet::default();
       self.quota_revision = self.quota_revision.saturating_add(1);
       actions.push(CoordinatorAction::PublishInvalidation(
-        self.invalidation(completion.commit.expect("normalized success has commit marker")),
+        self.invalidation(
+          completion
+            .commit
+            .expect("normalized success has commit marker"),
+        ),
       ));
     } else {
       self.live.failure_streak = self.live.failure_streak.saturating_add(1);
       let jitter = completion.retry_jitter.min(Duration::from_secs(1));
       let delay = retry_delay(self.live.failure_streak, self.config.interval, jitter);
-      self.live.retry_at = Some(now.checked_add(delay).unwrap_or(now));
+      let retry_at = now.checked_add(delay).unwrap_or(now);
+      self.live.retry_at = Some(retry_at);
+      self.live.disabled_retry_overdue_lag = None;
       self.live_retry_reasons = running.reasons;
+      self.live_retry_planned_due_at = Some(retry_at);
     }
     actions.push(CoordinatorAction::PublishCompletion(
       self.completed_event(RefreshLane::Live, &completion),
     ));
-    if !waiters.is_empty() {
-      actions.push(CoordinatorAction::ResolveLiveWaiters {
-        waiter_ids: waiters,
-        generation: completion.generation,
-        succeeded: completion.succeeded,
-        failure: completion.failure.clone(),
-      });
-    }
-    self.start_pending_live(&mut actions);
+    self.complete_live_waiters(
+      waiters,
+      completion.generation,
+      completion.succeeded,
+      completion.failure_code,
+      completion.failure.as_deref(),
+      &mut actions,
+    );
+    self.start_pending_live(now, &mut actions);
     actions
   }
 
-  fn start_pending_token(&mut self, actions: &mut Vec<CoordinatorAction>) {
+  fn start_pending_token(&mut self, now: Instant, actions: &mut Vec<CoordinatorAction>) {
     if self.token_retry_source_refresh {
       return;
     }
@@ -804,12 +1356,12 @@ impl CoordinatorState {
       return;
     }
     if let Some(request) = self.token_pending_manual.take() {
-      self.submit_token_request(request, actions);
+      self.submit_token_request(now, request, actions);
       return;
     }
     if let Some(request) = self.token_pending_automatic.take() {
       if self.config.auto_scan_enabled {
-        self.submit_token_request(request, actions);
+        self.submit_token_request(now, request, actions);
       }
     }
   }
@@ -817,21 +1369,231 @@ impl CoordinatorState {
   fn prune_automatic_pending_work(&mut self) {
     if let Some(pending) = self.token_pending_manual.as_mut() {
       pending.reasons = RefreshReason::Manual.into();
+      pending.planned_due_at = None;
     }
     self.token_pending_automatic = None;
     self.live_pending = ReasonSet::default();
+    self.live_pending_due_at = None;
   }
 
-  fn start_pending_live(&mut self, actions: &mut Vec<CoordinatorAction>) {
+  fn start_pending_live(&mut self, now: Instant, actions: &mut Vec<CoordinatorAction>) {
     let reasons = std::mem::take(&mut self.live_pending);
+    let planned_due_at = self.live_pending_due_at.take();
     if !reasons.is_empty() {
       self.submit_live_request(
+        now,
         LiveRequest {
           reasons,
           waiter: None,
+          planned_due_at,
         },
         actions,
       );
+    }
+  }
+
+  fn prepare_token_intake(
+    &self,
+    request: &mut TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) -> bool {
+    request.bind_source_if_needed(self.source_generation, self.config.codex_home.clone());
+    let had_waiters = !request.waiter_ids.is_empty();
+    if !had_waiters {
+      return true;
+    }
+
+    if !request.reasons.contains(RefreshReason::Manual) {
+      self.reject_token_waiters(
+        request.drain_waiters(),
+        RefreshRejectionCode::InvalidRequest,
+        Some("token waiters require a manual refresh request"),
+        actions,
+      );
+      return false;
+    }
+
+    let incoming = request.drain_waiters();
+    let mut accepted = Vec::with_capacity(incoming.len());
+    let mut rejected = Vec::with_capacity(incoming.len());
+    let mut owned_count = self.token_waiter_count();
+    for waiter in incoming {
+      if accepted.contains(&waiter) || self.token_waiter_is_owned(waiter) {
+        continue;
+      }
+      if owned_count >= REFRESH_WAITER_CAPACITY {
+        rejected.push(waiter);
+      } else {
+        accepted.push(waiter);
+        owned_count += 1;
+      }
+    }
+    for waiter in accepted {
+      request
+        .try_add_waiter(waiter)
+        .expect("normalized token waiter input stays within the fixed capacity");
+    }
+    if !rejected.is_empty() {
+      actions.push(CoordinatorAction::ResolveTokenWaiters {
+        waiter_ids: rejected,
+        outcome: rejected_outcome(RefreshRejectionCode::Busy, None),
+      });
+    }
+    !request.waiter_ids.is_empty()
+  }
+
+  fn token_waiter_count(&self) -> usize {
+    self
+      .token_running
+      .as_ref()
+      .map_or(0, |request| request.request.waiter_ids.len())
+      .saturating_add(
+        self
+          .token_pending_manual
+          .as_ref()
+          .map_or(0, |request| request.waiter_ids.len()),
+      )
+      .saturating_add(
+        self
+          .token_pending_automatic
+          .as_ref()
+          .map_or(0, |request| request.waiter_ids.len()),
+      )
+      .saturating_add(
+        self
+          .token_source_refresh_pending
+          .as_ref()
+          .map_or(0, |request| request.waiter_ids.len()),
+      )
+      .saturating_add(
+        self
+          .token_retry_request
+          .as_ref()
+          .map_or(0, |request| request.waiter_ids.len()),
+      )
+  }
+
+  fn token_waiter_is_owned(&self, waiter: TokenWaiterId) -> bool {
+    self
+      .token_running
+      .as_ref()
+      .is_some_and(|request| request.request.waiter_ids.contains(&waiter))
+      || self
+        .token_pending_manual
+        .as_ref()
+        .is_some_and(|request| request.waiter_ids.contains(&waiter))
+      || self
+        .token_pending_automatic
+        .as_ref()
+        .is_some_and(|request| request.waiter_ids.contains(&waiter))
+      || self
+        .token_source_refresh_pending
+        .as_ref()
+        .is_some_and(|request| request.waiter_ids.contains(&waiter))
+      || self
+        .token_retry_request
+        .as_ref()
+        .is_some_and(|request| request.waiter_ids.contains(&waiter))
+  }
+
+  fn reject_token_waiters(
+    &self,
+    waiter_ids: Vec<TokenWaiterId>,
+    code: RefreshRejectionCode,
+    detail: Option<&str>,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if !waiter_ids.is_empty() {
+      actions.push(CoordinatorAction::ResolveTokenWaiters {
+        waiter_ids,
+        outcome: rejected_outcome(code, detail),
+      });
+    }
+  }
+
+  fn complete_token_waiters(
+    &self,
+    waiter_ids: Vec<TokenWaiterId>,
+    generation: u64,
+    succeeded: bool,
+    failure_code: Option<RefreshFailureCode>,
+    detail: Option<&str>,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if !waiter_ids.is_empty() {
+      actions.push(CoordinatorAction::ResolveTokenWaiters {
+        waiter_ids,
+        outcome: completed_outcome(generation, succeeded, failure_code, detail),
+      });
+    }
+  }
+
+  fn complete_live_waiters(
+    &self,
+    waiter_ids: Vec<LiveWaiterId>,
+    generation: u64,
+    succeeded: bool,
+    failure_code: Option<RefreshFailureCode>,
+    detail: Option<&str>,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if !waiter_ids.is_empty() {
+      actions.push(CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids,
+        outcome: completed_outcome(generation, succeeded, failure_code, detail),
+      });
+    }
+  }
+
+  fn retarget_automatic_reasons(
+    &self,
+    target: &mut TokenRequest,
+    mut displaced: TokenRequest,
+    rejection: RefreshRejectionCode,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    self.reject_token_waiters(
+      displaced.drain_waiters(),
+      rejection,
+      Some("refresh source changed"),
+      actions,
+    );
+    displaced.reasons.remove(RefreshReason::Manual);
+    if displaced.reasons.is_empty() {
+      return;
+    }
+    target.reasons.merge(displaced.reasons);
+    target.kind = target.kind.max(displaced.kind);
+    target.planned_due_at = earliest_planned_due(target.planned_due_at, displaced.planned_due_at);
+  }
+
+  fn retain_automatic_request(
+    &mut self,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    request.reasons.remove(RefreshReason::Manual);
+    request.waiter_ids.clear();
+    if request.reasons.is_empty() {
+      return;
+    }
+    if let Some(mut automatic) = self.token_pending_automatic.take() {
+      if automatic.same_source_identity(&request) {
+        automatic
+          .try_merge(request)
+          .expect("same source identity was checked before retained merge");
+        self.token_pending_automatic = Some(automatic);
+      } else {
+        self.reject_token_waiters(
+          automatic.drain_waiters(),
+          RefreshRejectionCode::Superseded,
+          Some("refresh request was superseded"),
+          actions,
+        );
+        self.token_pending_automatic = Some(request);
+      }
+    } else {
+      self.token_pending_automatic = Some(request);
     }
   }
 
@@ -889,13 +1651,157 @@ impl CoordinatorState {
   pub(crate) fn usage_revision(&self) -> u64 {
     self.usage_revision
   }
+
+  pub(crate) fn snapshot(&self) -> CoordinatorSnapshot {
+    let mut token_pending_reasons = ReasonSet::default();
+    for request in [
+      self.token_pending_manual.as_ref(),
+      self.token_pending_automatic.as_ref(),
+      self.token_source_refresh_pending.as_ref(),
+      self.token_retry_request.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+      token_pending_reasons.merge(request.reasons);
+    }
+    let mut live_pending_reasons = self.live_pending;
+    live_pending_reasons.merge(self.live_retry_reasons);
+
+    CoordinatorSnapshot {
+      token: LaneScheduleSnapshot {
+        running_generation: self.token.running_generation,
+        next_normal_deadline: self.token.next_deadline,
+        retry_deadline: self.token.retry_at,
+        failure_streak: self.token.failure_streak,
+        pending: !token_pending_reasons.is_empty(),
+        pending_reasons: token_pending_reasons,
+        missed_deadline_count: self.token.missed_deadline_count,
+        coalesced_trigger_count: self.token.coalesced_trigger_count,
+      },
+      live: LaneScheduleSnapshot {
+        running_generation: self.live.running_generation,
+        next_normal_deadline: self.live.next_deadline,
+        retry_deadline: self.live.retry_at,
+        failure_streak: self.live.failure_streak,
+        pending: !live_pending_reasons.is_empty(),
+        pending_reasons: live_pending_reasons,
+        missed_deadline_count: self.live.missed_deadline_count,
+        coalesced_trigger_count: self.live.coalesced_trigger_count,
+      },
+      source_generation: self.source_generation,
+      interval: self.config.interval,
+      auto_scan_enabled: self.config.auto_scan_enabled,
+    }
+  }
+
+  pub(crate) fn next_wait(&self, now: Instant) -> Option<Duration> {
+    let mut wait = None;
+    if self.config.auto_scan_enabled {
+      wait = Some(if self.token.immediate_due_at.is_some() {
+        Duration::ZERO
+      } else {
+        self.token.next_deadline.saturating_duration_since(now)
+      });
+      wait = earliest_wait(
+        wait,
+        Some(if self.live.immediate_due_at.is_some() {
+          Duration::ZERO
+        } else {
+          self.live.next_deadline.saturating_duration_since(now)
+        }),
+      );
+    }
+
+    let token_retry_is_eligible = self.config.auto_scan_enabled
+      || self.token_retry_source_refresh
+      || self
+        .token_retry_request
+        .as_ref()
+        .is_some_and(|request| request.reasons.contains(RefreshReason::Manual));
+    if token_retry_is_eligible {
+      wait = earliest_wait(
+        wait,
+        self
+          .token
+          .retry_at
+          .map(|deadline| deadline.saturating_duration_since(now)),
+      );
+    }
+
+    let live_retry_is_eligible =
+      self.config.auto_scan_enabled || self.live_retry_reasons.contains(RefreshReason::Manual);
+    if live_retry_is_eligible {
+      wait = earliest_wait(
+        wait,
+        self
+          .live
+          .retry_at
+          .map(|deadline| deadline.saturating_duration_since(now)),
+      );
+    }
+    wait
+  }
 }
 
-fn merge_token_request(target: &mut Option<TokenRequest>, request: TokenRequest) {
+fn merge_token_request(
+  target: &mut Option<TokenRequest>,
+  request: TokenRequest,
+) -> Result<(), TokenRequest> {
   if let Some(target) = target {
-    target.merge(request);
+    target.try_merge(request)
   } else {
     *target = Some(request);
+    Ok(())
+  }
+}
+
+fn merge_live_request(target: &mut Option<LiveRequest>, request: LiveRequest) {
+  if let Some(target) = target {
+    target.reasons.merge(request.reasons);
+    target.planned_due_at = earliest_planned_due(target.planned_due_at, request.planned_due_at);
+    if target.waiter.is_none() {
+      target.waiter = request.waiter;
+    }
+  } else {
+    *target = Some(request);
+  }
+}
+
+fn earliest_planned_due(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.min(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
+  }
+}
+
+fn earliest_wait(left: Option<Duration>, right: Option<Duration>) -> Option<Duration> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.min(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
+  }
+}
+
+fn completed_outcome(
+  generation: u64,
+  succeeded: bool,
+  failure_code: Option<RefreshFailureCode>,
+  detail: Option<&str>,
+) -> RefreshWaiterOutcome {
+  RefreshWaiterOutcome::Completed {
+    generation,
+    succeeded,
+    failure_code,
+    detail: detail.map(RefreshDetail::new),
+  }
+}
+
+fn rejected_outcome(code: RefreshRejectionCode, detail: Option<&str>) -> RefreshWaiterOutcome {
+  RefreshWaiterOutcome::Rejected {
+    code,
+    detail: detail.map(RefreshDetail::new),
   }
 }
 
@@ -908,9 +1814,18 @@ fn push_unique_waiter(waiters: &mut Vec<LiveWaiterId>, waiter: LiveWaiterId) {
 fn normalize_completion(mut completion: ExecutionCompletion) -> ExecutionCompletion {
   if completion.succeeded && completion.commit.is_none() {
     completion.succeeded = false;
+    completion.failure_code = Some(RefreshFailureCode::InvalidCompletion);
     completion.failure = Some("successful refresh completion missing commit marker".to_string());
-  } else if !completion.succeeded && completion.failure.is_none() {
-    completion.failure = Some("refresh failed without an error".to_string());
+  } else if !completion.succeeded {
+    if completion.failure_code.is_none() {
+      completion.failure_code = Some(RefreshFailureCode::ExecutionFailed);
+    }
+    if completion.failure.is_none() {
+      completion.failure = Some("refresh failed without an error".to_string());
+    }
+  } else {
+    completion.failure_code = None;
+    completion.failure = None;
   }
   completion
 }
@@ -924,17 +1839,56 @@ fn retry_delay(failure_streak: u32, interval: Duration, jitter: Duration) -> Dur
     .min(Duration::from_secs(300))
 }
 
-fn advance_fixed_deadline(
-  mut deadline: Instant,
-  interval: Duration,
-  now: Instant,
-) -> (Instant, u64) {
-  let mut elapsed_intervals = 0_u64;
-  while deadline <= now {
-    deadline += interval;
-    elapsed_intervals += 1;
+fn advance_fixed_deadline(deadline: Instant, interval: Duration, now: Instant) -> (Instant, u64) {
+  if deadline > now {
+    return (deadline, 0);
   }
-  (deadline, elapsed_intervals.saturating_sub(1))
+
+  let interval_nanos = interval.as_nanos();
+  debug_assert!(interval_nanos > 0);
+  let overdue_nanos = now.duration_since(deadline).as_nanos();
+  let elapsed_intervals = overdue_nanos / interval_nanos + 1;
+  let remainder_nanos = overdue_nanos % interval_nanos;
+  let remaining = duration_from_nanos(interval_nanos - remainder_nanos);
+  let next_deadline = saturating_instant_add(now, remaining);
+  let missed = elapsed_intervals.saturating_sub(1).min(u64::MAX as u128) as u64;
+  (next_deadline, missed)
+}
+
+fn duration_from_nanos(value: u128) -> Duration {
+  Duration::new(
+    (value / 1_000_000_000).min(u64::MAX as u128) as u64,
+    (value % 1_000_000_000) as u32,
+  )
+}
+
+fn saturating_instant_add(base: Instant, duration: Duration) -> Instant {
+  if let Some(value) = base.checked_add(duration) {
+    return value;
+  }
+
+  let mut accepted_nanos = 0_u128;
+  let mut rejected_nanos = duration.as_nanos();
+  let mut accepted = base;
+  while accepted_nanos.saturating_add(1) < rejected_nanos {
+    let candidate_nanos = accepted_nanos + (rejected_nanos - accepted_nanos) / 2;
+    if let Some(candidate) = base.checked_add(duration_from_nanos(candidate_nanos)) {
+      accepted_nanos = candidate_nanos;
+      accepted = candidate;
+    } else {
+      rejected_nanos = candidate_nanos;
+    }
+  }
+  accepted
+}
+
+fn effective_interval(base: Instant, requested: Duration) -> Duration {
+  let effective = saturating_instant_add(base, requested).duration_since(base);
+  if effective.is_zero() {
+    Duration::from_nanos(1)
+  } else {
+    effective
+  }
 }
 
 fn duration_remainder(value: Duration, modulus: Duration) -> Duration {
@@ -956,7 +1910,7 @@ fn initial_deadline(
   else {
     return monotonic_now;
   };
-  monotonic_now + interval.saturating_sub(age)
+  saturating_instant_add(monotonic_now, interval.saturating_sub(age))
 }
 
 #[cfg(test)]
@@ -1182,6 +2136,61 @@ mod tests {
   }
 
   #[test]
+  fn interval_shrink_preserves_original_planned_due() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(60),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(30), Some(wall))),
+    );
+
+    let token = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("shorter interval starts token catch-up");
+    let live = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("shorter interval starts live catch-up");
+    assert_eq!(
+      token.request.planned_due_at,
+      Some(base + Duration::from_secs(30))
+    );
+    assert_eq!(live.planned_due_at, Some(base + Duration::from_secs(30)));
+  }
+
+  #[test]
+  fn interval_shrink_counts_only_skipped_new_deadlines() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+
+    state.handle(
+      base + Duration::from_secs(60),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(30), Some(wall))),
+    );
+
+    assert_eq!(state.snapshot().token.missed_deadline_count, 1);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 1);
+  }
+
+  #[test]
   fn shorter_interval_preserves_unaligned_fixed_deadline() {
     let base = Instant::now();
     let wall = utc("2026-07-10T10:00:00Z");
@@ -1215,11 +2224,8 @@ mod tests {
     let old_interval = Duration::MAX;
     let old_next_deadline = base + Duration::from_secs(60);
     assert!(old_next_deadline.checked_sub(old_interval).is_none());
-    let mut state = CoordinatorState::new(
-      test_config(Duration::from_secs(60), Some(wall)),
-      base,
-      wall,
-    );
+    let mut state =
+      CoordinatorState::new(test_config(Duration::from_secs(60), Some(wall)), base, wall);
     state.config.interval = old_interval;
     state.token = LaneState::new(old_next_deadline, base);
     state.live = LaneState::new(old_next_deadline, base);
@@ -1351,6 +2357,7 @@ mod tests {
       generation,
       source_generation,
       succeeded: true,
+      failure_code: None,
       failure: None,
       completed_at: "2026-07-10T10:00:00Z".to_string(),
       commit: Some(CommitMarker {
@@ -1370,6 +2377,7 @@ mod tests {
       generation,
       source_generation,
       succeeded: false,
+      failure_code: Some(RefreshFailureCode::ExecutionFailed),
       failure: Some("test failure".to_string()),
       completed_at: "2026-07-10T10:00:00Z".to_string(),
       commit: None,
@@ -1393,16 +2401,43 @@ mod tests {
 
   fn start_live_generation(state: &mut CoordinatorState, now: Instant) -> LiveExecutionRequest {
     state
-      .handle(
-        now,
-        CoordinatorEvent::RequestLive(LiveRequest::scheduled()),
-      )
+      .handle(now, CoordinatorEvent::RequestLive(LiveRequest::scheduled()))
       .into_iter()
       .find_map(|action| match action {
         CoordinatorAction::StartLive(request) => Some(request),
         _ => None,
       })
       .expect("live generation starts")
+  }
+
+  fn manual_token_request(waiter: TokenWaiterId, codex_home: Option<&str>) -> TokenRequest {
+    TokenRequest::manual_full_with_waiter(codex_home.map(str::to_string), waiter)
+  }
+
+  fn token_waiter_outcome<'a>(
+    actions: &'a [CoordinatorAction],
+    waiter: TokenWaiterId,
+  ) -> Option<&'a RefreshWaiterOutcome> {
+    actions.iter().find_map(|action| match action {
+      CoordinatorAction::ResolveTokenWaiters {
+        waiter_ids,
+        outcome,
+      } if waiter_ids.contains(&waiter) => Some(outcome),
+      _ => None,
+    })
+  }
+
+  fn live_waiter_outcome<'a>(
+    actions: &'a [CoordinatorAction],
+    waiter: LiveWaiterId,
+  ) -> Option<&'a RefreshWaiterOutcome> {
+    actions.iter().find_map(|action| match action {
+      CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids,
+        outcome,
+      } if waiter_ids.contains(&waiter) => Some(outcome),
+      _ => None,
+    })
   }
 
   #[test]
@@ -1486,9 +2521,7 @@ mod tests {
     assert_eq!(starts.len(), 1);
     assert!(starts[0].reasons.contains(RefreshReason::Scheduled));
     assert!(starts[0].reasons.contains(RefreshReason::Wake));
-    assert!(starts[0]
-      .reasons
-      .contains(RefreshReason::SettingsChanged));
+    assert!(starts[0].reasons.contains(RefreshReason::SettingsChanged));
   }
 
   #[test]
@@ -1528,9 +2561,12 @@ mod tests {
       action,
       CoordinatorAction::ResolveLiveWaiters {
         waiter_ids,
-        generation,
-        succeeded: true,
-        failure: None,
+        outcome: RefreshWaiterOutcome::Completed {
+          generation,
+          succeeded: true,
+          failure_code: None,
+          detail: None,
+        },
       } if waiter_ids == &[waiter_id] && *generation == first.generation
     )));
   }
@@ -1720,6 +2756,7 @@ mod tests {
       generation: first.generation,
       source_generation: first.source_generation,
       succeeded: true,
+      failure_code: None,
       failure: None,
       completed_at: "2026-07-10T10:00:00Z".to_string(),
       commit: None,
@@ -1812,12 +2849,15 @@ mod tests {
       action,
       CoordinatorAction::ResolveLiveWaiters {
         waiter_ids,
-        generation,
-        succeeded: false,
-        failure: Some(failure),
+        outcome: RefreshWaiterOutcome::Completed {
+          generation,
+          succeeded: false,
+          failure_code: Some(RefreshFailureCode::SourceChanged),
+          detail,
+        },
       } if waiter_ids == &[waiter_id]
         && *generation == first.generation
-        && failure == "refresh source changed"
+        && detail.as_ref().is_some_and(|value| value.as_str() == "refresh source changed")
     )));
     assert_eq!(
       actions
@@ -2427,5 +3467,2037 @@ mod tests {
           && request.request.codex_home.as_deref()
             == Some("/normalized/configured-home-b")
     ));
+  }
+
+  #[test]
+  fn manual_token_waiter_binds_to_follow_up_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let running = start_token_generation(&mut state, base);
+    let waiter = TokenWaiterId(1);
+
+    let queued = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+    );
+    assert!(queued.is_empty());
+
+    let first_completion = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    assert!(token_waiter_outcome(&first_completion, waiter).is_none());
+    let follow_up = first_completion
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual waiter starts in one follow-up generation");
+    assert_ne!(follow_up.generation, running.generation);
+    assert_eq!(follow_up.request.waiter_ids(), &[waiter]);
+
+    let follow_up_completion = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        follow_up.generation,
+        follow_up.source_generation,
+        2,
+        base + Duration::from_secs(3),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&follow_up_completion, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: true,
+        failure_code: None,
+        detail: None,
+      }) if *generation == follow_up.generation
+    ));
+  }
+
+  #[test]
+  fn same_source_manual_waiters_coalesce() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut config = test_config(Duration::from_secs(300), Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let running = start_token_generation(&mut state, base);
+    let first_waiter = TokenWaiterId(10);
+    let second_waiter = TokenWaiterId(11);
+
+    for waiter in [first_waiter, second_waiter, first_waiter] {
+      assert!(state
+        .handle(
+          base + Duration::from_secs(1),
+          CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-a"),)),
+        )
+        .is_empty());
+    }
+
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let follow_up = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("coalesced manual request starts");
+    assert_eq!(
+      follow_up.request.waiter_ids(),
+      &[first_waiter, second_waiter]
+    );
+    assert_eq!(
+      follow_up.request.codex_home.as_deref(),
+      Some("/normalized/home-a")
+    );
+  }
+
+  #[test]
+  fn different_source_manual_waiter_is_rejected_without_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let running = start_token_generation(&mut state, base);
+    let displaced = TokenWaiterId(20);
+    let replacement = TokenWaiterId(21);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(manual_token_request(displaced, Some("/normalized/home-a"))),
+    );
+
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(manual_token_request(
+        replacement,
+        Some("/normalized/home-b"),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&replacement_actions, displaced),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::Superseded,
+        ..
+      })
+    ));
+
+    let completion_actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+    let follow_up = completion_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("replacement manual source starts");
+    assert_eq!(follow_up.request.waiter_ids(), &[replacement]);
+    assert_eq!(
+      follow_up.request.codex_home.as_deref(),
+      Some("/normalized/home-b")
+    );
+  }
+
+  #[test]
+  fn failed_manual_waiter_resolves_once_before_retry() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let waiter = TokenWaiterId(30);
+    let manual = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token generation starts");
+
+    let failure_actions = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual.generation,
+        manual.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&failure_actions, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: false,
+        failure_code: Some(RefreshFailureCode::ExecutionFailed),
+        ..
+      }) if *generation == manual.generation
+    ));
+    assert_eq!(
+      failure_actions
+        .iter()
+        .filter(|action| matches!(action, CoordinatorAction::ResolveTokenWaiters { .. }))
+        .count(),
+      1
+    );
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(6)));
+
+    let retry_actions = state.handle(base + Duration::from_secs(6), CoordinatorEvent::Timer);
+    let retry = retry_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("automatic retry starts");
+    assert!(retry.request.waiter_ids.is_empty());
+  }
+
+  #[test]
+  fn retry_never_reresolves_old_waiter() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let waiter = TokenWaiterId(31);
+    let manual = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token generation starts");
+    let failed = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual.generation,
+        manual.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(token_waiter_outcome(&failed, waiter).is_some());
+    let retry = state
+      .handle(base + Duration::from_secs(6), CoordinatorEvent::Timer)
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("retry starts");
+
+    let succeeded = state.handle(
+      base + Duration::from_secs(7),
+      CoordinatorEvent::TokenFinished(execution_success(
+        retry.generation,
+        retry.source_generation,
+        1,
+        base + Duration::from_secs(7),
+      )),
+    );
+    assert!(token_waiter_outcome(&succeeded, waiter).is_none());
+  }
+
+  #[test]
+  fn source_change_does_not_orphan_token_waiter() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let waiter = TokenWaiterId(40);
+    let running = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token generation starts");
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+
+    let stale = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&stale, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: false,
+        failure_code: Some(RefreshFailureCode::SourceChanged),
+        ..
+      }) if *generation == running.generation
+    ));
+  }
+
+  #[test]
+  fn protected_waiter_survives_or_rejects_second_source_change() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let running = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let protected_waiter = TokenWaiterId(41);
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(manual_token_request(
+        protected_waiter,
+        Some("/normalized/home-b"),
+      )),
+    );
+
+    let mut home_c = test_config(interval, Some(wall));
+    home_c.codex_home = Some("/normalized/home-c".to_string());
+    let second_change = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::SettingsChanged(home_c),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&second_change, protected_waiter),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::SourceChanged,
+        ..
+      })
+    ));
+
+    let stale = state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::TokenFinished(execution_success(
+        running.generation,
+        running.source_generation,
+        1,
+        base + Duration::from_secs(4),
+      )),
+    );
+    let replacement = stale
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("latest protected source starts");
+    assert_eq!(
+      replacement.request.codex_home.as_deref(),
+      Some("/normalized/home-c")
+    );
+    assert!(replacement.request.waiter_ids.is_empty());
+  }
+
+  #[test]
+  fn stale_running_and_protected_waiters_are_drained_or_carried() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let stale_waiter = TokenWaiterId(50);
+    let stale_running = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(stale_waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("configured-source manual generation starts");
+
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let displaced_protected = TokenWaiterId(51);
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(manual_token_request(
+        displaced_protected,
+        Some("/normalized/home-b"),
+      )),
+    );
+
+    let mut home_a_again = test_config(interval, Some(wall));
+    home_a_again.codex_home = Some("/normalized/home-a".to_string());
+    let second_change = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::SettingsChanged(home_a_again),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&second_change, displaced_protected),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::SourceChanged,
+        ..
+      })
+    ));
+
+    let current_protected = TokenWaiterId(52);
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::RequestToken(manual_token_request(
+        current_protected,
+        Some("/normalized/home-a"),
+      )),
+    );
+    let discarded = state.handle(
+      base + Duration::from_secs(5),
+      CoordinatorEvent::TokenPrepared {
+        generation: stale_running.generation,
+        source_generation: stale_running.source_generation,
+      },
+    );
+    assert!(matches!(
+      token_waiter_outcome(&discarded, stale_waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: false,
+        failure_code: Some(RefreshFailureCode::SourceChanged),
+        ..
+      }) if *generation == stale_running.generation
+    ));
+    let protected = discarded
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("current protected source starts after stale discard");
+    assert_eq!(protected.request.waiter_ids(), &[current_protected]);
+  }
+
+  #[test]
+  fn protected_replacement_absorbs_same_source_waiter_behind_stale_source_refresh() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let home_b = state
+      .handle(
+        base + Duration::from_secs(2),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_a.generation,
+          home_a.source_generation,
+          1,
+          base + Duration::from_secs(2),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-b protected source refresh starts");
+
+    let mut home_c = test_config(interval, Some(wall));
+    home_c.codex_home = Some("/normalized/home-c".to_string());
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::SettingsChanged(home_c),
+    );
+    let waiter = TokenWaiterId(53);
+    assert!(state
+      .handle(
+        base + Duration::from_secs(4),
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-c"),)),
+      )
+      .is_empty());
+
+    let replacement = state
+      .handle(
+        base + Duration::from_secs(5),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_b.generation,
+          home_b.source_generation,
+          2,
+          base + Duration::from_secs(5),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-c protected replacement starts");
+    assert_eq!(replacement.request.waiter_ids(), &[waiter]);
+  }
+
+  #[test]
+  fn protected_retry_absorbs_same_source_follow_up_waiter() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let home_b = state
+      .handle(
+        base + Duration::from_secs(2),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_a.generation,
+          home_a.source_generation,
+          1,
+          base + Duration::from_secs(2),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-b protected source refresh starts");
+    let waiter = TokenWaiterId(54);
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-b"))),
+    );
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason(RefreshReason::Wake)),
+    );
+
+    let failed = state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        home_b.generation,
+        home_b.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(token_waiter_outcome(&failed, waiter).is_none());
+    let retry = state
+      .handle(base + Duration::from_secs(9), CoordinatorEvent::Timer)
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected retry starts at its deadline");
+    assert_eq!(retry.request.waiter_ids(), &[waiter]);
+    assert!(retry.request.reasons.contains(RefreshReason::Wake));
+
+    let completed = state.handle(
+      base + Duration::from_secs(10),
+      CoordinatorEvent::TokenFinished(execution_success(
+        retry.generation,
+        retry.source_generation,
+        2,
+        base + Duration::from_secs(10),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&completed, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: true,
+        ..
+      }) if *generation == retry.generation
+    ));
+  }
+
+  #[test]
+  fn protected_retry_absorbs_same_source_automatic_follow_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let home_b = state
+      .handle(
+        base + Duration::from_secs(2),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_a.generation,
+          home_a.source_generation,
+          1,
+          base + Duration::from_secs(2),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-b protected source refresh starts");
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason(RefreshReason::Wake)),
+    );
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        home_b.generation,
+        home_b.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let retry = state
+      .handle(base + Duration::from_secs(9), CoordinatorEvent::Timer)
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected retry starts at its deadline");
+    assert!(retry.request.reasons.contains(RefreshReason::Wake));
+    let completed = state.handle(
+      base + Duration::from_secs(10),
+      CoordinatorEvent::TokenFinished(execution_success(
+        retry.generation,
+        retry.source_generation,
+        2,
+        base + Duration::from_secs(10),
+      )),
+    );
+    assert_eq!(token_starts(&completed), 0);
+  }
+
+  #[test]
+  fn duplicate_completion_does_not_resolve_twice() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let waiter = TokenWaiterId(60);
+    let running = state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(waiter, None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual generation starts");
+    let completion = execution_success(
+      running.generation,
+      running.source_generation,
+      1,
+      base + Duration::from_secs(1),
+    );
+
+    let first = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(completion.clone()),
+    );
+    let duplicate = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(completion),
+    );
+    assert!(token_waiter_outcome(&first, waiter).is_some());
+    assert!(token_waiter_outcome(&duplicate, waiter).is_none());
+    assert!(duplicate.is_empty());
+  }
+
+  #[test]
+  fn waiter_cap_rejects_without_growth() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut token_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let token_running = start_token_generation(&mut token_state, base);
+    for raw in 0..REFRESH_WAITER_CAPACITY as u64 {
+      assert!(token_state
+        .handle(
+          base + Duration::from_secs(1),
+          CoordinatorEvent::RequestToken(manual_token_request(TokenWaiterId(raw), None)),
+        )
+        .is_empty());
+    }
+    let overflow = TokenWaiterId(REFRESH_WAITER_CAPACITY as u64);
+    let rejected = token_state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(manual_token_request(overflow, None)),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&rejected, overflow),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::Busy,
+        ..
+      })
+    ));
+    let token_follow_up = token_state
+      .handle(
+        base + Duration::from_secs(3),
+        CoordinatorEvent::TokenFinished(execution_success(
+          token_running.generation,
+          token_running.source_generation,
+          1,
+          base + Duration::from_secs(3),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("bounded token follow-up starts");
+    assert_eq!(
+      token_follow_up.request.waiter_ids.len(),
+      REFRESH_WAITER_CAPACITY
+    );
+
+    let mut live_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let live_running = start_live_generation(&mut live_state, base);
+    for raw in 0..REFRESH_WAITER_CAPACITY as u64 {
+      assert!(live_state
+        .handle(
+          base + Duration::from_secs(1),
+          CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(raw))),
+        )
+        .is_empty());
+    }
+    let live_overflow = LiveWaiterId(REFRESH_WAITER_CAPACITY as u64);
+    let live_rejected = live_state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestLive(LiveRequest::manual(live_overflow)),
+    );
+    assert!(matches!(
+      live_waiter_outcome(&live_rejected, live_overflow),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::Busy,
+        ..
+      })
+    ));
+    let live_completed = live_state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::LiveFinished(execution_success(
+        live_running.generation,
+        live_running.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+    let resolved_count = live_completed
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::ResolveLiveWaiters { waiter_ids, .. } => Some(waiter_ids.len()),
+        _ => None,
+      })
+      .expect("live waiters resolve");
+    assert_eq!(resolved_count, REFRESH_WAITER_CAPACITY);
+  }
+
+  #[test]
+  fn oversized_token_waiter_input_is_bounded_before_coordinator_intake() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut request = TokenRequest::manual_full(None);
+
+    for raw in 0..(REFRESH_WAITER_CAPACITY as u64 * 1_024) {
+      let result = request.try_add_waiter(TokenWaiterId(raw));
+      if raw < REFRESH_WAITER_CAPACITY as u64 {
+        assert_eq!(result, Ok(()));
+      } else {
+        assert_eq!(result, Err(RefreshRejectionCode::Busy));
+      }
+    }
+    assert_eq!(request.waiter_ids().len(), REFRESH_WAITER_CAPACITY);
+
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let actions = state.handle(base, CoordinatorEvent::RequestToken(request));
+    assert_eq!(actions.len(), 1);
+    assert!(matches!(
+      actions.as_slice(),
+      [CoordinatorAction::StartToken(execution)]
+        if execution.request.waiter_ids().len() == REFRESH_WAITER_CAPACITY
+    ));
+  }
+
+  #[test]
+  fn disabled_next_wait_returns_none_for_overdue_normal_deadline() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut disabled = test_config(Duration::from_secs(300), Some(wall));
+    disabled.auto_scan_enabled = false;
+    let state = CoordinatorState::new(disabled, base, wall);
+
+    assert_eq!(state.next_wait(base + Duration::from_secs(301)), None);
+
+    let immediate = CoordinatorState::new(test_config(Duration::from_secs(300), None), base, wall);
+    assert_eq!(immediate.next_wait(base), Some(Duration::ZERO));
+  }
+
+  #[test]
+  fn automatic_retry_is_ignored_while_disabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let automatic = start_token_generation(&mut state, base);
+    state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        automatic.generation,
+        automatic.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+
+    assert_eq!(state.next_wait(base + Duration::from_secs(5)), None);
+    assert!(state
+      .handle(base + Duration::from_secs(5), CoordinatorEvent::Timer)
+      .is_empty());
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(5)));
+  }
+
+  #[test]
+  fn manual_retry_controls_next_wait_while_disabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut token_state = CoordinatorState::new(disabled.clone(), base, wall);
+    let manual_token = token_state
+      .handle(
+        base,
+        CoordinatorEvent::RequestToken(manual_token_request(TokenWaiterId(70), None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token starts while disabled");
+    token_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        manual_token.generation,
+        manual_token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(
+      token_state.next_wait(base + Duration::from_secs(2)),
+      Some(Duration::from_secs(4))
+    );
+    assert_eq!(
+      token_starts(&token_state.handle(base + Duration::from_secs(6), CoordinatorEvent::Timer,)),
+      1
+    );
+
+    let mut live_state = CoordinatorState::new(disabled, base, wall);
+    let manual_live = live_state
+      .handle(
+        base,
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(71))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live starts while disabled");
+    live_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::LiveFinished(execution_failure(
+        manual_live.generation,
+        manual_live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(
+      live_state.next_wait(base + Duration::from_secs(2)),
+      Some(Duration::from_secs(4))
+    );
+  }
+
+  #[test]
+  fn next_wait_uses_earliest_lane_retry() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let token = start_token_generation(&mut state, base);
+    let live = start_live_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(7)));
+    assert_eq!(state.live_retry_at(), Some(base + Duration::from_secs(6)));
+    assert_eq!(
+      state.next_wait(base + Duration::from_secs(3)),
+      Some(Duration::from_secs(3))
+    );
+  }
+
+  #[test]
+  fn future_retry_preempted_by_manual_has_no_planned_due() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut token_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token = start_token_generation(&mut token_state, base);
+    token_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let token_manual = token_state
+      .handle(
+        base + Duration::from_secs(1),
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token request preempts future retry");
+    assert_eq!(token_manual.request.planned_due_at, None);
+    assert_eq!(token_state.snapshot().token.coalesced_trigger_count, 1);
+
+    let mut live_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let live = start_live_generation(&mut live_state, base);
+    live_state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let live_manual = live_state
+      .handle(
+        base + Duration::from_secs(1),
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(72))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live request preempts future retry");
+    assert_eq!(live_manual.planned_due_at, None);
+    assert_eq!(live_state.snapshot().live.coalesced_trigger_count, 1);
+  }
+
+  #[test]
+  fn overdue_retry_preempted_by_manual_keeps_original_planned_due() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let retry_due = base + Duration::from_secs(5);
+    let mut token_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token = start_token_generation(&mut token_state, base);
+    token_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let token_manual = token_state
+      .handle(
+        base + Duration::from_secs(10),
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual token request starts overdue retry");
+    assert_eq!(token_manual.request.planned_due_at, Some(retry_due));
+
+    let mut live_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let live = start_live_generation(&mut live_state, base);
+    live_state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let live_manual = live_state
+      .handle(
+        base + Duration::from_secs(10),
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(73))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live request starts overdue retry");
+    assert_eq!(live_manual.planned_due_at, Some(retry_due));
+  }
+
+  #[test]
+  fn disabled_retry_preemption_preserves_only_pre_disable_lag() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+
+    let mut overdue_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let overdue = start_token_generation(&mut overdue_state, base);
+    overdue_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        overdue.generation,
+        overdue.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    overdue_state.handle(
+      base + Duration::from_secs(8),
+      CoordinatorEvent::SettingsChanged(disabled.clone()),
+    );
+    let frozen = overdue_state
+      .handle(
+        base + Duration::from_secs(20),
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual request starts frozen overdue retry");
+    assert_eq!(
+      frozen.request.planned_due_at,
+      Some(base + Duration::from_secs(17))
+    );
+
+    let mut disabled_due_state =
+      CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let future = start_token_generation(&mut disabled_due_state, base);
+    disabled_due_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        future.generation,
+        future.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    disabled_due_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(disabled.clone()),
+    );
+    let newly_eligible = disabled_due_state
+      .handle(
+        base + Duration::from_secs(20),
+        CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual request starts retry that expired while disabled");
+    assert_eq!(newly_eligible.request.planned_due_at, None);
+
+    let mut overdue_live_state =
+      CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let overdue_live = start_live_generation(&mut overdue_live_state, base);
+    overdue_live_state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        overdue_live.generation,
+        overdue_live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    overdue_live_state.handle(
+      base + Duration::from_secs(8),
+      CoordinatorEvent::SettingsChanged(disabled.clone()),
+    );
+    let frozen_live = overdue_live_state
+      .handle(
+        base + Duration::from_secs(20),
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(76))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live request starts frozen overdue retry");
+    assert_eq!(
+      frozen_live.planned_due_at,
+      Some(base + Duration::from_secs(17))
+    );
+
+    let mut disabled_due_live_state =
+      CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let future_live = start_live_generation(&mut disabled_due_live_state, base);
+    disabled_due_live_state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        future_live.generation,
+        future_live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    disabled_due_live_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+    let newly_eligible_live = disabled_due_live_state
+      .handle(
+        base + Duration::from_secs(20),
+        CoordinatorEvent::RequestLive(LiveRequest::manual(LiveWaiterId(77))),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual live request starts retry that expired while disabled");
+    assert_eq!(newly_eligible_live.planned_due_at, None);
+  }
+
+  #[test]
+  fn non_manual_waiters_are_rejected_before_disabled_pruning() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut disabled = test_config(Duration::from_secs(300), Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut token_state = CoordinatorState::new(disabled.clone(), base, wall);
+    let token_waiter = TokenWaiterId(74);
+    let mut token_request = TokenRequest::scheduled();
+    token_request
+      .try_add_waiter(token_waiter)
+      .expect("test request accepts waiter before coordinator validation");
+    let token_actions = token_state.handle(base, CoordinatorEvent::RequestToken(token_request));
+    assert!(matches!(
+      token_waiter_outcome(&token_actions, token_waiter),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::InvalidRequest,
+        ..
+      })
+    ));
+
+    let mut live_state = CoordinatorState::new(disabled, base, wall);
+    let live_waiter = LiveWaiterId(75);
+    let live_actions = live_state.handle(
+      base,
+      CoordinatorEvent::RequestLive(LiveRequest {
+        reasons: RefreshReason::Scheduled.into(),
+        waiter: Some(live_waiter),
+        planned_due_at: None,
+      }),
+    );
+    assert!(matches!(
+      live_waiter_outcome(&live_actions, live_waiter),
+      Some(RefreshWaiterOutcome::Rejected {
+        code: RefreshRejectionCode::InvalidRequest,
+        ..
+      })
+    ));
+  }
+
+  #[test]
+  fn retry_and_normal_due_coalescence_increments_fixed_counter() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(5);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token = start_token_generation(&mut state, base);
+    let live = start_live_generation(&mut state, base);
+    state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    state.handle(
+      base,
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let actions = state.handle(base + interval, CoordinatorEvent::Timer);
+
+    assert_eq!(token_starts(&actions), 1);
+    assert_eq!(live_starts(&actions), 1);
+    assert_eq!(state.snapshot().token.coalesced_trigger_count, 1);
+    assert_eq!(state.snapshot().live.coalesced_trigger_count, 1);
+  }
+
+  #[test]
+  fn same_source_manual_at_normal_due_starts_one_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut token_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token_waiter = TokenWaiterId(78);
+
+    let token_actions = token_state.handle(
+      base + interval,
+      CoordinatorEvent::RequestToken(manual_token_request(token_waiter, None)),
+    );
+    assert_eq!(token_starts(&token_actions), 1);
+    let token = token_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("due manual token work starts");
+    assert!(token.request.reasons.contains(RefreshReason::Manual));
+    assert!(token.request.reasons.contains(RefreshReason::Scheduled));
+    assert_eq!(token.request.planned_due_at, Some(base + interval));
+    assert_eq!(token_state.token_next_deadline(), base + interval * 2);
+    assert_eq!(token_state.snapshot().token.coalesced_trigger_count, 1);
+    let token_completed = token_state.handle(
+      base + interval + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_success(
+        token.generation,
+        token.source_generation,
+        1,
+        base + interval + Duration::from_secs(1),
+      )),
+    );
+    assert_eq!(token_starts(&token_completed), 0);
+    assert!(token_waiter_outcome(&token_completed, token_waiter).is_some());
+    assert!(!token_state.snapshot().token.pending);
+
+    let mut live_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let live_waiter = LiveWaiterId(79);
+    let overdue = base + Duration::from_secs(950);
+    let live_actions = live_state.handle(
+      overdue,
+      CoordinatorEvent::RequestLive(LiveRequest::manual(live_waiter)),
+    );
+    assert_eq!(live_starts(&live_actions), 1);
+    let live = live_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("overdue manual live work starts");
+    assert!(live.reasons.contains(RefreshReason::Manual));
+    assert!(live.reasons.contains(RefreshReason::Scheduled));
+    assert_eq!(live.planned_due_at, Some(base + interval));
+    assert_eq!(
+      live_state.live_next_deadline(),
+      base + Duration::from_secs(1_200)
+    );
+    assert_eq!(live_state.snapshot().live.coalesced_trigger_count, 1);
+    let live_completed = live_state.handle(
+      overdue + Duration::from_secs(1),
+      CoordinatorEvent::LiveFinished(execution_success(
+        live.generation,
+        live.source_generation,
+        1,
+        overdue + Duration::from_secs(1),
+      )),
+    );
+    assert_eq!(live_starts(&live_completed), 0);
+    assert!(live_waiter_outcome(&live_completed, live_waiter).is_some());
+    assert!(!live_state.snapshot().live.pending);
+  }
+
+  #[test]
+  fn different_source_manual_at_normal_due_keeps_one_scheduled_follow_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let waiter = TokenWaiterId(80);
+
+    let actions = state.handle(
+      base + interval,
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-b"))),
+    );
+    assert_eq!(token_starts(&actions), 1);
+    let manual = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("different-source manual starts first");
+    assert_eq!(
+      manual.request.codex_home.as_deref(),
+      Some("/normalized/home-b")
+    );
+    assert_eq!(manual.request.waiter_ids(), &[waiter]);
+    assert!(!manual.request.reasons.contains(RefreshReason::Scheduled));
+    assert!(state
+      .snapshot()
+      .token
+      .pending_reasons
+      .contains(RefreshReason::Scheduled));
+    assert_eq!(state.snapshot().token.coalesced_trigger_count, 1);
+
+    let completed = state.handle(
+      base + interval + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual.generation,
+        manual.source_generation,
+        1,
+        base + interval + Duration::from_secs(1),
+      )),
+    );
+    assert!(matches!(
+      token_waiter_outcome(&completed, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: true,
+        ..
+      }) if *generation == manual.generation
+    ));
+    let scheduled = completed
+      .iter()
+      .filter_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(scheduled.len(), 1);
+    assert!(scheduled[0]
+      .request
+      .reasons
+      .contains(RefreshReason::Scheduled));
+    assert!(scheduled[0].request.waiter_ids().is_empty());
+    assert_eq!(
+      scheduled[0].request.codex_home.as_deref(),
+      Some("/normalized/home-a")
+    );
+  }
+
+  #[test]
+  fn due_work_merges_into_matching_protected_source_before_different_manual() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let waiter = TokenWaiterId(81);
+
+    let queued = state.handle(
+      base + interval,
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-c"))),
+    );
+    assert_eq!(token_starts(&queued), 0);
+    assert!(token_waiter_outcome(&queued, waiter).is_none());
+    assert_eq!(state.snapshot().token.coalesced_trigger_count, 3);
+
+    let protected_actions = state.handle(
+      base + interval + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_success(
+        home_a.generation,
+        home_a.source_generation,
+        1,
+        base + interval + Duration::from_secs(1),
+      )),
+    );
+    let protected = protected_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected home-b source refresh starts first");
+    assert_eq!(
+      protected.request.codex_home.as_deref(),
+      Some("/normalized/home-b")
+    );
+    assert!(protected
+      .request
+      .reasons
+      .contains(RefreshReason::SettingsChanged));
+    assert!(protected.request.reasons.contains(RefreshReason::Scheduled));
+    assert!(protected.request.waiter_ids().is_empty());
+
+    let manual_actions = state.handle(
+      base + interval + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        protected.generation,
+        protected.source_generation,
+        2,
+        base + interval + Duration::from_secs(2),
+      )),
+    );
+    let manual = manual_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("different-source manual starts after protected refresh");
+    assert_eq!(
+      manual.request.codex_home.as_deref(),
+      Some("/normalized/home-c")
+    );
+    assert_eq!(manual.request.waiter_ids(), &[waiter]);
+
+    let completed = state.handle(
+      base + interval + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual.generation,
+        manual.source_generation,
+        3,
+        base + interval + Duration::from_secs(3),
+      )),
+    );
+    assert_eq!(token_starts(&completed), 0);
+    assert!(matches!(
+      token_waiter_outcome(&completed, waiter),
+      Some(RefreshWaiterOutcome::Completed {
+        generation,
+        succeeded: true,
+        ..
+      }) if *generation == manual.generation
+    ));
+    assert!(!state.snapshot().token.pending);
+  }
+
+  #[test]
+  fn due_work_merges_into_matching_future_protected_retry() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let home_a = start_token_generation(&mut state, base);
+    let mut home_b = test_config(interval, Some(wall));
+    home_b.codex_home = Some("/normalized/home-b".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(home_b),
+    );
+    let home_b = state
+      .handle(
+        base + Duration::from_secs(2),
+        CoordinatorEvent::TokenFinished(execution_success(
+          home_a.generation,
+          home_a.source_generation,
+          1,
+          base + Duration::from_secs(2),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("home-b protected source refresh starts");
+    state.handle(
+      base + Duration::from_secs(298),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        home_b.generation,
+        home_b.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert_eq!(
+      state.token_retry_at(),
+      Some(base + Duration::from_secs(303))
+    );
+    let waiter = TokenWaiterId(82);
+    state.handle(
+      base + interval,
+      CoordinatorEvent::RequestToken(manual_token_request(waiter, Some("/normalized/home-c"))),
+    );
+    assert_eq!(state.snapshot().token.coalesced_trigger_count, 3);
+
+    let retry = state
+      .handle(base + Duration::from_secs(303), CoordinatorEvent::Timer)
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected home-b retry starts first");
+    assert_eq!(
+      retry.request.codex_home.as_deref(),
+      Some("/normalized/home-b")
+    );
+    assert!(retry.request.reasons.contains(RefreshReason::Scheduled));
+
+    let manual = state
+      .handle(
+        base + Duration::from_secs(304),
+        CoordinatorEvent::TokenFinished(execution_success(
+          retry.generation,
+          retry.source_generation,
+          2,
+          base + Duration::from_secs(304),
+        )),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("manual home-c request starts after protected retry");
+    assert_eq!(manual.request.waiter_ids(), &[waiter]);
+    let completed = state.handle(
+      base + Duration::from_secs(305),
+      CoordinatorEvent::TokenFinished(execution_success(
+        manual.generation,
+        manual.source_generation,
+        3,
+        base + Duration::from_secs(305),
+      )),
+    );
+    assert_eq!(token_starts(&completed), 0);
+    assert!(token_waiter_outcome(&completed, waiter).is_some());
+    assert!(!state.snapshot().token.pending);
+  }
+
+  #[test]
+  fn merged_request_keeps_earliest_planned_due() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut token_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let token_running = start_token_generation(&mut token_state, base);
+    token_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason_at(
+        RefreshReason::Scheduled,
+        base + Duration::from_secs(40),
+      )),
+    );
+    token_state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason_at(
+        RefreshReason::Wake,
+        base + Duration::from_secs(20),
+      )),
+    );
+    token_state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+    );
+    let token_actions = token_state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::TokenFinished(execution_success(
+        token_running.generation,
+        token_running.source_generation,
+        1,
+        base + Duration::from_secs(4),
+      )),
+    );
+    let token_follow_up = token_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("merged token follow-up starts");
+    assert_eq!(
+      token_follow_up.request.planned_due_at,
+      Some(base + Duration::from_secs(20))
+    );
+
+    let mut live_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let live_running = start_live_generation(&mut live_state, base);
+    live_state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestLive(LiveRequest::for_reason_at(
+        RefreshReason::Scheduled,
+        base + Duration::from_secs(30),
+      )),
+    );
+    live_state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestLive(LiveRequest::for_reason_at(
+        RefreshReason::Wake,
+        base + Duration::from_secs(10),
+      )),
+    );
+    let live_actions = live_state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::LiveFinished(execution_success(
+        live_running.generation,
+        live_running.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+    let live_follow_up = live_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("merged live follow-up starts");
+    assert_eq!(
+      live_follow_up.planned_due_at,
+      Some(base + Duration::from_secs(10))
+    );
+  }
+
+  #[test]
+  fn snapshot_reports_running_and_pending_state() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut config = test_config(interval, Some(wall));
+    config.codex_home = Some("/normalized/home-a".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let token = start_token_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason(RefreshReason::Wake)),
+    );
+    let live = start_live_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::LiveFinished(execution_failure(
+        live.generation,
+        live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let snapshot = state.snapshot();
+    assert_eq!(snapshot.token.running_generation, Some(token.generation));
+    assert_eq!(snapshot.token.next_normal_deadline, base + interval);
+    assert_eq!(snapshot.token.retry_deadline, None);
+    assert_eq!(snapshot.token.failure_streak, 0);
+    assert!(snapshot.token.pending);
+    assert!(snapshot.token.pending_reasons.contains(RefreshReason::Wake));
+    assert_eq!(snapshot.live.running_generation, None);
+    assert_eq!(
+      snapshot.live.retry_deadline,
+      Some(base + Duration::from_secs(7))
+    );
+    assert_eq!(snapshot.live.failure_streak, 1);
+    assert!(snapshot.live.pending);
+    assert!(snapshot
+      .live
+      .pending_reasons
+      .contains(RefreshReason::Scheduled));
+    assert_eq!(snapshot.source_generation, 0);
+    assert_eq!(snapshot.interval, interval);
+    assert!(snapshot.auto_scan_enabled);
+    assert_eq!(std::mem::size_of::<ReasonSet>(), 1);
+    assert_eq!(
+      RefreshReason::Wake as u8,
+      snapshot.token.pending_reasons.bits().trailing_zeros() as u8
+    );
+  }
+
+  #[test]
+  fn missed_deadline_counter_is_saturating_and_fixed() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(10);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    state.token.missed_deadline_count = u64::MAX;
+
+    state.handle(base + Duration::from_secs(35), CoordinatorEvent::Timer);
+
+    let snapshot = state.snapshot();
+    assert_eq!(snapshot.token.missed_deadline_count, u64::MAX);
+    assert_eq!(snapshot.live.missed_deadline_count, 2);
+  }
+
+  #[test]
+  fn many_missed_intervals_advance_in_constant_work() {
+    let base = Instant::now();
+    let interval = Duration::from_nanos(10);
+    let now = base + Duration::from_secs(100);
+
+    let (next, missed) = advance_fixed_deadline(base + interval, interval, now);
+
+    assert_eq!(next, now + interval);
+    assert_eq!(missed, 9_999_999_999);
+  }
+
+  #[test]
+  fn huge_interval_never_overflows_monotonic_deadlines() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let huge = Duration::MAX;
+    let mut state = CoordinatorState::new(test_config(huge, Some(wall)), base, wall);
+    assert!(state.token_next_deadline() > base);
+    assert!(state.live_next_deadline() > base);
+    assert!(state.snapshot().interval < huge);
+    assert!(base.checked_add(state.snapshot().interval).is_some());
+
+    let shortened = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(60), Some(wall))),
+    );
+    assert!(shortened.is_empty());
+    assert_eq!(state.token_next_deadline(), base + Duration::from_secs(60));
+    assert_eq!(state.live_next_deadline(), base + Duration::from_secs(60));
+
+    let (advanced, missed) = advance_fixed_deadline(base, huge, base);
+    assert!(advanced > base);
+    assert_eq!(missed, 0);
+
+    let mut changed =
+      CoordinatorState::new(test_config(Duration::from_secs(60), Some(wall)), base, wall);
+    let actions = changed.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(test_config(huge, Some(wall))),
+    );
+    assert!(actions.is_empty());
+    assert!(changed.token_next_deadline() > base + Duration::from_secs(1));
+    assert!(changed.live_next_deadline() > base + Duration::from_secs(1));
+  }
+
+  #[test]
+  fn disabled_intervals_do_not_count_as_missed() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(disabled, base, wall);
+
+    assert!(state
+      .handle(base + Duration::from_secs(1_800), CoordinatorEvent::Timer)
+      .is_empty());
+    assert_eq!(state.snapshot().token.missed_deadline_count, 0);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 0);
+
+    let reenabled = state.handle(
+      base + Duration::from_secs(1_800),
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    assert_eq!(token_starts(&reenabled), 1);
+    assert_eq!(live_starts(&reenabled), 1);
+    assert_eq!(state.snapshot().token.missed_deadline_count, 0);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 0);
+  }
+
+  #[test]
+  fn enabled_overdue_misses_survive_disable_and_reenable() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+
+    let disabling = state.handle(
+      base + Duration::from_secs(950),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+    assert!(disabling.is_empty());
+    assert_eq!(state.snapshot().token.missed_deadline_count, 2);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 2);
+
+    let reenabled = state.handle(
+      base + Duration::from_secs(1_850),
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    assert_eq!(token_starts(&reenabled), 1);
+    assert_eq!(live_starts(&reenabled), 1);
+    assert_eq!(state.snapshot().token.missed_deadline_count, 2);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 2);
+  }
+
+  #[test]
+  fn disabled_deadline_catch_up_is_planned_when_reenabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(disabled, base, wall);
+    let reenabled_at = base + Duration::from_secs(1_800);
+
+    let actions = state.handle(
+      reenabled_at,
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+
+    let token = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartToken(request) => Some(request),
+      _ => None,
+    });
+    let live = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartLive(request) => Some(request),
+      _ => None,
+    });
+    assert_eq!(
+      token.and_then(|value| value.request.planned_due_at),
+      Some(reenabled_at)
+    );
+    assert_eq!(
+      live.and_then(|value| value.planned_due_at),
+      Some(reenabled_at)
+    );
+  }
+
+  #[test]
+  fn disabled_time_does_not_inflate_preexisting_normal_start_lag() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let disabled_at = base + Duration::from_secs(950);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(disabled_at, CoordinatorEvent::SettingsChanged(disabled));
+    let reenabled_at = base + Duration::from_secs(1_850);
+
+    let actions = state.handle(
+      reenabled_at,
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    let expected_due = reenabled_at - disabled_at.duration_since(base + interval);
+    let token = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartToken(request) => Some(request),
+      _ => None,
+    });
+    let live = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartLive(request) => Some(request),
+      _ => None,
+    });
+    assert_eq!(
+      token.and_then(|value| value.request.planned_due_at),
+      Some(expected_due)
+    );
+    assert_eq!(
+      live.and_then(|value| value.planned_due_at),
+      Some(expected_due)
+    );
+    assert_eq!(state.snapshot().token.missed_deadline_count, 2);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 2);
+  }
+
+  #[test]
+  fn automatic_retry_due_while_disabled_is_planned_when_reenabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let token = start_token_generation(&mut state, base);
+    state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        token.generation,
+        token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+    let reenabled_at = base + Duration::from_secs(100);
+
+    let actions = state.handle(
+      reenabled_at,
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    let retry = actions.iter().find_map(|action| match action {
+      CoordinatorAction::StartToken(request) => Some(request),
+      _ => None,
+    });
+    assert_eq!(
+      retry.and_then(|value| value.request.planned_due_at),
+      Some(reenabled_at)
+    );
+  }
+
+  #[test]
+  fn reenable_before_deadline_does_not_suppress_future_misses() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(disabled, base, wall);
+    let reenabled = state.handle(
+      base + Duration::from_secs(100),
+      CoordinatorEvent::SettingsChanged(test_config(interval, Some(wall))),
+    );
+    assert!(reenabled.is_empty());
+
+    state.handle(base + Duration::from_secs(950), CoordinatorEvent::Timer);
+
+    assert_eq!(state.snapshot().token.missed_deadline_count, 2);
+    assert_eq!(state.snapshot().live.missed_deadline_count, 2);
+  }
+
+  #[test]
+  fn coalesced_trigger_counter_tracks_merged_work() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    start_token_generation(&mut state, base);
+    start_live_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(TokenRequest::for_reason(RefreshReason::Wake)),
+    );
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestLive(LiveRequest::scheduled()),
+    );
+
+    let snapshot = state.snapshot();
+    assert_eq!(snapshot.token.coalesced_trigger_count, 2);
+    assert_eq!(snapshot.live.coalesced_trigger_count, 1);
   }
 }

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -139,9 +139,11 @@ pub(crate) struct CoordinatorState {
   token: LaneState,
   live: LaneState,
   token_running: Option<TokenExecutionRequest>,
+  token_running_source_refresh: bool,
   token_pending: Option<TokenRequest>,
   token_source_refresh_pending: Option<TokenRequest>,
   token_retry_request: Option<TokenRequest>,
+  token_retry_source_refresh: bool,
   live_running: Option<LiveExecutionRequest>,
   live_pending: ReasonSet,
   live_retry_reasons: ReasonSet,
@@ -181,9 +183,11 @@ impl CoordinatorState {
       token: LaneState::new(token_next_deadline, monotonic_now),
       live: LaneState::new(live_next_deadline, monotonic_now),
       token_running: None,
+      token_running_source_refresh: false,
       token_pending: None,
       token_source_refresh_pending: None,
       token_retry_request: None,
+      token_retry_source_refresh: false,
       live_running: None,
       live_pending: ReasonSet::default(),
       live_retry_reasons: ReasonSet::default(),
@@ -235,8 +239,12 @@ impl CoordinatorState {
     let mut live_reasons = self.take_due_live_reasons(now, trigger_reason);
     let mut actions = Vec::with_capacity(2);
 
-    if let Some(request) = token_request.take() {
-      self.submit_token_request(request, &mut actions);
+    if let Some((request, source_refresh)) = token_request.take() {
+      if source_refresh {
+        self.submit_source_refresh_request(request, &mut actions);
+      } else {
+        self.submit_token_request(request, &mut actions);
+      }
     }
     if !live_reasons.is_empty() {
       self.submit_live_request(
@@ -284,6 +292,7 @@ impl CoordinatorState {
     }
 
     let mut token_request = None;
+    let mut token_request_is_source_refresh = false;
     let mut live_reasons = ReasonSet::default();
     if source_changed {
       self.source_generation = self
@@ -293,6 +302,7 @@ impl CoordinatorState {
       self.token.failure_streak = 0;
       self.token.retry_at = None;
       self.token_retry_request = None;
+      self.token_retry_source_refresh = false;
       self.live.failure_streak = 0;
       self.live.retry_at = None;
       self.live_retry_reasons = ReasonSet::default();
@@ -319,19 +329,23 @@ impl CoordinatorState {
         }
       }
       token_request = Some(request);
+      token_request_is_source_refresh = true;
       if self.config.auto_scan_enabled {
         live_reasons.insert(RefreshReason::SettingsChanged);
       }
     }
 
-    if let Some(due) = self.take_due_token_request(now, RefreshReason::SettingsChanged) {
+    if let Some((due, due_is_source_refresh)) =
+      self.take_due_token_request(now, RefreshReason::SettingsChanged)
+    {
       merge_token_request(&mut token_request, due);
+      token_request_is_source_refresh |= due_is_source_refresh;
     }
     live_reasons.merge(self.take_due_live_reasons(now, RefreshReason::SettingsChanged));
 
     let mut actions = Vec::with_capacity(2);
     if let Some(request) = token_request {
-      if source_changed {
+      if token_request_is_source_refresh {
         self.submit_source_refresh_request(request, &mut actions);
       } else {
         self.submit_token_request(request, &mut actions);
@@ -353,10 +367,12 @@ impl CoordinatorState {
     &mut self,
     now: Instant,
     trigger_reason: RefreshReason,
-  ) -> Option<TokenRequest> {
+  ) -> Option<(TokenRequest, bool)> {
     let mut request = None;
+    let mut source_refresh = false;
     if self.token.retry_at.is_some_and(|retry_at| retry_at <= now) {
       let retry_allowed = self.config.auto_scan_enabled
+        || self.token_retry_source_refresh
         || self
           .token_retry_request
           .as_ref()
@@ -365,6 +381,8 @@ impl CoordinatorState {
         self.token.retry_at = None;
         if let Some(retry) = self.token_retry_request.take() {
           merge_token_request(&mut request, retry);
+          source_refresh = self.token_retry_source_refresh;
+          self.token_retry_source_refresh = false;
         }
       }
     }
@@ -385,7 +403,7 @@ impl CoordinatorState {
         );
       }
     }
-    request
+    request.map(|request| (request, source_refresh))
   }
 
   fn take_due_live_reasons(
@@ -428,6 +446,15 @@ impl CoordinatorState {
     }
 
     if self.token.running_generation.is_some() {
+      let matches_running_source_refresh = self.token_running_source_refresh
+        && self
+          .token_running
+          .as_ref()
+          .is_some_and(|running| running.request.codex_home == request.codex_home);
+      if matches_running_source_refresh {
+        merge_token_request(&mut self.token_source_refresh_pending, request);
+        return;
+      }
       if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
         if source_refresh.codex_home == request.codex_home {
           source_refresh.merge(request);
@@ -438,11 +465,32 @@ impl CoordinatorState {
       return;
     }
 
+    if self.token_retry_source_refresh {
+      if let Some(source_retry) = self.token_retry_request.as_mut() {
+        if source_retry.codex_home == request.codex_home {
+          source_retry.merge(request);
+        } else {
+          merge_token_request(&mut self.token_pending, request);
+        }
+        return;
+      }
+      self.token_retry_source_refresh = false;
+    }
+
     if let Some(mut retry) = self.token_retry_request.take() {
       retry.merge(request);
       request = retry;
     }
     self.token.retry_at = None;
+    self.start_token_request(request, false, actions);
+  }
+
+  fn start_token_request(
+    &mut self,
+    request: TokenRequest,
+    source_refresh: bool,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
     let generation = self.token.start_generation();
     let execution = TokenExecutionRequest {
       generation,
@@ -450,6 +498,7 @@ impl CoordinatorState {
       request,
     };
     self.token_running = Some(execution.clone());
+    self.token_running_source_refresh = source_refresh;
     actions.push(CoordinatorAction::StartToken(execution));
   }
 
@@ -459,13 +508,25 @@ impl CoordinatorState {
     actions: &mut Vec<CoordinatorAction>,
   ) {
     if self.token.running_generation.is_some() {
+      let matches_running_source_refresh = self.token_running_source_refresh
+        && self
+          .token_running
+          .as_ref()
+          .is_some_and(|running| running.request.codex_home == request.codex_home);
+      if matches_running_source_refresh {
+        merge_token_request(&mut self.token_source_refresh_pending, request);
+        return;
+      }
       if let Some(previous) = self.token_source_refresh_pending.take() {
         request.reasons.merge(previous.reasons);
       }
       self.token_source_refresh_pending = Some(request);
       return;
     }
-    self.submit_token_request(request, actions);
+    self.token.retry_at = None;
+    self.token_retry_request = None;
+    self.token_retry_source_refresh = false;
+    self.start_token_request(request, true, actions);
   }
 
   fn submit_live_request(
@@ -538,6 +599,7 @@ impl CoordinatorState {
       .take()
       .expect("matching token generation remains present");
     self.token.clear_running();
+    self.token_running_source_refresh = false;
     actions.push(CoordinatorAction::DiscardToken {
       generation,
       source_generation,
@@ -569,7 +631,9 @@ impl CoordinatorState {
       .token_running
       .take()
       .expect("matching token generation remains present");
+    let running_source_refresh = self.token_running_source_refresh;
     self.token.clear_running();
+    self.token_running_source_refresh = false;
     if running.source_generation != completion.source_generation
       || completion.source_generation != self.source_generation
     {
@@ -584,6 +648,7 @@ impl CoordinatorState {
       self.token.failure_streak = 0;
       self.token.retry_at = None;
       self.token_retry_request = None;
+      self.token_retry_source_refresh = false;
       self.usage_revision = self.usage_revision.saturating_add(1);
       actions.push(CoordinatorAction::PublishInvalidation(
         self.invalidation(completion.commit.expect("normalized success has commit marker")),
@@ -593,7 +658,14 @@ impl CoordinatorState {
       let jitter = completion.retry_jitter.min(Duration::from_secs(1));
       let delay = retry_delay(self.token.failure_streak, self.config.interval, jitter);
       self.token.retry_at = Some(now.checked_add(delay).unwrap_or(now));
-      self.token_retry_request = Some(running.request);
+      let mut retry_request = running.request;
+      if running_source_refresh {
+        if let Some(pending) = self.token_source_refresh_pending.take() {
+          retry_request.merge(pending);
+        }
+      }
+      self.token_retry_request = Some(retry_request);
+      self.token_retry_source_refresh = running_source_refresh;
     }
     actions.push(CoordinatorAction::PublishCompletion(
       self.completed_event(RefreshLane::Token, &completion),
@@ -669,8 +741,11 @@ impl CoordinatorState {
   }
 
   fn start_pending_token(&mut self, actions: &mut Vec<CoordinatorAction>) {
+    if self.token_retry_source_refresh {
+      return;
+    }
     if let Some(request) = self.token_source_refresh_pending.take() {
-      self.submit_token_request(request, actions);
+      self.submit_source_refresh_request(request, actions);
       return;
     }
     if let Some(request) = self.token_pending.take() {
@@ -719,7 +794,9 @@ impl CoordinatorState {
     lane: RefreshLane,
     completion: &ExecutionCompletion,
   ) -> RefreshCompletedEvent {
-    self.refresh_revision = self.refresh_revision.saturating_add(1);
+    if completion.succeeded {
+      self.refresh_revision = self.refresh_revision.saturating_add(1);
+    }
     RefreshCompletedEvent {
       refresh_revision: self.refresh_revision,
       lane,
@@ -1574,7 +1651,7 @@ mod tests {
   }
 
   #[test]
-  fn success_without_commit_marker_is_rejected() {
+  fn success_without_commit_marker_does_not_advance_refresh_revision() {
     let base = Instant::now();
     let wall = utc("2026-07-10T10:00:00Z");
     let mut state = CoordinatorState::new(
@@ -1600,12 +1677,45 @@ mod tests {
     assert!(actions
       .iter()
       .all(|action| !matches!(action, CoordinatorAction::PublishInvalidation(_))));
-    assert!(actions.iter().any(|action| matches!(
+    let published = actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::PublishCompletion(event) => Some(event),
+        _ => None,
+      })
+      .expect("invalid success publishes a failed attempt");
+    assert!(!published.succeeded);
+    assert_eq!(
+      published.failure.as_deref(),
+      Some("successful refresh completion missing commit marker")
+    );
+    assert_eq!(published.refresh_revision, 0);
+    assert_eq!(published.usage_revision, 0);
+    assert_eq!(published.quota_revision, 0);
+    assert_eq!(published.generation, first.generation);
+
+    let mut failure_state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let failed = start_token_generation(&mut failure_state, base);
+    let failed_actions = failure_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        failed.generation,
+        failed.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(failed_actions.iter().any(|action| matches!(
       action,
       CoordinatorAction::PublishCompletion(event)
-        if !event.succeeded
-          && event.failure.as_deref()
-            == Some("successful refresh completion missing commit marker")
+        if event.refresh_revision == 0
+          && event.usage_revision == 0
+          && event.quota_revision == 0
+          && event.generation == failed.generation
+          && !event.succeeded
     )));
   }
 
@@ -1804,5 +1914,147 @@ mod tests {
       starts[0].request.codex_home.as_deref(),
       Some("/normalized/new-home")
     );
+  }
+
+  #[test]
+  fn protected_source_refresh_failure_retries_while_auto_scan_disabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.auto_scan_enabled = false;
+    changed.codex_home = Some("/normalized/configured-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("new source Full refresh starts");
+    assert_eq!(protected.request.kind, TokenScanKind::Full);
+    assert_eq!(
+      protected.request.codex_home.as_deref(),
+      Some("/normalized/configured-home")
+    );
+
+    let failure_actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        protected.generation,
+        protected.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    assert!(failure_actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(8)));
+
+    let early = state.handle(base + Duration::from_secs(7), CoordinatorEvent::Timer);
+    let retry_actions = state.handle(base + Duration::from_secs(8), CoordinatorEvent::Timer);
+    assert_eq!(token_starts(&early), 0);
+    assert!(matches!(
+      retry_actions.as_slice(),
+      [CoordinatorAction::StartToken(request)]
+        if request.request.kind == TokenScanKind::Full
+          && request.request.codex_home.as_deref()
+            == Some("/normalized/configured-home")
+    ));
+  }
+
+  #[test]
+  fn protected_source_retry_is_not_retargeted_by_different_home_manual_request() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.auto_scan_enabled = false;
+    changed.codex_home = Some("/normalized/configured-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("new source Full refresh starts");
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        protected.generation,
+        protected.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let manual_actions = state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home".to_string(),
+      ))),
+    );
+    assert!(manual_actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+
+    let retry_actions = state.handle(base + Duration::from_secs(8), CoordinatorEvent::Timer);
+    let retry = retry_actions
+      .iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("protected retry starts first");
+    assert_eq!(retry.request.kind, TokenScanKind::Full);
+    assert_eq!(
+      retry.request.codex_home.as_deref(),
+      Some("/normalized/configured-home")
+    );
+
+    let success_actions = state.handle(
+      base + Duration::from_secs(9),
+      CoordinatorEvent::TokenFinished(execution_success(
+        retry.generation,
+        retry.source_generation,
+        2,
+        base + Duration::from_secs(9),
+      )),
+    );
+    assert!(matches!(
+      success_actions.last(),
+      Some(CoordinatorAction::StartToken(request))
+        if request.request.kind == TokenScanKind::Full
+          && request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref() == Some("/normalized/manual-home")
+    ));
   }
 }

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -63,7 +63,7 @@ impl LaneState {
       }
     };
     self.next_deadline = now + remaining;
-    self.immediate_due |= elapsed >= new_interval;
+    self.immediate_due = elapsed >= new_interval;
   }
 
   fn take_due(
@@ -515,6 +515,77 @@ mod tests {
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(40));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(40));
+  }
+
+  #[test]
+  fn shorten_then_lengthen_while_disabled_does_not_refresh_on_reenable() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut initial = test_config(Duration::from_secs(300), Some(wall));
+    initial.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(initial, base, wall);
+    let mut shorter = test_config(Duration::from_secs(30), Some(wall));
+    shorter.auto_scan_enabled = false;
+    let mut longer = test_config(Duration::from_secs(300), Some(wall));
+    longer.auto_scan_enabled = false;
+
+    let shortened = state.handle(
+      base + Duration::from_secs(45),
+      CoordinatorEvent::SettingsChanged(shorter),
+    );
+    let lengthened = state.handle(
+      base + Duration::from_secs(50),
+      CoordinatorEvent::SettingsChanged(longer),
+    );
+    let reenabled = state.handle(
+      base + Duration::from_secs(50),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(300), Some(wall))),
+    );
+
+    assert!(shortened.is_empty());
+    assert!(lengthened.is_empty());
+    assert_eq!(
+      state.token_next_deadline().duration_since(base),
+      Duration::from_secs(330)
+    );
+    assert_eq!(
+      state.live_next_deadline().duration_since(base),
+      Duration::from_secs(330)
+    );
+    assert_eq!(token_starts(&reenabled), 0);
+    assert_eq!(live_starts(&reenabled), 0);
+  }
+
+  #[test]
+  fn same_interval_reenable_preserves_due_disabled_refresh() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut initial = test_config(Duration::from_secs(300), Some(wall));
+    initial.auto_scan_enabled = false;
+    let mut state = CoordinatorState::new(initial, base, wall);
+    let mut shorter = test_config(Duration::from_secs(30), Some(wall));
+    shorter.auto_scan_enabled = false;
+
+    let shortened = state.handle(
+      base + Duration::from_secs(45),
+      CoordinatorEvent::SettingsChanged(shorter),
+    );
+    let reenabled = state.handle(
+      base + Duration::from_secs(50),
+      CoordinatorEvent::SettingsChanged(test_config(Duration::from_secs(30), Some(wall))),
+    );
+
+    assert!(shortened.is_empty());
+    assert_eq!(token_starts(&reenabled), 1);
+    assert_eq!(live_starts(&reenabled), 1);
+    assert_eq!(
+      state.token_next_deadline().duration_since(base),
+      Duration::from_secs(60)
+    );
+    assert_eq!(
+      state.live_next_deadline().duration_since(base),
+      Duration::from_secs(60)
+    );
   }
 
   #[test]

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -1,4 +1,8 @@
-use super::{RefreshConfig, RefreshReason, TokenScanKind};
+use super::{
+  CommitMarker, DisplayInvalidation, ExecutionCompletion, LiveExecutionRequest, LiveRequest,
+  LiveWaiterId, ReasonSet, RefreshCompletedEvent, RefreshConfig, RefreshLane, RefreshReason,
+  TokenExecutionRequest, TokenRequest, TokenScanKind,
+};
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};
 
@@ -7,33 +11,58 @@ pub(crate) enum CoordinatorEvent {
   Timer,
   Wake,
   SettingsChanged(RefreshConfig),
+  RequestToken(TokenRequest),
+  RequestLive(LiveRequest),
+  TokenPrepared {
+    generation: u64,
+    source_generation: u64,
+  },
+  TokenFinished(ExecutionCompletion),
+  LiveFinished(ExecutionCompletion),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) enum CoordinatorAction {
-  StartToken {
-    kind: TokenScanKind,
-    reason: RefreshReason,
+  StartToken(TokenExecutionRequest),
+  StartLive(LiveExecutionRequest),
+  CommitToken {
+    generation: u64,
+    source_generation: u64,
   },
-  StartLive {
-    reason: RefreshReason,
+  DiscardToken {
+    generation: u64,
+    source_generation: u64,
+  },
+  PublishInvalidation(DisplayInvalidation),
+  PublishCompletion(RefreshCompletedEvent),
+  ResolveLiveWaiters {
+    waiter_ids: Vec<LiveWaiterId>,
+    generation: u64,
+    succeeded: bool,
+    failure: Option<String>,
   },
 }
 
 struct LaneState {
   next_deadline: Instant,
-  running: bool,
   startup_due: bool,
   immediate_due: bool,
+  last_generation: u64,
+  running_generation: Option<u64>,
+  failure_streak: u32,
+  retry_at: Option<Instant>,
 }
 
 impl LaneState {
   fn new(next_deadline: Instant, monotonic_now: Instant) -> Self {
     Self {
       next_deadline,
-      running: false,
       startup_due: next_deadline <= monotonic_now,
       immediate_due: false,
+      last_generation: 0,
+      running_generation: None,
+      failure_streak: 0,
+      retry_at: None,
     }
   }
 
@@ -66,7 +95,7 @@ impl LaneState {
     self.immediate_due = elapsed >= new_interval;
   }
 
-  fn take_due(
+  fn take_normal_due(
     &mut self,
     now: Instant,
     interval: Duration,
@@ -87,13 +116,21 @@ impl LaneState {
       trigger_reason
     };
     self.startup_due = false;
-
-    if self.running {
-      return None;
-    }
-
-    self.running = true;
     Some(reason)
+  }
+
+  fn start_generation(&mut self) -> u64 {
+    let generation = self
+      .last_generation
+      .checked_add(1)
+      .expect("refresh generation overflowed");
+    self.last_generation = generation;
+    self.running_generation = Some(generation);
+    generation
+  }
+
+  fn clear_running(&mut self) {
+    self.running_generation = None;
   }
 }
 
@@ -101,6 +138,19 @@ pub(crate) struct CoordinatorState {
   config: RefreshConfig,
   token: LaneState,
   live: LaneState,
+  token_running: Option<TokenExecutionRequest>,
+  token_pending: Option<TokenRequest>,
+  token_source_refresh_pending: Option<TokenRequest>,
+  token_retry_request: Option<TokenRequest>,
+  live_running: Option<LiveExecutionRequest>,
+  live_pending: ReasonSet,
+  live_retry_reasons: ReasonSet,
+  live_waiters: Vec<LiveWaiterId>,
+  source_generation: u64,
+  refresh_revision: u64,
+  usage_revision: u64,
+  quota_revision: u64,
+  settings_revision: u64,
 }
 
 impl CoordinatorState {
@@ -130,51 +180,557 @@ impl CoordinatorState {
       config,
       token: LaneState::new(token_next_deadline, monotonic_now),
       live: LaneState::new(live_next_deadline, monotonic_now),
+      token_running: None,
+      token_pending: None,
+      token_source_refresh_pending: None,
+      token_retry_request: None,
+      live_running: None,
+      live_pending: ReasonSet::default(),
+      live_retry_reasons: ReasonSet::default(),
+      live_waiters: Vec::new(),
+      source_generation: 0,
+      refresh_revision: 0,
+      usage_revision: 0,
+      quota_revision: 0,
+      settings_revision: 0,
     }
   }
 
   pub(crate) fn handle(&mut self, now: Instant, event: CoordinatorEvent) -> Vec<CoordinatorAction> {
-    let trigger_reason = match event {
-      CoordinatorEvent::Timer => RefreshReason::Scheduled,
-      CoordinatorEvent::Wake => RefreshReason::Wake,
-      CoordinatorEvent::SettingsChanged(config) => {
-        assert!(
-          !config.interval.is_zero(),
-          "refresh interval must be positive"
-        );
-        let old_interval = self.config.interval;
+    match event {
+      CoordinatorEvent::Timer => self.handle_due(now, RefreshReason::Scheduled),
+      CoordinatorEvent::Wake => self.handle_due(now, RefreshReason::Wake),
+      CoordinatorEvent::SettingsChanged(config) => self.handle_settings_changed(now, config),
+      CoordinatorEvent::RequestToken(request) => {
+        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+          return Vec::new();
+        }
+        let mut actions = Vec::with_capacity(1);
+        self.submit_token_request(request, &mut actions);
+        actions
+      }
+      CoordinatorEvent::RequestLive(request) => {
+        if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+          return Vec::new();
+        }
+        let mut actions = Vec::with_capacity(1);
+        self.submit_live_request(request, &mut actions);
+        actions
+      }
+      CoordinatorEvent::TokenPrepared {
+        generation,
+        source_generation,
+      } => self.handle_token_prepared(generation, source_generation),
+      CoordinatorEvent::TokenFinished(completion) => {
+        self.handle_token_finished(now, completion)
+      }
+      CoordinatorEvent::LiveFinished(completion) => {
+        self.handle_live_finished(now, completion)
+      }
+    }
+  }
+
+  fn handle_due(&mut self, now: Instant, trigger_reason: RefreshReason) -> Vec<CoordinatorAction> {
+    let mut token_request = self.take_due_token_request(now, trigger_reason);
+    let mut live_reasons = self.take_due_live_reasons(now, trigger_reason);
+    let mut actions = Vec::with_capacity(2);
+
+    if let Some(request) = token_request.take() {
+      self.submit_token_request(request, &mut actions);
+    }
+    if !live_reasons.is_empty() {
+      self.submit_live_request(
+        LiveRequest {
+          reasons: std::mem::take(&mut live_reasons),
+          waiter: None,
+        },
+        &mut actions,
+      );
+    }
+
+    actions
+  }
+
+  fn handle_settings_changed(
+    &mut self,
+    now: Instant,
+    config: RefreshConfig,
+  ) -> Vec<CoordinatorAction> {
+    assert!(
+      !config.interval.is_zero(),
+      "refresh interval must be positive"
+    );
+    let old_interval = self.config.interval;
+    let source_changed = self.config.codex_home != config.codex_home;
+    let disabling_auto_scan = self.config.auto_scan_enabled && !config.auto_scan_enabled;
+    let settings_changed = self.config.auto_scan_enabled != config.auto_scan_enabled
+      || old_interval != config.interval
+      || source_changed;
+
+    self
+      .token
+      .recalculate_interval(now, old_interval, config.interval);
+    self
+      .live
+      .recalculate_interval(now, old_interval, config.interval);
+    self.config = config;
+
+    if disabling_auto_scan {
+      self.prune_automatic_pending_work();
+    }
+
+    if settings_changed {
+      self.settings_revision = self.settings_revision.saturating_add(1);
+    }
+
+    let mut token_request = None;
+    let mut live_reasons = ReasonSet::default();
+    if source_changed {
+      self.source_generation = self
+        .source_generation
+        .checked_add(1)
+        .expect("refresh source generation overflowed");
+      self.token.failure_streak = 0;
+      self.token.retry_at = None;
+      self.token_retry_request = None;
+      self.live.failure_streak = 0;
+      self.live.retry_at = None;
+      self.live_retry_reasons = ReasonSet::default();
+
+      let mut request = TokenRequest {
+        reasons: RefreshReason::SettingsChanged.into(),
+        kind: TokenScanKind::Full,
+        codex_home: self.config.codex_home.clone(),
+      };
+      if let Some(previous_source_refresh) = self.token_source_refresh_pending.take() {
+        request.reasons.merge(previous_source_refresh.reasons);
+      }
+      if let Some(mut pending) = self.token_pending.take() {
+        let manual_for_another_home = pending.reasons.contains(RefreshReason::Manual)
+          && pending.codex_home != self.config.codex_home;
+        if manual_for_another_home {
+          let mut automatic_reasons = pending.reasons;
+          automatic_reasons.remove(RefreshReason::Manual);
+          request.reasons.merge(automatic_reasons);
+          pending.reasons = RefreshReason::Manual.into();
+          self.token_pending = Some(pending);
+        } else {
+          request.reasons.merge(pending.reasons);
+        }
+      }
+      token_request = Some(request);
+      if self.config.auto_scan_enabled {
+        live_reasons.insert(RefreshReason::SettingsChanged);
+      }
+    }
+
+    if let Some(due) = self.take_due_token_request(now, RefreshReason::SettingsChanged) {
+      merge_token_request(&mut token_request, due);
+    }
+    live_reasons.merge(self.take_due_live_reasons(now, RefreshReason::SettingsChanged));
+
+    let mut actions = Vec::with_capacity(2);
+    if let Some(request) = token_request {
+      if source_changed {
+        self.submit_source_refresh_request(request, &mut actions);
+      } else {
+        self.submit_token_request(request, &mut actions);
+      }
+    }
+    if !live_reasons.is_empty() {
+      self.submit_live_request(
+        LiveRequest {
+          reasons: live_reasons,
+          waiter: None,
+        },
+        &mut actions,
+      );
+    }
+    actions
+  }
+
+  fn take_due_token_request(
+    &mut self,
+    now: Instant,
+    trigger_reason: RefreshReason,
+  ) -> Option<TokenRequest> {
+    let mut request = None;
+    if self.token.retry_at.is_some_and(|retry_at| retry_at <= now) {
+      let retry_allowed = self.config.auto_scan_enabled
+        || self
+          .token_retry_request
+          .as_ref()
+          .is_some_and(|value| value.reasons.contains(RefreshReason::Manual));
+      if retry_allowed {
+        self.token.retry_at = None;
+        if let Some(retry) = self.token_retry_request.take() {
+          merge_token_request(&mut request, retry);
+        }
+      }
+    }
+
+    if self.config.auto_scan_enabled {
+      if let Some(reason) =
         self
           .token
-          .recalculate_interval(now, old_interval, config.interval);
+          .take_normal_due(now, self.config.interval, trigger_reason)
+      {
+        merge_token_request(
+          &mut request,
+          TokenRequest {
+            reasons: reason.into(),
+            kind: TokenScanKind::Incremental,
+            codex_home: self.config.codex_home.clone(),
+          },
+        );
+      }
+    }
+    request
+  }
+
+  fn take_due_live_reasons(
+    &mut self,
+    now: Instant,
+    trigger_reason: RefreshReason,
+  ) -> ReasonSet {
+    let mut reasons = ReasonSet::default();
+    if self.live.retry_at.is_some_and(|retry_at| retry_at <= now) {
+      let retry_allowed = self.config.auto_scan_enabled
+        || self.live_retry_reasons.contains(RefreshReason::Manual);
+      if retry_allowed {
+        self.live.retry_at = None;
+        reasons.merge(std::mem::take(&mut self.live_retry_reasons));
+      }
+    }
+
+    if self.config.auto_scan_enabled {
+      if let Some(reason) =
         self
           .live
-          .recalculate_interval(now, old_interval, config.interval);
-        self.config = config;
-        RefreshReason::SettingsChanged
+          .take_normal_due(now, self.config.interval, trigger_reason)
+      {
+        reasons.insert(reason);
       }
+    }
+    reasons
+  }
+
+  fn submit_token_request(
+    &mut self,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if request.reasons.is_empty() {
+      return;
+    }
+    if request.codex_home.is_none() {
+      request.codex_home = self.config.codex_home.clone();
+    }
+
+    if self.token.running_generation.is_some() {
+      if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
+        if source_refresh.codex_home == request.codex_home {
+          source_refresh.merge(request);
+          return;
+        }
+      }
+      merge_token_request(&mut self.token_pending, request);
+      return;
+    }
+
+    if let Some(mut retry) = self.token_retry_request.take() {
+      retry.merge(request);
+      request = retry;
+    }
+    self.token.retry_at = None;
+    let generation = self.token.start_generation();
+    let execution = TokenExecutionRequest {
+      generation,
+      source_generation: self.source_generation,
+      request,
+    };
+    self.token_running = Some(execution.clone());
+    actions.push(CoordinatorAction::StartToken(execution));
+  }
+
+  fn submit_source_refresh_request(
+    &mut self,
+    mut request: TokenRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if self.token.running_generation.is_some() {
+      if let Some(previous) = self.token_source_refresh_pending.take() {
+        request.reasons.merge(previous.reasons);
+      }
+      self.token_source_refresh_pending = Some(request);
+      return;
+    }
+    self.submit_token_request(request, actions);
+  }
+
+  fn submit_live_request(
+    &mut self,
+    mut request: LiveRequest,
+    actions: &mut Vec<CoordinatorAction>,
+  ) {
+    if self.live.running_generation.is_some() {
+      if let Some(waiter) = request.waiter {
+        push_unique_waiter(&mut self.live_waiters, waiter);
+      }
+      request.reasons.remove(RefreshReason::Manual);
+      self.live_pending.merge(request.reasons);
+      return;
+    }
+
+    if let Some(waiter) = request.waiter {
+      push_unique_waiter(&mut self.live_waiters, waiter);
+    }
+    request.reasons.merge(std::mem::take(&mut self.live_retry_reasons));
+    self.live.retry_at = None;
+    if request.reasons.is_empty() {
+      return;
+    }
+
+    let generation = self.live.start_generation();
+    let execution = LiveExecutionRequest {
+      generation,
+      source_generation: self.source_generation,
+      reasons: request.reasons,
+    };
+    self.live_running = Some(execution.clone());
+    actions.push(CoordinatorAction::StartLive(execution));
+  }
+
+  fn handle_token_prepared(
+    &mut self,
+    generation: u64,
+    source_generation: u64,
+  ) -> Vec<CoordinatorAction> {
+    let mut actions = Vec::with_capacity(2);
+    let Some(running) = self.token_running.as_ref() else {
+      actions.push(CoordinatorAction::DiscardToken {
+        generation,
+        source_generation,
+      });
+      return actions;
     };
 
-    if !self.config.auto_scan_enabled {
+    if running.generation != generation {
+      actions.push(CoordinatorAction::DiscardToken {
+        generation,
+        source_generation,
+      });
+      return actions;
+    }
+
+    if running.source_generation == source_generation
+      && source_generation == self.source_generation
+    {
+      actions.push(CoordinatorAction::CommitToken {
+        generation,
+        source_generation,
+      });
+      return actions;
+    }
+
+    let stale = self
+      .token_running
+      .take()
+      .expect("matching token generation remains present");
+    self.token.clear_running();
+    actions.push(CoordinatorAction::DiscardToken {
+      generation,
+      source_generation,
+    });
+    if self.token_source_refresh_pending.is_none() {
+      let mut request = stale.request;
+      request.kind = TokenScanKind::Full;
+      request.codex_home = self.config.codex_home.clone();
+      request.reasons.insert(RefreshReason::SettingsChanged);
+      self.token_source_refresh_pending = Some(request);
+    }
+    self.start_pending_token(&mut actions);
+    actions
+  }
+
+  fn handle_token_finished(
+    &mut self,
+    now: Instant,
+    completion: ExecutionCompletion,
+  ) -> Vec<CoordinatorAction> {
+    let Some(running) = self.token_running.as_ref() else {
+      return Vec::new();
+    };
+    if running.generation != completion.generation {
       return Vec::new();
     }
 
-    let mut actions = Vec::with_capacity(2);
-    if let Some(reason) = self
-      .token
-      .take_due(now, self.config.interval, trigger_reason)
+    let running = self
+      .token_running
+      .take()
+      .expect("matching token generation remains present");
+    self.token.clear_running();
+    if running.source_generation != completion.source_generation
+      || completion.source_generation != self.source_generation
     {
-      actions.push(CoordinatorAction::StartToken {
-        kind: TokenScanKind::Incremental,
-        reason,
+      let mut actions = Vec::with_capacity(1);
+      self.start_pending_token(&mut actions);
+      return actions;
+    }
+
+    let completion = normalize_completion(completion);
+    let mut actions = Vec::with_capacity(3);
+    if completion.succeeded {
+      self.token.failure_streak = 0;
+      self.token.retry_at = None;
+      self.token_retry_request = None;
+      self.usage_revision = self.usage_revision.saturating_add(1);
+      actions.push(CoordinatorAction::PublishInvalidation(
+        self.invalidation(completion.commit.expect("normalized success has commit marker")),
+      ));
+    } else {
+      self.token.failure_streak = self.token.failure_streak.saturating_add(1);
+      let jitter = completion.retry_jitter.min(Duration::from_secs(1));
+      let delay = retry_delay(self.token.failure_streak, self.config.interval, jitter);
+      self.token.retry_at = Some(now.checked_add(delay).unwrap_or(now));
+      self.token_retry_request = Some(running.request);
+    }
+    actions.push(CoordinatorAction::PublishCompletion(
+      self.completed_event(RefreshLane::Token, &completion),
+    ));
+    self.start_pending_token(&mut actions);
+    actions
+  }
+
+  fn handle_live_finished(
+    &mut self,
+    now: Instant,
+    completion: ExecutionCompletion,
+  ) -> Vec<CoordinatorAction> {
+    let Some(running) = self.live_running.as_ref() else {
+      return Vec::new();
+    };
+    if running.generation != completion.generation {
+      return Vec::new();
+    }
+
+    let running = self
+      .live_running
+      .take()
+      .expect("matching live generation remains present");
+    self.live.clear_running();
+    let waiters = std::mem::take(&mut self.live_waiters);
+    if running.source_generation != completion.source_generation
+      || completion.source_generation != self.source_generation
+    {
+      let mut actions = Vec::with_capacity(2);
+      if !waiters.is_empty() {
+        actions.push(CoordinatorAction::ResolveLiveWaiters {
+          waiter_ids: waiters,
+          generation: completion.generation,
+          succeeded: false,
+          failure: Some("refresh source changed".to_string()),
+        });
+      }
+      self.start_pending_live(&mut actions);
+      return actions;
+    }
+
+    let completion = normalize_completion(completion);
+    let mut actions = Vec::with_capacity(4);
+    if completion.succeeded {
+      self.live.failure_streak = 0;
+      self.live.retry_at = None;
+      self.live_retry_reasons = ReasonSet::default();
+      self.quota_revision = self.quota_revision.saturating_add(1);
+      actions.push(CoordinatorAction::PublishInvalidation(
+        self.invalidation(completion.commit.expect("normalized success has commit marker")),
+      ));
+    } else {
+      self.live.failure_streak = self.live.failure_streak.saturating_add(1);
+      let jitter = completion.retry_jitter.min(Duration::from_secs(1));
+      let delay = retry_delay(self.live.failure_streak, self.config.interval, jitter);
+      self.live.retry_at = Some(now.checked_add(delay).unwrap_or(now));
+      self.live_retry_reasons = running.reasons;
+    }
+    actions.push(CoordinatorAction::PublishCompletion(
+      self.completed_event(RefreshLane::Live, &completion),
+    ));
+    if !waiters.is_empty() {
+      actions.push(CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids: waiters,
+        generation: completion.generation,
+        succeeded: completion.succeeded,
+        failure: completion.failure.clone(),
       });
     }
-    if let Some(reason) = self
-      .live
-      .take_due(now, self.config.interval, trigger_reason)
-    {
-      actions.push(CoordinatorAction::StartLive { reason });
-    }
+    self.start_pending_live(&mut actions);
     actions
+  }
+
+  fn start_pending_token(&mut self, actions: &mut Vec<CoordinatorAction>) {
+    if let Some(request) = self.token_source_refresh_pending.take() {
+      self.submit_token_request(request, actions);
+      return;
+    }
+    if let Some(request) = self.token_pending.take() {
+      if !self.config.auto_scan_enabled && !request.reasons.contains(RefreshReason::Manual) {
+        return;
+      }
+      self.submit_token_request(request, actions);
+    }
+  }
+
+  fn prune_automatic_pending_work(&mut self) {
+    if let Some(mut pending) = self.token_pending.take() {
+      if pending.reasons.contains(RefreshReason::Manual) {
+        pending.reasons = RefreshReason::Manual.into();
+        self.token_pending = Some(pending);
+      }
+    }
+    self.live_pending = ReasonSet::default();
+  }
+
+  fn start_pending_live(&mut self, actions: &mut Vec<CoordinatorAction>) {
+    let reasons = std::mem::take(&mut self.live_pending);
+    if !reasons.is_empty() {
+      self.submit_live_request(
+        LiveRequest {
+          reasons,
+          waiter: None,
+        },
+        actions,
+      );
+    }
+  }
+
+  fn invalidation(&self, commit: CommitMarker) -> DisplayInvalidation {
+    DisplayInvalidation {
+      usage_revision: self.usage_revision,
+      quota_revision: self.quota_revision,
+      settings_revision: self.settings_revision,
+      source_generation: self.source_generation,
+      commit,
+    }
+  }
+
+  fn completed_event(
+    &mut self,
+    lane: RefreshLane,
+    completion: &ExecutionCompletion,
+  ) -> RefreshCompletedEvent {
+    self.refresh_revision = self.refresh_revision.saturating_add(1);
+    RefreshCompletedEvent {
+      refresh_revision: self.refresh_revision,
+      lane,
+      generation: completion.generation,
+      usage_revision: self.usage_revision,
+      quota_revision: self.quota_revision,
+      source_generation: self.source_generation,
+      succeeded: completion.succeeded,
+      failure: completion.failure.clone(),
+      completed_at: completion.completed_at.clone(),
+    }
   }
 
   pub(crate) fn token_next_deadline(&self) -> Instant {
@@ -184,6 +740,55 @@ impl CoordinatorState {
   pub(crate) fn live_next_deadline(&self) -> Instant {
     self.live.next_deadline
   }
+
+  pub(crate) fn token_retry_at(&self) -> Option<Instant> {
+    self.token.retry_at
+  }
+
+  pub(crate) fn live_retry_at(&self) -> Option<Instant> {
+    self.live.retry_at
+  }
+
+  pub(crate) fn source_generation(&self) -> u64 {
+    self.source_generation
+  }
+
+  pub(crate) fn usage_revision(&self) -> u64 {
+    self.usage_revision
+  }
+}
+
+fn merge_token_request(target: &mut Option<TokenRequest>, request: TokenRequest) {
+  if let Some(target) = target {
+    target.merge(request);
+  } else {
+    *target = Some(request);
+  }
+}
+
+fn push_unique_waiter(waiters: &mut Vec<LiveWaiterId>, waiter: LiveWaiterId) {
+  if !waiters.contains(&waiter) {
+    waiters.push(waiter);
+  }
+}
+
+fn normalize_completion(mut completion: ExecutionCompletion) -> ExecutionCompletion {
+  if completion.succeeded && completion.commit.is_none() {
+    completion.succeeded = false;
+    completion.failure = Some("successful refresh completion missing commit marker".to_string());
+  } else if !completion.succeeded && completion.failure.is_none() {
+    completion.failure = Some("refresh failed without an error".to_string());
+  }
+  completion
+}
+
+fn retry_delay(failure_streak: u32, interval: Duration, jitter: Duration) -> Duration {
+  const STEPS: [u64; 6] = [5, 15, 30, 60, 120, 300];
+  let index = failure_streak.saturating_sub(1) as usize;
+  Duration::from_secs(STEPS[index.min(STEPS.len() - 1)])
+    .saturating_add(jitter)
+    .min(interval)
+    .min(Duration::from_secs(300))
 }
 
 fn advance_fixed_deadline(
@@ -246,14 +851,14 @@ mod tests {
   fn token_starts(actions: &[CoordinatorAction]) -> usize {
     actions
       .iter()
-      .filter(|value| matches!(value, CoordinatorAction::StartToken { .. }))
+      .filter(|value| matches!(value, CoordinatorAction::StartToken(_)))
       .count()
   }
 
   fn live_starts(actions: &[CoordinatorAction]) -> usize {
     actions
       .iter()
-      .filter(|value| matches!(value, CoordinatorAction::StartLive { .. }))
+      .filter(|value| matches!(value, CoordinatorAction::StartLive(_)))
       .count()
   }
 
@@ -286,14 +891,11 @@ mod tests {
     assert!(matches!(
       first.as_slice(),
       [
-        CoordinatorAction::StartToken {
-          kind: TokenScanKind::Incremental,
-          reason: RefreshReason::Startup,
-        },
-        CoordinatorAction::StartLive {
-          reason: RefreshReason::Startup,
-        },
-      ]
+        CoordinatorAction::StartToken(token),
+        CoordinatorAction::StartLive(live),
+      ] if token.request.kind == TokenScanKind::Incremental
+        && token.request.reasons.contains(RefreshReason::Startup)
+        && live.reasons.contains(RefreshReason::Startup)
     ));
     assert!(duplicate.is_empty());
   }
@@ -352,10 +954,10 @@ mod tests {
 
     assert!(actions
       .iter()
-      .any(|value| matches!(value, CoordinatorAction::StartToken { .. })));
+      .any(|value| matches!(value, CoordinatorAction::StartToken(_))));
     assert!(actions
       .iter()
-      .any(|value| matches!(value, CoordinatorAction::StartLive { .. })));
+      .any(|value| matches!(value, CoordinatorAction::StartLive(_))));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
   }
@@ -382,9 +984,8 @@ mod tests {
     assert_eq!(live_starts(&live_due), 1);
     assert!(matches!(
       live_due.as_slice(),
-      [CoordinatorAction::StartLive {
-        reason: RefreshReason::Scheduled,
-      }]
+      [CoordinatorAction::StartLive(request)]
+        if request.reasons.contains(RefreshReason::Scheduled)
     ));
   }
 
@@ -402,14 +1003,10 @@ mod tests {
     assert!(matches!(
       actions.as_slice(),
       [
-        CoordinatorAction::StartToken {
-          reason: RefreshReason::Wake,
-          ..
-        },
-        CoordinatorAction::StartLive {
-          reason: RefreshReason::Wake,
-        },
-      ]
+        CoordinatorAction::StartToken(token),
+        CoordinatorAction::StartLive(live),
+      ] if token.request.reasons.contains(RefreshReason::Wake)
+        && live.reasons.contains(RefreshReason::Wake)
     ));
     assert_eq!(
       state.token_next_deadline(),
@@ -442,14 +1039,10 @@ mod tests {
     assert!(matches!(
       actions.as_slice(),
       [
-        CoordinatorAction::StartToken {
-          reason: RefreshReason::SettingsChanged,
-          ..
-        },
-        CoordinatorAction::StartLive {
-          reason: RefreshReason::SettingsChanged,
-        },
-      ]
+        CoordinatorAction::StartToken(token),
+        CoordinatorAction::StartLive(live),
+      ] if token.request.reasons.contains(RefreshReason::SettingsChanged)
+        && live.reasons.contains(RefreshReason::SettingsChanged)
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(90));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(90));
@@ -485,14 +1078,18 @@ mod tests {
   #[test]
   fn shorter_interval_recalculates_when_prior_anchor_predates_monotonic_epoch() {
     let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
     let old_interval = Duration::MAX;
     let old_next_deadline = base + Duration::from_secs(60);
     assert!(old_next_deadline.checked_sub(old_interval).is_none());
-    let mut state = CoordinatorState {
-      config: test_config(old_interval, None),
-      token: LaneState::new(old_next_deadline, base),
-      live: LaneState::new(old_next_deadline, base),
-    };
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(60), Some(wall)),
+      base,
+      wall,
+    );
+    state.config.interval = old_interval;
+    state.token = LaneState::new(old_next_deadline, base);
+    state.live = LaneState::new(old_next_deadline, base);
 
     let actions = state.handle(
       base + Duration::from_secs(30),
@@ -504,14 +1101,10 @@ mod tests {
     assert!(matches!(
       actions.as_slice(),
       [
-        CoordinatorAction::StartToken {
-          reason: RefreshReason::SettingsChanged,
-          ..
-        },
-        CoordinatorAction::StartLive {
-          reason: RefreshReason::SettingsChanged,
-        },
-      ]
+        CoordinatorAction::StartToken(token),
+        CoordinatorAction::StartLive(live),
+      ] if token.request.reasons.contains(RefreshReason::SettingsChanged)
+        && live.reasons.contains(RefreshReason::SettingsChanged)
     ));
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(40));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(40));
@@ -613,5 +1206,603 @@ mod tests {
     assert_eq!(live_starts(&due), 1);
     assert_eq!(state.token_next_deadline(), base + Duration::from_secs(600));
     assert_eq!(state.live_next_deadline(), base + Duration::from_secs(600));
+  }
+
+  fn execution_success(
+    generation: u64,
+    source_generation: u64,
+    sequence: u64,
+    committed_at: Instant,
+  ) -> ExecutionCompletion {
+    ExecutionCompletion {
+      generation,
+      source_generation,
+      succeeded: true,
+      failure: None,
+      completed_at: "2026-07-10T10:00:00Z".to_string(),
+      commit: Some(CommitMarker {
+        sequence,
+        committed_at,
+      }),
+      retry_jitter: Duration::ZERO,
+    }
+  }
+
+  fn execution_failure(
+    generation: u64,
+    source_generation: u64,
+    retry_jitter: Duration,
+  ) -> ExecutionCompletion {
+    ExecutionCompletion {
+      generation,
+      source_generation,
+      succeeded: false,
+      failure: Some("test failure".to_string()),
+      completed_at: "2026-07-10T10:00:00Z".to_string(),
+      commit: None,
+      retry_jitter,
+    }
+  }
+
+  fn start_token_generation(state: &mut CoordinatorState, now: Instant) -> TokenExecutionRequest {
+    state
+      .handle(
+        now,
+        CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("token generation starts")
+  }
+
+  fn start_live_generation(state: &mut CoordinatorState, now: Instant) -> LiveExecutionRequest {
+    state
+      .handle(
+        now,
+        CoordinatorEvent::RequestLive(LiveRequest::scheduled()),
+      )
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .expect("live generation starts")
+  }
+
+  #[test]
+  fn triggers_during_run_create_one_follow_up_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let first = start_token_generation(&mut state, base);
+
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(None)),
+    );
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    let starts = actions
+      .iter()
+      .filter_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(starts.len(), 1);
+    assert_eq!(starts[0].request.kind, TokenScanKind::Full);
+  }
+
+  #[test]
+  fn multiple_triggers_merge_reason_bits() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let first = start_live_generation(&mut state, base);
+
+    for reason in [
+      RefreshReason::Scheduled,
+      RefreshReason::Wake,
+      RefreshReason::SettingsChanged,
+    ] {
+      state.handle(
+        base + Duration::from_secs(1),
+        CoordinatorEvent::RequestLive(LiveRequest::for_reason(reason)),
+      );
+    }
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::LiveFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+
+    let starts = actions
+      .iter()
+      .filter_map(|action| match action {
+        CoordinatorAction::StartLive(request) => Some(request),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(starts.len(), 1);
+    assert!(starts[0].reasons.contains(RefreshReason::Scheduled));
+    assert!(starts[0].reasons.contains(RefreshReason::Wake));
+    assert!(starts[0]
+      .reasons
+      .contains(RefreshReason::SettingsChanged));
+  }
+
+  #[test]
+  fn manual_live_waiter_joins_running_generation() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let first = start_live_generation(&mut state, base);
+    let waiter_id = LiveWaiterId(41);
+
+    let joined = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestLive(LiveRequest::manual(waiter_id)),
+    );
+    assert!(joined
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartLive(_))));
+
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::LiveFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+
+    assert!(actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartLive(_))));
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids,
+        generation,
+        succeeded: true,
+        failure: None,
+      } if waiter_ids == &[waiter_id] && *generation == first.generation
+    )));
+  }
+
+  #[test]
+  fn failed_lanes_back_off_independently() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first_token = start_token_generation(&mut state, base);
+    let first_live = start_live_generation(&mut state, base);
+
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        first_token.generation,
+        first_token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::LiveFinished(execution_failure(
+        first_live.generation,
+        first_live.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(6)));
+    assert_eq!(state.live_retry_at(), Some(base + Duration::from_secs(7)));
+    assert_eq!(state.token_next_deadline(), base + interval);
+    assert_eq!(state.live_next_deadline(), base + interval);
+
+    let token_retry = state.handle(base + Duration::from_secs(6), CoordinatorEvent::Timer);
+    assert_eq!(token_starts(&token_retry), 1);
+    assert_eq!(live_starts(&token_retry), 0);
+    let second_token = token_retry
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("token retry starts");
+    state.handle(
+      base + Duration::from_secs(6),
+      CoordinatorEvent::TokenFinished(execution_failure(
+        second_token.generation,
+        second_token.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(21)));
+    assert_eq!(state.live_retry_at(), Some(base + Duration::from_secs(7)));
+    assert_eq!(
+      retry_delay(6, Duration::from_secs(600), Duration::ZERO),
+      Duration::from_secs(300)
+    );
+    assert_eq!(
+      retry_delay(1, Duration::from_secs(3), Duration::ZERO),
+      Duration::from_secs(3)
+    );
+
+    let mut jitter_state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let jittered = start_token_generation(&mut jitter_state, base);
+    jitter_state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        jittered.generation,
+        jittered.source_generation,
+        Duration::from_secs(2),
+      )),
+    );
+    assert_eq!(
+      jitter_state.token_retry_at(),
+      Some(base + Duration::from_secs(6))
+    );
+  }
+
+  #[test]
+  fn source_change_rejects_old_completion() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/new-home".to_string());
+
+    let settings_actions = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    assert!(settings_actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+
+    assert_eq!(state.source_generation(), first.source_generation + 1);
+    assert_eq!(state.usage_revision(), 0);
+    assert!(actions.iter().all(|action| !matches!(
+      action,
+      CoordinatorAction::PublishCompletion(_) | CoordinatorAction::PublishInvalidation(_)
+    )));
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::StartToken(request)
+        if request.source_generation == first.source_generation + 1
+          && request.request.kind == TokenScanKind::Full
+          && request.request.codex_home.as_deref() == Some("/normalized/new-home")
+    )));
+  }
+
+  #[test]
+  fn source_change_discards_prepared_token_before_commit() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/new-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenPrepared {
+        generation: first.generation,
+        source_generation: first.source_generation,
+      },
+    );
+
+    assert_eq!(state.usage_revision(), 0);
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::DiscardToken {
+        generation,
+        source_generation,
+      } if *generation == first.generation && *source_generation == first.source_generation
+    )));
+    assert!(actions.iter().all(|action| !matches!(
+      action,
+      CoordinatorAction::CommitToken { .. }
+        | CoordinatorAction::PublishCompletion(_)
+        | CoordinatorAction::PublishInvalidation(_)
+    )));
+    assert_eq!(
+      actions
+        .iter()
+        .filter(|action| matches!(action, CoordinatorAction::StartToken(_)))
+        .count(),
+      1
+    );
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::StartToken(request)
+        if request.source_generation == first.source_generation + 1
+          && request.request.kind == TokenScanKind::Full
+    )));
+  }
+
+  #[test]
+  fn success_without_commit_marker_is_rejected() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut state = CoordinatorState::new(
+      test_config(Duration::from_secs(300), Some(wall)),
+      base,
+      wall,
+    );
+    let first = start_token_generation(&mut state, base);
+    let completion = ExecutionCompletion {
+      generation: first.generation,
+      source_generation: first.source_generation,
+      succeeded: true,
+      failure: None,
+      completed_at: "2026-07-10T10:00:00Z".to_string(),
+      commit: None,
+      retry_jitter: Duration::ZERO,
+    };
+
+    let actions = state.handle(base, CoordinatorEvent::TokenFinished(completion));
+
+    assert_eq!(state.usage_revision(), 0);
+    assert_eq!(state.token_retry_at(), Some(base + Duration::from_secs(5)));
+    assert!(actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::PublishInvalidation(_))));
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::PublishCompletion(event)
+        if !event.succeeded
+          && event.failure.as_deref()
+            == Some("successful refresh completion missing commit marker")
+    )));
+  }
+
+  #[test]
+  fn stale_live_completion_resolves_waiters_without_publishing() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_live_generation(&mut state, base);
+    let waiter_id = LiveWaiterId(73);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestLive(LiveRequest::manual(waiter_id)),
+    );
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/new-home".to_string());
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::LiveFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    assert!(actions.iter().all(|action| !matches!(
+      action,
+      CoordinatorAction::PublishCompletion(_) | CoordinatorAction::PublishInvalidation(_)
+    )));
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::ResolveLiveWaiters {
+        waiter_ids,
+        generation,
+        succeeded: false,
+        failure: Some(failure),
+      } if waiter_ids == &[waiter_id]
+        && *generation == first.generation
+        && failure == "refresh source changed"
+    )));
+    assert_eq!(
+      actions
+        .iter()
+        .filter(|action| matches!(action, CoordinatorAction::StartLive(_)))
+        .count(),
+      1
+    );
+  }
+
+  #[test]
+  fn manual_full_request_supersedes_pending_retry_source() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let mut config = test_config(Duration::from_secs(300), Some(wall));
+    config.codex_home = Some("/normalized/configured-home".to_string());
+    let mut state = CoordinatorState::new(config, base, wall);
+    let first = start_token_generation(&mut state, base);
+    state.handle(
+      base,
+      CoordinatorEvent::TokenFinished(execution_failure(
+        first.generation,
+        first.source_generation,
+        Duration::ZERO,
+      )),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home".to_string(),
+      ))),
+    );
+
+    assert!(actions.iter().any(|action| matches!(
+      action,
+      CoordinatorAction::StartToken(request)
+        if request.request.kind == TokenScanKind::Full
+          && request.request.reasons.contains(RefreshReason::Manual)
+          && request.request.codex_home.as_deref() == Some("/normalized/manual-home")
+    )));
+  }
+
+  #[test]
+  fn disabling_auto_scan_cancels_queued_automatic_token_follow_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_token_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    assert!(actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
+  }
+
+  #[test]
+  fn disabling_auto_scan_cancels_queued_automatic_live_follow_up() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_live_generation(&mut state, base);
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::RequestLive(LiveRequest::scheduled()),
+    );
+    let mut disabled = test_config(interval, Some(wall));
+    disabled.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::SettingsChanged(disabled),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::LiveFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    assert!(actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartLive(_))));
+  }
+
+  #[test]
+  fn source_refresh_precedes_manual_request_for_another_home() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let first = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/new-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::RequestToken(TokenRequest::manual_full(Some(
+        "/normalized/manual-home".to_string(),
+      ))),
+    );
+
+    let actions = state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::TokenFinished(execution_success(
+        first.generation,
+        first.source_generation,
+        1,
+        base + Duration::from_secs(3),
+      )),
+    );
+
+    let starts = actions
+      .iter()
+      .filter_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(starts.len(), 1);
+    assert_eq!(starts[0].request.kind, TokenScanKind::Full);
+    assert_eq!(
+      starts[0].request.codex_home.as_deref(),
+      Some("/normalized/new-home")
+    );
   }
 }

--- a/src-tauri/src/refresh/schedule.rs
+++ b/src-tauri/src/refresh/schedule.rs
@@ -446,19 +446,12 @@ impl CoordinatorState {
     }
 
     if self.token.running_generation.is_some() {
-      let matches_running_source_refresh = self.token_running_source_refresh
-        && self
-          .token_running
-          .as_ref()
-          .is_some_and(|running| running.request.codex_home == request.codex_home);
-      if matches_running_source_refresh {
-        merge_token_request(&mut self.token_source_refresh_pending, request);
-        return;
-      }
-      if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
-        if source_refresh.codex_home == request.codex_home {
-          source_refresh.merge(request);
-          return;
+      if !self.token_running_source_refresh {
+        if let Some(source_refresh) = self.token_source_refresh_pending.as_mut() {
+          if source_refresh.codex_home == request.codex_home {
+            source_refresh.merge(request);
+            return;
+          }
         }
       }
       merge_token_request(&mut self.token_pending, request);
@@ -2056,5 +2049,64 @@ mod tests {
           && request.request.reasons.contains(RefreshReason::Manual)
           && request.request.codex_home.as_deref() == Some("/normalized/manual-home")
     ));
+  }
+
+  #[test]
+  fn automatic_follow_up_during_protected_run_is_pruned_when_disabled() {
+    let base = Instant::now();
+    let wall = utc("2026-07-10T10:00:00Z");
+    let interval = Duration::from_secs(300);
+    let mut state = CoordinatorState::new(test_config(interval, Some(wall)), base, wall);
+    let old_source = start_token_generation(&mut state, base);
+    let mut changed = test_config(interval, Some(wall));
+    changed.codex_home = Some("/normalized/configured-home".to_string());
+    state.handle(
+      base + Duration::from_secs(1),
+      CoordinatorEvent::SettingsChanged(changed.clone()),
+    );
+    let replacement_actions = state.handle(
+      base + Duration::from_secs(2),
+      CoordinatorEvent::TokenFinished(execution_success(
+        old_source.generation,
+        old_source.source_generation,
+        1,
+        base + Duration::from_secs(2),
+      )),
+    );
+    let protected = replacement_actions
+      .into_iter()
+      .find_map(|action| match action {
+        CoordinatorAction::StartToken(request) => Some(request),
+        _ => None,
+      })
+      .expect("configured-source Full refresh starts");
+    assert_eq!(protected.request.kind, TokenScanKind::Full);
+    assert_eq!(
+      protected.request.codex_home.as_deref(),
+      Some("/normalized/configured-home")
+    );
+
+    state.handle(
+      base + Duration::from_secs(3),
+      CoordinatorEvent::RequestToken(TokenRequest::scheduled()),
+    );
+    changed.auto_scan_enabled = false;
+    state.handle(
+      base + Duration::from_secs(4),
+      CoordinatorEvent::SettingsChanged(changed),
+    );
+    let completion_actions = state.handle(
+      base + Duration::from_secs(5),
+      CoordinatorEvent::TokenFinished(execution_success(
+        protected.generation,
+        protected.source_generation,
+        2,
+        base + Duration::from_secs(5),
+      )),
+    );
+
+    assert!(completion_actions
+      .iter()
+      .all(|action| !matches!(action, CoordinatorAction::StartToken(_))));
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Codex Pacer",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "identifier": "com.codex.counter",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Codex Pacer",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "identifier": "com.codex.counter",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tests/fixtures/v1.1.1-schema.sql
+++ b/src-tauri/tests/fixtures/v1.1.1-schema.sql
@@ -1,0 +1,138 @@
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id TEXT PRIMARY KEY,
+      root_session_id TEXT NOT NULL,
+      parent_session_id TEXT,
+      title TEXT,
+      source_state TEXT NOT NULL DEFAULT 'missing',
+      source_path TEXT,
+      source_bucket TEXT,
+      started_at TEXT,
+      updated_at TEXT,
+      agent_nickname TEXT,
+      agent_role TEXT,
+      explicit_fast_mode INTEGER,
+      fast_mode_default INTEGER NOT NULL DEFAULT 0,
+      latest_plan_type TEXT,
+      last_model_id TEXT,
+      contains_subagents INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      imported_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS conversation_links (
+      session_id TEXT PRIMARY KEY,
+      root_session_id TEXT NOT NULL,
+      parent_session_id TEXT,
+      depth INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS usage_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL,
+      cached_input_tokens INTEGER NOT NULL,
+      output_tokens INTEGER NOT NULL,
+      reasoning_output_tokens INTEGER NOT NULL,
+      total_tokens INTEGER NOT NULL,
+      value_usd REAL NOT NULL,
+      fast_mode_auto INTEGER NOT NULL,
+      fast_mode_effective INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS pricing_catalog (
+      model_id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      input_price_per_million REAL NOT NULL,
+      cached_input_price_per_million REAL NOT NULL,
+      output_price_per_million REAL NOT NULL,
+      effective_model_id TEXT NOT NULL,
+      is_official INTEGER NOT NULL,
+      note TEXT,
+      source_url TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS subscription_profile (
+      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+      plan_type TEXT NOT NULL,
+      currency TEXT NOT NULL,
+      monthly_price REAL NOT NULL,
+      billing_anchor_day INTEGER NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS session_overrides (
+      session_id TEXT PRIMARY KEY,
+      fast_mode_override INTEGER,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS sync_settings (
+      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+      sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
+      codex_home TEXT,
+      auto_scan_enabled INTEGER NOT NULL,
+      auto_scan_interval_minutes INTEGER NOT NULL,
+      live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
+      default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0,
+      hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0,
+      show_menu_bar_logo INTEGER NOT NULL DEFAULT 1,
+      show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1,
+      show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0,
+      menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent',
+      menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour',
+      menu_bar_bucket TEXT NOT NULL DEFAULT 'day',
+      menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1,
+      menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85,
+      menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115,
+      menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢',
+      menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥',
+      menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢',
+      menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1,
+      menu_bar_popup_modules TEXT NOT NULL DEFAULT '["api_value","scan_freshness"]',
+      menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1,
+      menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
+      last_scan_started_at TEXT,
+      last_scan_completed_at TEXT,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS import_state (
+      source_path TEXT PRIMARY KEY,
+      session_id TEXT,
+      source_bucket TEXT NOT NULL,
+      file_size INTEGER NOT NULL,
+      file_mtime_ms INTEGER NOT NULL,
+      last_imported_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS rate_limit_samples (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_kind TEXT NOT NULL,
+      source_session_id TEXT NOT NULL DEFAULT '',
+      bucket TEXT NOT NULL,
+      sample_timestamp TEXT NOT NULL,
+      limit_id TEXT NOT NULL DEFAULT '',
+      limit_name TEXT NOT NULL DEFAULT '',
+      plan_type TEXT NOT NULL DEFAULT '',
+      window_start TEXT NOT NULL,
+      resets_at TEXT NOT NULL,
+      used_percent INTEGER NOT NULL,
+      remaining_percent INTEGER NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_usage_events_session_id ON usage_events(session_id);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_timestamp ON usage_events(timestamp);
+    CREATE INDEX IF NOT EXISTS idx_sessions_root_session_id ON sessions(root_session_id);
+    CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
+    CREATE INDEX IF NOT EXISTS idx_sessions_source_state ON sessions(source_state);
+    CREATE INDEX IF NOT EXISTS idx_import_state_session_id ON import_state(session_id);
+    CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_bucket_window
+      ON rate_limit_samples(bucket, window_start, resets_at, sample_timestamp);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_rate_limit_samples_dedupe
+      ON rate_limit_samples(
+        bucket, sample_timestamp, source_kind, source_session_id, limit_id, window_start, resets_at
+      );

--- a/src-tauri/tests/fixtures/v1.1.2-schema.sql
+++ b/src-tauri/tests/fixtures/v1.1.2-schema.sql
@@ -1,0 +1,138 @@
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT PRIMARY KEY,
+  root_session_id TEXT NOT NULL,
+  parent_session_id TEXT,
+  title TEXT,
+  source_state TEXT NOT NULL DEFAULT 'missing',
+  source_path TEXT,
+  source_bucket TEXT,
+  started_at TEXT,
+  updated_at TEXT,
+  agent_nickname TEXT,
+  agent_role TEXT,
+  explicit_fast_mode INTEGER,
+  fast_mode_default INTEGER NOT NULL DEFAULT 0,
+  latest_plan_type TEXT,
+  last_model_id TEXT,
+  contains_subagents INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  imported_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS conversation_links (
+  session_id TEXT PRIMARY KEY,
+  root_session_id TEXT NOT NULL,
+  parent_session_id TEXT,
+  depth INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL,
+  cached_input_tokens INTEGER NOT NULL,
+  output_tokens INTEGER NOT NULL,
+  reasoning_output_tokens INTEGER NOT NULL,
+  total_tokens INTEGER NOT NULL,
+  value_usd REAL NOT NULL,
+  fast_mode_auto INTEGER NOT NULL,
+  fast_mode_effective INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pricing_catalog (
+  model_id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  input_price_per_million REAL NOT NULL,
+  cached_input_price_per_million REAL NOT NULL,
+  output_price_per_million REAL NOT NULL,
+  effective_model_id TEXT NOT NULL,
+  is_official INTEGER NOT NULL,
+  note TEXT,
+  source_url TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subscription_profile (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  plan_type TEXT NOT NULL,
+  currency TEXT NOT NULL,
+  monthly_price REAL NOT NULL,
+  billing_anchor_day INTEGER NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_overrides (
+  session_id TEXT PRIMARY KEY,
+  fast_mode_override INTEGER,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sync_settings (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  sync_settings_schema_version INTEGER NOT NULL DEFAULT 2,
+  codex_home TEXT,
+  auto_scan_enabled INTEGER NOT NULL,
+  auto_scan_interval_minutes INTEGER NOT NULL,
+  live_quota_refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
+  default_fast_mode_for_new_gpt54_sessions INTEGER NOT NULL DEFAULT 0,
+  hide_dock_icon_when_menu_bar_visible INTEGER NOT NULL DEFAULT 0,
+  show_menu_bar_logo INTEGER NOT NULL DEFAULT 1,
+  show_menu_bar_daily_api_value INTEGER NOT NULL DEFAULT 1,
+  show_menu_bar_live_quota_percent INTEGER NOT NULL DEFAULT 0,
+  menu_bar_live_quota_metric TEXT NOT NULL DEFAULT 'remaining_percent',
+  menu_bar_live_quota_bucket TEXT NOT NULL DEFAULT 'five_hour',
+  menu_bar_bucket TEXT NOT NULL DEFAULT 'day',
+  menu_bar_speed_show_emoji INTEGER NOT NULL DEFAULT 1,
+  menu_bar_speed_fast_threshold_percent INTEGER NOT NULL DEFAULT 85,
+  menu_bar_speed_slow_threshold_percent INTEGER NOT NULL DEFAULT 115,
+  menu_bar_speed_healthy_emoji TEXT NOT NULL DEFAULT '🟢',
+  menu_bar_speed_fast_emoji TEXT NOT NULL DEFAULT '🔥',
+  menu_bar_speed_slow_emoji TEXT NOT NULL DEFAULT '🐢',
+  menu_bar_popup_enabled INTEGER NOT NULL DEFAULT 1,
+  menu_bar_popup_modules TEXT NOT NULL DEFAULT '["api_value","scan_freshness"]',
+  menu_bar_popup_show_reset_timeline INTEGER NOT NULL DEFAULT 1,
+  menu_bar_popup_show_actions INTEGER NOT NULL DEFAULT 1,
+  last_scan_started_at TEXT,
+  last_scan_completed_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS import_state (
+  source_path TEXT PRIMARY KEY,
+  session_id TEXT,
+  source_bucket TEXT NOT NULL,
+  file_size INTEGER NOT NULL,
+  file_mtime_ms INTEGER NOT NULL,
+  last_imported_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS data_repairs (
+  repair_key TEXT PRIMARY KEY,
+  completed_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS data_repair_pending_files (
+  repair_key TEXT NOT NULL,
+  source_path TEXT NOT NULL,
+  last_error TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (repair_key, source_path)
+);
+
+CREATE TABLE IF NOT EXISTS rate_limit_samples (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_kind TEXT NOT NULL,
+  source_session_id TEXT NOT NULL DEFAULT '',
+  bucket TEXT NOT NULL,
+  sample_timestamp TEXT NOT NULL,
+  limit_id TEXT NOT NULL DEFAULT '',
+  limit_name TEXT NOT NULL DEFAULT '',
+  plan_type TEXT NOT NULL DEFAULT '',
+  window_start TEXT NOT NULL,
+  resets_at TEXT NOT NULL,
+  used_percent INTEGER NOT NULL,
+  remaining_percent INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,11 +24,13 @@ import {
   updateSyncSettings,
 } from './app/api'
 import {
+  loadConversationDetailForGeneration,
   refreshDashboardAfterBackgroundScan,
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
   waitForScanToSettleUntilCancelled,
 } from './app/dataFreshness'
+import { saveSettingsWithCodexHomeRollback } from './app/settingsSave'
 import {
   formatCompactDateTime,
   formatDateTime,
@@ -191,12 +193,16 @@ function App() {
           }
         }
 
+        latestDetailRequestIdRef.current += 1
         setOverview(snapshot.overview)
         setConversations(snapshot.conversations)
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
         setLiveRateLimits(snapshot.liveRateLimits)
         detailCacheRef.current = nextDetailCache
+        setDetail((current) =>
+          current && nextDetailCache.get(current.rootSessionId) === current ? current : null,
+        )
         setDashboardRevision((current) => current + 1)
         setLiveWindowOffset(snapshot.overview.liveWindowOffset)
         setLoadedQueryKey(
@@ -299,8 +305,12 @@ function App() {
 
     setDetail(null)
     try {
-      const nextDetail = await getConversationDetail(rootSessionId)
-      if (requestId !== latestDetailRequestIdRef.current) {
+      const nextDetail = await loadConversationDetailForGeneration(
+        () => getConversationDetail(rootSessionId),
+        requestId,
+        () => latestDetailRequestIdRef.current,
+      )
+      if (!nextDetail) {
         return
       }
       detailCacheRef.current.set(rootSessionId, nextDetail)
@@ -409,16 +419,31 @@ function App() {
     syncSettings: SyncSettings
     subscriptionProfile: SubscriptionProfile
   }) {
-    const previousCodexHome = syncSettingsRef.current?.codexHome ?? null
-    const [nextSyncSettings, nextSubscriptionProfile] = await Promise.all([
-      updateSyncSettings(payload.syncSettings),
-      updateSubscriptionProfile(payload.subscriptionProfile),
-    ])
-    const codexHomeChanged = previousCodexHome !== nextSyncSettings.codexHome
-    syncSettingsRef.current = nextSyncSettings
-    setSyncSettings(nextSyncSettings)
-    setSubscriptionProfile(nextSubscriptionProfile)
-    await loadShell(codexHomeChanged)
+    const previousSyncSettings = syncSettingsRef.current
+    const previousSubscriptionProfile = subscriptionProfile
+    if (!previousSyncSettings || !previousSubscriptionProfile) {
+      throw new Error(t.status.settingsStillLoading)
+    }
+
+    const saved = await saveSettingsWithCodexHomeRollback({
+      previousSyncSettings,
+      nextSyncSettings: payload.syncSettings,
+      previousSubscriptionProfile,
+      nextSubscriptionProfile: payload.subscriptionProfile,
+      updateSyncSettings,
+      updateSubscriptionProfile,
+      scanCodexHome: (codexHome) =>
+        runScanWithOverlapRetry(
+          () => scanCodexUsage(codexHome),
+          (error) => String(error).includes('already running'),
+          waitForScanToSettle,
+          () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
+        ),
+    })
+    syncSettingsRef.current = saved.syncSettings
+    setSyncSettings(saved.syncSettings)
+    setSubscriptionProfile(saved.subscriptionProfile)
+    await loadShell(false)
     if (isTauri()) {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import {
 import {
   getScanInProgress,
   getConversationDetail,
+  listConversations,
   loadDashboard,
   refreshPricing,
   scanCodexUsage,
@@ -105,8 +106,12 @@ function App() {
   const [shareDimension, setShareDimension] = useState<ShareDimension>('model')
   const [overview, setOverview] = useState<OverviewResponse | null>(null)
   const [conversations, setConversations] = useState<ConversationListItem[]>([])
+  const [conversationCursor, setConversationCursor] = useState<string | null>(null)
+  const [hasMoreConversations, setHasMoreConversations] = useState(false)
+  const [loadingMoreConversations, setLoadingMoreConversations] = useState(false)
   const [selectedRootSessionId, setSelectedRootSessionId] = useState<string | null>(null)
   const [detail, setDetail] = useState<ConversationDetail | null>(null)
+  const [loadingEarlierTurns, setLoadingEarlierTurns] = useState(false)
   const [syncSettings, setSyncSettings] = useState<SyncSettings | null>(null)
   const [subscriptionProfile, setSubscriptionProfile] = useState<SubscriptionProfile | null>(null)
   const [liveRateLimits, setLiveRateLimits] = useState<LiveRateLimitSnapshot | null>(null)
@@ -125,6 +130,7 @@ function App() {
   const latestDetailRequestIdRef = useRef(0)
   const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
   const refreshCompletionListenerReadyRef = useRef<Promise<boolean>>(Promise.resolve(false))
+  const refreshReloadTimerRef = useRef<number | null>(null)
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
   const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
@@ -181,7 +187,7 @@ function App() {
 
       startTransition(() => {
         const nextDetailCache = new Map<string, ConversationDetail>()
-        for (const conversation of snapshot.conversations) {
+        for (const conversation of snapshot.conversationPage.items) {
           const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
           if (
             cachedDetail &&
@@ -197,7 +203,9 @@ function App() {
 
         latestDetailRequestIdRef.current += 1
         setOverview(snapshot.overview)
-        setConversations(snapshot.conversations)
+        setConversations(snapshot.conversationPage.items)
+        setConversationCursor(snapshot.conversationPage.nextCursor)
+        setHasMoreConversations(snapshot.conversationPage.hasMore)
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
         setLiveRateLimits(snapshot.liveRateLimits)
@@ -218,9 +226,9 @@ function App() {
           ),
         )
         setSelectedRootSessionId((current) =>
-          current && snapshot.conversations.some((item) => item.rootSessionId === current)
+          current && snapshot.conversationPage.items.some((item) => item.rootSessionId === current)
             ? current
-            : snapshot.conversations[0]?.rootSessionId ?? null,
+            : snapshot.conversationPage.items[0]?.rootSessionId ?? null,
         )
       })
     } catch (error) {
@@ -232,6 +240,43 @@ function App() {
       }
     }
   }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t])
+
+  const loadMoreConversations = useCallback(async () => {
+    if (!conversationCursor || !hasMoreConversations || loadingMoreConversations) return
+    const requestId = latestLoadRequestIdRef.current
+    setLoadingMoreConversations(true)
+    try {
+      const page = await listConversations({
+        bucket,
+        anchor: bucketUsesAnchor(bucket) ? anchor : null,
+        customStart: bucket === 'custom' ? customStart : null,
+        customEnd: bucket === 'custom' ? customEnd : null,
+        search: deferredSearch || null,
+        liveWindowOffset: bucket === 'five_hour' || bucket === 'seven_day' ? liveWindowOffset : 0,
+        cursor: conversationCursor,
+        limit: 50,
+      })
+      if (requestId !== latestLoadRequestIdRef.current) return
+      setConversations((current) => {
+        const seen = new Set(current.map((item) => item.rootSessionId))
+        return [...current, ...page.items.filter((item) => !seen.has(item.rootSessionId))]
+      })
+      setConversationCursor(page.nextCursor)
+      setHasMoreConversations(page.hasMore)
+    } finally {
+      setLoadingMoreConversations(false)
+    }
+  }, [
+    anchor,
+    bucket,
+    conversationCursor,
+    customEnd,
+    customStart,
+    deferredSearch,
+    hasMoreConversations,
+    liveWindowOffset,
+    loadingMoreConversations,
+  ])
 
   const currentQueryKey = buildQueryKey(
     bucket,
@@ -314,7 +359,13 @@ function App() {
         .catch(() => {})
     }
     const reloadDashboard = () => {
-      void loadShellRef.current(true)
+      if (refreshReloadTimerRef.current !== null) {
+        window.clearTimeout(refreshReloadTimerRef.current)
+      }
+      refreshReloadTimerRef.current = window.setTimeout(() => {
+        refreshReloadTimerRef.current = null
+        void loadShellRef.current(true)
+      }, 200)
     }
     const handleCompletion = async (event: RefreshCompletedEvent) => {
       let visible: boolean
@@ -378,6 +429,10 @@ function App() {
     return () => {
       cancelled = true
       refreshCompletionListenerReadyRef.current = Promise.resolve(false)
+      if (refreshReloadTimerRef.current !== null) {
+        window.clearTimeout(refreshReloadTimerRef.current)
+        refreshReloadTimerRef.current = null
+      }
       document.removeEventListener('visibilitychange', handleDocumentVisibility)
       window.removeEventListener('focus', handleWindowFocus)
       for (const dispose of disposers) {
@@ -422,6 +477,30 @@ function App() {
       setStatusMessage(String(error))
     }
   }, [])
+
+  const loadEarlierTurns = useCallback(async () => {
+    if (!detail?.hasMoreTurns || detail.nextTurnCursor === null || loadingEarlierTurns) return
+    const requestId = latestDetailRequestIdRef.current
+    const rootSessionId = detail.rootSessionId
+    setLoadingEarlierTurns(true)
+    try {
+      const page = await getConversationDetail(rootSessionId, detail.nextTurnCursor)
+      if (requestId !== latestDetailRequestIdRef.current) return
+      setDetail((current) => {
+        if (!current || current.rootSessionId !== rootSessionId) return current
+        const merged = {
+          ...current,
+          turns: [...page.turns, ...current.turns],
+          nextTurnCursor: page.nextTurnCursor,
+          hasMoreTurns: page.hasMoreTurns,
+        }
+        detailCacheRef.current.set(rootSessionId, merged)
+        return merged
+      })
+    } finally {
+      setLoadingEarlierTurns(false)
+    }
+  }, [detail, loadingEarlierTurns])
 
   useEffect(() => {
     let cancelled = false
@@ -871,8 +950,9 @@ function App() {
                   {activeConversations.length === 0 ? (
                     <div className="empty-state">{t.conversationList.empty}</div>
                   ) : (
-                    activeConversations.map((conversation) => (
-                      <button
+                    <>
+                      {activeConversations.map((conversation) => (
+                        <button
                         key={conversation.rootSessionId}
                         className={`conversation-card ${
                           conversation.rootSessionId === selectedRootSessionId ? 'active' : ''
@@ -904,8 +984,21 @@ function App() {
                           <span>{formatShortDate(conversation.updatedAt, language)}</span>
                           <span>{formatPercent(conversation.subscriptionShare, language)}</span>
                         </div>
-                      </button>
-                    ))
+                        </button>
+                      ))}
+                      {hasMoreConversations ? (
+                        <button
+                          className="ghost-button"
+                          disabled={loadingMoreConversations}
+                          onClick={() => void loadMoreConversations()}
+                          type="button"
+                        >
+                          {loadingMoreConversations
+                            ? t.conversationList.loadingMore
+                            : t.conversationList.loadMore}
+                        </button>
+                      ) : null}
+                    </>
                   )}
                 </div>
               </aside>
@@ -967,14 +1060,26 @@ function App() {
                           <h3>{t.detail.turnUsage}</h3>
                         </div>
                         <p className="chart-note">
-                          {t.detail.latestTurns(Math.min(activeDetail.turns.length, 40))}
+                          {t.detail.latestTurns(activeDetail.turns.length)}
                         </p>
                       </div>
+                      {activeDetail.hasMoreTurns ? (
+                        <button
+                          className="ghost-button"
+                          disabled={loadingEarlierTurns}
+                          onClick={() => void loadEarlierTurns()}
+                          type="button"
+                        >
+                          {loadingEarlierTurns
+                            ? t.detail.loadingEarlierTurns
+                            : t.detail.loadEarlierTurns}
+                        </button>
+                      ) : null}
                       <div className="timeline-grid">
                         {activeDetail.turns.length === 0 ? (
                           <div className="empty-state">{t.detail.emptyTurns}</div>
                         ) : (
-                          activeDetail.turns.slice(-40).reverse().map((turn) => {
+                          [...activeDetail.turns].reverse().map((turn) => {
                             const session = sessionSummariesById.get(turn.sessionId)
                             const modelSummary = formatModelSummary(turn.modelIds, t)
                             const sessionLabel = formatSessionLabel(session, turn.sessionId, t)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import {
   shouldKeepConversationDetail,
 } from './app/dataFreshness'
 import {
+  selectionAfterDashboardReload,
   shouldLoadDashboardAfterManualRefresh,
   shouldLoadDashboardAfterSettingsSave,
   SurfaceRevisionGate,
@@ -126,6 +127,7 @@ function App() {
   const loadShellRef = useRef<(quiet?: boolean) => Promise<void>>(async () => {})
   const lastRequestedQueryKeyRef = useRef<string | null>(null)
   const latestLoadRequestIdRef = useRef(0)
+  const loadedQueryKeyRef = useRef<string | null>(null)
   const detailCacheRef = useRef(new Map<string, ConversationDetail>())
   const latestDetailRequestIdRef = useRef(0)
   const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
@@ -184,6 +186,15 @@ function App() {
       if (requestId !== latestLoadRequestIdRef.current) {
         return
       }
+      const resolvedQueryKey = buildQueryKey(
+        requestBucket,
+        requestAnchor,
+        requestCustomStart,
+        requestCustomEnd,
+        requestSearch,
+        snapshot.overview.liveWindowOffset,
+      )
+      const previousQueryKey = loadedQueryKeyRef.current
 
       startTransition(() => {
         const nextDetailCache = new Map<string, ConversationDetail>()
@@ -215,20 +226,10 @@ function App() {
         )
         setDashboardRevision((current) => current + 1)
         setLiveWindowOffset(snapshot.overview.liveWindowOffset)
-        setLoadedQueryKey(
-          buildQueryKey(
-            requestBucket,
-            requestAnchor,
-            requestCustomStart,
-            requestCustomEnd,
-            requestSearch,
-            snapshot.overview.liveWindowOffset,
-          ),
-        )
+        loadedQueryKeyRef.current = resolvedQueryKey
+        setLoadedQueryKey(resolvedQueryKey)
         setSelectedRootSessionId((current) =>
-          current && snapshot.conversationPage.items.some((item) => item.rootSessionId === current)
-            ? current
-            : null,
+          selectionAfterDashboardReload(current, previousQueryKey, resolvedQueryKey),
         )
       })
     } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -527,8 +527,8 @@ function App() {
 
   useEffect(() => {
     if (!hasBootstrapped || view !== 'conversations') return
-    void loadShell(false)
-  }, [hasBootstrapped, loadShell, view])
+    void loadShellRef.current(false)
+  }, [hasBootstrapped, view])
 
   useEffect(() => {
     if (!loadedQueryKey && selectedRootSessionId) return

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,10 @@ const BUCKETS: OverviewBucket[] = [
   'total',
 ]
 
+function unifiedRefreshIntervalMs(autoScanIntervalMinutes: number | null | undefined) {
+  return Math.max(60000, (autoScanIntervalMinutes ?? 5) * 60 * 1000)
+}
+
 function App() {
   const { language, setLanguage, t } = useI18n()
   const [view, setView] = useState<AppView>('overview')
@@ -105,9 +109,9 @@ function App() {
   const latestDetailRequestIdRef = useRef(0)
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
-  const waitForScanToSettle = useCallback(async () => {
+  const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
     const startedAt = Date.now()
-    while (Date.now() - startedAt < 15000) {
+    while (Date.now() - startedAt < timeoutMs) {
       if (!(await getScanInProgress())) {
         return
       }
@@ -304,7 +308,8 @@ function App() {
     let cancelled = false
 
     const bootstrap = async () => {
-      await loadShellRef.current(true)
+      await waitForScanToSettle(60000)
+      await loadShellRef.current(false)
       if (!cancelled) {
         setHasBootstrapped(true)
       }
@@ -315,7 +320,7 @@ function App() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [waitForScanToSettle])
 
   useEffect(() => {
     if (!hasBootstrapped) return
@@ -330,15 +335,11 @@ function App() {
 
   useEffect(() => {
     if (!hasBootstrapped) return
-    const refreshMs =
-      bucket === 'five_hour' || bucket === 'seven_day'
-        ? (syncSettings?.liveQuotaRefreshIntervalSeconds ?? 300) * 1000
-        : 60000
     const interval = window.setInterval(() => {
       void loadShell(false)
-    }, Math.max(5000, refreshMs))
+    }, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
     return () => window.clearInterval(interval)
-  }, [bucket, hasBootstrapped, loadShell, syncSettings?.liveQuotaRefreshIntervalSeconds])
+  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanIntervalMinutes])
 
   useEffect(() => {
     if (!settingsOpen) return
@@ -352,15 +353,12 @@ function App() {
         })
         .catch(() => {})
     refresh()
-    const interval = window.setInterval(
-      refresh,
-      Math.max(60000, (syncSettings?.liveQuotaRefreshIntervalSeconds ?? 300) * 1000),
-    )
+    const interval = window.setInterval(refresh, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
     return () => {
       cancelled = true
       window.clearInterval(interval)
     }
-  }, [settingsOpen, syncSettings?.liveQuotaRefreshIntervalSeconds])
+  }, [settingsOpen, syncSettings?.autoScanIntervalMinutes])
 
   async function handleRescan() {
     await loadShell(true)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -228,7 +228,7 @@ function App() {
         setSelectedRootSessionId((current) =>
           current && snapshot.conversationPage.items.some((item) => item.rootSessionId === current)
             ? current
-            : snapshot.conversationPage.items[0]?.rootSessionId ?? null,
+            : null,
         )
       })
     } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,12 @@
-import { startTransition, useCallback, useDeferredValue, useEffect, useRef, useState } from 'react'
+import {
+  startTransition,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import { isTauri } from '@tauri-apps/api/core'
 import { emitTo, listen } from '@tauri-apps/api/event'
 import { getCurrentWindow } from '@tauri-apps/api/window'
@@ -234,7 +242,7 @@ function App() {
     bucket === 'five_hour' || bucket === 'seven_day' ? liveWindowOffset : 0,
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     loadShellRef.current = loadShell
   }, [loadShell])
 
@@ -288,7 +296,7 @@ function App() {
     void emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_LANGUAGE_EVENT, { language }).catch(() => {})
   }, [language])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isTauri()) return
 
     let cancelled = false
@@ -450,7 +458,7 @@ function App() {
         () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
       )
       if (shouldLoadDashboardAfterManualRefresh(listenerReady)) {
-        await loadShell(true)
+        await loadShellRef.current(true)
       }
       setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
     } catch (error) {
@@ -503,7 +511,7 @@ function App() {
     setSyncSettings(saved.syncSettings)
     setSubscriptionProfile(saved.subscriptionProfile)
     if (shouldLoadDashboardAfterSettingsSave(saved.codexHomeChanged, listenerReady)) {
-      await loadShell(true)
+      await loadShellRef.current(true)
     }
     if (isTauri()) {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { startTransition, useCallback, useDeferredValue, useEffect, useRef, useState } from 'react'
 import { isTauri } from '@tauri-apps/api/core'
 import { emitTo, listen } from '@tauri-apps/api/event'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import {
   BadgeDollarSign,
   ChartNoAxesCombined,
@@ -15,9 +16,7 @@ import {
 import {
   getScanInProgress,
   getConversationDetail,
-  getLiveRateLimits,
   loadDashboard,
-  refreshBackgroundData,
   refreshPricing,
   scanCodexUsage,
   updateSubscriptionProfile,
@@ -25,11 +24,10 @@ import {
 } from './app/api'
 import {
   loadConversationDetailForGeneration,
-  refreshDashboardAfterBackgroundScan,
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
-  waitForScanToSettleUntilCancelled,
 } from './app/dataFreshness'
+import { SurfaceRevisionGate } from './app/refreshEvents'
 import { saveSettingsWithCodexHomeRollback } from './app/settingsSave'
 import {
   formatCompactDateTime,
@@ -54,6 +52,7 @@ import type {
   ModelShare,
   OverviewBucket,
   OverviewResponse,
+  RefreshCompletedEvent,
   ShareDimension,
   ShareMode,
   ShareSlice,
@@ -82,10 +81,6 @@ const BUCKETS: OverviewBucket[] = [
   'total',
 ]
 
-function unifiedRefreshIntervalMs(autoScanIntervalMinutes: number | null | undefined) {
-  return Math.max(60000, (autoScanIntervalMinutes ?? 5) * 60 * 1000)
-}
-
 function App() {
   const { language, setLanguage, t } = useI18n()
   const [view, setView] = useState<AppView>('overview')
@@ -111,11 +106,12 @@ function App() {
   const [search, setSearch] = useState('')
   const deferredSearch = useDeferredValue(search)
   const syncSettingsRef = useRef<SyncSettings | null>(null)
-  const loadShellRef = useRef<(requestScan?: boolean) => Promise<void>>(async () => {})
+  const loadShellRef = useRef<(quiet?: boolean) => Promise<void>>(async () => {})
   const lastRequestedQueryKeyRef = useRef<string | null>(null)
   const latestLoadRequestIdRef = useRef(0)
   const detailCacheRef = useRef(new Map<string, ConversationDetail>())
   const latestDetailRequestIdRef = useRef(0)
+  const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
   const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
@@ -133,7 +129,7 @@ function App() {
     syncSettingsRef.current = syncSettings
   }, [syncSettings])
 
-  const loadShell = useCallback(async (requestScan = false) => {
+  const loadShell = useCallback(async (quiet = false) => {
     const requestId = latestLoadRequestIdRef.current + 1
     latestLoadRequestIdRef.current = requestId
     const requestBucket = bucket
@@ -150,21 +146,14 @@ function App() {
       requestSearch,
       requestLiveWindowOffset,
     )
-    setIsBusy(true)
-    if ((requestBucket === 'five_hour' || requestBucket === 'seven_day') && requestLiveWindowOffset === 0) {
+    if (
+      !quiet &&
+      (requestBucket === 'five_hour' || requestBucket === 'seven_day') &&
+      requestLiveWindowOffset === 0
+    ) {
       setStatusMessage(t.status.fetchingLiveQuotaWindow)
     }
     try {
-      if (requestScan) {
-        const scan = await runScanWithOverlapRetry(
-          () => scanCodexUsage(syncSettingsRef.current?.codexHome ?? null),
-          (error) => String(error).includes('already running'),
-          waitForScanToSettle,
-          () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
-        )
-        setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
-      }
-
       const snapshot = await loadDashboard(
         requestBucket,
         requestAnchor,
@@ -225,16 +214,11 @@ function App() {
       if (requestId !== latestLoadRequestIdRef.current) {
         return
       }
-      startTransition(() => {
-        setLoadedQueryKey(null)
-      })
-      setStatusMessage(t.status.failedToLoad(t.buckets[requestBucket], String(error)))
-    } finally {
-      if (requestId === latestLoadRequestIdRef.current) {
-        setIsBusy(false)
+      if (!quiet) {
+        setStatusMessage(t.status.failedToLoad(t.buckets[requestBucket], String(error)))
       }
     }
-  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t, waitForScanToSettle])
+  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t])
 
   const currentQueryKey = buildQueryKey(
     bucket,
@@ -272,14 +256,24 @@ function App() {
   useEffect(() => {
     if (!isTauri()) return
 
+    let cancelled = false
     let dispose: (() => void) | undefined
     void listen('codex-counter://open-settings', () => {
-      setSettingsOpen(true)
-    }).then((unlisten) => {
-      dispose = unlisten
+      if (!cancelled) {
+        setSettingsOpen(true)
+      }
     })
+      .then((unlisten) => {
+        if (cancelled) {
+          unlisten()
+        } else {
+          dispose = unlisten
+        }
+      })
+      .catch(() => {})
 
     return () => {
+      cancelled = true
       dispose?.()
     }
   }, [])
@@ -288,6 +282,85 @@ function App() {
     if (!isTauri()) return
     void emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_LANGUAGE_EVENT, { language }).catch(() => {})
   }, [language])
+
+  useEffect(() => {
+    if (!isTauri()) return
+
+    let cancelled = false
+    const disposers = new Set<() => void>()
+    const appWindow = getCurrentWindow()
+    const trackRegistration = (registration: Promise<() => void>) => {
+      void registration
+        .then((dispose) => {
+          if (cancelled) {
+            dispose()
+          } else {
+            disposers.add(dispose)
+          }
+        })
+        .catch(() => {})
+    }
+    const reloadDashboard = () => {
+      void loadShellRef.current(true)
+    }
+    const handleCompletion = async (event: RefreshCompletedEvent) => {
+      let visible: boolean
+      try {
+        visible = await getCurrentWindow().isVisible()
+      } catch {
+        return
+      }
+      if (cancelled) return
+      if (refreshRevisionGateRef.current.accept(event, visible) === 'reload') {
+        reloadDashboard()
+      }
+    }
+    const handleVisible = async () => {
+      let visible: boolean
+      try {
+        visible = await getCurrentWindow().isVisible()
+      } catch {
+        return
+      }
+      if (cancelled || !visible) return
+      if (refreshRevisionGateRef.current.onVisible() === 'reload') {
+        reloadDashboard()
+      }
+    }
+    const handleDocumentVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        void handleVisible()
+      }
+    }
+    const handleWindowFocus = () => {
+      void handleVisible()
+    }
+
+    trackRegistration(
+      listen<RefreshCompletedEvent>('codex-counter://refresh-completed', (event) => {
+        void handleCompletion(event.payload)
+      }),
+    )
+    trackRegistration(
+      appWindow.onFocusChanged(({ payload: focused }) => {
+        if (focused) {
+          void handleVisible()
+        }
+      }),
+    )
+    document.addEventListener('visibilitychange', handleDocumentVisibility)
+    window.addEventListener('focus', handleWindowFocus)
+
+    return () => {
+      cancelled = true
+      document.removeEventListener('visibilitychange', handleDocumentVisibility)
+      window.removeEventListener('focus', handleWindowFocus)
+      for (const dispose of disposers) {
+        dispose()
+      }
+      disposers.clear()
+    }
+  }, [])
 
   const loadDetail = useCallback(async (rootSessionId: string | null) => {
     const requestId = latestDetailRequestIdRef.current + 1
@@ -327,27 +400,16 @@ function App() {
 
   useEffect(() => {
     let cancelled = false
-
-    const bootstrap = async () => {
-      const settled = await waitForScanToSettleUntilCancelled(
-        () => waitForScanToSettle(60000),
-        () => cancelled,
-      )
-      if (!settled || cancelled) {
-        return
-      }
-      await loadShellRef.current(false)
+    void loadShellRef.current(false).then(() => {
       if (!cancelled) {
         setHasBootstrapped(true)
       }
-    }
-
-    void bootstrap()
+    })
 
     return () => {
       cancelled = true
     }
-  }, [waitForScanToSettle])
+  }, [])
 
   useEffect(() => {
     if (!hasBootstrapped) return
@@ -360,46 +422,21 @@ function App() {
     void loadDetail(selectedRootSessionId)
   }, [dashboardRevision, loadDetail, loadedQueryKey, selectedRootSessionId])
 
-  useEffect(() => {
-    if (!hasBootstrapped || !syncSettings?.autoScanEnabled) return
-    let cancelled = false
-    const refresh = () => {
-      void refreshDashboardAfterBackgroundScan(
-        refreshBackgroundData,
-        getScanInProgress,
-        waitForScanToSettle,
-        () => loadShell(false),
-        () => cancelled,
-      )
-    }
-    const interval = window.setInterval(refresh, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-    }
-  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes, waitForScanToSettle])
-
-  useEffect(() => {
-    if (!settingsOpen || !syncSettings?.autoScanEnabled) return
-    let cancelled = false
-    const refresh = () =>
-      void getLiveRateLimits()
-        .then((snapshot) => {
-          if (!cancelled) {
-            setLiveRateLimits(snapshot)
-          }
-        })
-        .catch(() => {})
-    refresh()
-    const interval = window.setInterval(refresh, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-    }
-  }, [settingsOpen, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes])
-
   async function handleRescan() {
-    await loadShell(true)
+    setIsBusy(true)
+    try {
+      const scan = await runScanWithOverlapRetry(
+        () => scanCodexUsage(syncSettingsRef.current?.codexHome ?? null),
+        (error) => String(error).includes('already running'),
+        waitForScanToSettle,
+        () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
+      )
+      setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
+    } catch (error) {
+      setStatusMessage(String(error))
+    } finally {
+      setIsBusy(false)
+    }
   }
 
   async function handleRefreshPricing() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,11 @@ import {
   runScanWithOverlapRetry,
   shouldKeepConversationDetail,
 } from './app/dataFreshness'
-import { SurfaceRevisionGate } from './app/refreshEvents'
+import {
+  shouldLoadDashboardAfterManualRefresh,
+  shouldLoadDashboardAfterSettingsSave,
+  SurfaceRevisionGate,
+} from './app/refreshEvents'
 import { saveSettingsWithCodexHomeRollback } from './app/settingsSave'
 import {
   formatCompactDateTime,
@@ -112,6 +116,7 @@ function App() {
   const detailCacheRef = useRef(new Map<string, ConversationDetail>())
   const latestDetailRequestIdRef = useRef(0)
   const refreshRevisionGateRef = useRef(new SurfaceRevisionGate())
+  const refreshCompletionListenerReadyRef = useRef<Promise<boolean>>(Promise.resolve(false))
   const [hasBootstrapped, setHasBootstrapped] = useState(false)
 
   const waitForScanToSettle = useCallback(async (timeoutMs = 15000) => {
@@ -336,11 +341,22 @@ function App() {
       void handleVisible()
     }
 
-    trackRegistration(
-      listen<RefreshCompletedEvent>('codex-counter://refresh-completed', (event) => {
+    const completionRegistration = listen<RefreshCompletedEvent>(
+      'codex-counter://refresh-completed',
+      (event) => {
         void handleCompletion(event.payload)
-      }),
+      },
     )
+    refreshCompletionListenerReadyRef.current = completionRegistration
+      .then((dispose) => {
+        if (cancelled) {
+          dispose()
+          return false
+        }
+        disposers.add(dispose)
+        return true
+      })
+      .catch(() => false)
     trackRegistration(
       appWindow.onFocusChanged(({ payload: focused }) => {
         if (focused) {
@@ -353,6 +369,7 @@ function App() {
 
     return () => {
       cancelled = true
+      refreshCompletionListenerReadyRef.current = Promise.resolve(false)
       document.removeEventListener('visibilitychange', handleDocumentVisibility)
       window.removeEventListener('focus', handleWindowFocus)
       for (const dispose of disposers) {
@@ -425,12 +442,16 @@ function App() {
   async function handleRescan() {
     setIsBusy(true)
     try {
+      const listenerReady = await refreshCompletionListenerReadyRef.current
       const scan = await runScanWithOverlapRetry(
         () => scanCodexUsage(syncSettingsRef.current?.codexHome ?? null),
         (error) => String(error).includes('already running'),
         waitForScanToSettle,
         () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
       )
+      if (shouldLoadDashboardAfterManualRefresh(listenerReady)) {
+        await loadShell(true)
+      }
       setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
     } catch (error) {
       setStatusMessage(String(error))
@@ -462,6 +483,7 @@ function App() {
       throw new Error(t.status.settingsStillLoading)
     }
 
+    const listenerReady = await refreshCompletionListenerReadyRef.current
     const saved = await saveSettingsWithCodexHomeRollback({
       previousSyncSettings,
       nextSyncSettings: payload.syncSettings,
@@ -480,7 +502,9 @@ function App() {
     syncSettingsRef.current = saved.syncSettings
     setSyncSettings(saved.syncSettings)
     setSubscriptionProfile(saved.subscriptionProfile)
-    await loadShell(false)
+    if (shouldLoadDashboardAfterSettingsSave(saved.codexHomeChanged, listenerReady)) {
+      await loadShell(true)
+    }
     if (isTauri()) {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import {
   getConversationDetail,
   getLiveRateLimits,
   loadDashboard,
+  refreshBackgroundData,
   refreshPricing,
   scanCodexUsage,
   updateSubscriptionProfile,
@@ -334,15 +335,17 @@ function App() {
   }, [dashboardRevision, loadDetail, loadedQueryKey, selectedRootSessionId])
 
   useEffect(() => {
-    if (!hasBootstrapped) return
+    if (!hasBootstrapped || !syncSettings?.autoScanEnabled) return
     const interval = window.setInterval(() => {
-      void loadShell(false)
+      void refreshBackgroundData()
+        .catch(() => null)
+        .then(() => loadShell(false))
     }, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
     return () => window.clearInterval(interval)
-  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanIntervalMinutes])
+  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes])
 
   useEffect(() => {
-    if (!settingsOpen) return
+    if (!settingsOpen || !syncSettings?.autoScanEnabled) return
     let cancelled = false
     const refresh = () =>
       void getLiveRateLimits()
@@ -358,7 +361,7 @@ function App() {
       cancelled = true
       window.clearInterval(interval)
     }
-  }, [settingsOpen, syncSettings?.autoScanIntervalMinutes])
+  }, [settingsOpen, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes])
 
   async function handleRescan() {
     await loadShell(true)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,7 +96,7 @@ const BUCKETS: OverviewBucket[] = [
 function App() {
   const { language, setLanguage, t } = useI18n()
   const [view, setView] = useState<AppView>('overview')
-  const [bucket, setBucket] = useState<OverviewBucket>('subscription_month')
+  const [bucket, setBucket] = useState<OverviewBucket>('seven_day')
   const [liveWindowOffset, setLiveWindowOffset] = useState(0)
   const [anchor, setAnchor] = useState(todayInputValue())
   const [customStart, setCustomStart] = useState(todayInputValue())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,12 @@ import {
   updateSubscriptionProfile,
   updateSyncSettings,
 } from './app/api'
-import { shouldKeepConversationDetail, waitForOverlappingScan } from './app/dataFreshness'
+import {
+  refreshDashboardAfterBackgroundScan,
+  runScanWithOverlapRetry,
+  shouldKeepConversationDetail,
+  waitForScanToSettleUntilCancelled,
+} from './app/dataFreshness'
 import {
   formatCompactDateTime,
   formatDateTime,
@@ -115,10 +120,11 @@ function App() {
     const startedAt = Date.now()
     while (Date.now() - startedAt < timeoutMs) {
       if (!(await getScanInProgress())) {
-        return
+        return true
       }
       await new Promise((resolve) => window.setTimeout(resolve, 250))
     }
+    return false
   }, [])
 
   useEffect(() => {
@@ -148,17 +154,13 @@ function App() {
     }
     try {
       if (requestScan) {
-        try {
-          const scan = await scanCodexUsage(syncSettingsRef.current?.codexHome ?? null)
-          setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
-        } catch (error) {
-          const message = String(error)
-          if (!message.includes('already running')) {
-            throw error
-          }
-          setStatusMessage(t.status.backgroundScanAlreadyRunning)
-          await waitForScanToSettle()
-        }
+        const scan = await runScanWithOverlapRetry(
+          () => scanCodexUsage(syncSettingsRef.current?.codexHome ?? null),
+          (error) => String(error).includes('already running'),
+          waitForScanToSettle,
+          () => setStatusMessage(t.status.backgroundScanAlreadyRunning),
+        )
+        setStatusMessage(t.status.scannedFiles(scan.scannedFiles, scan.updatedSessions))
       }
 
       const snapshot = await loadDashboard(
@@ -317,7 +319,13 @@ function App() {
     let cancelled = false
 
     const bootstrap = async () => {
-      await waitForScanToSettle(60000)
+      const settled = await waitForScanToSettleUntilCancelled(
+        () => waitForScanToSettle(60000),
+        () => cancelled,
+      )
+      if (!settled || cancelled) {
+        return
+      }
       await loadShellRef.current(false)
       if (!cancelled) {
         setHasBootstrapped(true)
@@ -344,13 +352,21 @@ function App() {
 
   useEffect(() => {
     if (!hasBootstrapped || !syncSettings?.autoScanEnabled) return
-    const interval = window.setInterval(() => {
-      void refreshBackgroundData()
-        .catch(() => null)
-        .then(() => waitForOverlappingScan(getScanInProgress, waitForScanToSettle))
-        .then(() => loadShell(false))
-    }, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
-    return () => window.clearInterval(interval)
+    let cancelled = false
+    const refresh = () => {
+      void refreshDashboardAfterBackgroundScan(
+        refreshBackgroundData,
+        getScanInProgress,
+        waitForScanToSettle,
+        () => loadShell(false),
+        () => cancelled,
+      )
+    }
+    const interval = window.setInterval(refresh, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
   }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes, waitForScanToSettle])
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,6 +182,7 @@ function App() {
         requestLiveWindowOffset,
         requestCustomStart,
         requestCustomEnd,
+        view === 'conversations',
       )
       if (requestId !== latestLoadRequestIdRef.current) {
         return
@@ -197,33 +198,37 @@ function App() {
       const previousQueryKey = loadedQueryKeyRef.current
 
       startTransition(() => {
-        const nextDetailCache = new Map<string, ConversationDetail>()
-        for (const conversation of snapshot.conversationPage.items) {
-          const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
-          if (
-            cachedDetail &&
-            shouldKeepConversationDetail(
-              cachedDetail,
-              conversation,
-              snapshot.subscriptionProfile.monthlyPrice,
-            )
-          ) {
-            nextDetailCache.set(conversation.rootSessionId, cachedDetail)
+        if (view === 'conversations') {
+          const nextDetailCache = new Map<string, ConversationDetail>()
+          for (const conversation of snapshot.conversationPage.items) {
+            const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
+            if (
+              cachedDetail &&
+              shouldKeepConversationDetail(
+                cachedDetail,
+                conversation,
+                snapshot.subscriptionProfile.monthlyPrice,
+              )
+            ) {
+              nextDetailCache.set(conversation.rootSessionId, cachedDetail)
+            }
           }
-        }
 
-        latestDetailRequestIdRef.current += 1
+          latestDetailRequestIdRef.current += 1
+          detailCacheRef.current = nextDetailCache
+          setDetail((current) =>
+            current && nextDetailCache.get(current.rootSessionId) === current ? current : null,
+          )
+        }
         setOverview(snapshot.overview)
-        setConversations(snapshot.conversationPage.items)
-        setConversationCursor(snapshot.conversationPage.nextCursor)
-        setHasMoreConversations(snapshot.conversationPage.hasMore)
+        if (view === 'conversations') {
+          setConversations(snapshot.conversationPage.items)
+          setConversationCursor(snapshot.conversationPage.nextCursor)
+          setHasMoreConversations(snapshot.conversationPage.hasMore)
+        }
         setSyncSettings(snapshot.syncSettings)
         setSubscriptionProfile(snapshot.subscriptionProfile)
         setLiveRateLimits(snapshot.liveRateLimits)
-        detailCacheRef.current = nextDetailCache
-        setDetail((current) =>
-          current && nextDetailCache.get(current.rootSessionId) === current ? current : null,
-        )
         setDashboardRevision((current) => current + 1)
         setLiveWindowOffset(snapshot.overview.liveWindowOffset)
         loadedQueryKeyRef.current = resolvedQueryKey
@@ -240,7 +245,7 @@ function App() {
         setStatusMessage(t.status.failedToLoad(t.buckets[requestBucket], String(error)))
       }
     }
-  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t])
+  }, [anchor, bucket, customEnd, customStart, deferredSearch, liveWindowOffset, t, view])
 
   const loadMoreConversations = useCallback(async () => {
     if (!conversationCursor || !hasMoreConversations || loadingMoreConversations) return
@@ -368,26 +373,24 @@ function App() {
         void loadShellRef.current(true)
       }, 200)
     }
-    const handleCompletion = async (event: RefreshCompletedEvent) => {
-      let visible: boolean
+    const isDashboardActive = async () => {
       try {
-        visible = await getCurrentWindow().isVisible()
+        const [visible, focused] = await Promise.all([appWindow.isVisible(), appWindow.isFocused()])
+        return visible && focused
       } catch {
-        return
+        return false
       }
+    }
+    const handleCompletion = async (event: RefreshCompletedEvent) => {
+      const active = await isDashboardActive()
       if (cancelled) return
-      if (refreshRevisionGateRef.current.accept(event, visible) === 'reload') {
+      if (refreshRevisionGateRef.current.accept(event, active) === 'reload') {
         reloadDashboard()
       }
     }
     const handleVisible = async () => {
-      let visible: boolean
-      try {
-        visible = await getCurrentWindow().isVisible()
-      } catch {
-        return
-      }
-      if (cancelled || !visible) return
+      const active = await isDashboardActive()
+      if (cancelled || !active) return
       if (refreshRevisionGateRef.current.onVisible() === 'reload') {
         reloadDashboard()
       }
@@ -521,6 +524,11 @@ function App() {
     if (lastRequestedQueryKeyRef.current === currentQueryKey) return
     void loadShell(false)
   }, [currentQueryKey, hasBootstrapped, loadShell])
+
+  useEffect(() => {
+    if (!hasBootstrapped || view !== 'conversations') return
+    void loadShell(false)
+  }, [hasBootstrapped, loadShell, view])
 
   useEffect(() => {
     if (!loadedQueryKey && selectedRootSessionId) return

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
   updateSubscriptionProfile,
   updateSyncSettings,
 } from './app/api'
+import { shouldKeepConversationDetail, waitForOverlappingScan } from './app/dataFreshness'
 import {
   formatCompactDateTime,
   formatDateTime,
@@ -176,7 +177,14 @@ function App() {
         const nextDetailCache = new Map<string, ConversationDetail>()
         for (const conversation of snapshot.conversations) {
           const cachedDetail = detailCacheRef.current.get(conversation.rootSessionId)
-          if (cachedDetail && cachedDetail.updatedAt === conversation.updatedAt) {
+          if (
+            cachedDetail &&
+            shouldKeepConversationDetail(
+              cachedDetail,
+              conversation,
+              snapshot.subscriptionProfile.monthlyPrice,
+            )
+          ) {
             nextDetailCache.set(conversation.rootSessionId, cachedDetail)
           }
         }
@@ -339,10 +347,11 @@ function App() {
     const interval = window.setInterval(() => {
       void refreshBackgroundData()
         .catch(() => null)
+        .then(() => waitForOverlappingScan(getScanInProgress, waitForScanToSettle))
         .then(() => loadShell(false))
     }, unifiedRefreshIntervalMs(syncSettings?.autoScanIntervalMinutes))
     return () => window.clearInterval(interval)
-  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes])
+  }, [bucket, hasBootstrapped, loadShell, syncSettings?.autoScanEnabled, syncSettings?.autoScanIntervalMinutes, waitForScanToSettle])
 
   useEffect(() => {
     if (!settingsOpen || !syncSettings?.autoScanEnabled) return
@@ -384,13 +393,16 @@ function App() {
     syncSettings: SyncSettings
     subscriptionProfile: SubscriptionProfile
   }) {
+    const previousCodexHome = syncSettingsRef.current?.codexHome ?? null
     const [nextSyncSettings, nextSubscriptionProfile] = await Promise.all([
       updateSyncSettings(payload.syncSettings),
       updateSubscriptionProfile(payload.subscriptionProfile),
     ])
+    const codexHomeChanged = previousCodexHome !== nextSyncSettings.codexHome
+    syncSettingsRef.current = nextSyncSettings
     setSyncSettings(nextSyncSettings)
     setSubscriptionProfile(nextSubscriptionProfile)
-    await loadShell(false)
+    await loadShell(codexHomeChanged)
     if (isTauri()) {
       await emitTo(MENU_BAR_POPUP_WINDOW_LABEL, MENU_BAR_POPUP_REFRESH_EVENT, {}).catch(() => {})
     }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -214,10 +214,6 @@ export async function getScanInProgress() {
   return invokeOrMock('getScanInProgress', {}, () => false)
 }
 
-export async function refreshBackgroundData(): Promise<import('./types').ScanResult | null> {
-  return invokeOrMock('refreshBackgroundData', {}, () => null)
-}
-
 export async function refreshPricing() {
   return invokeOrMock('refreshPricing', {}, () => [])
 }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2,7 +2,7 @@ import { invoke, isTauri } from '@tauri-apps/api/core'
 
 import type {
   ConversationFilters,
-  ConversationListItem,
+  ConversationPage,
   LiveRateLimitSnapshot,
   MenuBarPopupSnapshot,
   OverviewBucket,
@@ -206,6 +206,10 @@ export async function scanCodexUsage(codexHome?: string | null): Promise<import(
     importedSessions: 0,
     updatedSessions: 0,
     missingSessions: 0,
+    scanKind: 'incremental',
+    sourceBytesRead: 0,
+    tailParsedFiles: 0,
+    fullyParsedFiles: 0,
     lastCompletedAt: nowIso(),
   }))
 }
@@ -257,7 +261,7 @@ export async function loadDashboard(
     },
     () => ({
       overview: createMockOverview(bucket, anchor, customStart, customEnd),
-      conversations: [] as ConversationListItem[],
+      conversationPage: { items: [], nextCursor: null, hasMore: false } satisfies ConversationPage,
       syncSettings: createMockSyncSettings(),
       subscriptionProfile: createMockSubscriptionProfile(),
       liveRateLimits: createMockLiveRateLimits(),
@@ -265,8 +269,12 @@ export async function loadDashboard(
   )
 }
 
-export async function listConversations(filters: ConversationFilters) {
-  return invokeOrMock('listConversations', { filters }, () => [] satisfies ConversationListItem[])
+export async function listConversations(filters: ConversationFilters): Promise<ConversationPage> {
+  return invokeOrMock(
+    'listConversations',
+    { filters },
+    () => ({ items: [], nextCursor: null, hasMore: false }) satisfies ConversationPage,
+  )
 }
 
 export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {
@@ -275,8 +283,9 @@ export async function getLiveRateLimits(): Promise<LiveRateLimitSnapshot> {
 
 export async function getConversationDetail(
   rootSessionId: string,
+  turnCursor?: number | null,
 ): Promise<import('./types').ConversationDetail> {
-  return invokeOrMock('getConversationDetail', { rootSessionId }, () => {
+  return invokeOrMock('getConversationDetail', { rootSessionId, turnCursor: turnCursor ?? null }, () => {
     throw new Error(`Conversation ${rootSessionId} is unavailable in browser preview mode.`)
   })
 }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -214,6 +214,10 @@ export async function getScanInProgress() {
   return invokeOrMock('getScanInProgress', {}, () => false)
 }
 
+export async function refreshBackgroundData(): Promise<import('./types').ScanResult | null> {
+  return invokeOrMock('refreshBackgroundData', {}, () => null)
+}
+
 export async function refreshPricing() {
   return invokeOrMock('refreshPricing', {}, () => [])
 }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -248,6 +248,7 @@ export async function loadDashboard(
   liveWindowOffset?: number | null,
   customStart?: string | null,
   customEnd?: string | null,
+  includeConversations = false,
 ): Promise<import('./types').DashboardSnapshot> {
   return invokeOrMock(
     'loadDashboard',
@@ -258,6 +259,7 @@ export async function loadDashboard(
       customEnd: bucket === 'custom' ? customEnd ?? null : null,
       search: search ?? null,
       liveWindowOffset: liveWindowOffset ?? null,
+      includeConversations,
     },
     () => ({
       overview: createMockOverview(bucket, anchor, customStart, customEnd),

--- a/src/app/dataFreshness.ts
+++ b/src/app/dataFreshness.ts
@@ -1,0 +1,30 @@
+import type { ConversationDetail, ConversationListItem } from './types.ts'
+
+const FLOAT_EPSILON = 1e-9
+
+function nearlyEqual(left: number, right: number): boolean {
+  return Math.abs(left - right) <= FLOAT_EPSILON
+}
+
+export function shouldKeepConversationDetail(
+  cached: ConversationDetail,
+  summary: ConversationListItem,
+  monthlyPrice: number,
+): boolean {
+  const expectedSubscriptionShare = monthlyPrice > 0 ? summary.apiValueUsd / monthlyPrice : 0
+
+  return (
+    cached.updatedAt === summary.updatedAt &&
+    nearlyEqual(cached.apiValueUsd, summary.apiValueUsd) &&
+    nearlyEqual(cached.subscriptionShare, expectedSubscriptionShare)
+  )
+}
+
+export async function waitForOverlappingScan(
+  getScanInProgress: () => Promise<boolean>,
+  waitForScanToSettle: () => Promise<void>,
+): Promise<void> {
+  if (await getScanInProgress()) {
+    await waitForScanToSettle()
+  }
+}

--- a/src/app/dataFreshness.ts
+++ b/src/app/dataFreshness.ts
@@ -22,9 +22,73 @@ export function shouldKeepConversationDetail(
 
 export async function waitForOverlappingScan(
   getScanInProgress: () => Promise<boolean>,
-  waitForScanToSettle: () => Promise<void>,
-): Promise<void> {
+  waitForScanToSettle: () => Promise<boolean>,
+): Promise<boolean> {
   if (await getScanInProgress()) {
-    await waitForScanToSettle()
+    return waitForScanToSettle()
   }
+  return true
+}
+
+export async function runScanWithOverlapRetry<T>(
+  runScan: () => Promise<T>,
+  isOverlappingScanError: (error: unknown) => boolean,
+  waitForScanToSettle: () => Promise<boolean>,
+  onOverlap: () => void = () => {},
+): Promise<T> {
+  try {
+    return await runScan()
+  } catch (error) {
+    if (!isOverlappingScanError(error)) {
+      throw error
+    }
+    onOverlap()
+    if (!(await waitForScanToSettle())) {
+      throw new Error('The active scan did not finish before the timeout.')
+    }
+    return runScan()
+  }
+}
+
+export async function refreshDashboardAfterBackgroundScan(
+  refreshBackgroundData: () => Promise<unknown>,
+  getScanInProgress: () => Promise<boolean>,
+  waitForScanToSettle: () => Promise<boolean>,
+  loadDashboard: () => Promise<void>,
+  isCancelled: () => boolean = () => false,
+): Promise<void> {
+  if (isCancelled()) {
+    return
+  }
+  try {
+    await refreshBackgroundData()
+  } catch {
+    // Keep loading persisted data when the background refresh itself fails.
+  }
+  if (isCancelled()) {
+    return
+  }
+
+  let settled: boolean
+  try {
+    settled = await waitForOverlappingScan(getScanInProgress, waitForScanToSettle)
+  } catch {
+    return
+  }
+  if (!settled || isCancelled()) {
+    return
+  }
+  await loadDashboard()
+}
+
+export async function waitForScanToSettleUntilCancelled(
+  waitForScanToSettle: () => Promise<boolean>,
+  isCancelled: () => boolean,
+): Promise<boolean> {
+  while (!isCancelled()) {
+    if (await waitForScanToSettle()) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/app/dataFreshness.ts
+++ b/src/app/dataFreshness.ts
@@ -6,18 +6,52 @@ function nearlyEqual(left: number, right: number): boolean {
   return Math.abs(left - right) <= FLOAT_EPSILON
 }
 
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false
+  const sortedLeft = [...left].sort()
+  const sortedRight = [...right].sort()
+  return sortedLeft.every((value, index) => value === sortedRight[index])
+}
+
 export function shouldKeepConversationDetail(
   cached: ConversationDetail,
   summary: ConversationListItem,
   monthlyPrice: number,
 ): boolean {
   const expectedSubscriptionShare = monthlyPrice > 0 ? summary.apiValueUsd / monthlyPrice : 0
+  const cachedModelIds = cached.modelBreakdown.map((item) => item.modelId)
+  const cachedSubagentCount = cached.sessions.filter((session) => session.isSubagent).length
+  const cachedHasFastMode = cached.sessions.some((session) => session.fastModeEffective)
 
   return (
+    cached.rootSessionId === summary.rootSessionId &&
+    cached.title === summary.title &&
+    cached.startedAt === summary.startedAt &&
     cached.updatedAt === summary.updatedAt &&
+    sameStringSet(cachedModelIds, summary.modelIds) &&
+    cached.inputTokens === summary.inputTokens &&
+    cached.cachedInputTokens === summary.cachedInputTokens &&
+    cached.outputTokens === summary.outputTokens &&
+    cached.reasoningOutputTokens === summary.reasoningOutputTokens &&
+    cached.totalTokens === summary.totalTokens &&
+    cached.sessions.length === summary.sessionCount &&
+    cachedSubagentCount === summary.subagentCount &&
+    cached.multipleAgent === (summary.sessionCount > 1) &&
+    cachedHasFastMode === summary.hasFastMode &&
     nearlyEqual(cached.apiValueUsd, summary.apiValueUsd) &&
-    nearlyEqual(cached.subscriptionShare, expectedSubscriptionShare)
+    nearlyEqual(summary.subscriptionShare, expectedSubscriptionShare) &&
+    nearlyEqual(cached.subscriptionShare, expectedSubscriptionShare) &&
+    sameStringSet(cached.sourceStates, summary.sourceStates)
   )
+}
+
+export async function loadConversationDetailForGeneration<T>(
+  loadDetail: () => Promise<T>,
+  requestGeneration: number,
+  getCurrentGeneration: () => number,
+): Promise<T | null> {
+  const detail = await loadDetail()
+  return requestGeneration === getCurrentGeneration() ? detail : null
 }
 
 export async function waitForOverlappingScan(

--- a/src/app/dataFreshness.ts
+++ b/src/app/dataFreshness.ts
@@ -54,16 +54,6 @@ export async function loadConversationDetailForGeneration<T>(
   return requestGeneration === getCurrentGeneration() ? detail : null
 }
 
-export async function waitForOverlappingScan(
-  getScanInProgress: () => Promise<boolean>,
-  waitForScanToSettle: () => Promise<boolean>,
-): Promise<boolean> {
-  if (await getScanInProgress()) {
-    return waitForScanToSettle()
-  }
-  return true
-}
-
 export async function runScanWithOverlapRetry<T>(
   runScan: () => Promise<T>,
   isOverlappingScanError: (error: unknown) => boolean,
@@ -82,47 +72,4 @@ export async function runScanWithOverlapRetry<T>(
     }
     return runScan()
   }
-}
-
-export async function refreshDashboardAfterBackgroundScan(
-  refreshBackgroundData: () => Promise<unknown>,
-  getScanInProgress: () => Promise<boolean>,
-  waitForScanToSettle: () => Promise<boolean>,
-  loadDashboard: () => Promise<void>,
-  isCancelled: () => boolean = () => false,
-): Promise<void> {
-  if (isCancelled()) {
-    return
-  }
-  try {
-    await refreshBackgroundData()
-  } catch {
-    // Keep loading persisted data when the background refresh itself fails.
-  }
-  if (isCancelled()) {
-    return
-  }
-
-  let settled: boolean
-  try {
-    settled = await waitForOverlappingScan(getScanInProgress, waitForScanToSettle)
-  } catch {
-    return
-  }
-  if (!settled || isCancelled()) {
-    return
-  }
-  await loadDashboard()
-}
-
-export async function waitForScanToSettleUntilCancelled(
-  waitForScanToSettle: () => Promise<boolean>,
-  isCancelled: () => boolean,
-): Promise<boolean> {
-  while (!isCancelled()) {
-    if (await waitForScanToSettle()) {
-      return true
-    }
-  }
-  return false
 }

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -96,6 +96,8 @@ export type TranslationSet = {
     title: string
     shown: (count: number) => string
     empty: string
+    loadMore: string
+    loadingMore: string
   }
   detail: {
     eyebrow: string
@@ -105,6 +107,8 @@ export type TranslationSet = {
     turnTimelineEyebrow: string
     turnUsage: string
     latestTurns: (count: number) => string
+    loadEarlierTurns: string
+    loadingEarlierTurns: string
     emptyTurns: string
     emptySelection: string
     untitledTurn: string
@@ -345,6 +349,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       title: '根会话',
       shown: (count) => `显示 ${count} 条`,
       empty: '当前筛选条件下没有匹配对话。',
+      loadMore: '加载更多',
+      loadingMore: '正在加载…',
     },
     detail: {
       eyebrow: '对话详情',
@@ -353,6 +359,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       conversationCostBreakdown: '对话成本结构',
       turnTimelineEyebrow: 'Turn 时间线',
       turnUsage: 'Turn 用量',
+      loadEarlierTurns: '加载更早记录',
+      loadingEarlierTurns: '正在加载…',
       latestTurns: (count) => `最近 ${count} 个 turn`,
       emptyTurns: '该对话暂无 turn 级来源数据。',
       emptySelection: '选择一个对话以查看详细账本。',
@@ -587,6 +595,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       title: 'Root sessions',
       shown: (count) => `${count} shown`,
       empty: 'No conversations matched the current filter.',
+      loadMore: 'Load more',
+      loadingMore: 'Loading…',
     },
     detail: {
       eyebrow: 'Conversation detail',
@@ -596,6 +606,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       turnTimelineEyebrow: 'Turn timeline',
       turnUsage: 'Turn usage',
       latestTurns: (count) => `Latest ${count} turns`,
+      loadEarlierTurns: 'Load earlier turns',
+      loadingEarlierTurns: 'Loading…',
       emptyTurns: 'No turn-level source data is available for this conversation.',
       emptySelection: 'Select a conversation to inspect its detailed ledger.',
       untitledTurn: 'Untitled turn',

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -184,8 +184,6 @@ export type TranslationSet = {
         autoScanEnabled: string
         autoScanEnabledNote: string
         autoScanIntervalMinutes: string
-        liveQuotaRefreshIntervalSeconds: string
-        liveQuotaRefreshNote: string
       }
       menuBar: {
         eyebrow: string
@@ -427,14 +425,12 @@ const translations: Record<AppLanguage, TranslationSet> = {
         sync: {
           eyebrow: '同步',
           title: '扫描与数据源',
-          description: '控制 Codex 数据目录、自动扫描频率，以及 live quota 的刷新周期。',
+          description: '控制 Codex 数据目录，以及所有后台自动刷新的统一频率。',
           codexHome: 'Codex home',
           codexHomePlaceholder: '默认使用 CODEX_HOME 或 ~/.codex',
           autoScanEnabled: '启用自动扫描',
           autoScanEnabledNote: '关闭后仅保留手动扫描，不再按周期自动刷新数据。',
-          autoScanIntervalMinutes: '自动扫描间隔（分钟）',
-          liveQuotaRefreshIntervalSeconds: 'Live quota 刷新间隔（分钟）',
-          liveQuotaRefreshNote: '独立控制 `5小时 / 7天` live quota 的主动刷新与历史持久化频率。',
+          autoScanIntervalMinutes: '后台自动刷新间隔（分钟）',
         },
         menuBar: {
           eyebrow: '托盘',
@@ -669,14 +665,12 @@ const translations: Record<AppLanguage, TranslationSet> = {
         sync: {
           eyebrow: 'Sync',
           title: 'Scan and data sources',
-          description: 'Control the Codex data directory, automatic scan cadence, and live quota refresh interval.',
+          description: 'Control the Codex data directory and the unified cadence for all background refreshes.',
           codexHome: 'Codex home',
           codexHomePlaceholder: 'Defaults to CODEX_HOME or ~/.codex',
           autoScanEnabled: 'Auto scan enabled',
           autoScanEnabledNote: 'When disabled, only manual scans are kept and periodic refresh stops.',
-          autoScanIntervalMinutes: 'Auto scan interval (minutes)',
-          liveQuotaRefreshIntervalSeconds: 'Live quota refresh interval (minutes)',
-          liveQuotaRefreshNote: 'Separately controls active refresh and history persistence for `5h / 7d` live quota snapshots.',
+          autoScanIntervalMinutes: 'Background refresh interval (minutes)',
         },
         menuBar: {
           eyebrow: 'Tray',

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -59,6 +59,8 @@ export type TranslationSet = {
     failedToLoad: (bucketLabel: string, error: string) => string
     pricingRefreshed: string
     settingsSaved: string
+    settingsSaveFailed: (error: string) => string
+    settingsStillLoading: string
     waitingLiveQuota: string
   }
   buckets: Record<OverviewBucket, string>
@@ -296,6 +298,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       failedToLoad: (bucketLabel, error) => `加载${bucketLabel}失败：${error}`,
       pricingRefreshed: '已按 OpenAI 标准短上下文定价刷新目录。',
       settingsSaved: '设置已保存。',
+      settingsSaveFailed: (error) => `设置未保存：${error}`,
+      settingsStillLoading: '设置仍在加载，请稍后重试。',
       waitingLiveQuota: '等待 live quota',
     },
     buckets: {
@@ -536,6 +540,8 @@ const translations: Record<AppLanguage, TranslationSet> = {
       failedToLoad: (bucketLabel, error) => `Failed to load ${bucketLabel}: ${error}`,
       pricingRefreshed: 'Pricing catalog refreshed from OpenAI Standard short-context pricing.',
       settingsSaved: 'Settings saved.',
+      settingsSaveFailed: (error) => `Settings were not saved: ${error}`,
+      settingsStillLoading: 'Settings are still loading. Try again in a moment.',
       waitingLiveQuota: 'Waiting for live quota',
     },
     buckets: {

--- a/src/app/refreshEvents.ts
+++ b/src/app/refreshEvents.ts
@@ -1,0 +1,50 @@
+import type { RefreshCompletedEvent } from './types.ts'
+
+export type SurfaceRevisionDecision = 'reload' | 'defer' | 'ignore'
+
+export class SurfaceRevisionGate {
+  private appliedRevision = 0
+  private pendingRevision = 0
+
+  accept(event: RefreshCompletedEvent, visible: boolean): SurfaceRevisionDecision {
+    if (
+      !event.succeeded ||
+      event.refreshRevision <= Math.max(this.appliedRevision, this.pendingRevision)
+    ) {
+      return 'ignore'
+    }
+    if (!visible) {
+      this.pendingRevision = event.refreshRevision
+      return 'defer'
+    }
+    this.appliedRevision = event.refreshRevision
+    return 'reload'
+  }
+
+  onVisible(): 'reload' | 'ignore' {
+    if (this.pendingRevision <= this.appliedRevision) {
+      return 'ignore'
+    }
+    this.appliedRevision = this.pendingRevision
+    return 'reload'
+  }
+}
+
+export interface RefreshSurfaceState<T> {
+  data: T | null
+  loading: boolean
+  refreshing: boolean
+  error: string | null
+}
+
+export function settleRefreshFailure<T>(
+  state: RefreshSurfaceState<T>,
+  error: unknown,
+): RefreshSurfaceState<T> {
+  return {
+    ...state,
+    loading: false,
+    refreshing: false,
+    error: state.data === null ? String(error) : null,
+  }
+}

--- a/src/app/refreshEvents.ts
+++ b/src/app/refreshEvents.ts
@@ -41,6 +41,14 @@ export function shouldLoadDashboardAfterSettingsSave(
   return !codexHomeChanged || !listenerReady
 }
 
+export function selectionAfterDashboardReload(
+  currentSelection: string | null,
+  loadedQueryKey: string | null,
+  resolvedQueryKey: string,
+): string | null {
+  return loadedQueryKey === resolvedQueryKey ? currentSelection : null
+}
+
 export type SurfaceRequestKind = 'passive' | 'manual'
 
 export interface SurfaceRequestClaim {

--- a/src/app/refreshEvents.ts
+++ b/src/app/refreshEvents.ts
@@ -30,6 +30,55 @@ export class SurfaceRevisionGate {
   }
 }
 
+export function shouldLoadDashboardAfterManualRefresh(listenerReady: boolean): boolean {
+  return !listenerReady
+}
+
+export function shouldLoadDashboardAfterSettingsSave(
+  codexHomeChanged: boolean,
+  listenerReady: boolean,
+): boolean {
+  return !codexHomeChanged || !listenerReady
+}
+
+export type SurfaceRequestKind = 'passive' | 'manual'
+
+export interface SurfaceRequestClaim {
+  readonly id: number
+  readonly kind: SurfaceRequestKind
+}
+
+export class SurfaceRequestController {
+  private latestRequestId = 0
+  private manualRequestId: number | null = null
+
+  get manualInFlight(): boolean {
+    return this.manualRequestId !== null
+  }
+
+  claim(kind: SurfaceRequestKind): SurfaceRequestClaim | null {
+    if (kind === 'manual' && this.manualRequestId !== null) {
+      return null
+    }
+    const claim = { id: this.latestRequestId + 1, kind }
+    this.latestRequestId = claim.id
+    if (kind === 'manual') {
+      this.manualRequestId = claim.id
+    }
+    return claim
+  }
+
+  isLatest(claim: SurfaceRequestClaim): boolean {
+    return claim.id === this.latestRequestId
+  }
+
+  finish(claim: SurfaceRequestClaim): void {
+    if (claim.kind === 'manual' && claim.id === this.manualRequestId) {
+      this.manualRequestId = null
+    }
+  }
+}
+
 export interface RefreshSurfaceState<T> {
   data: T | null
   loading: boolean

--- a/src/app/settingsSave.ts
+++ b/src/app/settingsSave.ts
@@ -1,0 +1,98 @@
+interface CodexHomeSettings {
+  codexHome: string | null
+}
+
+interface SaveSettingsOptions<TSyncSettings extends CodexHomeSettings, TSubscriptionProfile> {
+  previousSyncSettings: TSyncSettings
+  nextSyncSettings: TSyncSettings
+  previousSubscriptionProfile: TSubscriptionProfile
+  nextSubscriptionProfile: TSubscriptionProfile
+  updateSyncSettings: (settings: TSyncSettings) => Promise<TSyncSettings>
+  updateSubscriptionProfile: (profile: TSubscriptionProfile) => Promise<TSubscriptionProfile>
+  scanCodexHome: (codexHome: string | null) => Promise<unknown>
+}
+
+interface SavedSettings<TSyncSettings, TSubscriptionProfile> {
+  syncSettings: TSyncSettings
+  subscriptionProfile: TSubscriptionProfile
+  codexHomeChanged: boolean
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function closeSettingsPanelIfIdle(saving: boolean, onClose: () => void): boolean {
+  if (saving) return false
+  onClose()
+  return true
+}
+
+export async function saveSettingsWithCodexHomeRollback<
+  TSyncSettings extends CodexHomeSettings,
+  TSubscriptionProfile,
+>({
+  previousSyncSettings,
+  nextSyncSettings,
+  previousSubscriptionProfile,
+  nextSubscriptionProfile,
+  updateSyncSettings,
+  updateSubscriptionProfile,
+  scanCodexHome,
+}: SaveSettingsOptions<TSyncSettings, TSubscriptionProfile>): Promise<
+  SavedSettings<TSyncSettings, TSubscriptionProfile>
+> {
+  let savedSyncSettings: TSyncSettings | null = null
+  let savedSubscriptionProfile: TSubscriptionProfile | null = null
+
+  try {
+    savedSyncSettings = await updateSyncSettings(nextSyncSettings)
+    savedSubscriptionProfile = await updateSubscriptionProfile(nextSubscriptionProfile)
+    const codexHomeChanged = previousSyncSettings.codexHome !== savedSyncSettings.codexHome
+    if (codexHomeChanged) {
+      await scanCodexHome(savedSyncSettings.codexHome)
+    }
+
+    return {
+      syncSettings: savedSyncSettings,
+      subscriptionProfile: savedSubscriptionProfile,
+      codexHomeChanged,
+    }
+  } catch (error) {
+    const rollbackErrors: string[] = []
+    let syncSettingsRestored = savedSyncSettings === null
+    if (savedSyncSettings) {
+      try {
+        await updateSyncSettings(previousSyncSettings)
+        syncSettingsRestored = true
+      } catch (rollbackError) {
+        rollbackErrors.push(errorMessage(rollbackError))
+      }
+    }
+    if (savedSubscriptionProfile) {
+      try {
+        await updateSubscriptionProfile(previousSubscriptionProfile)
+      } catch (rollbackError) {
+        rollbackErrors.push(errorMessage(rollbackError))
+      }
+    }
+    if (
+      savedSyncSettings &&
+      syncSettingsRestored &&
+      previousSyncSettings.codexHome !== savedSyncSettings.codexHome
+    ) {
+      try {
+        await scanCodexHome(previousSyncSettings.codexHome)
+      } catch (rollbackError) {
+        rollbackErrors.push(errorMessage(rollbackError))
+      }
+    }
+
+    if (rollbackErrors.length > 0) {
+      throw new Error(
+        `${errorMessage(error)} Previous settings could not be fully restored: ${rollbackErrors.join('; ')}`,
+      )
+    }
+    throw error
+  }
+}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -64,6 +64,18 @@ export interface ScanResult {
   lastCompletedAt: string
 }
 
+export interface RefreshCompletedEvent {
+  refreshRevision: number
+  lane: 'token' | 'live'
+  generation: number
+  usageRevision: number
+  quotaRevision: number
+  sourceGeneration: number
+  succeeded: boolean
+  failure: string | null
+  completedAt: string
+}
+
 export interface OverviewStats {
   apiValueUsd: number
   subscriptionCostUsd: number

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -61,6 +61,10 @@ export interface ScanResult {
   importedSessions: number
   updatedSessions: number
   missingSessions: number
+  scanKind: 'incremental' | 'reconcile' | 'full'
+  sourceBytesRead: number
+  tailParsedFiles: number
+  fullyParsedFiles: number
   lastCompletedAt: string
 }
 
@@ -200,7 +204,7 @@ export interface OverviewResponse {
 
 export interface DashboardSnapshot {
   overview: OverviewResponse
-  conversations: ConversationListItem[]
+  conversationPage: ConversationPage
   syncSettings: SyncSettings
   subscriptionProfile: SubscriptionProfile
   liveRateLimits: LiveRateLimitSnapshot | null
@@ -213,6 +217,14 @@ export interface ConversationFilters {
   customEnd?: string | null
   search?: string | null
   liveWindowOffset?: number | null
+  cursor?: string | null
+  limit?: number | null
+}
+
+export interface ConversationPage {
+  items: ConversationListItem[]
+  nextCursor: string | null
+  hasMore: boolean
 }
 
 export interface ConversationListItem {
@@ -291,6 +303,8 @@ export interface ConversationDetail {
   sourceStates: string[]
   sessions: ConversationSessionSummary[]
   turns: ConversationTurnPoint[]
+  nextTurnCursor: number | null
+  hasMoreTurns: boolean
   modelBreakdown: ModelShare[]
   compositionBreakdown: CompositionShare[]
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -52,14 +52,6 @@ function SwitchField({ label, checked, disabled = false, onChange }: SwitchField
   )
 }
 
-function refreshSecondsToMinutes(seconds: number) {
-  return Math.max(1, Math.round(seconds / 60))
-}
-
-function refreshMinutesToSeconds(minutes: number) {
-  return Math.min(60, Math.max(1, minutes)) * 60
-}
-
 function isMacOs() {
   return typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac')
 }
@@ -272,37 +264,16 @@ export function SettingsPanel({
                     type="number"
                     value={draftSync.autoScanIntervalMinutes}
                     onChange={(event) =>
-                      setDraftSync((current) =>
-                        current
+                      setDraftSync((current) => {
+                        const intervalMinutes = Math.max(1, Number(event.target.value || 5))
+                        return current
                           ? {
                               ...current,
-                              autoScanIntervalMinutes: Math.max(1, Number(event.target.value || 5)),
+                              autoScanIntervalMinutes: intervalMinutes,
+                              liveQuotaRefreshIntervalSeconds: intervalMinutes * 60,
                             }
-                          : current,
-                      )
-                    }
-                  />
-                </label>
-
-                <label className="field">
-                  <span>{t.settings.sections.sync.liveQuotaRefreshIntervalSeconds}</span>
-                  <input
-                    min={1}
-                    max={60}
-                    step={1}
-                    type="number"
-                    value={refreshSecondsToMinutes(draftSync.liveQuotaRefreshIntervalSeconds)}
-                    onChange={(event) =>
-                      setDraftSync((current) =>
-                        current
-                          ? {
-                              ...current,
-                              liveQuotaRefreshIntervalSeconds: refreshMinutesToSeconds(
-                                Number(event.target.value || 5),
-                              ),
-                            }
-                          : current,
-                      )
+                          : current
+                      })
                     }
                   />
                 </label>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 
 import { formatPercent, formatRemainingDuration } from '../app/format'
 import { SUPPORTED_LANGUAGES, type AppLanguage } from '../app/i18n'
+import { closeSettingsPanelIfIdle } from '../app/settingsSave'
 import { useI18n } from '../app/useI18n'
 import type {
   LiveRateLimitSnapshot,
@@ -72,8 +73,10 @@ export function SettingsPanel({
     subscriptionProfile,
   )
   const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const wasOpenRef = useRef(false)
   const showDockSettings = isMacOs()
+  const handleClose = () => closeSettingsPanelIfIdle(saving, onClose)
 
   useEffect(() => {
     const justOpened = isOpen && !wasOpenRef.current
@@ -82,10 +85,12 @@ export function SettingsPanel({
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
       setSaving(false)
+      setSaveError(null)
     } else if (!isOpen && wasOpenRef.current) {
       setDraftSync(syncSettings)
       setDraftSubscription(subscriptionProfile)
       setSaving(false)
+      setSaveError(null)
     }
 
     wasOpenRef.current = isOpen
@@ -165,6 +170,7 @@ export function SettingsPanel({
   async function handleSubmit() {
     if (!draftSync || !draftSubscription) return
     setSaving(true)
+    setSaveError(null)
     try {
       const nextSync = draftSync
       const nextSubscription = draftSubscription
@@ -173,20 +179,22 @@ export function SettingsPanel({
         subscriptionProfile: nextSubscription,
       })
       onClose()
+    } catch (error) {
+      setSaveError(t.status.settingsSaveFailed(String(error)))
     } finally {
       setSaving(false)
     }
   }
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <div className="modal-backdrop" onClick={handleClose}>
       <div className="modal-panel settings-modal-panel" onClick={(event) => event.stopPropagation()}>
         <div className="modal-header">
           <div>
             <p className="eyebrow">{t.settings.appSettings}</p>
             <h3>{t.settings.syncAndSubscriptionProfile}</h3>
           </div>
-          <button className="ghost-button" onClick={onClose} type="button">
+          <button className="ghost-button" disabled={saving} onClick={handleClose} type="button">
             {t.actions.close}
           </button>
         </div>
@@ -757,8 +765,14 @@ export function SettingsPanel({
           </div>
         </div>
 
+        {saveError ? (
+          <p className="settings-save-error" role="alert">
+            {saveError}
+          </p>
+        ) : null}
+
         <div className="modal-actions">
-          <button className="ghost-button" onClick={onClose} type="button">
+          <button className="ghost-button" disabled={saving} onClick={handleClose} type="button">
             {t.actions.cancel}
           </button>
           <button className="accent-button" disabled={saving} onClick={handleSubmit} type="button">

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -13,6 +13,7 @@ import {
   formatTokenCount,
   formatUsd,
 } from '../app/format'
+import { settleRefreshFailure, type RefreshSurfaceState } from '../app/refreshEvents'
 import type { MenuBarPopupModuleId, MenuBarPopupSnapshot } from '../app/types'
 import { useI18n } from '../app/useI18n'
 import { PopupStatModuleGrid } from '../components/PopupStatModuleGrid'
@@ -46,42 +47,51 @@ export function MenuBarPopup() {
   const panelRef = useRef<HTMLDivElement | null>(null)
   const lastMeasuredHeightRef = useRef<number | null>(null)
   const resizeFrameRef = useRef(0)
-  const [snapshot, setSnapshot] = useState<MenuBarPopupSnapshot | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [refreshing, setRefreshing] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [loadState, setLoadState] = useState<RefreshSurfaceState<MenuBarPopupSnapshot>>({
+    data: null,
+    loading: true,
+    refreshing: false,
+    error: null,
+  })
+  const { data: snapshot, loading, refreshing, error } = loadState
 
   const loadSnapshot = useCallback(async (forceRefresh = false) => {
-    if (forceRefresh) {
-      setRefreshing(true)
-    } else {
-      setLoading(true)
-    }
+    setLoadState((current) => {
+      if (forceRefresh) {
+        return { ...current, refreshing: true }
+      }
+      return current.data === null ? { ...current, loading: true } : current
+    })
 
+    let failed = false
+    let failure: unknown
     try {
       const nextSnapshot = await getMenuBarPopupSnapshot(forceRefresh)
-      setSnapshot(nextSnapshot)
-      setError(null)
+      setLoadState((current) => ({
+        ...current,
+        data: nextSnapshot,
+        loading: false,
+        error: null,
+      }))
     } catch (loadError) {
-      setError(String(loadError))
+      failed = true
+      failure = loadError
     } finally {
-      setLoading(false)
-      setRefreshing(false)
+      setLoadState((current) => {
+        if (failed) {
+          const settled = settleRefreshFailure(current, failure)
+          return forceRefresh ? settled : { ...settled, refreshing: current.refreshing }
+        }
+        return forceRefresh
+          ? { ...current, refreshing: false }
+          : { ...current, loading: false }
+      })
     }
   }, [])
 
   useEffect(() => {
     void loadSnapshot(false)
   }, [loadSnapshot])
-
-  useEffect(() => {
-    const intervalSeconds = snapshot?.refreshIntervalSeconds ?? 300
-    const interval = window.setInterval(() => {
-      void loadSnapshot(false)
-    }, Math.max(60000, intervalSeconds * 1000))
-
-    return () => window.clearInterval(interval)
-  }, [loadSnapshot, snapshot?.refreshIntervalSeconds])
 
   const schedulePopupResize = useCallback(() => {
     if (!isTauri()) return
@@ -113,8 +123,19 @@ export function MenuBarPopup() {
   useEffect(() => {
     if (!isTauri()) return
 
-    let refreshDispose: (() => void) | undefined
-    let languageDispose: (() => void) | undefined
+    let cancelled = false
+    const disposers = new Set<() => void>()
+    const trackRegistration = (registration: Promise<() => void>) => {
+      void registration
+        .then((dispose) => {
+          if (cancelled) {
+            dispose()
+          } else {
+            disposers.add(dispose)
+          }
+        })
+        .catch(() => {})
+    }
     const resizeObserver = new ResizeObserver(() => {
       schedulePopupResize()
     })
@@ -125,26 +146,31 @@ export function MenuBarPopup() {
     window.addEventListener('resize', schedulePopupResize)
     schedulePopupResize()
 
-    void listen('codex-counter://menu-bar-popup-refresh', () => {
-      void loadSnapshot(false)
-    }).then((unlisten) => {
-      refreshDispose = unlisten
-    })
+    trackRegistration(
+      listen('codex-counter://menu-bar-popup-refresh', () => {
+        if (!cancelled) {
+          void loadSnapshot(false)
+        }
+      }),
+    )
 
-    void listen<{ language?: 'zh-CN' | 'en' }>('codex-counter://language-changed', (event) => {
-      if (event.payload?.language) {
-        setLanguage(event.payload.language)
-      }
-    }).then((unlisten) => {
-      languageDispose = unlisten
-    })
+    trackRegistration(
+      listen<{ language?: 'zh-CN' | 'en' }>('codex-counter://language-changed', (event) => {
+        if (!cancelled && event.payload?.language) {
+          setLanguage(event.payload.language)
+        }
+      }),
+    )
 
     return () => {
+      cancelled = true
       window.cancelAnimationFrame(resizeFrameRef.current)
       window.removeEventListener('resize', schedulePopupResize)
       resizeObserver.disconnect()
-      refreshDispose?.()
-      languageDispose?.()
+      for (const dispose of disposers) {
+        dispose()
+      }
+      disposers.clear()
     }
   }, [loadSnapshot, schedulePopupResize, setLanguage])
 

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { isTauri } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import { ChartNoAxesCombined, RefreshCw } from 'lucide-react'
 
 import { getMenuBarPopupSnapshot, handleMenuBarPopupAction, resizeMenuBarPopup } from '../app/api'
@@ -105,7 +106,16 @@ export function MenuBarPopup() {
   }, [])
 
   useEffect(() => {
-    void loadSnapshot(false)
+    if (!isTauri()) {
+      void loadSnapshot(false)
+      return
+    }
+    void getCurrentWindow()
+      .isVisible()
+      .then((visible) => {
+        if (visible) void loadSnapshot(false)
+      })
+      .catch(() => {})
   }, [loadSnapshot])
 
   const schedulePopupResize = useCallback(() => {
@@ -164,7 +174,12 @@ export function MenuBarPopup() {
     trackRegistration(
       listen('codex-counter://menu-bar-popup-refresh', () => {
         if (!cancelled) {
-          void loadSnapshot(false)
+          void getCurrentWindow()
+            .isVisible()
+            .then((visible) => {
+              if (!cancelled && visible) void loadSnapshot(false)
+            })
+            .catch(() => {})
         }
       }),
     )

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -13,7 +13,11 @@ import {
   formatTokenCount,
   formatUsd,
 } from '../app/format'
-import { settleRefreshFailure, type RefreshSurfaceState } from '../app/refreshEvents'
+import {
+  settleRefreshFailure,
+  SurfaceRequestController,
+  type RefreshSurfaceState,
+} from '../app/refreshEvents'
 import type { MenuBarPopupModuleId, MenuBarPopupSnapshot } from '../app/types'
 import { useI18n } from '../app/useI18n'
 import { PopupStatModuleGrid } from '../components/PopupStatModuleGrid'
@@ -47,6 +51,7 @@ export function MenuBarPopup() {
   const panelRef = useRef<HTMLDivElement | null>(null)
   const lastMeasuredHeightRef = useRef<number | null>(null)
   const resizeFrameRef = useRef(0)
+  const requestControllerRef = useRef(new SurfaceRequestController())
   const [loadState, setLoadState] = useState<RefreshSurfaceState<MenuBarPopupSnapshot>>({
     data: null,
     loading: true,
@@ -56,35 +61,45 @@ export function MenuBarPopup() {
   const { data: snapshot, loading, refreshing, error } = loadState
 
   const loadSnapshot = useCallback(async (forceRefresh = false) => {
+    const claim = requestControllerRef.current.claim(forceRefresh ? 'manual' : 'passive')
+    if (claim === null) return
+    const manualInFlight = requestControllerRef.current.manualInFlight
     setLoadState((current) => {
-      if (forceRefresh) {
-        return { ...current, refreshing: true }
+      return {
+        ...current,
+        loading: forceRefresh ? current.loading : current.data === null,
+        refreshing: manualInFlight,
       }
-      return current.data === null ? { ...current, loading: true } : current
     })
 
     let failed = false
     let failure: unknown
+    let nextSnapshot: MenuBarPopupSnapshot | null = null
     try {
-      const nextSnapshot = await getMenuBarPopupSnapshot(forceRefresh)
-      setLoadState((current) => ({
-        ...current,
-        data: nextSnapshot,
-        loading: false,
-        error: null,
-      }))
+      nextSnapshot = await getMenuBarPopupSnapshot(forceRefresh)
     } catch (loadError) {
       failed = true
       failure = loadError
     } finally {
+      requestControllerRef.current.finish(claim)
       setLoadState((current) => {
-        if (failed) {
-          const settled = settleRefreshFailure(current, failure)
-          return forceRefresh ? settled : { ...settled, refreshing: current.refreshing }
+        let nextState = current
+        if (requestControllerRef.current.isLatest(claim)) {
+          if (failed) {
+            nextState = settleRefreshFailure(current, failure)
+          } else if (nextSnapshot !== null) {
+            nextState = {
+              ...current,
+              data: nextSnapshot,
+              loading: false,
+              error: null,
+            }
+          }
         }
-        return forceRefresh
-          ? { ...current, refreshing: false }
-          : { ...current, loading: false }
+        return {
+          ...nextState,
+          refreshing: requestControllerRef.current.manualInFlight,
+        }
       })
     }
   }, [])
@@ -249,6 +264,7 @@ export function MenuBarPopup() {
               <button
                 aria-label={t.popup.actions.refresh}
                 className="ghost-button popup-icon-button"
+                disabled={refreshing}
                 onClick={() => void loadSnapshot(true)}
                 type="button"
               >

--- a/src/styles.css
+++ b/src/styles.css
@@ -1887,6 +1887,16 @@ select:focus-visible {
   flex: none;
 }
 
+.settings-save-error {
+  margin: 16px 0 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  border-radius: 14px;
+  background: rgba(127, 29, 29, 0.18);
+  color: #fecaca;
+  overflow-wrap: anywhere;
+}
+
 @media (max-width: 1240px) {
   .app-frame {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## What this releases

- brings the completed `develop` work to `main` as Codex Pacer 1.2.2
- stops routine one-minute refreshes from repeatedly walking the full Codex archive
- bounds dashboard and quota reads to the selected window, including exact normalized quota-window queries
- opens the dashboard on the 7-day view and uses that window for the menu bar API-equivalent value when no 5-hour quota exists
- paginates conversation history and loads turn details only after a conversation is selected
- updates application versions, bilingual documentation, upgrade guidance, and 1.2.2 release notes

## Why

Large local Codex histories could make automatic refreshes read far more data than necessary. Accounts without a 5-hour quota could also have their 7-day quota misclassified. This release fixes both problems while preserving existing local data and settings.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --locked --quiet`: 411 passed, 2 ignored
- `npm test -- --run`: 16 passed
- `npm run lint`: passed
- `npm run build`: passed, with the existing Vite chunk-size warning
- `./scripts/release/audit-public-branding.sh`: passed
- `./scripts/release/test-build-macos-release.sh`: passed
- 30-minute one-minute-refresh sample: 34.41 MiB read, 0.14% average single-core CPU, with no recurring full archive scan
- packaged-app 130-second smoke sample: 4 KiB read after launch

## Release scope

After this PR is reviewed and merged, the macOS Apple Silicon DMG will be Developer ID signed, notarized by Apple, stapled, checked with Gatekeeper, and published with its SHA-256 checksum. Windows installer publishing remains paused for 1.2.2.
