### PR TITLE
Fix seven-day API value after quota resets

### DIFF
--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -2931,14 +2931,15 @@ fn read_parent_replay_snapshots_counted(
         let timestamp = envelope.timestamp.ok_or(reader.get_ref().bytes_read)?;
         let details = serde_json::from_str::<ReplayParentTokenDetails>(&line)
           .map_err(|_| reader.get_ref().bytes_read)?;
+        let Some(info) = details.payload.info else {
+          continue;
+        };
 
         snapshots.push(UsageSnapshot {
           timestamp: timestamp.to_string(),
           model_id: String::new(),
-          usage: details.payload.info.total_token_usage.into_token_usage(),
-          last_token_usage: details
-            .payload
-            .info
+          usage: info.total_token_usage.into_token_usage(),
+          last_token_usage: info
             .last_token_usage
             .map(ReplayParentTokenUsage::into_token_usage),
           plan_type: None,
@@ -2987,7 +2988,8 @@ struct ReplayParentTokenDetails {
 
 #[derive(Deserialize)]
 struct ReplayParentTokenPayload {
-  info: ReplayParentTokenInfo,
+  #[serde(default)]
+  info: Option<ReplayParentTokenInfo>,
 }
 
 #[derive(Deserialize)]
@@ -5336,6 +5338,38 @@ mod tests {
   }
 
   #[test]
+  fn parent_replay_reader_ignores_rate_limit_only_token_count() {
+    let directory = tempdir().expect("tempdir");
+    let parent_session_id = "31313131-3131-4131-8131-313131313131";
+    let parent_path = directory.path().join(format!(
+      "rollout-2026-03-24T00-00-00-{parent_session_id}.jsonl"
+    ));
+    let mut body = token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:01Z",
+      total: (100, 0, 0, 100),
+      last: (100, 0, 0, 100),
+    });
+    body.push_str(concat!(
+      "{\"timestamp\":\"2026-03-24T00:00:02Z\",\"type\":\"event_msg\",",
+      "\"payload\":{\"type\":\"token_count\",\"info\":null,",
+      "\"rate_limits\":{\"limit_id\":\"codex\",\"primary\":{",
+      "\"used_percent\":46.0,\"window_minutes\":10080}}}}\n"
+    ));
+    body.push_str(&token_count_line(TokenFixture {
+      timestamp: "2026-03-24T00:00:03Z",
+      total: (180, 0, 0, 180),
+      last: (80, 0, 0, 80),
+    }));
+    std::fs::write(&parent_path, body).expect("write replay parent with rate-limit-only record");
+
+    let snapshots = read_parent_replay_snapshots(&parent_path, parent_session_id)
+      .expect("ignore rate-limit-only token count");
+    assert_eq!(snapshots.len(), 2);
+    assert_eq!(snapshots[0].usage.total_tokens, 100);
+    assert_eq!(snapshots[1].usage.total_tokens, 180);
+  }
+
+  #[test]
   fn parent_replay_reader_rejects_non_numeric_token_usage() {
     let directory = tempdir().expect("tempdir");
     let parent_session_id = "40404040-4040-4040-8040-404040404040";
@@ -7147,6 +7181,12 @@ mod tests {
       ),
       parent_session_id,
     );
+    parent_body.push_str(concat!(
+      "{\"timestamp\":\"2026-03-24T00:00:00Z\",\"type\":\"event_msg\",",
+      "\"payload\":{\"type\":\"token_count\",\"info\":null,",
+      "\"rate_limits\":{\"limit_id\":\"codex\",\"primary\":{",
+      "\"used_percent\":46.0,\"window_minutes\":10080}}}}\n"
+    ));
     for fixture in parent_fixtures.iter().copied() {
       parent_body.push_str(&token_count_line(fixture));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1761,6 +1761,20 @@ fn build_passive_menu_bar_popup_snapshot(state: &AppState) -> Result<MenuBarPopu
   } else {
     get_quota_trend(&state.db_path, "seven_day".to_string(), live_rate_limits.clone()).unwrap_or_default()
   };
+  let api_value_7d = if selected_bucket == "seven_day" {
+    overview.as_ref().map(|value| value.stats.api_value_usd).unwrap_or(0.0)
+  } else {
+    get_window_api_value(
+      &state.db_path,
+      "seven_day".to_string(),
+      None,
+      None,
+      None,
+      live_rate_limits.clone(),
+      None,
+    )
+    .unwrap_or(0.0)
+  };
 
   Ok(MenuBarPopupSnapshot {
     fetched_at: Local::now().to_rfc3339(),
@@ -1773,6 +1787,7 @@ fn build_passive_menu_bar_popup_snapshot(state: &AppState) -> Result<MenuBarPopu
       .as_ref()
       .and_then(|snapshot| snapshot.secondary.as_ref().map(menu_bar_popup_quota_snapshot)),
     quota_trend_7d,
+    api_value_7d,
     suggested_speed_7d: live_rate_limits
       .as_ref()
       .and_then(|snapshot| snapshot.secondary.as_ref())
@@ -3147,6 +3162,77 @@ mod tests {
       snapshot.quota_7d.map(|window| window.remaining_percent),
       Some(79)
     );
+    runtime.shutdown_and_join().expect("shutdown runtime");
+  }
+
+  #[test]
+  fn popup_seven_day_api_value_restarts_after_an_early_quota_reset() {
+    let (runtime, _, _) = start_recording_runtime(disabled_refresh_config(None));
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("prepare app database");
+    let conn = open_connection(&db_path).expect("open database");
+    let mut settings = get_sync_settings(&conn).expect("load settings");
+    settings.menu_bar_bucket = "five_hour".to_string();
+    save_sync_settings(&conn, &settings).expect("save menu bar bucket");
+    for (session_id, timestamp, value_usd) in [
+      ("before-reset", "2026-07-15T03:00:00+08:00", 10.0),
+      ("after-reset", "2026-07-15T05:00:00+08:00", 2.0),
+    ] {
+      conn
+        .execute(
+          "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES (?1, ?2, ?3, 'gpt-5.4', 1, 0, 1, 0, 2, ?4, 0, 0)",
+          params![
+            session_id,
+            timestamp,
+            parse_rfc3339_local(timestamp)
+              .expect("parse event timestamp")
+              .timestamp_millis(),
+            value_usd,
+          ],
+        )
+        .expect("insert usage event");
+    }
+    drop(conn);
+
+    let cache = refresh::LiveQuotaCache::new();
+    cache.publish_fallback(
+      Arc::new(LiveRateLimitSnapshot {
+        limit_id: Some("codex".to_string()),
+        limit_name: Some("Codex".to_string()),
+        plan_type: Some("pro".to_string()),
+        primary: Some(RateLimitWindowSnapshot {
+          used_percent: 30,
+          remaining_percent: 70,
+          window_duration_mins: Some(300),
+          resets_at: Some("2026-07-15T06:00:00+08:00".to_string()),
+          window_start: Some("2026-07-15T01:00:00+08:00".to_string()),
+        }),
+        secondary: Some(RateLimitWindowSnapshot {
+          used_percent: 1,
+          remaining_percent: 99,
+          window_duration_mins: Some(10_080),
+          resets_at: Some("2026-07-22T04:36:00+08:00".to_string()),
+          window_start: Some("2026-07-15T04:36:00+08:00".to_string()),
+        }),
+        fetched_at: "2026-07-15T05:30:00+08:00".to_string(),
+      }),
+      Instant::now(),
+      Utc::now(),
+    );
+    let state = test_app_state(
+      db_path,
+      runtime.handle(),
+      refresh::UsageMutationCoordinator::new(),
+      cache,
+    );
+
+    let snapshot = build_passive_menu_bar_popup_snapshot(&state)
+      .expect("build popup snapshot after early reset");
+
+    assert_eq!(snapshot.selected_bucket, "five_hour");
+    assert_eq!(snapshot.api_value_selected_bucket, 12.0);
+    assert_eq!(snapshot.api_value_7d, 2.0);
     runtime.shutdown_and_join().expect("shutdown runtime");
   }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -266,6 +266,7 @@ pub struct MenuBarPopupSnapshot {
   pub quota_5h: Option<MenuBarPopupQuotaSnapshot>,
   pub quota_7d: Option<MenuBarPopupQuotaSnapshot>,
   pub quota_trend_7d: Vec<QuotaTrendPoint>,
+  pub api_value_7d: f64,
   pub suggested_speed_7d: Option<MenuBarPopupSuggestedSpeed>,
   pub speed_fast_threshold_percent: i64,
   pub speed_slow_threshold_percent: i64,

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -2143,6 +2143,65 @@ mod tests {
   }
 
   #[test]
+  fn seven_day_overview_restarts_after_an_early_live_quota_reset() {
+    let conn = Connection::open_in_memory().expect("open database");
+    init_db(&conn).expect("initialize database");
+    for (session_id, timestamp, value_usd) in [
+      ("before-reset", "2026-07-15T03:00:00+08:00", 10.0),
+      ("after-reset", "2026-07-15T05:00:00+08:00", 2.0),
+    ] {
+      conn
+        .execute(
+          "INSERT INTO usage_events (session_id, timestamp, timestamp_ms, model_id, input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens, value_usd, fast_mode_auto, fast_mode_effective) VALUES (?1, ?2, ?3, 'gpt-5.4', 1, 0, 1, 0, 2, ?4, 0, 0)",
+          rusqlite::params![
+            session_id,
+            timestamp,
+            parse_rfc3339_local(timestamp)
+              .expect("parse event timestamp")
+              .timestamp_millis(),
+            value_usd,
+          ],
+        )
+        .expect("insert usage event");
+    }
+    let live_rate_limits = LiveRateLimitSnapshot {
+      limit_id: Some("codex".to_string()),
+      limit_name: Some("Codex".to_string()),
+      plan_type: Some("pro".to_string()),
+      primary: None,
+      secondary: Some(crate::models::RateLimitWindowSnapshot {
+        used_percent: 1,
+        remaining_percent: 99,
+        window_duration_mins: Some(10_080),
+        resets_at: Some("2026-07-22T04:36:00+08:00".to_string()),
+        window_start: Some("2026-07-15T04:36:00+08:00".to_string()),
+      }),
+      fetched_at: "2026-07-15T05:30:00+08:00".to_string(),
+    };
+
+    let overview = get_overview_with_connection(
+      &conn,
+      Some("seven_day".to_string()),
+      None,
+      None,
+      None,
+      Some(live_rate_limits),
+      None,
+    )
+    .expect("load overview after early reset");
+
+    assert_eq!(overview.window_start, "2026-07-15T04:36:00+08:00");
+    assert_eq!(overview.stats.api_value_usd, 2.0);
+    assert_eq!(
+      overview
+        .quota_trend
+        .last()
+        .map(|point| point.cumulative_api_value_usd),
+      Some(2.0)
+    );
+  }
+
+  #[test]
   fn conversation_query_pages_in_sql_without_loading_every_item() {
     let conn = Connection::open_in_memory().expect("open database");
     init_db(&conn).expect("initialize database");

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -166,6 +166,7 @@ function createMockMenuBarPopupSnapshot(): MenuBarPopupSnapshot {
       windowStart: quota7dWindowStart,
     },
     quotaTrend7d: createMockQuotaTrend7d(quota7dWindowStart, fetchedAt),
+    apiValue7d: 14.3,
     suggestedSpeed7d: {
       percent: 82,
       displayValue: '82%',

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -136,6 +136,7 @@ export interface MenuBarPopupSnapshot {
   quota5h: MenuBarPopupQuotaSnapshot | null
   quota7d: MenuBarPopupQuotaSnapshot | null
   quotaTrend7d: QuotaTrendPoint[]
+  apiValue7d: number
   suggestedSpeed7d: MenuBarPopupSuggestedSpeed | null
   speedFastThresholdPercent: number
   speedSlowThresholdPercent: number

--- a/src/components/PopupSevenDayUsageChart.tsx
+++ b/src/components/PopupSevenDayUsageChart.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '../app/useI18n'
 
 interface PopupSevenDayUsageChartProps {
   ariaLabel: string
+  apiValueUsd: number
   data: QuotaTrendPoint[]
   fetchedAt: string | null
   quota: MenuBarPopupQuotaSnapshot | null
@@ -27,7 +28,7 @@ const PADDING_TOP = 12
 const PADDING_BOTTOM = 14
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
 
-export function PopupSevenDayUsageChart({ ariaLabel, data, fetchedAt, quota, speed }: PopupSevenDayUsageChartProps) {
+export function PopupSevenDayUsageChart({ ariaLabel, apiValueUsd, data, fetchedAt, quota, speed }: PopupSevenDayUsageChartProps) {
   const { language } = useI18n()
   const dataTimes = data
     .map((point) => toTimestamp(point.timestamp))
@@ -47,7 +48,6 @@ export function PopupSevenDayUsageChart({ ariaLabel, data, fetchedAt, quota, spe
   const referenceStart = toPlotPoint({ time: windowStart, value: 100 }, windowStart, safeWindowEnd)
   const referenceEnd = toPlotPoint({ time: safeWindowEnd, value: 0 }, windowStart, safeWindowEnd)
   const currentPoint = plotPoints.find((point) => point.time === currentTime) ?? plotPoints[plotPoints.length - 1] ?? null
-  const apiValueUsd = getSevenDayApiValue(data, windowStart, currentTime)
   const dayLines = Array.from({ length: 8 }, (_, index) => {
     const x = PADDING_X + ((CHART_WIDTH - PADDING_X * 2) * index) / 7
     return <line className="popup-seven-day-grid-line popup-seven-day-grid-line--vertical" key={index} x1={x} x2={x} y1={PADDING_TOP} y2={chartBottom()} />
@@ -146,20 +146,6 @@ function buildValuePoints(
   }
 
   return points
-}
-
-function getSevenDayApiValue(data: QuotaTrendPoint[], windowStart: number, currentTime: number) {
-  const values = data
-    .map((point) => ({
-      time: toTimestamp(point.timestamp),
-      value: point.cumulativeApiValueUsd,
-    }))
-    .filter((point): point is { time: number; value: number } => {
-      return point.time !== null && point.time >= windowStart && point.time <= currentTime && Number.isFinite(point.value)
-    })
-    .sort((left, right) => left.time - right.time)
-
-  return values[values.length - 1]?.value ?? 0
 }
 
 function buildSmoothPath(points: PlotPoint[]) {

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -325,6 +325,7 @@ export function MenuBarPopup() {
 
             <PopupSevenDayUsageChart
               ariaLabel={t.popup.sevenDayUsageChart}
+              apiValueUsd={snapshot.apiValue7d}
               data={snapshot.quotaTrend7d}
               fetchedAt={snapshot.liveQuotaFetchedAt ?? snapshot.fetchedAt}
               quota={snapshot.quota7d}


### PR DESCRIPTION
## What changed

- Tie the seven-day API value to the active Codex quota window, so an early reset starts the value from the new window.
- Return the corrected value in the overview and menu bar popup snapshots.
- Repair forked-agent usage imports when parent logs contain rate-limit-only `token_count` records with `info: null`. This prevents inherited conversation history from being counted again.

## Why

Codex can reset a seven-day quota before the previous window was expected to end. The app kept summing API value from the old window. Separately, rate-limit-only token records caused the fork replay repair to treat the parent as unavailable, so subagent logs counted inherited parent usage repeatedly. On the affected local database, this inflated the current value from about $453 to more than $4,000.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --locked` (414 passed, 2 ignored)
- `npm test`
- `npm run lint`
- `npm run build`
- Rebuilt and installed version 1.2.2 locally. Pending fork repairs went from 55 to 0, SQLite `quick_check` passed, and the menu bar value changed from $4058 to $453.5.