### PR TITLE
Windows compatibility and tray fixes, GPT-6 Astra support (v1.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-07-13
+
+### Added
+- the dashboard now opens on the 7-day view, and conversation history is loaded in pages with detail fetched only after selection
+- the menu bar uses the current 7-day window for API-equivalent value when Codex does not provide a 5-hour quota
+
+### Changed
+- routine refreshes use incremental file discovery, durable parser checkpoints, bounded database queries, and cached dashboard results
+- quota charts read only the selected normalized window and keep one sample per chart bin instead of loading the full bucket history
+- frontend refresh and conversation loading avoid duplicate requests when the view, search, or time window changes
+
+### Fixed
+- Codex accounts without a 5-hour quota no longer lose their 7-day quota or fail to open the default dashboard
+- incremental scans no longer revisit the full archived session tree every minute, while pending repair files still receive targeted retries
+- subscription profile changes invalidate cached overview values immediately
+- conversation search keeps complete root-session totals and metadata when only a child session matches
+- historical quota samples with second-level timestamps remain visible after epoch backfill
+
+### Upgrade notes
+- install 1.2.2 over 1.2.0 without uninstalling or deleting the local database
+- existing usage, quota history, subscription settings, menu bar preferences, and custom Codex paths are retained
+- automatic refresh remains incremental; a bounded full reconciliation runs only when the source changes or scheduled maintenance is due
+
 ## [1.2.0] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-09-05
+
+### Added
+- GPT-6 Astra model labels, chart color, and bundled Standard short-context pricing: $10 input, $1 cached input, and $50 output per million tokens, verified against [OpenAI's model documentation](https://developers.openai.com/api/docs/models/gpt-6-astra)
+- existing GPT-6 Astra usage is revalued on upgrade when its pricing is first added; token counts and session history are retained
+
+### Pricing scope
+- values use the same Standard short-context estimate as other models, not an API invoice; long-context, cache-write, and service-tier surcharges are not included
+
 ### Changed
 - updated the Windows frontend toolchain to Vite 8.2.2 and `@vitejs/plugin-react` 6.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- updated the Windows frontend toolchain to Vite 8.2.2 and `@vitejs/plugin-react` 6.1.1
+
+### Fixed
+- Windows builds no longer compile the macOS-only Objective-C dependencies
+- Windows test and application binaries now embed the Common Controls v6 manifest, fixing the `STATUS_ENTRYPOINT_NOT_FOUND` test startup failure
+- the local Windows NSIS installer now builds, installs, launches, and reads existing Codex history successfully on an x64 Windows validation host
+
 ## [1.2.2] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Windows tray popups use physical click coordinates to select the monitor at any display scale
+- reopening a resized tray popup resets its size to match its initial position before displaying it
+
 ## [1.2.3] - 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ English | [简体中文](./README.zh-CN.md)
 **Codex Pacer** is a local-first desktop app for understanding Codex usage as pace, value, and session-level activity. It helps you see how quickly you are consuming quota, what that usage is worth in API-equivalent terms, and which conversations or subagents are driving it.
 
 > Current stable release: **v1.2.2**
+> Development version: **v1.2.3**, with GPT-6 Astra pricing and Windows compatibility fixes. Not yet published.
 > Official download: signed and notarized **macOS Apple Silicon DMG** via GitHub Releases. Windows installer publishing is paused for this release.
 
 ## Highlights

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ English | [简体中文](./README.zh-CN.md)
 
 **Codex Pacer** is a local-first desktop app for understanding Codex usage as pace, value, and session-level activity. It helps you see how quickly you are consuming quota, what that usage is worth in API-equivalent terms, and which conversations or subagents are driving it.
 
-> Current stable release: **v1.2.0**
+> Current stable release: **v1.2.2**
 > Official download: signed and notarized **macOS Apple Silicon DMG** via GitHub Releases. Windows installer publishing is paused for this release.
 
 ## Highlights
@@ -40,13 +40,13 @@ Codex Pacer is local-first:
 
 ## Getting started
 
-The documentation set for installation, packaging, and release notes is maintained for the public `v1.2.0` release. Start with:
+The documentation set for installation, packaging, and release notes is maintained for the public `v1.2.2` release. Start with:
 
 - [Getting started](./docs/en/getting-started.md)
 - [Installing on macOS](./docs/en/installing-on-macos.md)
 - [Installing on Windows](./docs/en/installing-on-windows.md)
 - [Packaging and release](./docs/en/packaging-and-release.md)
-- [Release notes for v1.2.0](./docs/en/release-notes-v1.2.0.md)
+- [Release notes for v1.2.2](./docs/en/release-notes-v1.2.2.md)
 
 On macOS, Codex Pacer can use the Codex CLI bundled with the ChatGPT desktop app for live quota reads. It discovers `/Applications/ChatGPT.app/Contents/Resources/codex` automatically. A standalone Codex CLI and the `CODEX_BIN` override remain supported.
 
@@ -83,7 +83,7 @@ npm run tauri build
 
 ## Project status
 
-`v1.2.0` is the current stable release line.
+`v1.2.2` is the current stable release line.
 
 Current release packaging focus:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 **Codex Pacer** 是一个本地优先的桌面应用，用来把 Codex 使用情况转换成更容易行动的视角：额度节奏、API 等价价值，以及会话级别的使用分析。你可以更快看清自己消耗额度的速度、订阅回报，以及哪些对话或 subagent 正在驱动这些使用量。
 
-> 当前稳定版本：**v1.2.0**
+> 当前稳定版本：**v1.2.2**
 > 官方下载：通过 GitHub Releases 获取已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**。本版本暂缓发布 Windows 安装包。
 
 ## 核心能力
@@ -40,13 +40,13 @@ Codex Pacer 是本地优先的：
 
 ## 开始使用
 
-安装、打包和发布说明已按公开 `v1.2.0` 版本维护。可以从这些文档入口开始：
+安装、打包和发布说明已按公开 `v1.2.2` 版本维护。可以从这些文档入口开始：
 
 - [快速开始](./docs/zh-CN/getting-started.md)
 - [在 macOS 上安装](./docs/zh-CN/installing-on-macos.md)
 - [在 Windows 上安装](./docs/zh-CN/installing-on-windows.md)
 - [打包与发布](./docs/zh-CN/packaging-and-release.md)
-- [v1.2.0 发布说明](./docs/zh-CN/release-notes-v1.2.0.md)
+- [v1.2.2 发布说明](./docs/zh-CN/release-notes-v1.2.2.md)
 
 在 macOS 上，Codex Pacer 可以使用 ChatGPT 桌面应用内置的 Codex CLI 读取实时额度。应用会自动发现 `/Applications/ChatGPT.app/Contents/Resources/codex`。独立安装的 Codex CLI 和 `CODEX_BIN` 覆盖配置仍然可用。
 
@@ -83,7 +83,7 @@ npm run tauri build
 
 ## 项目状态
 
-`v1.2.0` 是当前稳定发布线。
+`v1.2.2` 是当前稳定发布线。
 
 当前发布重点：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,7 @@
 **Codex Pacer** 是一个本地优先的桌面应用，用来把 Codex 使用情况转换成更容易行动的视角：额度节奏、API 等价价值，以及会话级别的使用分析。你可以更快看清自己消耗额度的速度、订阅回报，以及哪些对话或 subagent 正在驱动这些使用量。
 
 > 当前稳定版本：**v1.2.2**
+> 当前开发版本：**v1.2.3**，新增 GPT-6 Astra 计价与 Windows 兼容性修复，尚未发布。
 > 官方下载：通过 GitHub Releases 获取已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**。本版本暂缓发布 Windows 安装包。
 
 ## 核心能力

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -12,7 +12,7 @@ It is built to help you answer practical questions such as:
 
 ## Requirements
 
-- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.2.0`.
+- Apple Silicon macOS for the stable packaged app. Windows compatibility is test-stage and installer publishing is paused for `v1.2.2`.
 - Local Codex data under `~/.codex` or a custom `CODEX_HOME`
 
 For development from source, you will also need:
@@ -26,7 +26,7 @@ For development from source, you will also need:
 Official public downloads are published through GitHub Releases:
 
 - signed and notarized **macOS Apple Silicon DMG**
-- no Windows installer is attached to `v1.2.0`; use the Windows guide only for source validation
+- no Windows installer is attached to `v1.2.2`; use the Windows guide only for source validation
 
 Start here:
 
@@ -106,4 +106,4 @@ npm run tauri build
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Packaging and release](./packaging-and-release.md)
-- [Release notes for v1.2.0](./release-notes-v1.2.0.md)
+- [Release notes for v1.2.2](./release-notes-v1.2.2.md)

--- a/docs/en/installing-on-windows.md
+++ b/docs/en/installing-on-windows.md
@@ -2,7 +2,7 @@
 
 ## Windows test-stage status
 
-Windows installer publishing is paused for `v1.2.0`. No Windows setup `.exe` is attached to the current stable GitHub Release.
+Windows installer publishing is paused for `v1.2.2`. No Windows setup `.exe` is attached to the current stable GitHub Release.
 
 Windows support is currently in a test stage. When a future release includes a Windows installer, it is unsigned unless Windows code signing is separately configured for that release, and Windows SmartScreen may warn that the publisher is unknown.
 
@@ -12,7 +12,7 @@ Windows support is currently in a test stage. When a future release includes a W
 2. Install the Windows Tauri prerequisites.
 3. Run `npm ci`.
 4. Run `npm run lint`, `npm run build`, and `cargo test --manifest-path src-tauri/Cargo.toml --locked`.
-5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.2.0` on Windows.
+5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.2.2` on Windows.
 
 ## After installation
 
@@ -27,7 +27,7 @@ When testing a local Windows build:
 ## Notes
 
 - GitHub Releases is the official distribution channel.
-- `v1.2.0` only publishes the macOS Apple Silicon DMG asset.
+- `v1.2.2` only publishes the macOS Apple Silicon DMG asset.
 - Any locally built Windows setup `.exe` remains a test-stage NSIS installer.
 - A Windows installer does not install the Codex CLI and does not create Codex usage history.
 - Stable Windows support, Windows code signing, and auto-update delivery are not currently promised.

--- a/docs/en/installing-on-windows.md
+++ b/docs/en/installing-on-windows.md
@@ -6,13 +6,25 @@ Windows installer publishing is paused for `v1.2.2`. No Windows setup `.exe` is 
 
 Windows support is currently in a test stage. When a future release includes a Windows installer, it is unsigned unless Windows code signing is separately configured for that release, and Windows SmartScreen may warn that the publisher is unknown.
 
+## Local validation result
+
+The `v1.2.2` source tree has now completed a local Windows x64 validation on Windows build 26200 with WebView2 151.0.4129.107:
+
+- frontend lint, build, and tests passed
+- all 416 enabled Rust tests passed; 2 tests remained ignored as designed
+- the release script produced an NSIS setup executable and SHA-256 checksum
+- the installer completed with its default per-user location, registered an uninstaller, and created a desktop shortcut
+- the installed app launched normally, imported existing local Codex history, and displayed aggregate usage and conversation data
+
+The validated installer is still unsigned and is not part of the public `v1.2.2` GitHub Release.
+
 ## Source validation flow
 
 1. Check out the release tag from the GitHub repository.
 2. Install the Windows Tauri prerequisites.
 3. Run `npm ci`.
 4. Run `npm run lint`, `npm run build`, and `cargo test --manifest-path src-tauri/Cargo.toml --locked`.
-5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 1.2.2` on Windows.
+5. For local installer validation only, run `.\scripts\release\build-windows-release.ps1 -Version 1.2.2` on Windows.
 
 ## After installation
 

--- a/docs/en/packaging-and-release.md
+++ b/docs/en/packaging-and-release.md
@@ -8,7 +8,7 @@ The stable packaged asset is:
 
 - signed and notarized **macOS Apple Silicon DMG**
 
-Windows installer publishing is paused for `v1.2.0`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
+Windows installer publishing is paused for `v1.2.2`. Windows compatibility remains test-stage and should be checked from source or on a Windows build host before a future Windows installer is published:
 
 - unsigned **Windows NSIS setup EXE** for local compatibility testing and early validation only
 
@@ -29,7 +29,7 @@ The intended public release flow is:
 
 1. Confirm public branding and documentation are ready for release.
 2. Build, notarize, and staple the macOS Apple Silicon DMG.
-3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.2.0`.
+3. Run Windows compatibility checks separately when Windows changes are included; do not publish a Windows installer for `v1.2.2`.
 4. Publish the release assets through GitHub Releases.
 5. Attach or include release notes for the tagged version.
 
@@ -39,15 +39,15 @@ Public release preparation is driven by the release scripts below:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.2.0
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
-Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, submits it for notarization, staples the ticket, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.2.0`.
+Those scripts are the stable local entry points for public release preparation. The macOS build script verifies the version, runs the audit/lint/build/test checks, produces the signed DMG, submits it for notarization, staples the ticket, and writes a checksum beside the artifact. The Windows build script runs on Windows, verifies the version, runs lint/build/Rust tests, produces the NSIS setup EXE, and writes a checksum beside the installer for local compatibility validation. The Windows installer is unsigned and test-stage unless Windows code signing and a stable Windows release policy are separately configured. The publish script verifies the tag and uploads the macOS DMG plus checksum to GitHub Releases; do not upload Windows EXE assets for `v1.2.2`.
 
 ## Platform isolation rules
 
@@ -77,7 +77,7 @@ Windows-specific tray popup placement, hidden child-process windows, and unsigne
 - Create the Git tag for the stable release version.
 - Create the GitHub Release from that tag.
 - Upload the signed, notarized, and stapled Apple Silicon DMG.
-- Do not upload a Windows NSIS setup EXE for `v1.2.0`.
+- Do not upload a Windows NSIS setup EXE for `v1.2.2`.
 - Add the matching release notes document for the version being published.
 - Verify the download and install flow after publication.
 
@@ -89,8 +89,8 @@ For public docs and announcements, use this message consistently:
 
 - official distribution channel: GitHub Releases
 - stable release asset: signed and notarized macOS Apple Silicon DMG
-- Windows installer: paused for `v1.2.0`
-- current stable line: `v1.2.0`
+- Windows installer: paused for `v1.2.2`
+- current stable line: `v1.2.2`
 
 ## Related docs
 
@@ -98,4 +98,4 @@ For public docs and announcements, use this message consistently:
 - [Installing on macOS](./installing-on-macos.md)
 - [Installing on Windows](./installing-on-windows.md)
 - [Release runbook](./release-runbook.md)
-- [Release notes for v1.2.0](./release-notes-v1.2.0.md)
+- [Release notes for v1.2.2](./release-notes-v1.2.2.md)

--- a/docs/en/release-notes-v1.2.2.md
+++ b/docs/en/release-notes-v1.2.2.md
@@ -1,0 +1,38 @@
+# Codex Pacer v1.2.2
+
+## Summary
+
+Version 1.2.2 fixes the repeated disk reads reported on large Codex histories. Routine one-minute refreshes now inspect the small set of active, changed, or pending-repair files instead of walking the full archive. Dashboard and quota queries are bounded to the selected window, and conversation history loads in pages.
+
+This release also supports Codex accounts that no longer expose a 5-hour quota. The dashboard opens on the 7-day view, keeps the weekly quota visible, and uses that same 7-day window for the menu bar API-equivalent value.
+
+## What changed
+
+- default dashboard view changed to the current 7-day window
+- 7-day quota remains available when the 5-hour quota is absent
+- menu bar API-equivalent value falls back to the current 7-day window
+- routine scans use incremental discovery and durable parser checkpoints
+- archived sessions are reconciled during bounded maintenance instead of every automatic refresh
+- quota trends query the exact normalized window and retain one point per chart bin
+- overview data is cached and invalidated when usage, quota, or subscription settings change
+- conversation lists use SQL pagination, and turn details load only after selection
+- duplicate dashboard reads on view and search changes have been removed
+- pending repair files without import state are retried directly
+
+## Resource validation
+
+The release work was tested with automatic scanning set to one minute. Over a 30-minute sample, Codex Pacer read 34.41 MiB and averaged 0.14% of one CPU core. The trace did not show recurring full archive scans. A separate 130-second smoke test of the packaged app recorded 4 KiB of reads after launch.
+
+These figures come from the release test machine and its local Codex history. Results will vary with active sessions, database size, and whether a scheduled reconciliation is due.
+
+## Upgrading from 1.2.0
+
+Install 1.2.2 over the existing app. Do not uninstall the previous version or delete the local database.
+
+Codex Pacer keeps the same app name, bundle identifier, and data location. Existing conversations, token usage, quota samples, subscription settings, menu bar preferences, and custom Codex paths remain in place.
+
+## Packaging
+
+The public macOS asset is an Apple Silicon DMG distributed through GitHub Releases with a SHA-256 checksum. The release is Developer ID signed, notarized by Apple, stapled, and checked with Gatekeeper before publication.
+
+Windows installer publishing remains paused for this release.

--- a/docs/en/release-runbook.md
+++ b/docs/en/release-runbook.md
@@ -5,19 +5,19 @@
 This runbook is for maintainers producing public **Codex Pacer** release assets:
 
 - signed, notarized, and stapled Apple Silicon DMG
-- Windows compatibility checks, with Windows installer publishing paused for `v1.2.0`
+- Windows compatibility checks, with Windows installer publishing paused for `v1.2.2`
 - published through GitHub Releases
 
 The local release entry points are:
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.2.0
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
 The macOS release scripts default `CARGO_TARGET_DIR` to `~/Library/Caches/CodexPacer/cargo-target` so signed macOS bundles are produced outside cloud-synced folders such as iCloud Drive. This avoids `codesign` failures caused by Finder and file-provider metadata on `.app` bundles.
@@ -101,7 +101,7 @@ GitHub Releases is the handoff point between maintainer workflow and user instal
 ## Build the signed DMG
 
 ```bash
-./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
 ```
 
 What the build script does:
@@ -129,7 +129,7 @@ What the build script does:
 Run this on Windows:
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
 What the Windows build script does:
@@ -152,7 +152,7 @@ If you need to override the Windows build output location, set `CARGO_TARGET_DIR
 
 ```powershell
 $env:CARGO_TARGET_DIR = "C:\Users\you\AppData\Local\CodexPacer\cargo-target"
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
 ### Optional target override
@@ -161,7 +161,7 @@ If you need to pass a specific Tauri target triple, set `TAURI_TARGET` before ru
 
 ```bash
 export TAURI_TARGET="aarch64-apple-darwin"
-./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
 ```
 
 `TAURI_TARGET` stays on the Tauri CLI side of the command, before the final `--` that introduces Cargo runner args such as `--locked`.
@@ -174,8 +174,8 @@ If you need to override the build output location, export `CARGO_TARGET_DIR` bef
 
 ```bash
 export CARGO_TARGET_DIR="$HOME/Library/Caches/CodexPacer/custom-target"
-./scripts/release/build-macos-release.sh 1.2.0
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other cloud/file-provider folders. Signed `.app` bundles created there can pick up `com.apple.FinderInfo` metadata and fail during `codesign`.
@@ -184,8 +184,8 @@ Do not point `CARGO_TARGET_DIR` at iCloud Drive, Dropbox, OneDrive, or other clo
 
 ```bash
 git status --short
-git tag v1.2.0
-git push origin v1.2.0
+git tag v1.2.2
+git push origin v1.2.2
 ```
 
 The publish script expects:
@@ -198,18 +198,18 @@ The publish script expects:
 ## Publish the GitHub Release
 
 ```bash
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 The publish script uses:
 
-- the built DMG for `v1.2.0`
+- the built DMG for `v1.2.2`
 - the sibling `.sha256` checksum file
-- `docs/en/release-notes-v1.2.0.md`
+- `docs/en/release-notes-v1.2.2.md`
 
 It publishes those assets with `gh release create`.
 
-For `v1.2.0`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
+For `v1.2.2`, do not attach Windows installer assets. For later releases that explicitly include Windows, attach the generated NSIS setup `.exe` and its `.sha256` checksum to the same GitHub Release and note in the release body that the Windows installer is test-stage and unsigned unless Windows signing was separately configured for that release.
 
 ## macOS manual smoke test
 
@@ -255,7 +255,7 @@ Run this before announcing Windows availability publicly:
 Useful spot check:
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.0_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.2_x64-setup.exe"
 ```
 
 ## Troubleshooting

--- a/docs/windows-tray-validation.md
+++ b/docs/windows-tray-validation.md
@@ -1,0 +1,18 @@
+# Windows tray popup validation
+
+Validated on 2026-09-05 with a local v1.2.3 build using the isolated application identifier `com.codex.counter.traytest`. The installed application and its database were not replaced.
+
+## Changes
+
+- Windows monitor lookup uses the physical tray click position without dividing it by the display scale.
+- Before a hidden popup is shown again, its size is reset to the height used to calculate its position.
+
+## Results
+
+- All 10 tray positioning tests passed, including scaled coordinates, negative-coordinate monitors, bottom taskbar placement, and upward resizing.
+- The full Rust suite passed: 419 passed and 2 ignored.
+- The frontend production build passed.
+- Computer Use clicked the Windows tray icon and captured the popup after its content loaded. The complete popup appeared above the bottom taskbar.
+- After the popup was hidden, Computer Use clicked the icon again. The returned screenshot origin and dimensions matched the first capture: origin `(2970, 1218)`, dimensions `423 x 575` in the capture tool's coordinate units.
+
+The desktop check covers the current display configuration only. Other scale factors and monitor layouts were covered by automated tests, not by changing the user's Windows display settings.

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -12,7 +12,7 @@
 
 ## 环境要求
 
-- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.2.0` 暂缓发布 Windows 安装包
+- 稳定打包版本面向 Apple Silicon macOS；Windows 兼容性仍处于测试阶段，`v1.2.2` 暂缓发布 Windows 安装包
 - 本地 Codex 数据位于 `~/.codex` 或自定义 `CODEX_HOME`
 
 如果你要从源码开发，还需要：
@@ -26,7 +26,7 @@
 官方公开下载方式均通过 GitHub Releases 提供：
 
 - 已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**
-- `v1.2.0` 不附加 Windows 安装包；Windows 文档仅用于源码验证
+- `v1.2.2` 不附加 Windows 安装包；Windows 文档仅用于源码验证
 
 请先阅读：
 
@@ -106,4 +106,4 @@ npm run tauri build
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [打包与发布](./packaging-and-release.md)
-- [v1.2.0 发布说明](./release-notes-v1.2.0.md)
+- [v1.2.2 发布说明](./release-notes-v1.2.2.md)

--- a/docs/zh-CN/installing-on-windows.md
+++ b/docs/zh-CN/installing-on-windows.md
@@ -6,13 +6,25 @@
 
 Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windows 安装包，除非该版本单独配置了 Windows code signing，否则安装包默认未签名，Windows SmartScreen 可能会提示发布者未知。
 
+## 本地验证结果
+
+`v1.2.2` 源码已在 Windows x64 build 26200、WebView2 151.0.4129.107 环境完成本地验证：
+
+- 前端 lint、构建和测试全部通过
+- 416 个启用的 Rust 测试全部通过，另有 2 个测试按设计保持 ignored
+- 发布脚本成功生成 NSIS 安装程序和 SHA-256 校验文件
+- 安装程序使用默认的当前用户目录完成安装，正确登记卸载程序并创建桌面快捷方式
+- 安装后的应用可以正常启动、导入现有 Codex 本地历史，并显示累计用量和对话数据
+
+这份已验证的安装程序仍未签名，也不属于公开的 `v1.2.2` GitHub Release 资产。
+
 ## 源码验证流程
 
 1. 从 GitHub 仓库检出对应 release tag。
 2. 安装 Windows Tauri 前置依赖。
 3. 运行 `npm ci`。
 4. 运行 `npm run lint`、`npm run build` 和 `cargo test --manifest-path src-tauri/Cargo.toml --locked`。
-5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.2.2`。
+5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 -Version 1.2.2`。
 
 ## 安装后
 

--- a/docs/zh-CN/installing-on-windows.md
+++ b/docs/zh-CN/installing-on-windows.md
@@ -2,7 +2,7 @@
 
 ## Windows 测试阶段状态
 
-`v1.2.0` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
+`v1.2.2` 暂缓发布 Windows 安装包。当前稳定版 GitHub Release 不附加 Windows setup `.exe`。
 
 Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windows 安装包，除非该版本单独配置了 Windows code signing，否则安装包默认未签名，Windows SmartScreen 可能会提示发布者未知。
 
@@ -12,7 +12,7 @@ Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windo
 2. 安装 Windows Tauri 前置依赖。
 3. 运行 `npm ci`。
 4. 运行 `npm run lint`、`npm run build` 和 `cargo test --manifest-path src-tauri/Cargo.toml --locked`。
-5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.2.0`。
+5. 仅用于本地安装包验证时，在 Windows 上运行 `.\scripts\release\build-windows-release.ps1 1.2.2`。
 
 ## 安装后
 
@@ -27,7 +27,7 @@ Windows 支持目前仍处于测试阶段。后续某个版本如果包含 Windo
 ## 说明
 
 - GitHub Releases 是官方分发渠道。
-- `v1.2.0` 只发布 macOS Apple Silicon DMG 资产。
+- `v1.2.2` 只发布 macOS Apple Silicon DMG 资产。
 - 任何本地构建的 Windows setup `.exe` 仍是测试阶段的 NSIS 安装包。
 - Windows 安装包不会安装 Codex CLI，也不会创建 Codex 使用历史。
 - Windows 稳定支持、Windows code signing 和自动更新交付目前都不承诺。

--- a/docs/zh-CN/packaging-and-release.md
+++ b/docs/zh-CN/packaging-and-release.md
@@ -8,7 +8,7 @@
 
 - 已签名并完成 Apple notarization 的 **macOS Apple Silicon DMG**
 
-`v1.2.0` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
+`v1.2.2` 暂缓发布 Windows 安装包。Windows 兼容性仍处于测试阶段，后续发布 Windows 安装包前应先在源码或 Windows 构建机上验证：
 
 - 未签名的 **Windows NSIS setup EXE**，仅用于本地兼容性测试和早期验证
 
@@ -29,7 +29,7 @@
 
 1. 确认公开品牌文案和文档已经准备完成。
 2. 构建并完成 macOS Apple Silicon DMG 的 notarization 与 staple。
-3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.2.0` 不发布 Windows 安装包。
+3. 如果包含 Windows 相关改动，单独执行 Windows 兼容性检查；`v1.2.2` 不发布 Windows 安装包。
 4. 通过 GitHub Releases 发布这些安装资产。
 5. 附上对应版本的发布说明。
 
@@ -39,15 +39,15 @@
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.2.0
-./scripts/release/publish-github-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
+./scripts/release/publish-github-release.sh 1.2.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
-这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，提交 Apple notarization，执行 staple，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.2.0` 不上传 Windows EXE 资产。
+这些脚本是当前稳定公开发布准备的本地入口。macOS 构建脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，生成已签名的 DMG，提交 Apple notarization，执行 staple，并在旁边写入 checksum。Windows 构建脚本在 Windows 上运行，会校验版本，运行 lint、前端构建和 Rust 测试，生成 NSIS setup EXE，并在旁边写入 checksum，供本地兼容性验证使用。Windows 安装包默认未签名且仍处于测试阶段，除非单独配置了 Windows code signing 和稳定 Windows 发布策略。发布脚本会继续校验 tag，并把 macOS DMG 与 checksum 上传到 GitHub Releases；`v1.2.2` 不上传 Windows EXE 资产。
 
 ## 平台隔离规则
 
@@ -77,7 +77,7 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 - 为稳定版本创建 Git tag
 - 基于该 tag 创建 GitHub Release
 - 上传已签名、完成 notarization 并已 staple 的 Apple Silicon DMG
-- `v1.2.0` 不上传 Windows NSIS setup EXE
+- `v1.2.2` 不上传 Windows NSIS setup EXE
 - 附上该版本对应的发布说明
 - 发布后再次验证下载与安装流程
 
@@ -89,8 +89,8 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 
 - 官方分发渠道：GitHub Releases
 - 稳定发布资产：已签名并完成 Apple notarization 的 macOS Apple Silicon DMG
-- Windows 安装包：`v1.2.0` 暂缓发布
-- 当前稳定版本线：`v1.2.0`
+- Windows 安装包：`v1.2.2` 暂缓发布
+- 当前稳定版本线：`v1.2.2`
 
 ## 相关文档
 
@@ -98,4 +98,4 @@ Windows 专属的托盘弹窗定位、隐藏子进程命令行窗口、未签名
 - [在 macOS 上安装](./installing-on-macos.md)
 - [在 Windows 上安装](./installing-on-windows.md)
 - [发布 Runbook](./release-runbook.md)
-- [v1.2.0 发布说明](./release-notes-v1.2.0.md)
+- [v1.2.2 发布说明](./release-notes-v1.2.2.md)

--- a/docs/zh-CN/release-notes-v1.2.2.md
+++ b/docs/zh-CN/release-notes-v1.2.2.md
@@ -1,0 +1,38 @@
+# Codex Pacer v1.2.2
+
+## 概要
+
+1.2.2 修复了大型 Codex 历史记录下反复大量读取磁盘的问题。常规的一分钟自动刷新现在只检查 active、发生变化或等待修复的少量文件，不再遍历全部 archive。Dashboard 与额度查询只读取所选窗口，对话历史也改为分页加载。
+
+这个版本同时适配不再提供 5 小时额度的 Codex 账号。程序默认打开 7 天视图，保留 7 天额度，并用同一个 7 天窗口计算菜单栏的 API 等价值。
+
+## 本次更新
+
+- 默认打开当前 7 天窗口
+- 没有 5 小时额度时仍正常显示 7 天额度
+- 菜单栏 API 等价值自动改用当前 7 天窗口
+- 常规扫描使用增量发现和持久化解析检查点
+- archived session 改由受限的维护任务校正，不再每次自动刷新都遍历
+- 额度趋势只查询精确的归一化窗口，并在每个图表时间段保留一个点
+- overview 数据使用缓存，并在 usage、quota 或订阅设置变化时立即失效
+- 对话列表使用 SQL 分页，选中对话后才读取 turn 详情
+- 移除切换视图和搜索条件时的重复 dashboard 读取
+- 没有 import state 的 pending repair 文件也会被直接重试
+
+## 资源验证
+
+测试时把自动扫描间隔设为一分钟。连续 30 分钟采样中，Codex Pacer 共读取 34.41 MiB，平均占用约 0.14% 单核 CPU，trace 中没有再次出现周期性全量 archive 扫描。另一次对打包应用进行的 130 秒 smoke test 在启动后记录到 4 KiB 读取。
+
+这些数字来自发布测试机器及其本地 Codex 历史。实际结果会受 active session、数据库大小和定期校正任务影响。
+
+## 从 1.2.0 升级
+
+直接覆盖安装 1.2.2 即可。不要卸载旧版本，也不要删除本地数据库。
+
+应用名称、bundle identifier 和数据位置保持不变。已有 conversation、token usage、quota 样本、订阅设置、菜单栏偏好和自定义 Codex 路径都会保留。
+
+## 发布形式
+
+公开 macOS 资产是通过 GitHub Releases 分发的 Apple Silicon DMG，并附带 SHA-256 checksum。发布前会完成 Developer ID 签名、Apple notarization、staple 和 Gatekeeper 检查。
+
+本版本仍暂缓发布 Windows 安装包。

--- a/docs/zh-CN/release-runbook.md
+++ b/docs/zh-CN/release-runbook.md
@@ -5,21 +5,21 @@
 本文面向维护者，说明如何生成 **Codex Pacer** 的公开发布资产：
 
 - 已签名、完成 notarization 并已 staple 的 Apple Silicon DMG
-- Windows 兼容性检查，且 `v1.2.0` 暂缓发布 Windows 安装包
+- Windows 兼容性检查，且 `v1.2.2` 暂缓发布 Windows 安装包
 - 通过 GitHub Releases 分发
 
 本地发布入口：
 
 ```bash
 ./scripts/release/audit-public-branding.sh
-./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
 ```
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
-macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.0` 上传 DMG 与 checksum。`v1.2.0` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
+macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.2` 上传 DMG 与 checksum。`v1.2.2` 不附加 Windows setup EXE；后续明确包含 Windows 的 release 再把 Windows setup EXE 与对应 checksum 附加到同一个 GitHub Release。
 
 ## macOS 发布要求
 
@@ -44,7 +44,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.
 ## macOS 构建
 
 ```bash
-./scripts/release/build-macos-release.sh 1.2.0
+./scripts/release/build-macos-release.sh 1.2.2
 ```
 
 脚本会校验版本，运行品牌审计、lint、前端构建和 Rust 测试，构建 app/dmg，执行 codesign，并写入 `<artifact>.dmg.sha256`。如果配置了 notarization 凭据，脚本还会执行 notarytool、stapling、Gatekeeper 与 stapler 校验；如果未配置，则跳过这些 notarization 专属步骤。
@@ -52,7 +52,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.
 ## Windows 构建
 
 ```powershell
-.\scripts\release\build-windows-release.ps1 1.2.0
+.\scripts\release\build-windows-release.ps1 1.2.2
 ```
 
 脚本会校验版本，运行 `npm ci`、lint、前端构建和 Rust 测试，执行 `npm run tauri build -- --ci --bundles nsis -- --locked`，定位生成的 NSIS setup `.exe`，并写入 `<installer>.exe.sha256`。
@@ -98,7 +98,7 @@ macOS 发布流程继续使用 `./scripts/release/publish-github-release.sh 1.2.
 10. 刷新 live quota 数据，确认不会弹出黑色命令行窗口。
 
 ```powershell
-Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.0_x64-setup.exe"
+Get-FileHash -Algorithm SHA256 -LiteralPath "C:\path\to\Codex Pacer_1.2.2_x64-setup.exe"
 ```
 
 ## 相关文档

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-pacer",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-pacer",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-pacer",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-pacer",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,14 +22,14 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.1",
+        "@vitejs/plugin-react": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.2.2"
       },
       "engines": {
         "node": ">=22.18.0"
@@ -273,40 +273,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -568,29 +534,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -633,10 +580,27 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
       "cpu": [
         "arm64"
       ],
@@ -651,9 +615,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
       "cpu": [
         "arm64"
       ],
@@ -668,9 +632,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
       "cpu": [
         "x64"
       ],
@@ -685,9 +649,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
       "cpu": [
         "x64"
       ],
@@ -702,9 +666,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
       "cpu": [
         "arm"
       ],
@@ -719,9 +683,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
       "cpu": [
         "arm64"
       ],
@@ -736,9 +700,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
       "cpu": [
         "arm64"
       ],
@@ -753,9 +717,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
       "cpu": [
         "ppc64"
       ],
@@ -770,9 +734,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
       "cpu": [
         "s390x"
       ],
@@ -787,9 +751,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
       "cpu": [
         "x64"
       ],
@@ -804,9 +768,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
       "cpu": [
         "x64"
       ],
@@ -821,9 +785,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
       "cpu": [
         "arm64"
       ],
@@ -837,29 +801,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
       "cpu": [
         "arm64"
       ],
@@ -874,9 +819,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
       "cpu": [
         "x64"
       ],
@@ -891,9 +836,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
-      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1134,17 +1079,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1459,16 +1393,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -1556,13 +1490,13 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
-      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz",
+      "integrity": "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.7"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -1570,6 +1504,7 @@
       "peerDependencies": {
         "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
         "babel-plugin-react-compiler": "^1.0.0",
+        "oxc-transform-react": "^0.145.0",
         "vite": "^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -1577,6 +1512,9 @@
           "optional": true
         },
         "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "oxc-transform-react": {
           "optional": true
         }
       }
@@ -1665,9 +1603,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2486,9 +2424,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -2580,9 +2518,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -2596,23 +2534,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -2631,9 +2569,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -2652,9 +2590,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -2673,9 +2611,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -2694,9 +2632,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -2715,9 +2653,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -2736,9 +2674,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -2757,9 +2695,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -2778,9 +2716,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -2799,9 +2737,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -2820,9 +2758,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -2903,9 +2841,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3042,9 +2980,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3062,7 +3000,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3203,13 +3141,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
+        "@oxc-project/types": "=0.147.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3219,29 +3157,22 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -3353,14 +3284,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3493,16 +3416,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
+        "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -3519,7 +3442,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.1",
+    "@vitejs/plugin-react": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.2.2"
   },
   "description": "Local-first desktop analytics for Codex Pacer usage, quota pacing, and subscription payoff.",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-pacer",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "engines": {
     "node": ">=22.18.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-pacer",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.2",
   "type": "module",
   "engines": {
     "node": ">=22.18.0"

--- a/scripts/test-refresh-events.mjs
+++ b/scripts/test-refresh-events.mjs
@@ -14,6 +14,31 @@ const popupSource = readFileSync(join(repoRoot, 'src/menu-bar-popup/MenuBarPopup
 const apiSource = readFileSync(join(repoRoot, 'src/app/api.ts'), 'utf8')
 const dataFreshnessSource = readFileSync(join(repoRoot, 'src/app/dataFreshness.ts'), 'utf8')
 
+test('popup_reopen_invalidates_height_cache_and_resizes_before_snapshot_load', () => {
+  const start = popupSource.indexOf("listen('codex-counter://menu-bar-popup-refresh'")
+  const end = popupSource.indexOf('codex-counter://language-changed', start)
+  assert.ok(start >= 0 && end > start)
+  const callback = popupSource.slice(start, end).match(/\.then\(\(visible\) => \{([\s\S]*?)\n\s*\}\)/)
+  assert.ok(callback, 'popup visibility callback must exist')
+  const onVisible = new Function('visible', 'cancelled', 'lastMeasuredHeightRef', 'schedulePopupResize', 'loadSnapshot', callback[1])
+  for (const [visible, cancelled] of [[true, false], [false, false], [true, true]]) {
+    const heightRef = { current: 575 }
+    const calls = []
+    const resize = () => {
+      assert.equal(heightRef.current, null, 'same-height content must be measured again')
+      calls.push('resize')
+    }
+    const load = (force) => {
+      assert.equal(force, false)
+      calls.push('load')
+    }
+    onVisible(visible, cancelled, heightRef, resize, load)
+    onVisible(visible, cancelled, heightRef, resize, load)
+    assert.deepEqual(calls, visible && !cancelled ? ['resize', 'load', 'resize', 'load'] : [])
+    assert.equal(heightRef.current, visible && !cancelled ? null : 575)
+  }
+})
+
 function completion(refreshRevision, succeeded = true) {
   return {
     refreshRevision,
@@ -144,7 +169,7 @@ test('frontend_refresh_sources_are_event_driven_without_automatic_polling', () =
   )
   assert.match(
     popupSource,
-    /listen\('codex-counter:\/\/menu-bar-popup-refresh'[\s\S]{0,220}loadSnapshot\(false\)/,
+    /listen\('codex-counter:\/\/menu-bar-popup-refresh'[\s\S]{0,450}loadSnapshot\(false\)/,
   )
   assert.doesNotMatch(popupSource, /codex-counter:\/\/refresh-completed/)
 })

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-pacer"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "codex-pacer"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,8 +23,6 @@ dirs = "6.0.0"
 flate2 = "1.1.9"
 log = "0.4"
 mimalloc = "0.1.52"
-objc2 = "0.6.4"
-objc2-foundation = { version = "0.3.2", features = ["NSProcessInfo", "NSString"] }
 rusqlite = { version = "0.37.0", features = ["bundled", "chrono"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -34,6 +32,10 @@ tempfile = "3.23.0"
 tokio = { version = "1.48.0", features = ["time"] }
 ureq = "2.12.1"
 walkdir = "2.5.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-foundation = { version = "0.3.2", features = ["NSProcessInfo", "NSString"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-pacer"
-version = "1.2.0"
+version = "1.2.2"
 description = "Codex Pacer desktop analytics"
 authors = ["Codex"]
 license = ""

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-pacer"
-version = "1.2.2"
+version = "1.2.3"
 description = "Codex Pacer desktop analytics"
 authors = ["Codex"]
 license = ""

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,28 @@
 fn main() {
-  tauri_build::build()
+  let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+    && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+  let mut attributes = tauri_build::Attributes::new();
+
+  if is_windows_msvc {
+    attributes =
+      attributes.windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
+  }
+
+  tauri_build::try_build(attributes).expect("failed to run tauri-build");
+
+  if is_windows_msvc {
+    embed_windows_test_manifest();
+  }
+}
+
+fn embed_windows_test_manifest() {
+  let manifest = std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+    .join("windows-app-manifest.xml");
+
+  println!("cargo:rerun-if-changed={}", manifest.display());
+  println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+  println!(
+    "cargo:rustc-link-arg=/MANIFESTINPUT:{}",
+    manifest.display()
+  );
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1966,9 +1966,13 @@ fn position_menu_bar_popup(
   rect: Rect,
   click_position: PhysicalPosition<f64>,
 ) -> Result<(), String> {
-  if let (_, Some(position)) = menu_bar_popup_geometry(window, rect, click_position, MENU_BAR_POPUP_INITIAL_HEIGHT)? {
-    return window
+  if let (height, Some(position)) = menu_bar_popup_geometry(window, rect, click_position, MENU_BAR_POPUP_INITIAL_HEIGHT)? {
+    window
       .set_position(Position::Physical(position))
+      .map_err(|error| error.to_string())?;
+    // Match the height used for positioning before showing a previously resized popup.
+    return window
+      .set_size(tauri::Size::Logical(tauri::LogicalSize::new(MENU_BAR_POPUP_WIDTH, height)))
       .map_err(|error| error.to_string());
   }
 
@@ -2049,7 +2053,7 @@ fn tray_event_monitor(
 
   for monitor in monitors {
     let scale_factor = normalized_scale_factor(monitor.scale_factor());
-    // macOS tray events report scaled global positions; monitor_from_point expects CoreGraphics coordinates.
+    // Lookup coordinates follow the platform contract, not the popup's current DPI.
     let lookup_point = tray_event_monitor_lookup_point(rect, click_position, scale_factor);
     let Some(candidate) = window
       .monitor_from_point(lookup_point.x, lookup_point.y)
@@ -2100,8 +2104,17 @@ fn tray_event_monitor_lookup_point(
   click_position: PhysicalPosition<f64>,
   scale_factor: f64,
 ) -> PhysicalPosition<f64> {
+  #[cfg(target_os = "windows")]
+  {
+    // Windows tray clicks and monitor lookup both use physical screen coordinates.
+    let _ = (rect, scale_factor);
+    return click_position;
+  }
+  #[cfg(not(target_os = "windows"))]
+  {
   let anchor = tray_rect_anchor_physical(rect, click_position, scale_factor);
   PhysicalPosition::new(anchor.x / scale_factor, anchor.y / scale_factor)
+  }
 }
 
 fn tray_monitor_scale_score(rect: Rect, scale_factor: f64) -> f64 {
@@ -4683,6 +4696,7 @@ mod tests {
   }
 
   #[test]
+  #[cfg(not(target_os = "windows"))]
   fn tray_popup_monitor_lookup_undoes_status_item_scale() {
     let rect = Rect {
       position: Position::Physical((4000.0, 10.0).into()),
@@ -4807,6 +4821,20 @@ mod tests {
     assert_eq!(expanded.height, 700.0);
     assert_eq!(expanded.position.y, 332);
     assert!(expanded.position.y < compact.position.y);
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn tray_popup_monitor_lookup_preserves_windows_physical_click_on_scaled_monitors() {
+    let rect = Rect {
+      position: Position::Physical((3970.0, 1380.0).into()),
+      size: tauri::Size::Physical((48u32, 60u32).into()),
+    };
+    for scale in [1.0, 1.25, 1.5, 2.0] {
+      for click in [PhysicalPosition::new(3994.0, 1410.0), PhysicalPosition::new(-1200.0, 1410.0)] {
+        assert_eq!(tray_event_monitor_lookup_point(rect, click, scale), click);
+      }
+    }
   }
 
   #[cfg(target_os = "windows")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1966,24 +1966,31 @@ fn position_menu_bar_popup(
   rect: Rect,
   click_position: PhysicalPosition<f64>,
 ) -> Result<(), String> {
-  if let (height, Some(position)) = menu_bar_popup_geometry(window, rect, click_position, MENU_BAR_POPUP_INITIAL_HEIGHT)? {
-    window
-      .set_position(Position::Physical(position))
-      .map_err(|error| error.to_string())?;
-    // Match the height used for positioning before showing a previously resized popup.
-    return window
-      .set_size(tauri::Size::Logical(tauri::LogicalSize::new(MENU_BAR_POPUP_WIDTH, height)))
-      .map_err(|error| error.to_string());
-  }
-
-  let anchor = tray_rect_anchor_physical(rect, click_position, 1.0);
-  let anchor_x = anchor.x.round() as i32;
-  let anchor_y = anchor.y.round() as i32;
-  let x = (anchor_x - MENU_BAR_POPUP_WIDTH as i32 / 2).max(0);
-  let y = (anchor_y + MENU_BAR_POPUP_OFFSET_Y).max(0);
+  let (height, position) =
+    menu_bar_popup_geometry(window, rect, click_position, MENU_BAR_POPUP_INITIAL_HEIGHT)?;
+  let geometry = popup_opening_geometry(height, position, rect, click_position);
   window
-    .set_position(Position::Physical(PhysicalPosition::new(x, y)))
+    .set_position(Position::Physical(geometry.position))
+    .map_err(|error| error.to_string())?;
+  // Reset the previous size even when monitor lookup falls back to the tray anchor.
+  window
+    .set_size(tauri::Size::Logical(tauri::LogicalSize::new(MENU_BAR_POPUP_WIDTH, geometry.height)))
     .map_err(|error| error.to_string())
+}
+
+fn popup_opening_geometry(
+  height: f64,
+  position: Option<PhysicalPosition<i32>>,
+  rect: Rect,
+  click_position: PhysicalPosition<f64>,
+) -> MenuBarPopupGeometry {
+  let position = position.unwrap_or_else(|| {
+    let anchor = tray_rect_anchor_physical(rect, click_position, 1.0);
+    let x = (anchor.x.round() as i32 - MENU_BAR_POPUP_WIDTH as i32 / 2).max(0);
+    let y = (anchor.y.round() as i32 + MENU_BAR_POPUP_OFFSET_Y).max(0);
+    PhysicalPosition::new(x, y)
+  });
+  MenuBarPopupGeometry { position, height }
 }
 
 fn menu_bar_popup_geometry(
@@ -4673,6 +4680,22 @@ mod tests {
     assert!(should_hide_dock_icon(&enabled_with_menu_bar));
     assert!(!should_hide_dock_icon(&enabled_without_menu_bar));
     assert!(!should_hide_dock_icon(&disabled_with_menu_bar));
+  }
+
+  #[test]
+  fn tray_popup_opening_geometry_retains_height_without_a_monitor() {
+    let rect = Rect {
+      position: Position::Physical((1000.0, 20.0).into()),
+      size: tauri::Size::Physical((24u32, 24u32).into()),
+    };
+    let height = MENU_BAR_POPUP_INITIAL_HEIGHT.clamp(MENU_BAR_POPUP_MIN_HEIGHT, MENU_BAR_POPUP_MAX_HEIGHT);
+    let geometry = popup_opening_geometry(height, None, rect, PhysicalPosition::new(1012.0, 32.0));
+    assert_eq!(geometry.height, height);
+    assert_eq!(geometry.position.y, 44 + MENU_BAR_POPUP_OFFSET_Y);
+    let known_position = PhysicalPosition::new(-900, 200);
+    let geometry = popup_opening_geometry(height, Some(known_position), rect, PhysicalPosition::new(1012.0, 32.0));
+    assert_eq!(geometry.height, height);
+    assert_eq!(geometry.position, known_position);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3826,6 +3826,36 @@ mod tests {
   }
 
   #[test]
+  fn startup_adds_astra_pricing_and_revalues_existing_usage() {
+    let directory = tempdir().expect("tempdir");
+    let db_path = directory.path().join("usage.sqlite");
+    prepare_app_database(&db_path).expect("initialize database");
+    let conn = open_connection(&db_path).expect("open database");
+    conn.execute("DELETE FROM pricing_catalog WHERE model_id = 'gpt-6-astra'", [])
+      .expect("simulate pre-Astra catalog");
+    conn.execute_batch("
+      INSERT INTO sessions (session_id, root_session_id, source_state, source_bucket,
+        last_model_id, created_at, imported_at)
+      VALUES ('astra', 'astra', 'active', 'active', 'gpt-6-astra', '2026-09-05', '2026-09-05');
+      INSERT INTO usage_events (session_id, timestamp, model_id, input_tokens,
+        cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens,
+        value_usd, fast_mode_auto, fast_mode_effective)
+      VALUES ('astra', '2026-09-05T00:00:00Z', 'gpt-6-astra',
+        100000, 40000, 10000, 0, 110000, 0, 0, 0);
+    ").expect("insert historical Astra usage");
+    drop(conn);
+    prepare_app_database(&db_path).expect("upgrade");
+    prepare_app_database(&db_path).expect("repeat startup");
+    let conn = open_connection(&db_path).expect("reopen database");
+    let (value, tokens): (f64, i64) = conn.query_row(
+      "SELECT value_usd, total_tokens FROM usage_events WHERE session_id = 'astra'",
+      [], |row| Ok((row.get(0)?, row.get(1)?)),
+    ).expect("historical usage");
+    assert!((value - 1.14).abs() < 1e-9);
+    assert_eq!(tokens, 110000);
+  }
+
+  #[test]
   fn startup_database_prepare_rolls_back_pricing_when_recalculation_fails() {
     let directory = tempdir().expect("tempdir");
     let db_path = directory.path().join("usage.sqlite");

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -36,6 +36,14 @@ struct OfficialPricingRow {
 fn pricing_seed() -> Vec<PricingCatalogEntry> {
     let updated_at = now_utc_string();
     vec![
+        fallback_entry(
+            "gpt-6-astra",
+            "GPT-6 Astra",
+            10.00,
+            1.00,
+            50.00,
+            &updated_at,
+        ),
         PricingCatalogEntry {
             model_id: "gpt-5.6".to_string(),
             display_name: "GPT-5.6".to_string(),
@@ -563,6 +571,8 @@ pub fn resolve_pricing(
         catalog.get("gpt-5.6-sol")?.clone()
     } else if let Some(entry) = catalog.get(&normalized) {
         entry.clone()
+    } else if matches_canonical_or_dated_model_id(&normalized, "gpt-6-astra") {
+        catalog.get("gpt-6-astra")?.clone()
     } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-sol") {
         catalog.get("gpt-5.6-sol")?.clone()
     } else if matches_canonical_or_dated_model_id(&normalized, "gpt-5.6-terra") {
@@ -643,6 +653,7 @@ pub fn display_name_for_model(model_id: &str) -> String {
     match normalize_model_id(model_id).as_str() {
         "codex-auto-review" => "Codex Auto Review".to_string(),
         "codex-mini-latest" => "Codex Mini Latest".to_string(),
+        "gpt-6-astra" => "GPT-6 Astra".to_string(),
         "gpt-5.6" => "GPT-5.6".to_string(),
         "gpt-5.6-sol" => "GPT-5.6 Sol".to_string(),
         "gpt-5.6-terra" => "GPT-5.6 Terra".to_string(),
@@ -675,6 +686,7 @@ pub fn display_name_for_model(model_id: &str) -> String {
 pub fn model_color(model_id: &str) -> &'static str {
     match normalize_model_id(model_id).as_str() {
         "codex-auto-review" => "#60a5fa",
+        "gpt-6-astra" => "#06b6d4",
         "gpt-5.6" => "#f59e0b",
         "gpt-5.6-sol" => "#ffd166",
         "gpt-5.6-terra" => "#2ec4b6",
@@ -779,6 +791,50 @@ mod tests {
         assert_eq!(nano.input_price_per_million, 0.20);
         assert!(flagship.input_price_per_million > mini.input_price_per_million);
         assert!(mini.input_price_per_million > nano.input_price_per_million);
+    }
+
+    #[test]
+    fn gpt_6_astra_pricing_and_presentation() {
+        let catalog = pricing_seed()
+            .into_iter()
+            .map(|entry| (entry.model_id.clone(), entry))
+            .collect::<HashMap<_, _>>();
+        for model in ["gpt-6-astra", " GPT-6-ASTRA ", "gpt-6-astra-2026-09-05"] {
+            let pricing = resolve_pricing(&catalog, model).expect("Astra pricing");
+            assert_eq!(pricing.input_price_per_million, 10.0);
+            assert_eq!(pricing.cached_input_price_per_million, 1.0);
+            assert_eq!(pricing.output_price_per_million, 50.0);
+            let usage = TokenUsage {
+                input_tokens: 100_000,
+                cached_input_tokens: 40_000,
+                output_tokens: 10_000,
+                reasoning_output_tokens: 0,
+                total_tokens: 110_000,
+            };
+            assert!((calculate_value_usd(&usage, Some(&pricing)) - 1.14).abs() < 1e-9);
+        }
+        for model in [
+            "gpt-6",
+            "gpt-6-astra-preview",
+            "gpt-6-astra-2026-02-30",
+            "gpt-6-astra-2026-09-05-preview",
+        ] {
+            assert!(resolve_pricing(&catalog, model).is_none(), "{model}");
+        }
+        assert_eq!(display_name_for_model("gpt-6-astra"), "GPT-6 Astra");
+        assert_eq!(model_color("gpt-6-astra"), "#06b6d4");
+    }
+
+    #[test]
+    fn gpt_6_astra_official_row_uses_output_not_cache_write_price() {
+        let rows =
+            extract_pricing_rows("[[0,&quot;gpt-6-astra&quot;],[0,10],[0,1],[0,12.5],[0,50]]");
+        assert_eq!(rows.len(), 1);
+        let entry = official_entry(rows[0].clone(), "2026-09-05");
+        assert_eq!(entry.model_id, "gpt-6-astra");
+        assert_eq!(entry.display_name, "GPT-6 Astra");
+        assert_eq!(entry.output_price_per_million, 50.0);
+        assert!(entry.is_official);
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -653,7 +653,9 @@ pub fn display_name_for_model(model_id: &str) -> String {
     match normalize_model_id(model_id).as_str() {
         "codex-auto-review" => "Codex Auto Review".to_string(),
         "codex-mini-latest" => "Codex Mini Latest".to_string(),
-        "gpt-6-astra" => "GPT-6 Astra".to_string(),
+        model if matches_canonical_or_dated_model_id(model, "gpt-6-astra") => {
+            "GPT-6 Astra".to_string()
+        }
         "gpt-5.6" => "GPT-5.6".to_string(),
         "gpt-5.6-sol" => "GPT-5.6 Sol".to_string(),
         "gpt-5.6-terra" => "GPT-5.6 Terra".to_string(),
@@ -686,7 +688,7 @@ pub fn display_name_for_model(model_id: &str) -> String {
 pub fn model_color(model_id: &str) -> &'static str {
     match normalize_model_id(model_id).as_str() {
         "codex-auto-review" => "#60a5fa",
-        "gpt-6-astra" => "#06b6d4",
+        model if matches_canonical_or_dated_model_id(model, "gpt-6-astra") => "#06b6d4",
         "gpt-5.6" => "#f59e0b",
         "gpt-5.6-sol" => "#ffd166",
         "gpt-5.6-terra" => "#2ec4b6",
@@ -800,6 +802,8 @@ mod tests {
             .map(|entry| (entry.model_id.clone(), entry))
             .collect::<HashMap<_, _>>();
         for model in ["gpt-6-astra", " GPT-6-ASTRA ", "gpt-6-astra-2026-09-05"] {
+            assert_eq!(display_name_for_model(model), "GPT-6 Astra");
+            assert_eq!(model_color(model), "#06b6d4");
             let pricing = resolve_pricing(&catalog, model).expect("Astra pricing");
             assert_eq!(pricing.input_price_per_million, 10.0);
             assert_eq!(pricing.cached_input_price_per_million, 1.0);
@@ -820,6 +824,8 @@ mod tests {
             "gpt-6-astra-2026-09-05-preview",
         ] {
             assert!(resolve_pricing(&catalog, model).is_none(), "{model}");
+            assert_eq!(display_name_for_model(model), model.to_ascii_uppercase());
+            assert_eq!(model_color(model), "#7c7f86");
         }
         assert_eq!(display_name_for_model("gpt-6-astra"), "GPT-6 Astra");
         assert_eq!(model_color("gpt-6-astra"), "#06b6d4");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Codex Pacer",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "identifier": "com.codex.counter",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Codex Pacer",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "identifier": "com.codex.counter",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/windows-app-manifest.xml
+++ b/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/menu-bar-popup/MenuBarPopup.tsx
+++ b/src/menu-bar-popup/MenuBarPopup.tsx
@@ -177,7 +177,11 @@ export function MenuBarPopup() {
           void getCurrentWindow()
             .isVisible()
             .then((visible) => {
-              if (!cancelled && visible) void loadSnapshot(false)
+              if (!cancelled && visible) {
+                lastMeasuredHeightRef.current = null
+                schedulePopupResize()
+                void loadSnapshot(false)
+              }
             })
             .catch(() => {})
         }


### PR DESCRIPTION
## Changes

- Restore Windows builds by limiting Objective-C dependencies to macOS, updating Vite and its React plugin, and embedding the Common Controls v6 manifest.
- Fix Windows tray popup monitor selection under display scaling and reset popup size before reopening. Computer Use verified placement above the tray and consistent positioning after reopening.
- Add GPT-6 Astra labels, chart color, Standard short-context pricing, and tests for historical usage revaluation. Prices per million tokens: $10 input, $1 cached input, $50 output, based on https://developers.openai.com/api/docs/models/gpt-6-astra.
- Update application versions to 1.2.3 and include the previously synchronized v1.2.2 release documentation from main.

## Validation

- `npm run lint`, `npm test`, and `npm run build`: passed during development.
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`: 419 passed, 2 ignored.
- `scripts/release/build-windows-release.ps1 -Version 1.2.3`: passed, including lint, frontend build, Rust tests, and NSIS packaging.
- Installed the NSIS build over the existing app. Verified the installed executable matches the build apart from Tauri's expected NSIS bundle marker. Database, WAL, and SHM file hashes were unchanged by installation before startup.
- The installed process starts and responds. Desktop tray checks used an isolated application identifier; details are in `docs/windows-tray-validation.md`.

## Limits and unresolved issues

- An earlier startup check of the existing user database reported integrity errors. The cause remains undiagnosed. Backups were retained; this PR does not repair or reset that database. Successful installation and tray checks do not establish end-to-end data integrity.
- Windows artifacts are unsigned. No public release is published by this PR.
- The current npm audit reports one moderate and one high vulnerability in ESLint-related dependencies (`@humanfs/node` and `browserslist`); they have not been updated here.
- Other monitor layouts and scale factors have automated coverage but were not exercised by changing Windows display settings. macOS was not built on this Windows host.
- API-equivalent values retain the application's Standard short-context estimate rather than invoice-level billing.
